### PR TITLE
Add comprehensive Prometheus metrics and Grafana dashboard

### DIFF
--- a/crates/engine-geotiff/src/lib.rs
+++ b/crates/engine-geotiff/src/lib.rs
@@ -188,6 +188,21 @@ impl GeoTiffEngine {
         &self.collection_id
     }
 
+    /// Return (hits, misses) for the tile cache.
+    pub fn tile_cache_stats(&self) -> (u64, u64) {
+        self.tile_cache.stats()
+    }
+
+    /// Return total bytes read from remote storage (0 for local engines).
+    pub fn storage_bytes_read(&self) -> u64 {
+        match &self.store_mode {
+            StoreMode::Remote { store, .. } | StoreMode::RemoteDynamic { store, .. } => {
+                store.bytes_read()
+            }
+            _ => 0,
+        }
+    }
+
     /// Returns `None` if the catalog has never been updated after initial load.
     pub fn catalog_age(&self) -> Option<chrono::Duration> {
         let updated_at = self

--- a/crates/engine-grib/src/cache.rs
+++ b/crates/engine-grib/src/cache.rs
@@ -3,6 +3,7 @@
 //! Caches decoded f64 arrays keyed by (grib_url, offset) to avoid
 //! repeated byte-range fetches and GRIB decoding.
 
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
 /// Cache key: identifies a specific GRIB message.
@@ -217,6 +218,8 @@ impl DecodedGrid {
 /// LRU cache for decoded grids, weighted by byte size.
 pub struct GridCache {
     cache: quick_cache::sync::Cache<GridKey, Arc<DecodedGrid>, GridWeighter>,
+    hits: AtomicU64,
+    misses: AtomicU64,
 }
 
 impl GridCache {
@@ -232,6 +235,8 @@ impl GridCache {
         let items = estimated_items.max(16);
         Some(Self {
             cache: quick_cache::sync::Cache::with_weighter(items, max_bytes, GridWeighter),
+            hits: AtomicU64::new(0),
+            misses: AtomicU64::new(0),
         })
     }
 
@@ -241,7 +246,13 @@ impl GridCache {
             url: Arc::from(url),
             offset,
         };
-        self.cache.get(&key)
+        let result = self.cache.get(&key);
+        if result.is_some() {
+            self.hits.fetch_add(1, Ordering::Relaxed);
+        } else {
+            self.misses.fetch_add(1, Ordering::Relaxed);
+        }
+        result
     }
 
     /// Insert a decoded grid into the cache.
@@ -251,5 +262,13 @@ impl GridCache {
             offset,
         };
         self.cache.insert(key, grid);
+    }
+
+    /// Return (hits, misses) counters.
+    pub fn stats(&self) -> (u64, u64) {
+        (
+            self.hits.load(Ordering::Relaxed),
+            self.misses.load(Ordering::Relaxed),
+        )
     }
 }

--- a/crates/engine-grib/src/lib.rs
+++ b/crates/engine-grib/src/lib.rs
@@ -54,6 +54,19 @@ impl GribEngine {
         &self.collection_id
     }
 
+    /// Return total bytes read from storage.
+    pub fn storage_bytes_read(&self) -> u64 {
+        self.store.bytes_read()
+    }
+
+    /// Return (hits, misses) for the grid cache, or (0, 0) if disabled.
+    pub fn grid_cache_stats(&self) -> (u64, u64) {
+        self.grid_cache
+            .as_ref()
+            .map(|c| c.stats())
+            .unwrap_or((0, 0))
+    }
+
     /// Create a new GRIB engine from config.
     pub fn new(collection_id: &str, config: &GribConfig) -> Result<Self, DataServerError> {
         // Validate config

--- a/crates/render/src/lib.rs
+++ b/crates/render/src/lib.rs
@@ -8,6 +8,7 @@ pub use colormap::{
 pub use encode::{encode_jpeg, encode_png, encode_webp};
 
 use std::hash::{Hash, Hasher};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
 use bytes::Bytes;
@@ -102,6 +103,8 @@ impl quick_cache::Weighter<CacheKey, Bytes> for RenderedWeighter {
 /// Cache is invalidated on collection reload.
 pub struct RenderedCache {
     cache: Cache<CacheKey, Bytes, RenderedWeighter>,
+    hits: AtomicU64,
+    misses: AtomicU64,
 }
 
 impl RenderedCache {
@@ -115,15 +118,31 @@ impl RenderedCache {
         };
         Self {
             cache: Cache::with_weighter(estimated_items, max_bytes, RenderedWeighter),
+            hits: AtomicU64::new(0),
+            misses: AtomicU64::new(0),
         }
     }
 
     pub fn get(&self, key: &CacheKey) -> Option<Bytes> {
-        self.cache.get(key)
+        let result = self.cache.get(key);
+        if result.is_some() {
+            self.hits.fetch_add(1, Ordering::Relaxed);
+        } else {
+            self.misses.fetch_add(1, Ordering::Relaxed);
+        }
+        result
     }
 
     pub fn insert(&self, key: CacheKey, value: Bytes) {
         self.cache.insert(key, value);
+    }
+
+    /// Return (hits, misses) counters.
+    pub fn stats(&self) -> (u64, u64) {
+        (
+            self.hits.load(Ordering::Relaxed),
+            self.misses.load(Ordering::Relaxed),
+        )
     }
 }
 

--- a/crates/server/src/admin.rs
+++ b/crates/server/src/admin.rs
@@ -77,6 +77,109 @@ static COLLECTIONS_FAILED: LazyLock<IntGauge> = LazyLock::new(|| {
     gauge
 });
 
+static HTTP_RESPONSE_BYTES: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    let counter = IntCounterVec::new(
+        Opts::new(
+            "http_response_bytes_total",
+            "Total HTTP response body bytes sent",
+        ),
+        &["method", "path"],
+    )
+    .unwrap();
+    REGISTRY.register(Box::new(counter.clone())).unwrap();
+    counter
+});
+
+static TILE_CACHE_HITS: LazyLock<IntGauge> = LazyLock::new(|| {
+    let gauge = IntGauge::new(
+        "tile_cache_hits_total",
+        "GeoTIFF tile cache hits (cumulative)",
+    )
+    .unwrap();
+    REGISTRY.register(Box::new(gauge.clone())).unwrap();
+    gauge
+});
+
+static TILE_CACHE_MISSES: LazyLock<IntGauge> = LazyLock::new(|| {
+    let gauge = IntGauge::new(
+        "tile_cache_misses_total",
+        "GeoTIFF tile cache misses (cumulative)",
+    )
+    .unwrap();
+    REGISTRY.register(Box::new(gauge.clone())).unwrap();
+    gauge
+});
+
+static RENDERED_CACHE_HITS: LazyLock<IntGauge> = LazyLock::new(|| {
+    let gauge = IntGauge::new(
+        "rendered_cache_hits_total",
+        "Rendered image cache hits (cumulative)",
+    )
+    .unwrap();
+    REGISTRY.register(Box::new(gauge.clone())).unwrap();
+    gauge
+});
+
+static RENDERED_CACHE_MISSES: LazyLock<IntGauge> = LazyLock::new(|| {
+    let gauge = IntGauge::new(
+        "rendered_cache_misses_total",
+        "Rendered image cache misses (cumulative)",
+    )
+    .unwrap();
+    REGISTRY.register(Box::new(gauge.clone())).unwrap();
+    gauge
+});
+
+static GRID_CACHE_HITS: LazyLock<IntGauge> = LazyLock::new(|| {
+    let gauge =
+        IntGauge::new("grid_cache_hits_total", "GRIB grid cache hits (cumulative)").unwrap();
+    REGISTRY.register(Box::new(gauge.clone())).unwrap();
+    gauge
+});
+
+static GRID_CACHE_MISSES: LazyLock<IntGauge> = LazyLock::new(|| {
+    let gauge = IntGauge::new(
+        "grid_cache_misses_total",
+        "GRIB grid cache misses (cumulative)",
+    )
+    .unwrap();
+    REGISTRY.register(Box::new(gauge.clone())).unwrap();
+    gauge
+});
+
+static RENDER_SEMAPHORE_AVAILABLE: LazyLock<IntGauge> = LazyLock::new(|| {
+    let gauge = IntGauge::new(
+        "render_semaphore_available",
+        "Available render semaphore permits",
+    )
+    .unwrap();
+    REGISTRY.register(Box::new(gauge.clone())).unwrap();
+    gauge
+});
+
+static RENDER_SEMAPHORE_TOTAL: LazyLock<IntGauge> = LazyLock::new(|| {
+    let gauge = IntGauge::new(
+        "render_semaphore_total",
+        "Total render semaphore permits (CPU cores)",
+    )
+    .unwrap();
+    REGISTRY.register(Box::new(gauge.clone())).unwrap();
+    gauge
+});
+
+static STORAGE_BYTES_READ: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    let counter = IntCounterVec::new(
+        Opts::new(
+            "storage_bytes_read_total",
+            "Total bytes read from storage by engine",
+        ),
+        &["collection", "engine_type"],
+    )
+    .unwrap();
+    REGISTRY.register(Box::new(counter.clone())).unwrap();
+    counter
+});
+
 // ---------------------------------------------------------------------------
 // Health types
 // ---------------------------------------------------------------------------
@@ -731,6 +834,9 @@ pub fn load_collections(collections: &[CollectionConfig], base_url: &str) -> Loa
     let render_semaphore = Arc::new(tokio::sync::Semaphore::new(render_concurrency));
     let rendered_cache = Arc::new(ds_render::RenderedCache::new(rendered_cache_mb));
 
+    // Set initial render semaphore total gauge
+    RENDER_SEMAPHORE_TOTAL.set(render_concurrency as i64);
+
     LoadResult {
         edr_state: EdrState {
             engines: edr_engines,
@@ -762,8 +868,8 @@ pub fn load_collections(collections: &[CollectionConfig], base_url: &str) -> Loa
             map_engines: tiles_engines,
             collections: tiles_collections,
             styles: tiles_styles,
-            render_semaphore,
-            rendered_cache,
+            render_semaphore: render_semaphore.clone(),
+            rendered_cache: rendered_cache.clone(),
             base_url: base_url.to_string(),
         },
         health,
@@ -1256,7 +1362,63 @@ pub async fn health_handler(State(state): State<AdminState>) -> impl IntoRespons
 }
 
 /// GET /metrics — Prometheus text format.
-pub async fn metrics_handler() -> impl IntoResponse {
+///
+/// Updates gauge-style metrics from engine/cache state before gathering,
+/// so Prometheus always gets a fresh snapshot.
+pub async fn metrics_handler(State(state): State<AdminState>) -> impl IntoResponse {
+    // Read from current WMS state (survives reloads via ArcSwap)
+    let wms = state.wms.load();
+    RENDER_SEMAPHORE_AVAILABLE.set(wms.render_semaphore.available_permits() as i64);
+
+    let (r_hits, r_misses) = wms.rendered_cache.stats();
+    RENDERED_CACHE_HITS.set(r_hits as i64);
+    RENDERED_CACHE_MISSES.set(r_misses as i64);
+
+    // Update tile cache gauges (sum across all GeoTIFF engines)
+    if let Ok(engines) = state.geotiff_engines.read() {
+        let (mut total_hits, mut total_misses) = (0u64, 0u64);
+        for engine in engines.iter() {
+            let (h, m) = engine.tile_cache_stats();
+            total_hits += h;
+            total_misses += m;
+
+            // Update per-collection storage bytes
+            let bytes = engine.storage_bytes_read();
+            if bytes > 0 {
+                STORAGE_BYTES_READ
+                    .with_label_values(&[engine.collection_id(), "geotiff"])
+                    .reset();
+                STORAGE_BYTES_READ
+                    .with_label_values(&[engine.collection_id(), "geotiff"])
+                    .inc_by(bytes);
+            }
+        }
+        TILE_CACHE_HITS.set(total_hits as i64);
+        TILE_CACHE_MISSES.set(total_misses as i64);
+    }
+
+    // Update GRIB grid cache and storage bytes
+    if let Ok(engines) = state.grib_engines.read() {
+        let (mut total_hits, mut total_misses) = (0u64, 0u64);
+        for engine in engines.iter() {
+            let (h, m) = engine.grid_cache_stats();
+            total_hits += h;
+            total_misses += m;
+
+            let bytes = engine.storage_bytes_read();
+            if bytes > 0 {
+                STORAGE_BYTES_READ
+                    .with_label_values(&[engine.collection_id(), "grib"])
+                    .reset();
+                STORAGE_BYTES_READ
+                    .with_label_values(&[engine.collection_id(), "grib"])
+                    .inc_by(bytes);
+            }
+        }
+        GRID_CACHE_HITS.set(total_hits as i64);
+        GRID_CACHE_MISSES.set(total_misses as i64);
+    }
+
     let encoder = TextEncoder::new();
     let metric_families = REGISTRY.gather();
     let mut buffer = Vec::new();
@@ -1286,6 +1448,15 @@ pub async fn metrics_middleware(
 
     let duration = start.elapsed().as_secs_f64();
     let status = response.status().as_u16().to_string();
+
+    // Track response body size from content-length header if present
+    if let Some(content_length) = response.headers().get(header::CONTENT_LENGTH) {
+        if let Ok(len) = content_length.to_str().unwrap_or("0").parse::<u64>() {
+            HTTP_RESPONSE_BYTES
+                .with_label_values(&[&method, &path])
+                .inc_by(len);
+        }
+    }
 
     HTTP_REQUESTS_TOTAL
         .with_label_values(&[&method, &path, &status])

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -140,7 +140,10 @@ async fn main() {
             "/health",
             get(admin::health_handler).with_state(server_state.clone()),
         )
-        .route("/metrics", get(admin::metrics_handler));
+        .route(
+            "/metrics",
+            get(admin::metrics_handler).with_state(server_state.clone()),
+        );
 
     // Admin routes (protected by bearer token auth, not CORS)
     let admin_routes = Router::new().route(

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -6,6 +6,7 @@
 mod error;
 
 use std::ops::Range;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
 use bytes::Bytes;
@@ -26,20 +27,27 @@ pub use object_store;
 #[derive(Clone)]
 pub struct DataStore {
     inner: Arc<dyn ObjectStore>,
+    bytes_read: Arc<AtomicU64>,
 }
 
 impl DataStore {
     pub fn new(store: Arc<dyn ObjectStore>) -> Self {
-        Self { inner: store }
+        Self {
+            inner: store,
+            bytes_read: Arc::new(AtomicU64::new(0)),
+        }
     }
 
     /// Get the entire contents of an object.
     #[allow(clippy::needless_question_mark)]
     pub fn get(&self, path: &ObjectPath) -> Result<Bytes, DataServerError> {
-        self.block_on(async {
+        let result = self.block_on(async {
             let result = self.inner.get(path).await?;
             Ok(result.bytes().await?)
-        })
+        })?;
+        self.bytes_read
+            .fetch_add(result.len() as u64, Ordering::Relaxed);
+        Ok(result)
     }
 
     /// Get a byte range from an object.
@@ -49,7 +57,15 @@ impl DataStore {
         path: &ObjectPath,
         range: Range<usize>,
     ) -> Result<Bytes, DataServerError> {
-        self.block_on(async { Ok(self.inner.get_range(path, range).await?) })
+        let result = self.block_on(async { Ok(self.inner.get_range(path, range).await?) })?;
+        self.bytes_read
+            .fetch_add(result.len() as u64, Ordering::Relaxed);
+        Ok(result)
+    }
+
+    /// Return total bytes read from this store since creation.
+    pub fn bytes_read(&self) -> u64 {
+        self.bytes_read.load(Ordering::Relaxed)
     }
 
     /// List objects under a prefix.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,67 @@
+services:
+  meteocore:
+    build: .
+    volumes:
+      - ./config.toml:/data/config.toml:ro
+      - ./testdata:/data/testdata:ro
+    environment:
+      - RUST_LOG=info
+      - CONFIG_PATH=/data/config.toml
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      interval: 30s
+      timeout: 5s
+      start_period: 10s
+      retries: 3
+    restart: unless-stopped
+
+  varnish:
+    image: varnish:7.6
+    ports:
+      - "80:80"
+    volumes:
+      - ./varnish/default.vcl:/etc/varnish/default.vcl:ro
+    environment:
+      - VARNISH_SIZE=512m
+    command: >
+      -a :80
+      -f /etc/varnish/default.vcl
+      -s malloc,512m
+      -p thread_pool_min=50
+      -p thread_pool_max=1000
+      -p thread_pool_timeout=120
+    depends_on:
+      meteocore:
+        condition: service_healthy
+    restart: unless-stopped
+
+  prometheus:
+    image: prom/prometheus:v3.4.0
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus-data:/prometheus
+    depends_on:
+      meteocore:
+        condition: service_healthy
+    restart: unless-stopped
+
+  grafana:
+    image: grafana/grafana:12.0.0
+    ports:
+      - "3000:3000"
+    volumes:
+      - grafana-data:/var/lib/grafana
+      - ./grafana/dashboards:/var/lib/grafana/dashboards:ro
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro
+    environment:
+      - GF_SECURITY_ADMIN_PASSWORD=meteocore
+      - GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH=/var/lib/grafana/dashboards/meteocore-overview.json
+    depends_on:
+      - prometheus
+    restart: unless-stopped
+
+volumes:
+  prometheus-data:
+  grafana-data:

--- a/grafana/dashboards/meteocore-overview.json
+++ b/grafana/dashboards/meteocore-overview.json
@@ -1,0 +1,559 @@
+{
+  "annotations": { "list": [] },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "links": [],
+  "panels": [
+    {
+      "title": "HTTP Traffic",
+      "type": "row",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "collapsed": false
+    },
+    {
+      "title": "Request Rate",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 1 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": { "fillOpacity": 10, "lineWidth": 2 }
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(http_requests_total[5m]))",
+          "legendFormat": "Total"
+        },
+        {
+          "expr": "sum(rate(http_requests_total{path=~\"/wms.*\"}[5m]))",
+          "legendFormat": "WMS"
+        },
+        {
+          "expr": "sum(rate(http_requests_total{path=~\"/tiles.*\"}[5m]))",
+          "legendFormat": "Tiles"
+        },
+        {
+          "expr": "sum(rate(http_requests_total{path=~\"/maps.*\"}[5m]))",
+          "legendFormat": "Maps"
+        },
+        {
+          "expr": "sum(rate(http_requests_total{path=~\"/edr.*\"}[5m]))",
+          "legendFormat": "EDR"
+        },
+        {
+          "expr": "sum(rate(http_requests_total{path=~\"/features.*\"}[5m]))",
+          "legendFormat": "Features"
+        }
+      ]
+    },
+    {
+      "title": "Error Rate",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 1 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": { "fillOpacity": 10, "lineWidth": 2 },
+          "color": { "mode": "palette-classic" }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "5xx" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "4xx" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "yellow", "mode": "fixed" } }]
+          }
+        ]
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(http_requests_total{status=~\"5..\"}[5m]))",
+          "legendFormat": "5xx"
+        },
+        {
+          "expr": "sum(rate(http_requests_total{status=~\"4..\"}[5m]))",
+          "legendFormat": "4xx"
+        }
+      ]
+    },
+    {
+      "title": "Request Latency (p50 / p95 / p99)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 9 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": { "fillOpacity": 5, "lineWidth": 2 }
+        }
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum(rate(http_request_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p50"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p95"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(http_request_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p99"
+        }
+      ]
+    },
+    {
+      "title": "Latency by API (p95)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 9 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": { "fillOpacity": 5, "lineWidth": 2 }
+        }
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket{path=~\"/wms.*\"}[5m])) by (le))",
+          "legendFormat": "WMS p95"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket{path=~\"/tiles.*\"}[5m])) by (le))",
+          "legendFormat": "Tiles p95"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket{path=~\"/maps.*\"}[5m])) by (le))",
+          "legendFormat": "Maps p95"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket{path=~\"/edr.*\"}[5m])) by (le))",
+          "legendFormat": "EDR p95"
+        }
+      ]
+    },
+    {
+      "title": "Data Transfer",
+      "type": "row",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 17 },
+      "collapsed": false
+    },
+    {
+      "title": "Response Throughput",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 18 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Bps",
+          "custom": { "fillOpacity": 10, "lineWidth": 2 }
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(http_response_bytes_total[5m]))",
+          "legendFormat": "Total"
+        },
+        {
+          "expr": "sum(rate(http_response_bytes_total{path=~\"/wms.*\"}[5m]))",
+          "legendFormat": "WMS"
+        },
+        {
+          "expr": "sum(rate(http_response_bytes_total{path=~\"/tiles.*\"}[5m]))",
+          "legendFormat": "Tiles"
+        },
+        {
+          "expr": "sum(rate(http_response_bytes_total{path=~\"/maps.*\"}[5m]))",
+          "legendFormat": "Maps"
+        },
+        {
+          "expr": "sum(rate(http_response_bytes_total{path=~\"/edr.*\"}[5m]))",
+          "legendFormat": "EDR"
+        }
+      ]
+    },
+    {
+      "title": "Storage Bytes Read by Engine",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 18 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Bps",
+          "custom": { "fillOpacity": 10, "lineWidth": 2 }
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(storage_bytes_read_total[5m])) by (collection)",
+          "legendFormat": "{{collection}}"
+        }
+      ]
+    },
+    {
+      "title": "Response Bytes Transferred (24h)",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 26 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "thresholds": {
+            "steps": [{ "color": "blue", "value": null }]
+          }
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(increase(http_response_bytes_total[24h]))",
+          "legendFormat": "Sent"
+        }
+      ]
+    },
+    {
+      "title": "Storage Bytes Read (24h)",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 26 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "thresholds": {
+            "steps": [{ "color": "purple", "value": null }]
+          }
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(increase(storage_bytes_read_total[24h]))",
+          "legendFormat": "Read"
+        }
+      ]
+    },
+    {
+      "title": "Caches",
+      "type": "row",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 30 },
+      "collapsed": false
+    },
+    {
+      "title": "Tile Cache Hit Rate",
+      "type": "gauge",
+      "gridPos": { "h": 6, "w": 6, "x": 0, "y": 31 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "thresholds": {
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "yellow", "value": 0.5 },
+              { "color": "green", "value": 0.8 }
+            ]
+          }
+        }
+      },
+      "targets": [
+        {
+          "expr": "tile_cache_hits_total / clamp_min(tile_cache_hits_total + tile_cache_misses_total, 1)",
+          "legendFormat": "Hit Rate"
+        }
+      ]
+    },
+    {
+      "title": "Rendered Cache Hit Rate",
+      "type": "gauge",
+      "gridPos": { "h": 6, "w": 6, "x": 6, "y": 31 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "thresholds": {
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "yellow", "value": 0.5 },
+              { "color": "green", "value": 0.8 }
+            ]
+          }
+        }
+      },
+      "targets": [
+        {
+          "expr": "rendered_cache_hits_total / clamp_min(rendered_cache_hits_total + rendered_cache_misses_total, 1)",
+          "legendFormat": "Hit Rate"
+        }
+      ]
+    },
+    {
+      "title": "GRIB Grid Cache Hit Rate",
+      "type": "gauge",
+      "gridPos": { "h": 6, "w": 6, "x": 12, "y": 31 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "thresholds": {
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "yellow", "value": 0.5 },
+              { "color": "green", "value": 0.8 }
+            ]
+          }
+        }
+      },
+      "targets": [
+        {
+          "expr": "grid_cache_hits_total / clamp_min(grid_cache_hits_total + grid_cache_misses_total, 1)",
+          "legendFormat": "Hit Rate"
+        }
+      ]
+    },
+    {
+      "title": "Render Semaphore",
+      "type": "gauge",
+      "gridPos": { "h": 6, "w": 6, "x": 18, "y": 31 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "min": 0,
+          "thresholds": {
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "yellow", "value": 1 },
+              { "color": "green", "value": 2 }
+            ]
+          }
+        }
+      },
+      "targets": [
+        {
+          "expr": "render_semaphore_available",
+          "legendFormat": "Available"
+        }
+      ],
+      "options": {
+        "text": { "titleSize": 14 }
+      }
+    },
+    {
+      "title": "Cache Hits vs Misses",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 37 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": { "fillOpacity": 10, "lineWidth": 2 }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byRegexp", "options": ".*Hits" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "green", "mode": "fixed" } }]
+          },
+          {
+            "matcher": { "id": "byRegexp", "options": ".*Misses" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } }]
+          }
+        ]
+      },
+      "targets": [
+        {
+          "expr": "rate(tile_cache_hits_total[5m])",
+          "legendFormat": "Tile Hits"
+        },
+        {
+          "expr": "rate(tile_cache_misses_total[5m])",
+          "legendFormat": "Tile Misses"
+        },
+        {
+          "expr": "rate(rendered_cache_hits_total[5m])",
+          "legendFormat": "Rendered Hits"
+        },
+        {
+          "expr": "rate(rendered_cache_misses_total[5m])",
+          "legendFormat": "Rendered Misses"
+        }
+      ]
+    },
+    {
+      "title": "Render Semaphore Utilization",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 37 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": { "fillOpacity": 10, "lineWidth": 2 }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "In Use" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "orange", "mode": "fixed" } }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "Total" },
+            "properties": [
+              { "id": "color", "value": { "fixedColor": "green", "mode": "fixed" } },
+              { "id": "custom.lineStyle", "value": { "fill": "dash", "dash": [10, 10] } }
+            ]
+          }
+        ]
+      },
+      "targets": [
+        {
+          "expr": "render_semaphore_total - render_semaphore_available",
+          "legendFormat": "In Use"
+        },
+        {
+          "expr": "render_semaphore_total",
+          "legendFormat": "Total"
+        }
+      ]
+    },
+    {
+      "title": "Collections & Endpoints",
+      "type": "row",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 45 },
+      "collapsed": false
+    },
+    {
+      "title": "Collection Health",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 46 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          }
+        }
+      },
+      "targets": [
+        { "expr": "collections_total", "legendFormat": "Total" },
+        { "expr": "collections_healthy", "legendFormat": "Healthy" }
+      ]
+    },
+    {
+      "title": "Degraded",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 3, "x": 6, "y": 46 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 1 }
+            ]
+          }
+        }
+      },
+      "targets": [
+        { "expr": "collections_degraded", "legendFormat": "Degraded" }
+      ]
+    },
+    {
+      "title": "Failed",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 3, "x": 9, "y": 46 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 1 }
+            ]
+          }
+        }
+      },
+      "targets": [
+        { "expr": "collections_failed", "legendFormat": "Failed" }
+      ]
+    },
+    {
+      "title": "Requests by Status Code",
+      "type": "piechart",
+      "gridPos": { "h": 8, "w": 6, "x": 12, "y": 46 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        {
+          "expr": "sum(increase(http_requests_total[1h])) by (status)",
+          "legendFormat": "{{status}}"
+        }
+      ]
+    },
+    {
+      "title": "Top Endpoints by Request Count",
+      "type": "bargauge",
+      "gridPos": { "h": 8, "w": 6, "x": 18, "y": 46 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        }
+      },
+      "options": {
+        "orientation": "horizontal",
+        "displayMode": "gradient"
+      },
+      "targets": [
+        {
+          "expr": "topk(10, sum(increase(http_requests_total[1h])) by (path))",
+          "legendFormat": "{{path}}"
+        }
+      ]
+    },
+    {
+      "title": "Request Rate by Endpoint",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 54 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": { "fillOpacity": 10, "lineWidth": 1, "stacking": { "mode": "normal" } }
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(http_requests_total[5m])) by (path)",
+          "legendFormat": "{{path}}"
+        }
+      ]
+    }
+  ],
+  "schemaVersion": 39,
+  "tags": ["meteocore"],
+  "templating": {
+    "list": [
+      {
+        "name": "DS_PROMETHEUS",
+        "type": "datasource",
+        "query": "prometheus",
+        "current": { "text": "Prometheus", "value": "Prometheus" }
+      }
+    ]
+  },
+  "time": { "from": "now-1h", "to": "now" },
+  "timepicker": {},
+  "timezone": "utc",
+  "title": "MeteoCore",
+  "uid": "meteocore-overview",
+  "version": 2
+}

--- a/grafana/provisioning/dashboards/dashboards.yml
+++ b/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,9 @@
+apiVersion: 1
+providers:
+  - name: MeteoCore
+    type: file
+    disableDeletion: false
+    editable: true
+    options:
+      path: /var/lib/grafana/dashboards
+      foldersFromFilesStructure: false

--- a/grafana/provisioning/datasources/prometheus.yml
+++ b/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,8 @@
+apiVersion: 1
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false


### PR DESCRIPTION
## Summary

- Add 10 new Prometheus metrics: response bytes, storage I/O per collection/engine, tile/rendered/grid cache hit/miss rates, and render semaphore utilization
- Add byte-read tracking to `DataStore`, hit/miss counters to `RenderedCache` and `GridCache`, expose stats via engine public APIs
- Move `grafana-dashboard.json` into `grafana/dashboards/` and track Grafana provisioning configs, update `docker-compose.yml` volume mount
- Reorganize dashboard into 4 collapsible rows (HTTP Traffic, Data Transfer, Caches, Collections & Endpoints) with 24 panels

## New metrics

| Metric | Type | Labels |
|--------|------|--------|
| `http_response_bytes_total` | counter | method, path |
| `storage_bytes_read_total` | counter | collection, engine_type |
| `tile_cache_hits/misses_total` | gauge | — |
| `rendered_cache_hits/misses_total` | gauge | — |
| `grid_cache_hits/misses_total` | gauge | — |
| `render_semaphore_available` | gauge | — |
| `render_semaphore_total` | gauge | — |

## Test plan

- [x] `cargo test` — all tests pass
- [x] `cargo clippy` — no warnings
- [x] `cargo fmt --check` — formatted
- [ ] Deploy with docker-compose, verify Grafana auto-provisions dashboard
- [ ] Generate traffic, verify new metrics appear at `/metrics`
- [ ] Confirm cache hit rate gauges and data transfer panels populate in Grafana

🤖 Generated with [Claude Code](https://claude.com/claude-code)