### PR TITLE
fix: only return 503 when all collections have failed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1099,7 +1099,7 @@ Response: `{"status": "ok", "loaded": N, "configured": M, "collections": [...]}`
 | `degraded` | Engine loaded but no data yet (e.g., GeoTIFF waiting for first poll) |
 | `failed` | Engine failed to load (error message included) |
 
-Overall status: `healthy` (all ready), `degraded` (some degraded, none failed), `unhealthy` (any failed). Returns HTTP 503 when unhealthy.
+Overall status: `healthy` (all ready), `degraded` (some degraded or failed, but at least one working), `unhealthy` (all failed). Returns HTTP 503 only when all collections have failed (nothing to serve). A single failed collection does not take down the service.
 
 ### Prometheus metrics
 

--- a/crates/server/src/admin.rs
+++ b/crates/server/src/admin.rs
@@ -1214,18 +1214,24 @@ pub async fn health_handler(State(state): State<AdminState>) -> impl IntoRespons
         })
         .collect();
 
+    let all_failed =
+        !health.is_empty() && health.iter().all(|h| h.status == CollectionStatus::Failed);
+
     let overall = if health.iter().all(|h| h.status == CollectionStatus::Ready) {
         "healthy"
-    } else if health.iter().any(|h| h.status == CollectionStatus::Failed) {
+    } else if all_failed {
+        // Every collection failed — nothing to serve
         "unhealthy"
     } else {
+        // Mix of ready/degraded/failed — server is functional but not fully healthy
         "degraded"
     };
 
-    let status_code = match overall {
-        "healthy" => StatusCode::OK,
-        "degraded" => StatusCode::OK,
-        _ => StatusCode::SERVICE_UNAVAILABLE,
+    // Only return 503 when the server can't serve anything at all
+    let status_code = if all_failed {
+        StatusCode::SERVICE_UNAVAILABLE
+    } else {
+        StatusCode::OK
     };
 
     (


### PR DESCRIPTION
## Summary

A single failed collection (e.g., unknown engine type from a stale Docker image) made the health endpoint return "unhealthy" with HTTP 503. This caused reverse proxies to stop routing traffic, even though all other collections were serving fine.

**Before:** any failed collection -> unhealthy -> 503
**After:** all failed -> unhealthy -> 503, some failed + some working -> degraded -> 200

## Test plan

- [x] All tests pass
- [x] cargo clippy clean