### PR TITLE
fix: address review findings (perf, architecture, validation)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,6 +90,7 @@ version = "0.1.0"
 dependencies = [
  "arc-swap",
  "axum",
+ "bytes",
  "chrono",
  "ds-core",
  "ds-render",
@@ -107,6 +108,7 @@ version = "0.1.0"
 dependencies = [
  "arc-swap",
  "axum",
+ "bytes",
  "chrono",
  "ds-core",
  "ds-render",
@@ -124,6 +126,7 @@ version = "0.1.0"
 dependencies = [
  "arc-swap",
  "axum",
+ "bytes",
  "chrono",
  "ds-core",
  "ds-render",
@@ -592,6 +595,7 @@ dependencies = [
 name = "ds-render"
 version = "0.1.0"
 dependencies = [
+ "bytes",
  "chrono",
  "ds-core",
  "jpeg-encoder",

--- a/crates/api-maps/Cargo.toml
+++ b/crates/api-maps/Cargo.toml
@@ -8,6 +8,7 @@ ds-core = { path = "../core" }
 ds-render = { path = "../render" }
 arc-swap = "1"
 axum = "0.8"
+bytes = "1"
 chrono = { version = "0.4", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/api-maps/src/handlers.rs
+++ b/crates/api-maps/src/handlers.rs
@@ -730,7 +730,7 @@ async fn render_map(
                 "nosniff",
             )
             .header(header::HeaderName::from_static("x-cache"), "HIT")
-            .body(axum::body::Body::from(cached.as_ref().clone()))
+            .body(axum::body::Body::from(cached))
             .unwrap()
             .into_response());
     }
@@ -773,16 +773,16 @@ async fn render_map(
 
     let (image_bytes, x_cache) = match render_result {
         Ok(Some(bytes)) => {
-            let image_arc = Arc::new(bytes);
-            rendered_cache.insert(cache_key, image_arc.clone());
-            (image_arc.as_ref().clone(), "MISS")
+            let image_bytes = bytes::Bytes::from(bytes);
+            rendered_cache.insert(cache_key, image_bytes.clone());
+            (image_bytes, "MISS")
         }
         Ok(None) => {
             // Empty tile: return transparent PNG without caching
             let rgba = vec![0u8; (width * height * 4) as usize];
             let png = ds_render::encode_png(&rgba, width, height)
                 .map_err(|e| MapsError::Internal(format!("Failed to encode empty tile: {e}")))?;
-            (png, "EMPTY")
+            (bytes::Bytes::from(png), "EMPTY")
         }
         Err(e) => {
             tracing::warn!("Maps render error for collection '{}': {e}", collection_id);

--- a/crates/api-tiles/Cargo.toml
+++ b/crates/api-tiles/Cargo.toml
@@ -8,6 +8,7 @@ ds-core = { path = "../core" }
 ds-render = { path = "../render" }
 arc-swap = "1"
 axum = "0.8"
+bytes = "1"
 chrono = { version = "0.4", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/api-tiles/src/handlers.rs
+++ b/crates/api-tiles/src/handlers.rs
@@ -18,10 +18,12 @@ use crate::tilematrixset::{self, SUPPORTED_TILE_MATRIX_SETS};
 
 /// Pre-generated 256x256 fully transparent PNG for empty (all-nodata) tiles.
 /// Avoids running the colorization + encoding pipeline when a tile has no data.
-static EMPTY_TILE_PNG: LazyLock<Vec<u8>> = LazyLock::new(|| {
+static EMPTY_TILE_PNG: LazyLock<bytes::Bytes> = LazyLock::new(|| {
     let size = params::TILE_SIZE;
     let rgba = vec![0u8; (size * size * 4) as usize];
-    ds_render::encode_png(&rgba, size, size).expect("encoding empty tile PNG must not fail")
+    bytes::Bytes::from(
+        ds_render::encode_png(&rgba, size, size).expect("encoding empty tile PNG must not fail"),
+    )
 });
 
 /// Shared state for the OGC API Tiles service.
@@ -731,7 +733,7 @@ async fn render_tile(
                 "nosniff",
             )
             .header(header::HeaderName::from_static("x-cache"), "HIT")
-            .body(axum::body::Body::from(cached.as_ref().clone()))
+            .body(axum::body::Body::from(cached))
             .unwrap()
             .into_response());
     }
@@ -781,9 +783,9 @@ async fn render_tile(
     let (image_bytes, x_cache) = match maybe_bytes {
         None => (EMPTY_TILE_PNG.clone(), "EMPTY"),
         Some(bytes) => {
-            let image_arc = Arc::new(bytes);
-            rendered_cache.insert(cache_key, image_arc.clone());
-            (image_arc.as_ref().clone(), "MISS")
+            let image_bytes = bytes::Bytes::from(bytes);
+            rendered_cache.insert(cache_key, image_bytes.clone());
+            (image_bytes, "MISS")
         }
     };
 

--- a/crates/api-wms/Cargo.toml
+++ b/crates/api-wms/Cargo.toml
@@ -8,6 +8,7 @@ ds-core = { path = "../core" }
 ds-render = { path = "../render" }
 arc-swap = "1"
 axum = "0.8"
+bytes = "1"
 chrono = { version = "0.4", features = ["serde"] }
 quick-xml = "0.37"
 serde = { version = "1", features = ["derive"] }

--- a/crates/api-wms/src/handlers.rs
+++ b/crates/api-wms/src/handlers.rs
@@ -144,7 +144,7 @@ pub async fn wms_handler(
                         "nosniff",
                     )
                     .header(header::HeaderName::from_static("x-cache"), "HIT")
-                    .body(axum::body::Body::from(cached.as_ref().clone()))
+                    .body(axum::body::Body::from(cached))
                     .unwrap()
                     .into_response());
             }
@@ -190,9 +190,9 @@ pub async fn wms_handler(
 
             let (image_bytes, x_cache) = match render_result {
                 Ok(Some(bytes)) => {
-                    let image_arc = Arc::new(bytes);
-                    rendered_cache.insert(cache_key, image_arc.clone());
-                    (image_arc.as_ref().clone(), "MISS")
+                    let image_bytes = bytes::Bytes::from(bytes);
+                    rendered_cache.insert(cache_key, image_bytes.clone());
+                    (image_bytes, "MISS")
                 }
                 Ok(None) => {
                     // Empty tile: return transparent PNG without caching
@@ -201,11 +201,14 @@ pub async fn wms_handler(
                         ds_render::encode_png(&rgba, params.width, params.height).map_err(|e| {
                             WmsError::Internal(format!("Failed to encode empty tile: {e}"))
                         })?;
-                    (png, "EMPTY")
+                    (bytes::Bytes::from(png), "EMPTY")
                 }
                 Err(e) => {
                     tracing::warn!("WMS render error for layer '{}': {e}", params.layer);
-                    (render_error_tile(params.width, params.height)?, "ERROR")
+                    (
+                        bytes::Bytes::from(render_error_tile(params.width, params.height)?),
+                        "ERROR",
+                    )
                 }
             };
 

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -11,8 +11,8 @@ pub enum DataServerError {
     #[error("Invalid datetime format: {0}")]
     InvalidDatetime(String),
 
-    #[error("CSV error: {0}")]
-    Csv(String),
+    #[error("Engine error: {0}")]
+    Engine(String),
 
     #[error("Config error: {0}")]
     Config(String),
@@ -25,18 +25,6 @@ pub enum DataServerError {
 
     #[error("Invalid parameter: {0}")]
     InvalidParameter(String),
-
-    #[error("GeoJSON error: {0}")]
-    GeoJson(String),
-
-    #[error("GeoTIFF error: {0}")]
-    GeoTiff(String),
-
-    #[error("QueryData error: {0}")]
-    QueryData(String),
-
-    #[error("GRIB error: {0}")]
-    Grib(String),
 
     #[error("Storage error: {0}")]
     Storage(String),

--- a/crates/engine-csv/src/loader.rs
+++ b/crates/engine-csv/src/loader.rs
@@ -24,11 +24,11 @@ pub struct CsvDataStore {
 impl CsvDataStore {
     pub fn load(path: &str) -> Result<Self, DataServerError> {
         let mut reader = csv::Reader::from_path(path)
-            .map_err(|e| DataServerError::Csv(format!("Failed to open {path}: {e}")))?;
+            .map_err(|e| DataServerError::Engine(format!("Failed to open {path}: {e}")))?;
 
         let headers: Vec<String> = reader
             .headers()
-            .map_err(|e| DataServerError::Csv(format!("Failed to read headers: {e}")))?
+            .map_err(|e| DataServerError::Engine(format!("Failed to read headers: {e}")))?
             .iter()
             .map(|h| h.to_string())
             .collect();
@@ -37,7 +37,7 @@ impl CsvDataStore {
         // Everything else is a parameter
         let param_start = 4;
         if headers.len() < param_start {
-            return Err(DataServerError::Csv(format!(
+            return Err(DataServerError::Engine(format!(
                 "CSV must have at least {} columns (location, latitude, longitude, time), found {}",
                 param_start,
                 headers.len()
@@ -66,18 +66,18 @@ impl CsvDataStore {
 
         for result in reader.records() {
             let record =
-                result.map_err(|e| DataServerError::Csv(format!("Failed to read row: {e}")))?;
+                result.map_err(|e| DataServerError::Engine(format!("Failed to read row: {e}")))?;
 
             let location = record[0].to_string();
             let latitude: f64 = record[1]
                 .parse()
-                .map_err(|e| DataServerError::Csv(format!("Invalid latitude: {e}")))?;
+                .map_err(|e| DataServerError::Engine(format!("Invalid latitude: {e}")))?;
             let longitude: f64 = record[2]
                 .parse()
-                .map_err(|e| DataServerError::Csv(format!("Invalid longitude: {e}")))?;
+                .map_err(|e| DataServerError::Engine(format!("Invalid longitude: {e}")))?;
             let time: DateTime<Utc> = record[3]
                 .parse()
-                .map_err(|e| DataServerError::Csv(format!("Invalid time: {e}")))?;
+                .map_err(|e| DataServerError::Engine(format!("Invalid time: {e}")))?;
 
             let mut values = HashMap::new();
             for (i, param_name) in parameter_names.iter().enumerate() {

--- a/crates/engine-geojson/src/loader.rs
+++ b/crates/engine-geojson/src/loader.rs
@@ -38,24 +38,24 @@ impl GeoJsonEngine {
     pub fn load(path: &str) -> Result<Self, DataServerError> {
         // Check file size
         let metadata = std::fs::metadata(path)
-            .map_err(|e| DataServerError::GeoJson(format!("Failed to read file metadata: {e}")))?;
+            .map_err(|e| DataServerError::Engine(format!("Failed to read file metadata: {e}")))?;
         if metadata.len() > MAX_FILE_SIZE {
-            return Err(DataServerError::GeoJson(format!(
+            return Err(DataServerError::Engine(format!(
                 "File exceeds maximum size of {} MB",
                 MAX_FILE_SIZE / (1024 * 1024)
             )));
         }
 
         let file = std::fs::File::open(path)
-            .map_err(|e| DataServerError::GeoJson(format!("Failed to open file: {e}")))?;
+            .map_err(|e| DataServerError::Engine(format!("Failed to open file: {e}")))?;
         let reader = BufReader::new(file);
 
         let geojson: serde_json::Value = serde_json::from_reader(reader)
-            .map_err(|e| DataServerError::GeoJson(format!("Invalid JSON: {e}")))?;
+            .map_err(|e| DataServerError::Engine(format!("Invalid JSON: {e}")))?;
 
         let fc_type = geojson.get("type").and_then(|v| v.as_str()).unwrap_or("");
         if fc_type != "FeatureCollection" {
-            return Err(DataServerError::GeoJson(
+            return Err(DataServerError::Engine(
                 "Expected a GeoJSON FeatureCollection".into(),
             ));
         }
@@ -63,10 +63,10 @@ impl GeoJsonEngine {
         let raw_features = geojson
             .get("features")
             .and_then(|v| v.as_array())
-            .ok_or_else(|| DataServerError::GeoJson("Missing 'features' array".into()))?;
+            .ok_or_else(|| DataServerError::Engine("Missing 'features' array".into()))?;
 
         if raw_features.len() > MAX_FEATURES {
-            return Err(DataServerError::GeoJson(format!(
+            return Err(DataServerError::Engine(format!(
                 "File has {} features, exceeding limit of {}",
                 raw_features.len(),
                 MAX_FEATURES
@@ -244,7 +244,7 @@ fn extract_feature_id(feature: &serde_json::Value, fallback_idx: usize) -> Strin
 }
 
 fn parse_geometry(geom: Option<&serde_json::Value>) -> Result<Geometry, DataServerError> {
-    let geom = geom.ok_or_else(|| DataServerError::GeoJson("Feature missing geometry".into()))?;
+    let geom = geom.ok_or_else(|| DataServerError::Engine("Feature missing geometry".into()))?;
 
     if geom.is_null() {
         return Ok(Geometry::Null);
@@ -257,15 +257,15 @@ fn parse_geometry(geom: Option<&serde_json::Value>) -> Result<Geometry, DataServ
             let coords = geom
                 .get("coordinates")
                 .and_then(|v| v.as_array())
-                .ok_or_else(|| DataServerError::GeoJson("Point missing coordinates".into()))?;
+                .ok_or_else(|| DataServerError::Engine("Point missing coordinates".into()))?;
             let x = coords
                 .first()
                 .and_then(|v| v.as_f64())
-                .ok_or_else(|| DataServerError::GeoJson("Invalid Point x coordinate".into()))?;
+                .ok_or_else(|| DataServerError::Engine("Invalid Point x coordinate".into()))?;
             let y = coords
                 .get(1)
                 .and_then(|v| v.as_f64())
-                .ok_or_else(|| DataServerError::GeoJson("Invalid Point y coordinate".into()))?;
+                .ok_or_else(|| DataServerError::Engine("Invalid Point y coordinate".into()))?;
             validate_coord(x, y)?;
             Ok(Geometry::Point { x, y })
         }
@@ -273,7 +273,7 @@ fn parse_geometry(geom: Option<&serde_json::Value>) -> Result<Geometry, DataServ
             let rings = geom
                 .get("coordinates")
                 .and_then(|v| v.as_array())
-                .ok_or_else(|| DataServerError::GeoJson("Polygon missing coordinates".into()))?;
+                .ok_or_else(|| DataServerError::Engine("Polygon missing coordinates".into()))?;
             let (exterior, holes) = parse_polygon_rings(rings)?;
             Ok(Geometry::Polygon { exterior, holes })
         }
@@ -282,7 +282,7 @@ fn parse_geometry(geom: Option<&serde_json::Value>) -> Result<Geometry, DataServ
                 .get("coordinates")
                 .and_then(|v| v.as_array())
                 .ok_or_else(|| {
-                    DataServerError::GeoJson("MultiPolygon missing coordinates".into())
+                    DataServerError::Engine("MultiPolygon missing coordinates".into())
                 })?;
 
             let mut polygons = Vec::with_capacity(polygons_raw.len());
@@ -290,7 +290,7 @@ fn parse_geometry(geom: Option<&serde_json::Value>) -> Result<Geometry, DataServ
 
             for poly_raw in polygons_raw {
                 let rings = poly_raw.as_array().ok_or_else(|| {
-                    DataServerError::GeoJson("Invalid MultiPolygon ring array".into())
+                    DataServerError::Engine("Invalid MultiPolygon ring array".into())
                 })?;
                 let (ext, holes) = parse_polygon_rings(rings)?;
                 total_coords += ext.len();
@@ -298,7 +298,7 @@ fn parse_geometry(geom: Option<&serde_json::Value>) -> Result<Geometry, DataServ
                     total_coords += h.len();
                 }
                 if total_coords > MAX_COORDS_PER_GEOMETRY {
-                    return Err(DataServerError::GeoJson(format!(
+                    return Err(DataServerError::Engine(format!(
                         "Geometry exceeds maximum coordinate count of {}",
                         MAX_COORDS_PER_GEOMETRY
                     )));
@@ -308,7 +308,7 @@ fn parse_geometry(geom: Option<&serde_json::Value>) -> Result<Geometry, DataServ
 
             Ok(Geometry::MultiPolygon { polygons })
         }
-        other => Err(DataServerError::GeoJson(format!(
+        other => Err(DataServerError::Engine(format!(
             "Unsupported geometry type: {other}"
         ))),
     }
@@ -319,7 +319,7 @@ fn parse_polygon_rings(
     rings: &[serde_json::Value],
 ) -> Result<(Vec<[f64; 2]>, Vec<Vec<[f64; 2]>>), DataServerError> {
     if rings.is_empty() {
-        return Err(DataServerError::GeoJson(
+        return Err(DataServerError::Engine(
             "Polygon must have at least one ring".into(),
         ));
     }
@@ -336,21 +336,21 @@ fn parse_polygon_rings(
 fn parse_ring(ring: &serde_json::Value) -> Result<Vec<[f64; 2]>, DataServerError> {
     let coords_raw = ring
         .as_array()
-        .ok_or_else(|| DataServerError::GeoJson("Ring is not an array".into()))?;
+        .ok_or_else(|| DataServerError::Engine("Ring is not an array".into()))?;
 
     let mut coords = Vec::with_capacity(coords_raw.len());
     for c in coords_raw {
         let pair = c
             .as_array()
-            .ok_or_else(|| DataServerError::GeoJson("Coordinate is not an array".into()))?;
+            .ok_or_else(|| DataServerError::Engine("Coordinate is not an array".into()))?;
         let x = pair
             .first()
             .and_then(|v| v.as_f64())
-            .ok_or_else(|| DataServerError::GeoJson("Invalid x coordinate".into()))?;
+            .ok_or_else(|| DataServerError::Engine("Invalid x coordinate".into()))?;
         let y = pair
             .get(1)
             .and_then(|v| v.as_f64())
-            .ok_or_else(|| DataServerError::GeoJson("Invalid y coordinate".into()))?;
+            .ok_or_else(|| DataServerError::Engine("Invalid y coordinate".into()))?;
         validate_coord(x, y)?;
         coords.push([x, y]);
     }
@@ -360,12 +360,12 @@ fn parse_ring(ring: &serde_json::Value) -> Result<Vec<[f64; 2]>, DataServerError
 
 fn validate_coord(x: f64, y: f64) -> Result<(), DataServerError> {
     if !x.is_finite() || !y.is_finite() {
-        return Err(DataServerError::GeoJson(
+        return Err(DataServerError::Engine(
             "Coordinates must be finite numbers".into(),
         ));
     }
     if !(-180.0..=180.0).contains(&x) || !(-90.0..=90.0).contains(&y) {
-        return Err(DataServerError::GeoJson(format!(
+        return Err(DataServerError::Engine(format!(
             "Coordinates ({x}, {y}) outside WGS84 range. \
              If your data uses a projected CRS, convert to WGS84 first."
         )));
@@ -376,7 +376,7 @@ fn validate_coord(x: f64, y: f64) -> Result<(), DataServerError> {
 fn validate_wgs84_bbox(bbox: &[f64; 4]) -> Result<(), DataServerError> {
     for &v in bbox {
         if !v.is_finite() {
-            return Err(DataServerError::GeoJson(
+            return Err(DataServerError::Engine(
                 "Geometry has non-finite coordinates".into(),
             ));
         }

--- a/crates/engine-geotiff/src/catalog.rs
+++ b/crates/engine-geotiff/src/catalog.rs
@@ -265,7 +265,7 @@ pub fn scan_directory(
     existing: &HashMap<&Path, &FileEntry>,
 ) -> Result<Catalog, DataServerError> {
     let read_dir = std::fs::read_dir(dir).map_err(|e| {
-        DataServerError::GeoTiff(format!("Cannot read directory {}: {e}", dir.display()))
+        DataServerError::Engine(format!("Cannot read directory {}: {e}", dir.display()))
     })?;
 
     let mut entries = BTreeMap::new();

--- a/crates/engine-geotiff/src/lib.rs
+++ b/crates/engine-geotiff/src/lib.rs
@@ -126,7 +126,7 @@ impl GeoTiffEngine {
                 .unwrap_or_else(|e| e.into_inner());
             if let Some(last) = *last_attempt {
                 if last.elapsed() < STAC_CIRCUIT_BREAKER_COOLDOWN {
-                    return Err(DataServerError::GeoTiff(format!(
+                    return Err(DataServerError::Engine(format!(
                         "STAC API temporarily unavailable, circuit breaker open \
                          ({} consecutive failures, retry in {}s)",
                         failures,
@@ -215,7 +215,7 @@ impl GeoTiffEngine {
         let (pattern_str, timestamp_format) = resolve_filename_config(config)?;
 
         let filename_pattern = Regex::new(&pattern_str).map_err(|e| {
-            DataServerError::GeoTiff(format!("Invalid filename pattern '{}': {e}", pattern_str))
+            DataServerError::Engine(format!("Invalid filename pattern '{}': {e}", pattern_str))
         })?;
 
         // Determine store mode from config
@@ -263,12 +263,12 @@ impl GeoTiffEngine {
             } else {
                 let directory = PathBuf::from(data_path);
                 if !directory.is_dir() {
-                    return Err(DataServerError::GeoTiff(format!(
+                    return Err(DataServerError::Engine(format!(
                         "{data_path} is not a directory"
                     )));
                 }
                 let directory = directory.canonicalize().map_err(|e| {
-                    DataServerError::GeoTiff(format!("Cannot resolve directory {data_path}: {e}"))
+                    DataServerError::Engine(format!("Cannot resolve directory {data_path}: {e}"))
                 })?;
                 (
                     StoreMode::Local {
@@ -279,7 +279,7 @@ impl GeoTiffEngine {
                 )
             }
         } else {
-            return Err(DataServerError::GeoTiff(
+            return Err(DataServerError::Engine(
                 "Either data_path, endpoint+bucket, or stac_url must be configured".into(),
             ));
         };
@@ -514,7 +514,7 @@ impl GeoTiffEngine {
         let stac_client = match &self.store_mode {
             StoreMode::RemoteStac { client } => client,
             _ => {
-                return Err(DataServerError::GeoTiff(
+                return Err(DataServerError::Engine(
                     "load_stac_entry_metadata called on non-STAC engine".into(),
                 ))
             }
@@ -528,7 +528,7 @@ impl GeoTiffEngine {
         };
 
         if actual_size > catalog::MAX_REMOTE_FILE_SIZE as u64 {
-            return Err(DataServerError::GeoTiff(format!(
+            return Err(DataServerError::Engine(format!(
                 "File too large ({} > {} max)",
                 format_bytes(actual_size),
                 format_bytes(catalog::MAX_REMOTE_FILE_SIZE as u64)
@@ -1030,7 +1030,7 @@ impl GeoTiffEngine {
         let first_entry = entries[0].1;
         let first_metadata = first_entry
             .metadata()
-            .ok_or_else(|| DataServerError::GeoTiff("First entry has no metadata loaded".into()))?;
+            .ok_or_else(|| DataServerError::Engine("First entry has no metadata loaded".into()))?;
         let (col_start, row_start, col_end, row_end) = first_metadata
             .geo_transform
             .bbox_to_pixels(west, south, east, north)
@@ -1208,7 +1208,7 @@ impl ds_core::map_engine::MapEngine for GeoTiffEngine {
                 catalog.entries.iter().next_back()
             };
             let (ts, _) = entry.ok_or_else(|| {
-                DataServerError::GeoTiff("No data available for the requested time".into())
+                DataServerError::Engine("No data available for the requested time".into())
             })?;
             *ts
         };
@@ -1220,14 +1220,14 @@ impl ds_core::map_engine::MapEngine for GeoTiffEngine {
         let (_timestamp, entry) = catalog
             .entries
             .get_key_value(&target_timestamp)
-            .ok_or_else(|| DataServerError::GeoTiff("Entry disappeared after loading".into()))?;
+            .ok_or_else(|| DataServerError::Engine("Entry disappeared after loading".into()))?;
 
         let metadata = entry
             .metadata()
-            .ok_or_else(|| DataServerError::GeoTiff("Entry metadata not loaded".into()))?;
+            .ok_or_else(|| DataServerError::Engine("Entry metadata not loaded".into()))?;
         let source = entry
             .source()
-            .ok_or_else(|| DataServerError::GeoTiff("Entry source not loaded".into()))?;
+            .ok_or_else(|| DataServerError::Engine("Entry source not loaded".into()))?;
 
         let [west, south, east, north] = bbox;
         let total_pixels = (width as usize) * (height as usize);
@@ -1571,12 +1571,12 @@ fn validate_config(
     // endpoint and bucket must both be set or both absent
     match (&config.endpoint, &config.bucket) {
         (Some(_), None) => {
-            return Err(DataServerError::GeoTiff(format!(
+            return Err(DataServerError::Engine(format!(
                 "[{collection_id}] 'endpoint' is set but 'bucket' is missing — both are required for S3 access"
             )));
         }
         (None, Some(_)) => {
-            return Err(DataServerError::GeoTiff(format!(
+            return Err(DataServerError::Engine(format!(
                 "[{collection_id}] 'bucket' is set but 'endpoint' is missing — both are required for S3 access"
             )));
         }
@@ -1586,24 +1586,24 @@ fn validate_config(
     // stac_url is mutually exclusive with data_path and endpoint+bucket
     if config.stac_url.is_some() {
         if data_path.is_some() {
-            return Err(DataServerError::GeoTiff(format!(
+            return Err(DataServerError::Engine(format!(
                 "[{collection_id}] 'stac_url' and 'data_path' are mutually exclusive"
             )));
         }
         if config.endpoint.is_some() {
-            return Err(DataServerError::GeoTiff(format!(
+            return Err(DataServerError::Engine(format!(
                 "[{collection_id}] 'stac_url' and 'endpoint+bucket' are mutually exclusive"
             )));
         }
         // stac_asset_allowlist is required for SSRF protection
         match &config.stac_asset_allowlist {
             None => {
-                return Err(DataServerError::GeoTiff(format!(
+                return Err(DataServerError::Engine(format!(
                     "[{collection_id}] 'stac_asset_allowlist' is required when 'stac_url' is set (SSRF protection)"
                 )));
             }
             Some(list) if list.is_empty() => {
-                return Err(DataServerError::GeoTiff(format!(
+                return Err(DataServerError::Engine(format!(
                     "[{collection_id}] 'stac_asset_allowlist' must not be empty"
                 )));
             }
@@ -1620,13 +1620,13 @@ fn validate_config(
     }
 
     if config.poll_interval_secs == 0 {
-        return Err(DataServerError::GeoTiff(format!(
+        return Err(DataServerError::Engine(format!(
             "[{collection_id}] poll_interval_secs must be > 0"
         )));
     }
 
     if config.band == 0 {
-        return Err(DataServerError::GeoTiff(format!(
+        return Err(DataServerError::Engine(format!(
             "[{collection_id}] band must be >= 1 (1-based index)"
         )));
     }
@@ -1658,13 +1658,13 @@ fn resolve_filename_config(config: &GeoTiffConfig) -> Result<(String, String), D
         (&config.filename_pattern, &config.timestamp_format)
     {
         if !pattern.contains("(?P<timestamp>") {
-            return Err(DataServerError::GeoTiff(
+            return Err(DataServerError::Engine(
                 "filename_pattern must contain a named capture group (?P<timestamp>...)".into(),
             ));
         }
         Ok((pattern.clone(), format.clone()))
     } else {
-        Err(DataServerError::GeoTiff(
+        Err(DataServerError::Engine(
             "Either filename_template or both filename_pattern + timestamp_format must be set"
                 .into(),
         ))
@@ -1716,7 +1716,7 @@ fn expand_filename_template(template: &str) -> Result<(String, String), DataServ
                 }
             }
             if !matched {
-                return Err(DataServerError::GeoTiff(format!(
+                return Err(DataServerError::Engine(format!(
                     "Unknown strftime code '{}' in filename_template",
                     &template[i..i + 2]
                 )));
@@ -1768,7 +1768,7 @@ fn expand_filename_template(template: &str) -> Result<(String, String), DataServ
     }
 
     if !timestamp_started {
-        return Err(DataServerError::GeoTiff(format!(
+        return Err(DataServerError::Engine(format!(
             "filename_template '{}' contains no strftime codes (%%Y, %%m, etc.)",
             template
         )));

--- a/crates/engine-geotiff/src/reader.rs
+++ b/crates/engine-geotiff/src/reader.rs
@@ -42,9 +42,9 @@ fn safe_tile_index(
     let index = (tile_row as u64)
         .checked_mul(tiles_across as u64)
         .and_then(|v| v.checked_add(tile_col as u64))
-        .ok_or_else(|| DataServerError::GeoTiff("Tile index overflow".into()))?;
+        .ok_or_else(|| DataServerError::Engine("Tile index overflow".into()))?;
     if index > u32::MAX as u64 {
-        return Err(DataServerError::GeoTiff("Tile index overflow".into()));
+        return Err(DataServerError::Engine("Tile index overflow".into()));
     }
     Ok(index as u32)
 }
@@ -133,22 +133,22 @@ impl DataSource {
         match self {
             DataSource::LocalFile(path) => {
                 let file = File::open(path).map_err(|e| {
-                    DataServerError::GeoTiff(format!("Cannot open {}: {e}", path.display()))
+                    DataServerError::Engine(format!("Cannot open {}: {e}", path.display()))
                 })?;
                 Ok(DecoderWrapper::File(
                     Decoder::new(BufReader::new(file)).map_err(|e| {
-                        DataServerError::GeoTiff(format!("Invalid TIFF {}: {e}", path.display()))
+                        DataServerError::Engine(format!("Invalid TIFF {}: {e}", path.display()))
                     })?,
                 ))
             }
             DataSource::InMemory(bytes) => {
                 let cursor = Cursor::new(bytes.to_vec());
                 Ok(DecoderWrapper::Memory(Decoder::new(cursor).map_err(
-                    |e| DataServerError::GeoTiff(format!("Invalid TIFF (in-memory): {e}")),
+                    |e| DataServerError::Engine(format!("Invalid TIFF (in-memory): {e}")),
                 )?))
             }
             DataSource::Remote { .. } | DataSource::HttpDirect { .. } => {
-                Err(DataServerError::GeoTiff(
+                Err(DataServerError::Engine(
                     "Cannot open decoder for remote source; use range reads".into(),
                 ))
             }
@@ -176,10 +176,10 @@ impl DecoderWrapper {
         match self {
             Self::File(d) => d
                 .dimensions()
-                .map_err(|e| DataServerError::GeoTiff(format!("{e}"))),
+                .map_err(|e| DataServerError::Engine(format!("{e}"))),
             Self::Memory(d) => d
                 .dimensions()
-                .map_err(|e| DataServerError::GeoTiff(format!("{e}"))),
+                .map_err(|e| DataServerError::Engine(format!("{e}"))),
         }
     }
 
@@ -188,10 +188,10 @@ impl DecoderWrapper {
         match self {
             Self::File(d) => d
                 .colortype()
-                .map_err(|e| DataServerError::GeoTiff(format!("{e}"))),
+                .map_err(|e| DataServerError::Engine(format!("{e}"))),
             Self::Memory(d) => d
                 .colortype()
-                .map_err(|e| DataServerError::GeoTiff(format!("{e}"))),
+                .map_err(|e| DataServerError::Engine(format!("{e}"))),
         }
     }
 
@@ -282,28 +282,28 @@ impl TiffMetadata {
     ) -> Result<Self, DataServerError> {
         let (width, height) = decoder
             .dimensions()
-            .map_err(|e| DataServerError::GeoTiff(format!("Cannot read dimensions: {e}")))?;
+            .map_err(|e| DataServerError::Engine(format!("Cannot read dimensions: {e}")))?;
 
         if width > MAX_RASTER_DIMENSION || height > MAX_RASTER_DIMENSION {
-            return Err(DataServerError::GeoTiff(format!(
+            return Err(DataServerError::Engine(format!(
                 "Raster dimensions {}x{} exceed maximum {}",
                 width, height, MAX_RASTER_DIMENSION
             )));
         }
 
         let tile_width = read_tag_u32(decoder, Tag::TileWidth)
-            .ok_or_else(|| DataServerError::GeoTiff(format!(
+            .ok_or_else(|| DataServerError::Engine(format!(
                 "{source_name}: Not a tiled TIFF (TileWidth missing). \
                  Convert to tiled COG with: gdal_translate -co TILED=YES -co COMPRESS=DEFLATE input.tif output.tif"
             )))?;
         let tile_height = read_tag_u32(decoder, Tag::TileLength)
-            .ok_or_else(|| DataServerError::GeoTiff(format!(
+            .ok_or_else(|| DataServerError::Engine(format!(
                 "{source_name}: Not a tiled TIFF (TileLength missing). \
                  Convert to tiled COG with: gdal_translate -co TILED=YES -co COMPRESS=DEFLATE input.tif output.tif"
             )))?;
 
         if tile_width == 0 || tile_height == 0 {
-            return Err(DataServerError::GeoTiff(format!(
+            return Err(DataServerError::Engine(format!(
                 "{source_name}: Invalid tile dimensions {}x{} (must be > 0)",
                 tile_width, tile_height
             )));
@@ -323,13 +323,13 @@ impl TiffMetadata {
             .and_then(|v| v.checked_mul(bytes_per_sample))
             .and_then(|v| v.checked_mul(samples_per_pixel as usize))
             .ok_or_else(|| {
-                DataServerError::GeoTiff(format!(
+                DataServerError::Engine(format!(
                     "Decoded tile size overflow ({}x{} px, {} bands, {} bytes/sample)",
                     tile_width, tile_height, samples_per_pixel, bytes_per_sample
                 ))
             })?;
         if decoded_tile_bytes > MAX_DECODED_TILE_BYTES {
-            return Err(DataServerError::GeoTiff(format!(
+            return Err(DataServerError::Engine(format!(
                 "Decoded tile size {} bytes ({}x{} px, {} bands, {} bytes/sample) exceeds maximum {}",
                 decoded_tile_bytes, tile_width, tile_height, samples_per_pixel, bytes_per_sample,
                 MAX_DECODED_TILE_BYTES
@@ -619,7 +619,7 @@ fn decode_chunk_f64(
 ) -> Result<Vec<Option<f64>>, DataServerError> {
     let result = decoder
         .read_chunk(chunk_index)
-        .map_err(|e| DataServerError::GeoTiff(format!("Failed to read tile: {e}")))?;
+        .map_err(|e| DataServerError::Engine(format!("Failed to read tile: {e}")))?;
 
     let spp = metadata.samples_per_pixel as usize;
 
@@ -684,7 +684,7 @@ fn decode_chunk_f64(
                 }
             })
             .collect(),
-        _ => return Err(DataServerError::GeoTiff("Unsupported data type".into())),
+        _ => return Err(DataServerError::Engine("Unsupported data type".into())),
     };
 
     Ok(values)
@@ -824,10 +824,10 @@ fn decompress_tile(
                 .take(MAX_DECODED_TILE_BYTES as u64)
                 .read_to_end(&mut decompressed)
                 .map_err(|e| {
-                    DataServerError::GeoTiff(format!("Deflate decompression failed: {e}"))
+                    DataServerError::Engine(format!("Deflate decompression failed: {e}"))
                 })?;
             if decompressed.len() >= MAX_DECODED_TILE_BYTES {
-                return Err(DataServerError::GeoTiff(format!(
+                return Err(DataServerError::Engine(format!(
                     "Decompressed tile exceeds maximum size ({} bytes)",
                     MAX_DECODED_TILE_BYTES
                 )));
@@ -841,9 +841,9 @@ fn decompress_tile(
                 weezl::decode::Decoder::with_tiff_size_switch(weezl::BitOrder::Msb, 8);
             let decompressed = decoder
                 .decode(compressed)
-                .map_err(|e| DataServerError::GeoTiff(format!("LZW decompression failed: {e}")))?;
+                .map_err(|e| DataServerError::Engine(format!("LZW decompression failed: {e}")))?;
             if decompressed.len() > MAX_DECODED_TILE_BYTES {
-                return Err(DataServerError::GeoTiff(format!(
+                return Err(DataServerError::Engine(format!(
                     "Decompressed tile exceeds maximum size ({} bytes)",
                     MAX_DECODED_TILE_BYTES
                 )));
@@ -887,7 +887,7 @@ fn decode_raw_tile_f64(
 
     // Validate buffer is large enough for at least one pixel
     if sample_stride == 0 {
-        return Err(DataServerError::GeoTiff(
+        return Err(DataServerError::Engine(
             "Invalid tile: zero sample stride".into(),
         ));
     }
@@ -897,7 +897,7 @@ fn decode_raw_tile_f64(
     if pixel_count > 0 {
         let last_offset = (pixel_count - 1) * sample_stride + band_byte_offset + bps;
         if last_offset > raw.len() {
-            return Err(DataServerError::GeoTiff(format!(
+            return Err(DataServerError::Engine(format!(
                 "Truncated tile data: need {} bytes for {} pixels but got {}",
                 last_offset,
                 pixel_count,
@@ -998,7 +998,7 @@ fn read_remote_chunk_f64(
 ) -> Result<Vec<Option<f64>>, DataServerError> {
     let idx = chunk_index as usize;
     if idx >= tile_info.tile_offsets.len() {
-        return Err(DataServerError::GeoTiff(format!(
+        return Err(DataServerError::Engine(format!(
             "Tile index {} out of range ({})",
             idx,
             tile_info.tile_offsets.len()
@@ -1031,7 +1031,7 @@ fn read_remote_chunk_f64(
 
     // Validate range doesn't overflow
     let end = offset.checked_add(byte_count).ok_or_else(|| {
-        DataServerError::GeoTiff(format!(
+        DataServerError::Engine(format!(
             "Tile {} byte range overflow: offset={} + count={}",
             idx, offset, byte_count
         ))
@@ -1044,10 +1044,10 @@ fn read_remote_chunk_f64(
         } else {
             let fetched = store
                 .get_range(obj_path, offset..end)
-                .map_err(|e| DataServerError::GeoTiff(format!("Failed to read tile range: {e}")))?;
+                .map_err(|e| DataServerError::Engine(format!("Failed to read tile range: {e}")))?;
             // Validate response length matches request
             if fetched.len() != byte_count {
-                return Err(DataServerError::GeoTiff(format!(
+                return Err(DataServerError::Engine(format!(
                     "Tile {} truncated: requested {} bytes, got {}",
                     idx,
                     byte_count,
@@ -1060,9 +1060,9 @@ fn read_remote_chunk_f64(
     } else {
         let fetched = store
             .get_range(obj_path, offset..end)
-            .map_err(|e| DataServerError::GeoTiff(format!("Failed to read tile range: {e}")))?;
+            .map_err(|e| DataServerError::Engine(format!("Failed to read tile range: {e}")))?;
         if fetched.len() != byte_count {
-            return Err(DataServerError::GeoTiff(format!(
+            return Err(DataServerError::Engine(format!(
                 "Tile {} truncated: requested {} bytes, got {}",
                 idx,
                 byte_count,
@@ -1099,16 +1099,16 @@ fn read_http_range(
             .header(reqwest::header::RANGE, &range_header)
             .send()
             .await
-            .map_err(|e| DataServerError::GeoTiff(format!("HTTP range read failed: {e}")))?;
+            .map_err(|e| DataServerError::Engine(format!("HTTP range read failed: {e}")))?;
         if !resp.status().is_success() {
-            return Err(DataServerError::GeoTiff(format!(
+            return Err(DataServerError::Engine(format!(
                 "HTTP range read returned {}",
                 resp.status()
             )));
         }
         resp.bytes()
             .await
-            .map_err(|e| DataServerError::GeoTiff(format!("Failed to read body: {e}")))
+            .map_err(|e| DataServerError::Engine(format!("Failed to read body: {e}")))
     })
 }
 
@@ -1128,7 +1128,7 @@ fn read_http_chunk_f64(
 ) -> Result<Vec<Option<f64>>, DataServerError> {
     let idx = chunk_index as usize;
     if idx >= tile_info.tile_offsets.len() {
-        return Err(DataServerError::GeoTiff(format!(
+        return Err(DataServerError::Engine(format!(
             "Tile index {} out of range ({})",
             idx,
             tile_info.tile_offsets.len()
@@ -1156,7 +1156,7 @@ fn read_http_chunk_f64(
     }
 
     let end = offset.checked_add(byte_count).ok_or_else(|| {
-        DataServerError::GeoTiff(format!(
+        DataServerError::Engine(format!(
             "Tile {} byte range overflow: offset={} + count={}",
             idx, offset, byte_count
         ))
@@ -1168,7 +1168,7 @@ fn read_http_chunk_f64(
         } else {
             let fetched = read_http_range(http, url, offset..end)?;
             if fetched.len() != byte_count {
-                return Err(DataServerError::GeoTiff(format!(
+                return Err(DataServerError::Engine(format!(
                     "Tile {} truncated: requested {} bytes, got {}",
                     idx,
                     byte_count,
@@ -1181,7 +1181,7 @@ fn read_http_chunk_f64(
     } else {
         let fetched = read_http_range(http, url, offset..end)?;
         if fetched.len() != byte_count {
-            return Err(DataServerError::GeoTiff(format!(
+            return Err(DataServerError::Engine(format!(
                 "Tile {} truncated: requested {} bytes, got {}",
                 idx,
                 byte_count,
@@ -1330,7 +1330,7 @@ pub fn read_bbox_overview(
 
     if let DataSource::Remote { store, path, .. } = source {
         let ov_tile_info = overview.tile_info.as_ref().ok_or_else(|| {
-            DataServerError::GeoTiff(format!(
+            DataServerError::Engine(format!(
                 "Overview IFD {} has no tile info for remote source (header too small?)",
                 overview.ifd_index
             ))
@@ -1364,7 +1364,7 @@ pub fn read_bbox_overview(
     } = source
     {
         let ov_tile_info = overview.tile_info.as_ref().ok_or_else(|| {
-            DataServerError::GeoTiff(format!(
+            DataServerError::Engine(format!(
                 "Overview IFD {} has no tile info for remote source (header too small?)",
                 overview.ifd_index
             ))
@@ -1394,7 +1394,7 @@ pub fn read_bbox_overview(
     // For local files, seek to the overview IFD and read tiles
     let mut decoder = source.open_decoder()?;
     decoder.seek_to_image(overview.ifd_index).map_err(|e| {
-        DataServerError::GeoTiff(format!(
+        DataServerError::Engine(format!(
             "Failed to seek to overview IFD {}: {e}",
             overview.ifd_index
         ))
@@ -1925,12 +1925,12 @@ fn parse_geo_transform(
 
     if let (Ok(tiepoint), Ok(pixelscale)) = (tiepoint_result, pixelscale_result) {
         let tp = extract_doubles(&tiepoint)
-            .ok_or_else(|| DataServerError::GeoTiff("Cannot parse ModelTiepointTag".into()))?;
+            .ok_or_else(|| DataServerError::Engine("Cannot parse ModelTiepointTag".into()))?;
         let ps = extract_doubles(&pixelscale)
-            .ok_or_else(|| DataServerError::GeoTiff("Cannot parse ModelPixelScaleTag".into()))?;
+            .ok_or_else(|| DataServerError::Engine("Cannot parse ModelPixelScaleTag".into()))?;
 
         if tp.len() < 6 || ps.len() < 2 {
-            return Err(DataServerError::GeoTiff(
+            return Err(DataServerError::Engine(
                 "ModelTiepointTag or ModelPixelScaleTag has too few values".into(),
             ));
         }
@@ -1951,15 +1951,14 @@ fn parse_geo_transform(
 
     // Fallback: try ModelTransformationTag (34264) — a 4x4 affine matrix
     if let Ok(transform_tag) = decoder.get_tag(Tag::Unknown(34264)) {
-        let matrix = extract_doubles(&transform_tag).ok_or_else(|| {
-            DataServerError::GeoTiff("Cannot parse ModelTransformationTag".into())
-        })?;
+        let matrix = extract_doubles(&transform_tag)
+            .ok_or_else(|| DataServerError::Engine("Cannot parse ModelTransformationTag".into()))?;
 
         return GeoTransform::from_transformation_matrix(&matrix, width, height, crs)
-            .map_err(DataServerError::GeoTiff);
+            .map_err(DataServerError::Engine);
     }
 
-    Err(DataServerError::GeoTiff(
+    Err(DataServerError::Engine(
         "Missing geolocation tags — need either ModelTiepointTag (33922) + \
          ModelPixelScaleTag (33550), or ModelTransformationTag (34264)"
             .into(),
@@ -2056,7 +2055,7 @@ fn parse_crs(decoder: &mut DecoderWrapper) -> Result<Crs, DataServerError> {
                 false_e: 4_321_000.0,
                 false_n: 3_210_000.0,
             }),
-            _ => Err(DataServerError::GeoTiff(format!(
+            _ => Err(DataServerError::Engine(format!(
                 "EPSG:{} is not supported and GeoKeys lack projection parameters. \
                  Convert with: gdalwarp -t_srs EPSG:4326 -of COG input.tif output.tif",
                 epsg
@@ -2138,7 +2137,7 @@ fn parse_crs(decoder: &mut DecoderWrapper) -> Result<Crs, DataServerError> {
                 false_n,
             })
         }
-        _ => Err(DataServerError::GeoTiff(format!(
+        _ => Err(DataServerError::Engine(format!(
             "Unsupported projection method {} (GeoKey 3075). \
                  Supported: Transverse Mercator (1), Lambert Conformal Conic 2SP (8), \
                  Lambert Azimuthal Equal Area (10). \

--- a/crates/engine-geotiff/src/stac.rs
+++ b/crates/engine-geotiff/src/stac.rs
@@ -69,11 +69,11 @@ impl StacClient {
         asset_allowlist: Vec<String>,
     ) -> Result<Self, DataServerError> {
         let parsed_url = Url::parse(items_url).map_err(|e| {
-            DataServerError::GeoTiff(format!("Invalid STAC URL '{}': {}", items_url, e))
+            DataServerError::Engine(format!("Invalid STAC URL '{}': {}", items_url, e))
         })?;
 
         if parsed_url.scheme() != "https" && parsed_url.scheme() != "http" {
-            return Err(DataServerError::GeoTiff(format!(
+            return Err(DataServerError::Engine(format!(
                 "STAC URL must use http or https scheme, got '{}'",
                 parsed_url.scheme()
             )));
@@ -84,16 +84,16 @@ impl StacClient {
             .redirect(reqwest::redirect::Policy::none())
             .user_agent("MeteoCore/0.1")
             .build()
-            .map_err(|e| DataServerError::GeoTiff(format!("Failed to build HTTP client: {}", e)))?;
+            .map_err(|e| DataServerError::Engine(format!("Failed to build HTTP client: {}", e)))?;
 
         // Validate allowlist entries are valid http/https URLs
         let mut parsed_allowlist = Vec::with_capacity(asset_allowlist.len());
         for entry in &asset_allowlist {
             let parsed = Url::parse(entry).map_err(|e| {
-                DataServerError::GeoTiff(format!("Invalid allowlist URL '{}': {}", entry, e))
+                DataServerError::Engine(format!("Invalid allowlist URL '{}': {}", entry, e))
             })?;
             if parsed.scheme() != "http" && parsed.scheme() != "https" {
-                return Err(DataServerError::GeoTiff(format!(
+                return Err(DataServerError::Engine(format!(
                     "Allowlist URL must use http or https scheme, got '{}' in '{}'",
                     parsed.scheme(),
                     entry
@@ -109,7 +109,7 @@ impl StacClient {
             .or_else(|| items_str.strip_suffix("/items/"))
             .unwrap_or(items_str);
         let collection_url = Url::parse(collection_str).map_err(|e| {
-            DataServerError::GeoTiff(format!("Failed to derive collection URL: {}", e))
+            DataServerError::Engine(format!("Failed to derive collection URL: {}", e))
         })?;
 
         Ok(StacClient {
@@ -136,7 +136,7 @@ impl StacClient {
             Ok(handle) => tokio::task::block_in_place(|| handle.block_on(future)),
             Err(_) => {
                 let rt = tokio::runtime::Runtime::new().map_err(|e| {
-                    DataServerError::GeoTiff(format!("Failed to create runtime: {}", e))
+                    DataServerError::Engine(format!("Failed to create runtime: {}", e))
                 })?;
                 rt.block_on(future)
             }
@@ -154,7 +154,7 @@ impl StacClient {
         let body: serde_json::Value = self.block_on(async {
             let response = http.get(&url).send().await.map_err(|e| {
                 tracing::warn!("STAC collection request to {} failed: {}", url, e);
-                DataServerError::GeoTiff("STAC collection request failed".into())
+                DataServerError::Engine("STAC collection request failed".into())
             })?;
 
             if !response.status().is_success() {
@@ -163,14 +163,14 @@ impl StacClient {
                     url,
                     response.status()
                 );
-                return Err(DataServerError::GeoTiff(
+                return Err(DataServerError::Engine(
                     "STAC collection request failed".into(),
                 ));
             }
 
             response.json().await.map_err(|e| {
                 tracing::warn!("STAC collection response from {} invalid JSON: {}", url, e);
-                DataServerError::GeoTiff("STAC collection response invalid".into())
+                DataServerError::Engine("STAC collection response invalid".into())
             })
         })?;
 
@@ -273,7 +273,7 @@ impl StacClient {
                                         url_str,
                                         e
                                     );
-                                    DataServerError::GeoTiff("STAC response invalid".into())
+                                    DataServerError::Engine("STAC response invalid".into())
                                 });
                             }
                             // 4xx: do not retry (client error)
@@ -283,7 +283,7 @@ impl StacClient {
                                     url_str,
                                     status
                                 );
-                                return Err(DataServerError::GeoTiff(
+                                return Err(DataServerError::Engine(
                                     "STAC metadata request failed".into(),
                                 ));
                             }
@@ -295,7 +295,7 @@ impl StacClient {
                                 attempt + 1,
                                 max_attempts
                             );
-                            last_err = Some(DataServerError::GeoTiff(
+                            last_err = Some(DataServerError::Engine(
                                 "STAC metadata request failed".into(),
                             ));
                         }
@@ -307,7 +307,7 @@ impl StacClient {
                                 attempt + 1,
                                 max_attempts
                             );
-                            last_err = Some(DataServerError::GeoTiff(
+                            last_err = Some(DataServerError::Engine(
                                 "STAC metadata request failed".into(),
                             ));
                         }
@@ -320,13 +320,13 @@ impl StacClient {
                 }
 
                 Err(last_err.unwrap_or_else(|| {
-                    DataServerError::GeoTiff("STAC metadata request failed".into())
+                    DataServerError::Engine("STAC metadata request failed".into())
                 }))
             })?;
 
             // Parse features array
             let features = body["features"].as_array().ok_or_else(|| {
-                DataServerError::GeoTiff("STAC response missing 'features' array".to_string())
+                DataServerError::Engine("STAC response missing 'features' array".to_string())
             })?;
 
             if features.is_empty() {
@@ -538,11 +538,11 @@ impl StacClient {
         self.block_on(async {
             let resp = http.head(&url_owned).send().await.map_err(|e| {
                 tracing::warn!("HEAD failed for '{}': {}", url_owned, e);
-                DataServerError::GeoTiff("Failed to fetch remote file metadata".into())
+                DataServerError::Engine("Failed to fetch remote file metadata".into())
             })?;
             if !resp.status().is_success() {
                 tracing::warn!("HEAD returned {} for '{}'", resp.status(), url_owned);
-                return Err(DataServerError::GeoTiff(
+                return Err(DataServerError::Engine(
                     "Failed to fetch remote file metadata".into(),
                 ));
             }
@@ -574,17 +574,15 @@ impl StacClient {
                 .await
                 .map_err(|e| {
                     tracing::warn!("Range read failed for '{}': {}", url_owned, e);
-                    DataServerError::GeoTiff("Failed to read remote file".into())
+                    DataServerError::Engine("Failed to read remote file".into())
                 })?;
             if !resp.status().is_success() {
                 tracing::warn!("Range read returned {} for '{}'", resp.status(), url_owned);
-                return Err(DataServerError::GeoTiff(
-                    "Failed to read remote file".into(),
-                ));
+                return Err(DataServerError::Engine("Failed to read remote file".into()));
             }
             let data = resp.bytes().await.map_err(|e| {
                 tracing::warn!("Failed to read body from '{}': {}", url_owned, e);
-                DataServerError::GeoTiff("Failed to read remote file".into())
+                DataServerError::Engine("Failed to read remote file".into())
             })?;
             Ok(data)
         })
@@ -597,17 +595,17 @@ impl StacClient {
         self.block_on(async {
             let resp = http.get(&url_owned).send().await.map_err(|e| {
                 tracing::warn!("Download failed for '{}': {:?}", url_owned, e);
-                DataServerError::GeoTiff("Failed to download remote file".into())
+                DataServerError::Engine("Failed to download remote file".into())
             })?;
             if !resp.status().is_success() {
                 tracing::warn!("Download returned {} for '{}'", resp.status(), url_owned);
-                return Err(DataServerError::GeoTiff(
+                return Err(DataServerError::Engine(
                     "Failed to download remote file".into(),
                 ));
             }
             let data = resp.bytes().await.map_err(|e| {
                 tracing::warn!("Failed to read download body from '{}': {}", url_owned, e);
-                DataServerError::GeoTiff("Failed to download remote file".into())
+                DataServerError::Engine("Failed to download remote file".into())
             })?;
             Ok(data)
         })

--- a/crates/engine-grib/src/cache.rs
+++ b/crates/engine-grib/src/cache.rs
@@ -6,7 +6,7 @@
 use std::sync::Arc;
 
 /// Cache key: identifies a specific GRIB message.
-/// Uses `Arc<str>` instead of `String` to avoid allocation on every lookup.
+/// Uses `Arc<str>` instead of `String` for a smaller allocation (no capacity field).
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 struct GridKey {
     /// URL or path to the GRIB file.

--- a/crates/engine-grib/src/cache.rs
+++ b/crates/engine-grib/src/cache.rs
@@ -5,15 +5,24 @@
 
 use std::sync::Arc;
 
-use quick_cache::sync::Cache;
-
 /// Cache key: identifies a specific GRIB message.
+/// Uses `Arc<str>` instead of `String` to avoid allocation on every lookup.
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 struct GridKey {
     /// URL or path to the GRIB file.
-    url: String,
+    url: Arc<str>,
     /// Byte offset of the message within the file.
     offset: u64,
+}
+
+/// Weight function: count the byte size of each cached grid.
+#[derive(Clone)]
+struct GridWeighter;
+
+impl quick_cache::Weighter<GridKey, Arc<DecodedGrid>> for GridWeighter {
+    fn weight(&self, _key: &GridKey, val: &Arc<DecodedGrid>) -> u64 {
+        val.size_bytes() as u64
+    }
 }
 
 /// A decoded grid with its metadata.
@@ -205,9 +214,9 @@ impl DecodedGrid {
     }
 }
 
-/// LRU cache for decoded grids.
+/// LRU cache for decoded grids, weighted by byte size.
 pub struct GridCache {
-    cache: Cache<GridKey, Arc<DecodedGrid>>,
+    cache: quick_cache::sync::Cache<GridKey, Arc<DecodedGrid>, GridWeighter>,
 }
 
 impl GridCache {
@@ -217,19 +226,19 @@ impl GridCache {
         if size_mb == 0 {
             return None;
         }
+        let max_bytes = size_mb * 1024 * 1024;
         // Estimate: each grid is ~8 MB (1440*721*8 bytes).
-        // With 256 MB, that's ~32 grids.
         let estimated_items = (size_mb as usize * 1024 * 1024) / (8 * 1024 * 1024);
         let items = estimated_items.max(16);
         Some(Self {
-            cache: Cache::new(items),
+            cache: quick_cache::sync::Cache::with_weighter(items, max_bytes, GridWeighter),
         })
     }
 
     /// Get a cached grid, or None if not cached.
     pub fn get(&self, url: &str, offset: u64) -> Option<Arc<DecodedGrid>> {
         let key = GridKey {
-            url: url.to_string(),
+            url: Arc::from(url),
             offset,
         };
         self.cache.get(&key)
@@ -238,11 +247,9 @@ impl GridCache {
     /// Insert a decoded grid into the cache.
     pub fn insert(&self, url: &str, offset: u64, grid: Arc<DecodedGrid>) {
         let key = GridKey {
-            url: url.to_string(),
+            url: Arc::from(url),
             offset,
         };
-        let weight = grid.size_bytes() as u64;
-        let _ = weight; // quick_cache uses item count, not weight
         self.cache.insert(key, grid);
     }
 }

--- a/crates/engine-grib/src/lib.rs
+++ b/crates/engine-grib/src/lib.rs
@@ -366,7 +366,7 @@ impl GribEngine {
         let catalog = self.catalog.load();
 
         if catalog.runs.is_empty() {
-            return Err(DataServerError::Grib(
+            return Err(DataServerError::Engine(
                 "No forecast data available".to_string(),
             ));
         }
@@ -472,7 +472,7 @@ impl Engine for GribEngine {
         let catalog = self.catalog.load();
 
         if catalog.runs.is_empty() {
-            return Err(DataServerError::Grib(
+            return Err(DataServerError::Engine(
                 "No forecast data available".to_string(),
             ));
         }

--- a/crates/engine-grib/src/reader.rs
+++ b/crates/engine-grib/src/reader.rs
@@ -34,12 +34,12 @@ pub fn read_message(
 /// Decode a GRIB2 message from raw bytes.
 pub fn decode_message(bytes: &[u8], param: &str) -> Result<DecodedGrid, DataServerError> {
     let grib2 = grib::from_reader(std::io::Cursor::new(bytes)).map_err(|e| {
-        DataServerError::Grib(format!("Failed to parse GRIB2 message for {param}: {e}"))
+        DataServerError::Engine(format!("Failed to parse GRIB2 message for {param}: {e}"))
     })?;
 
     // A single byte-range-fetched message should contain exactly one submessage
     let (_index, submessage) = grib2.iter().next().ok_or_else(|| {
-        DataServerError::Grib(format!("GRIB2 message for {param} contains no submessages"))
+        DataServerError::Engine(format!("GRIB2 message for {param} contains no submessages"))
     })?;
 
     // Extract grid definition
@@ -47,16 +47,17 @@ pub fn decode_message(bytes: &[u8], param: &str) -> Result<DecodedGrid, DataServ
 
     let (ni, nj, lon_first, lat_first, lon_inc, lat_inc) = extract_grid_params(grid_def)
         .ok_or_else(|| {
-            DataServerError::Grib(format!(
+            DataServerError::Engine(format!(
                 "Unsupported grid type in GRIB2 message for {param}"
             ))
         })?;
 
     // Decode values using Grib2SubmessageDecoder
-    let decoder = Grib2SubmessageDecoder::from(submessage)
-        .map_err(|e| DataServerError::Grib(format!("Failed to create decoder for {param}: {e}")))?;
+    let decoder = Grib2SubmessageDecoder::from(submessage).map_err(|e| {
+        DataServerError::Engine(format!("Failed to create decoder for {param}: {e}"))
+    })?;
     let decoded = decoder.dispatch().map_err(|e| {
-        DataServerError::Grib(format!("Failed to decode GRIB2 values for {param}: {e}"))
+        DataServerError::Engine(format!("Failed to decode GRIB2 values for {param}: {e}"))
     })?;
 
     // Convert f32 values to f64, NaN → value (not filtered)
@@ -64,7 +65,7 @@ pub fn decode_message(bytes: &[u8], param: &str) -> Result<DecodedGrid, DataServ
 
     let expected = ni * nj;
     if values.len() != expected {
-        return Err(DataServerError::Grib(format!(
+        return Err(DataServerError::Engine(format!(
             "GRIB2 grid size mismatch for {param}: expected {expected}, got {}",
             values.len()
         )));

--- a/crates/engine-querydata/src/engine.rs
+++ b/crates/engine-querydata/src/engine.rs
@@ -50,7 +50,7 @@ impl QueryDataEngine {
         poll_interval_secs: u64,
     ) -> Result<Self, DataServerError> {
         let latest = find_latest_sqd(data_dir).ok_or_else(|| {
-            DataServerError::QueryData(format!(
+            DataServerError::Engine(format!(
                 "[{collection_id}] No .sqd files found in {}",
                 data_dir.display()
             ))
@@ -232,7 +232,7 @@ impl Engine for QueryDataEngine {
 
         let time_indices = find_time_range(&data, datetime);
         if time_indices.is_empty() {
-            return Err(DataServerError::QueryData(
+            return Err(DataServerError::Engine(
                 "No data available for the requested time range".into(),
             ));
         }
@@ -316,7 +316,7 @@ impl MapEngine for QueryDataEngine {
         };
 
         let time_idx = find_time_idx(&data, time).ok_or_else(|| {
-            DataServerError::QueryData("No data available for the requested time".into())
+            DataServerError::Engine("No data available for the requested time".into())
         })?;
 
         let [west, south, east, north] = bbox;
@@ -415,7 +415,7 @@ fn find_latest_sqd(dir: &Path) -> Option<PathBuf> {
 
 fn load_file(path: &Path, collection_id: &str) -> Result<QueryData, DataServerError> {
     QueryData::open(path).map_err(|e| {
-        DataServerError::QueryData(format!(
+        DataServerError::Engine(format!(
             "[{collection_id}] Failed to load {}: {e}",
             path.display()
         ))

--- a/crates/render/Cargo.toml
+++ b/crates/render/Cargo.toml
@@ -9,4 +9,5 @@ png = "0.17"
 jpeg-encoder = "0.6"
 webp = { version = "0.3", default-features = false }
 quick_cache = "0.6"
+bytes = "1"
 chrono = { version = "0.4", features = ["serde"] }

--- a/crates/render/src/lib.rs
+++ b/crates/render/src/lib.rs
@@ -10,6 +10,7 @@ pub use encode::{encode_jpeg, encode_png, encode_webp};
 use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 
+use bytes::Bytes;
 use chrono::{DateTime, Utc};
 use quick_cache::sync::Cache;
 
@@ -90,7 +91,7 @@ pub fn quantize_bbox(bbox: &[f64; 4]) -> [i64; 4] {
 /// No TTL — radar measurements are immutable once produced.
 /// Cache is invalidated on collection reload.
 pub struct RenderedCache {
-    cache: Cache<CacheKey, Arc<Vec<u8>>>,
+    cache: Cache<CacheKey, Bytes>,
 }
 
 impl RenderedCache {
@@ -106,11 +107,11 @@ impl RenderedCache {
         }
     }
 
-    pub fn get(&self, key: &CacheKey) -> Option<Arc<Vec<u8>>> {
+    pub fn get(&self, key: &CacheKey) -> Option<Bytes> {
         self.cache.get(key)
     }
 
-    pub fn insert(&self, key: CacheKey, value: Arc<Vec<u8>>) {
+    pub fn insert(&self, key: CacheKey, value: Bytes) {
         self.cache.insert(key, value);
     }
 }

--- a/crates/render/src/lib.rs
+++ b/crates/render/src/lib.rs
@@ -86,24 +86,35 @@ pub fn quantize_bbox(bbox: &[f64; 4]) -> [i64; 4] {
     ]
 }
 
-/// Cache for rendered map images (Tier 2).
+/// Weight function: count the byte size of each cached rendered image.
+#[derive(Clone)]
+struct RenderedWeighter;
+
+impl quick_cache::Weighter<CacheKey, Bytes> for RenderedWeighter {
+    fn weight(&self, _key: &CacheKey, val: &Bytes) -> u64 {
+        val.len() as u64 + 64 // data + overhead
+    }
+}
+
+/// Cache for rendered map images (Tier 2), weighted by byte size.
 /// Keys are quantized to improve hit rates for tiled clients.
 /// No TTL — radar measurements are immutable once produced.
 /// Cache is invalidated on collection reload.
 pub struct RenderedCache {
-    cache: Cache<CacheKey, Bytes>,
+    cache: Cache<CacheKey, Bytes, RenderedWeighter>,
 }
 
 impl RenderedCache {
     pub fn new(capacity_mb: u64) -> Self {
-        let estimated_tile_size = 60 * 1024;
-        let capacity = if capacity_mb == 0 {
+        let max_bytes = capacity_mb * 1024 * 1024;
+        // Estimate ~60 KB per tile for initial hash map sizing
+        let estimated_items = if capacity_mb == 0 {
             0
         } else {
-            ((capacity_mb * 1024 * 1024) / estimated_tile_size).max(1) as usize
+            ((capacity_mb * 1024 * 1024) / (60 * 1024)).max(1) as usize
         };
         Self {
-            cache: Cache::new(capacity),
+            cache: Cache::with_weighter(estimated_items, max_bytes, RenderedWeighter),
         }
     }
 

--- a/crates/server/src/admin.rs
+++ b/crates/server/src/admin.rs
@@ -169,6 +169,40 @@ pub fn load_collections(collections: &[CollectionConfig], base_url: &str) -> Loa
             collection.id, collection.engine_type, data_path_display
         );
 
+        // Validate engine+API compatibility
+        let supported_apis: &[&str] = match collection.engine_type.as_str() {
+            "csv" => &["edr", "features"],
+            "geojson" => &["features"],
+            "geotiff" => &["edr", "wms", "maps", "tiles"],
+            "querydata" => &["edr", "wms", "maps", "tiles"],
+            "grib" => &["edr", "wms", "maps", "tiles"],
+            _ => &[],
+        };
+        let mut has_unsupported = false;
+        for api in &collection.apis {
+            if !supported_apis.contains(&api.as_str()) {
+                tracing::error!(
+                    "Collection '{}': engine '{}' does not support '{}' API, skipping collection",
+                    collection.id,
+                    collection.engine_type,
+                    api
+                );
+                has_unsupported = true;
+            }
+        }
+        if has_unsupported {
+            health.push(CollectionHealth {
+                id: collection.id.clone(),
+                engine_type: collection.engine_type.clone(),
+                status: CollectionStatus::Failed,
+                error: Some(format!(
+                    "engine '{}' does not support requested APIs: {:?}",
+                    collection.engine_type, collection.apis
+                )),
+            });
+            continue;
+        }
+
         match collection.engine_type.as_str() {
             "csv" => {
                 let data_path = match collection.data_path.as_deref() {
@@ -285,13 +319,6 @@ pub fn load_collections(collections: &[CollectionConfig], base_url: &str) -> Loa
                     );
                     feature_collections.insert(collection.id.clone(), collection.clone());
                 }
-                if collection.apis.contains(&"edr".to_string()) {
-                    info!(
-                        "Warning: GeoJSON engine does not support EDR API, \
-                         skipping EDR wiring for collection '{}'",
-                        collection.id
-                    );
-                }
                 health.push(CollectionHealth {
                     id: collection.id.clone(),
                     engine_type: "geojson".into(),
@@ -356,13 +383,6 @@ pub fn load_collections(collections: &[CollectionConfig], base_url: &str) -> Loa
                         engine.clone() as Arc<dyn ds_core::engine::Engine>,
                     );
                     edr_collections.insert(collection.id.clone(), collection.clone());
-                }
-                if collection.apis.contains(&"features".to_string()) {
-                    info!(
-                        "Warning: GeoTIFF engine does not support Features API, \
-                         skipping Features wiring for collection '{}'",
-                        collection.id
-                    );
                 }
                 if collection.apis.contains(&"wms".to_string()) {
                     map_engines.insert(
@@ -601,14 +621,6 @@ pub fn load_collections(collections: &[CollectionConfig], base_url: &str) -> Loa
                     );
                     edr_collections.insert(collection.id.clone(), collection.clone());
                 }
-                if collection.apis.contains(&"features".to_string()) {
-                    info!(
-                        "Warning: GRIB engine does not support Features API, \
-                         skipping Features wiring for collection '{}'",
-                        collection.id
-                    );
-                }
-
                 // Get parameter list for per-parameter-layer styles
                 let raster_params =
                     ds_core::map_engine::MapEngine::raster_info(engine.as_ref()).parameters;

--- a/crates/server/src/admin.rs
+++ b/crates/server/src/admin.rs
@@ -178,26 +178,26 @@ pub fn load_collections(collections: &[CollectionConfig], base_url: &str) -> Loa
             "grib" => &["edr", "wms", "maps", "tiles"],
             _ => &[],
         };
-        let mut has_unsupported = false;
-        for api in &collection.apis {
-            if !supported_apis.contains(&api.as_str()) {
-                tracing::error!(
-                    "Collection '{}': engine '{}' does not support '{}' API, skipping collection",
-                    collection.id,
-                    collection.engine_type,
-                    api
-                );
-                has_unsupported = true;
-            }
-        }
-        if has_unsupported {
+        let unsupported: Vec<&str> = collection
+            .apis
+            .iter()
+            .map(|s| s.as_str())
+            .filter(|api| !supported_apis.contains(api))
+            .collect();
+        if !unsupported.is_empty() {
+            tracing::error!(
+                "Collection '{}': engine '{}' does not support APIs {:?}, skipping collection",
+                collection.id,
+                collection.engine_type,
+                unsupported
+            );
             health.push(CollectionHealth {
                 id: collection.id.clone(),
                 engine_type: collection.engine_type.clone(),
                 status: CollectionStatus::Failed,
                 error: Some(format!(
-                    "engine '{}' does not support requested APIs: {:?}",
-                    collection.engine_type, collection.apis
+                    "engine '{}' does not support APIs: {:?}",
+                    collection.engine_type, unsupported
                 )),
             });
             continue;


### PR DESCRIPTION
## Summary

Fixes from comprehensive codebase review (performance, security, architecture, code quality + devil's advocate).

- **GRIB GridCache weight tracking** (#60): Cache used item count instead of byte size, allowing unbounded memory. Now uses `with_weighter()` like `TileCache`. Also switched cache keys from `String` to `Arc<str>`.
- **Rendered image cache zero-copy** (#61): Cache hits deep-copied 50-100 KB image buffers. Now stores `bytes::Bytes` — clone is a refcount bump.
- **Error type decoupling** (#62): Replaced 5 engine-specific error variants (`Csv`, `GeoJson`, `GeoTiff`, `QueryData`, `Grib`) in ds-core with a single `Engine(String)`. Adding new engines no longer requires modifying core.
- **Config validation** (#63): Engine+API compatibility is now validated at config load time. Unsupported combinations (e.g., `geojson` + `edr`) fail with a clear error instead of silently skipping.

Closes #60, closes #61, closes #62, closes #63

## Test plan

- [x] `cargo test` — all tests pass
- [x] `cargo clippy --all` — no warnings
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)