### PR TITLE
Security hardening: admin auth, metrics fix, config validation, CORS

### DIFF
--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -13,6 +13,10 @@ pub struct ServerSettings {
     /// External base URL for generating absolute links (e.g. "https://api.example.com").
     /// If not set, defaults to "http://{host}:{port}".
     pub base_url: Option<String>,
+    /// Bearer token for admin endpoints (e.g. /admin/collections/reload).
+    /// Can also be set via `ADMIN_TOKEN` env var (takes priority).
+    /// If neither is set, admin endpoints are disabled (return 403).
+    pub admin_token: Option<String>,
 }
 
 impl ServerSettings {
@@ -214,8 +218,41 @@ impl ServerConfig {
         let content = std::fs::read_to_string(path).map_err(|e| {
             crate::error::DataServerError::Config(format!("Failed to read {path}: {e}"))
         })?;
-        toml::from_str(&content).map_err(|e| {
+        let config: Self = toml::from_str(&content).map_err(|e| {
             crate::error::DataServerError::Config(format!("Failed to parse config: {e}"))
-        })
+        })?;
+        config.validate()?;
+        Ok(config)
+    }
+
+    /// Validate configuration for common errors before starting the server.
+    pub fn validate(&self) -> Result<(), crate::error::DataServerError> {
+        for collection in &self.collections {
+            let id = &collection.id;
+
+            if id.is_empty() {
+                return Err(crate::error::DataServerError::Config(
+                    "Collection has an empty 'id' field".to_string(),
+                ));
+            }
+
+            // GeoTIFF engine requires geotiff config section
+            if collection.engine_type == "geotiff" && collection.geotiff.is_none() {
+                return Err(crate::error::DataServerError::Config(format!(
+                    "Collection '{id}': engine_type 'geotiff' requires a [collections.geotiff] config section"
+                )));
+            }
+
+            // GeoTIFF poll_interval_secs must be > 0
+            if let Some(geotiff) = &collection.geotiff {
+                if geotiff.poll_interval_secs == 0 {
+                    return Err(crate::error::DataServerError::Config(format!(
+                        "Collection '{id}': poll_interval_secs must be > 0"
+                    )));
+                }
+            }
+        }
+
+        Ok(())
     }
 }

--- a/crates/server/src/admin.rs
+++ b/crates/server/src/admin.rs
@@ -4,7 +4,7 @@ use std::time::Instant;
 
 use arc_swap::ArcSwap;
 use axum::extract::{MatchedPath, State};
-use axum::http::{header, StatusCode};
+use axum::http::{header, HeaderMap, StatusCode};
 use axum::response::IntoResponse;
 use axum::Json;
 use prometheus::{
@@ -113,6 +113,9 @@ pub struct ServerState {
     pub geotiff_engines: RwLock<Vec<Arc<engine_geotiff::GeoTiffEngine>>>,
     /// Serializes reload requests to prevent concurrent reloads from racing.
     pub reload_lock: tokio::sync::Mutex<()>,
+    /// Bearer token for admin endpoint authentication.
+    /// If None, admin endpoints are disabled (return 403).
+    pub admin_token: Option<String>,
 }
 
 pub type AdminState = Arc<ServerState>;
@@ -626,7 +629,35 @@ pub fn update_health_gauges(health: &[CollectionHealth]) {
 /// POST /admin/collections/reload — re-read config and swap engines atomically.
 pub async fn reload_handler(
     State(state): State<AdminState>,
+    headers: HeaderMap,
 ) -> Result<impl IntoResponse, (StatusCode, Json<serde_json::Value>)> {
+    // Check admin token authentication
+    match &state.admin_token {
+        None => {
+            return Err((
+                StatusCode::FORBIDDEN,
+                Json(json!({
+                    "error": "Admin endpoint is disabled. Set ADMIN_TOKEN env var or admin_token in [server] config to enable."
+                })),
+            ));
+        }
+        Some(expected_token) => {
+            let provided = headers
+                .get(header::AUTHORIZATION)
+                .and_then(|v| v.to_str().ok())
+                .and_then(|v| v.strip_prefix("Bearer "));
+            match provided {
+                Some(token) if token == expected_token => {} // OK
+                _ => {
+                    return Err((
+                        StatusCode::UNAUTHORIZED,
+                        Json(json!({ "error": "Invalid or missing Bearer token" })),
+                    ));
+                }
+            }
+        }
+    }
+
     // Serialize reload requests — prevent concurrent reloads from racing
     let _reload_guard = state.reload_lock.try_lock().map_err(|_| {
         (
@@ -771,7 +802,7 @@ pub async fn metrics_middleware(
     let method = req.method().to_string();
     let path = matched_path
         .map(|p| p.as_str().to_string())
-        .unwrap_or_else(|| req.uri().path().to_string());
+        .unwrap_or_else(|| "unmatched".to_string());
 
     let response = next.run(req).await;
 

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -72,6 +72,16 @@ async fn main() {
     let maps_swap = Arc::new(ArcSwap::from_pointee(result.maps_state));
     let tiles_swap = Arc::new(ArcSwap::from_pointee(result.tiles_state));
 
+    // Resolve admin token: ADMIN_TOKEN env var takes priority over config
+    let admin_token = std::env::var("ADMIN_TOKEN")
+        .ok()
+        .or(config.server.admin_token.clone());
+    if admin_token.is_some() {
+        info!("Admin endpoint authentication enabled");
+    } else {
+        info!("Admin endpoint authentication disabled (no ADMIN_TOKEN set)");
+    }
+
     let server_state: AdminState = Arc::new(ServerState {
         edr: edr_swap.clone(),
         features: features_swap.clone(),
@@ -82,11 +92,13 @@ async fn main() {
         health: RwLock::new(result.health),
         geotiff_engines: RwLock::new(result.geotiff_engines),
         reload_lock: tokio::sync::Mutex::new(()),
+        admin_token,
     });
 
     let root_state = server_state.clone();
 
-    let app = Router::new()
+    // Public routes get permissive CORS (OGC APIs, health, metrics)
+    let public = Router::new()
         .route("/", get(move || root_landing_page(root_state)))
         .nest("/edr", api_edr::router(edr_swap.clone()))
         .nest("/features", api_features::router(features_swap.clone()))
@@ -110,19 +122,22 @@ async fn main() {
             "/tiles/",
             get(api_tiles::handlers::landing_page).with_state(tiles_swap),
         )
-        // Admin endpoints
-        .route(
-            "/admin/collections/reload",
-            post(admin::reload_handler).with_state(server_state.clone()),
-        )
         .route(
             "/health",
             get(admin::health_handler).with_state(server_state.clone()),
         )
         .route("/metrics", get(admin::metrics_handler))
-        // Middleware
-        .layer(middleware::from_fn(admin::metrics_middleware))
         .layer(CorsLayer::permissive());
+
+    // Admin routes: no CORS layer (browser requests blocked by default)
+    let admin_routes = Router::new().route(
+        "/admin/collections/reload",
+        post(admin::reload_handler).with_state(server_state.clone()),
+    );
+
+    let app = public
+        .merge(admin_routes)
+        .layer(middleware::from_fn(admin::metrics_middleware));
 
     // Normalize trailing slashes (e.g., /wms/ → /wms) before routing
     let app = NormalizePathLayer::trim_trailing_slash().layer(app);


### PR DESCRIPTION
## Summary

Four pre-deployment security and reliability improvements:

- **Admin endpoint authentication**: `POST /admin/collections/reload` requires `Authorization: Bearer <token>`. Token from `ADMIN_TOKEN` env var or `admin_token` in `[server]` config. Returns 403 if unconfigured, 401 if wrong.
- **Metrics cardinality fix**: Unmatched routes use `"unmatched"` as Prometheus path label instead of raw URI. Prevents OOM from bot/scanner traffic creating unbounded labels.
- **Config validation at startup**: `ServerConfig::validate()` catches empty collection IDs, missing `[collections.geotiff]` for geotiff engines, and `poll_interval_secs = 0`. Fails fast before loading anything.
- **CORS restriction on admin**: OGC API routes get `CorsLayer::permissive()`, admin endpoint gets no CORS (browser requests blocked). Health/metrics remain public.

## Test plan

- [x] All existing tests pass
- [x] cargo fmt and clippy clean
- [x] Manual verification: admin returns 403 without token, 401 with wrong token, 200 with correct token
- [x] Config validation rejects empty IDs and missing geotiff config

🤖 Generated with [Claude Code](https://claude.com/claude-code)