### PR TITLE
feat: per-collection cache metrics and utilization gauges

### DIFF
--- a/crates/engine-geotiff/src/cache.rs
+++ b/crates/engine-geotiff/src/cache.rs
@@ -36,6 +36,7 @@ impl quick_cache::Weighter<TileCacheKey, Bytes> for TileWeighter {
 /// Thread-safe tile cache backed by quick_cache (lock-free concurrent LRU).
 pub struct TileCache {
     inner: quick_cache::sync::Cache<TileCacheKey, Bytes, TileWeighter>,
+    capacity_bytes: u64,
     hits: AtomicU64,
     misses: AtomicU64,
 }
@@ -56,6 +57,7 @@ impl TileCache {
                 max_bytes,
                 TileWeighter,
             ),
+            capacity_bytes: max_bytes,
             hits: AtomicU64::new(0),
             misses: AtomicU64::new(0),
         }
@@ -95,6 +97,22 @@ impl TileCache {
             self.hits.load(Ordering::Relaxed),
             self.misses.load(Ordering::Relaxed),
         )
+    }
+
+    /// Current weight (bytes used) of the cache.
+    pub fn weight(&self) -> u64 {
+        self.inner.weight()
+    }
+
+    /// Maximum weight (bytes) the cache will hold.
+    pub fn capacity(&self) -> u64 {
+        self.capacity_bytes
+    }
+
+    /// Number of entries currently in the cache.
+    #[allow(clippy::len_without_is_empty)]
+    pub fn len(&self) -> usize {
+        self.inner.len()
     }
 }
 

--- a/crates/engine-geotiff/src/lib.rs
+++ b/crates/engine-geotiff/src/lib.rs
@@ -193,6 +193,15 @@ impl GeoTiffEngine {
         self.tile_cache.stats()
     }
 
+    /// Return current tile cache utilization as (bytes_used, capacity_bytes, entries).
+    pub fn tile_cache_utilization(&self) -> (u64, u64, usize) {
+        (
+            self.tile_cache.weight(),
+            self.tile_cache.capacity(),
+            self.tile_cache.len(),
+        )
+    }
+
     /// Return total bytes read from remote storage (0 for local engines).
     pub fn storage_bytes_read(&self) -> u64 {
         match &self.store_mode {

--- a/crates/engine-grib/src/cache.rs
+++ b/crates/engine-grib/src/cache.rs
@@ -218,6 +218,7 @@ impl DecodedGrid {
 /// LRU cache for decoded grids, weighted by byte size.
 pub struct GridCache {
     cache: quick_cache::sync::Cache<GridKey, Arc<DecodedGrid>, GridWeighter>,
+    capacity_bytes: u64,
     hits: AtomicU64,
     misses: AtomicU64,
 }
@@ -235,6 +236,7 @@ impl GridCache {
         let items = estimated_items.max(16);
         Some(Self {
             cache: quick_cache::sync::Cache::with_weighter(items, max_bytes, GridWeighter),
+            capacity_bytes: max_bytes,
             hits: AtomicU64::new(0),
             misses: AtomicU64::new(0),
         })
@@ -270,5 +272,25 @@ impl GridCache {
             self.hits.load(Ordering::Relaxed),
             self.misses.load(Ordering::Relaxed),
         )
+    }
+
+    /// Current weight (bytes used) of the cache.
+    pub fn weight(&self) -> u64 {
+        self.cache.weight()
+    }
+
+    /// Maximum weight (bytes) the cache will hold.
+    pub fn capacity(&self) -> u64 {
+        self.capacity_bytes
+    }
+
+    /// Number of entries currently in the cache.
+    pub fn len(&self) -> usize {
+        self.cache.len()
+    }
+
+    /// Whether the cache is currently empty.
+    pub fn is_empty(&self) -> bool {
+        self.cache.len() == 0
     }
 }

--- a/crates/engine-grib/src/lib.rs
+++ b/crates/engine-grib/src/lib.rs
@@ -67,6 +67,15 @@ impl GribEngine {
             .unwrap_or((0, 0))
     }
 
+    /// Return grid cache utilization as (bytes_used, capacity_bytes, entries).
+    /// Zeroes if the cache is disabled.
+    pub fn grid_cache_utilization(&self) -> (u64, u64, usize) {
+        self.grid_cache
+            .as_ref()
+            .map(|c| (c.weight(), c.capacity(), c.len()))
+            .unwrap_or((0, 0, 0))
+    }
+
     /// Create a new GRIB engine from config.
     pub fn new(collection_id: &str, config: &GribConfig) -> Result<Self, DataServerError> {
         // Validate config

--- a/crates/render/src/lib.rs
+++ b/crates/render/src/lib.rs
@@ -103,6 +103,7 @@ impl quick_cache::Weighter<CacheKey, Bytes> for RenderedWeighter {
 /// Cache is invalidated on collection reload.
 pub struct RenderedCache {
     cache: Cache<CacheKey, Bytes, RenderedWeighter>,
+    capacity_bytes: u64,
     hits: AtomicU64,
     misses: AtomicU64,
 }
@@ -118,6 +119,7 @@ impl RenderedCache {
         };
         Self {
             cache: Cache::with_weighter(estimated_items, max_bytes, RenderedWeighter),
+            capacity_bytes: max_bytes,
             hits: AtomicU64::new(0),
             misses: AtomicU64::new(0),
         }
@@ -143,6 +145,26 @@ impl RenderedCache {
             self.hits.load(Ordering::Relaxed),
             self.misses.load(Ordering::Relaxed),
         )
+    }
+
+    /// Current weight (bytes used) of the cache.
+    pub fn weight(&self) -> u64 {
+        self.cache.weight()
+    }
+
+    /// Maximum weight (bytes) the cache will hold.
+    pub fn capacity(&self) -> u64 {
+        self.capacity_bytes
+    }
+
+    /// Number of entries currently in the cache.
+    pub fn len(&self) -> usize {
+        self.cache.len()
+    }
+
+    /// Whether the cache is currently empty.
+    pub fn is_empty(&self) -> bool {
+        self.cache.len() == 0
     }
 }
 

--- a/crates/server/src/admin.rs
+++ b/crates/server/src/admin.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::sync::{Arc, LazyLock, RwLock};
+use std::sync::{Arc, LazyLock, Mutex, RwLock};
 use std::time::Instant;
 
 use arc_swap::ArcSwap;
@@ -8,7 +8,8 @@ use axum::http::{header, HeaderMap, StatusCode};
 use axum::response::IntoResponse;
 use axum::Json;
 use prometheus::{
-    Encoder, HistogramOpts, HistogramVec, IntCounterVec, IntGauge, Opts, Registry, TextEncoder,
+    Encoder, HistogramOpts, HistogramVec, IntCounter, IntCounterVec, IntGauge, IntGaugeVec, Opts,
+    Registry, TextEncoder,
 };
 use serde::Serialize;
 use serde_json::json;
@@ -90,62 +91,187 @@ static HTTP_RESPONSE_BYTES: LazyLock<IntCounterVec> = LazyLock::new(|| {
     counter
 });
 
-static TILE_CACHE_HITS: LazyLock<IntGauge> = LazyLock::new(|| {
-    let gauge = IntGauge::new(
-        "tile_cache_hits_total",
-        "GeoTIFF tile cache hits (cumulative)",
+// Tile cache (per-collection).
+static TILE_CACHE_HITS: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    let counter = IntCounterVec::new(
+        Opts::new("tile_cache_hits_total", "GeoTIFF tile cache hits"),
+        &["collection"],
+    )
+    .unwrap();
+    REGISTRY.register(Box::new(counter.clone())).unwrap();
+    counter
+});
+
+static TILE_CACHE_MISSES: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    let counter = IntCounterVec::new(
+        Opts::new("tile_cache_misses_total", "GeoTIFF tile cache misses"),
+        &["collection"],
+    )
+    .unwrap();
+    REGISTRY.register(Box::new(counter.clone())).unwrap();
+    counter
+});
+
+static TILE_CACHE_BYTES: LazyLock<IntGaugeVec> = LazyLock::new(|| {
+    let gauge = IntGaugeVec::new(
+        Opts::new(
+            "tile_cache_bytes",
+            "Bytes currently held in the GeoTIFF tile cache",
+        ),
+        &["collection"],
     )
     .unwrap();
     REGISTRY.register(Box::new(gauge.clone())).unwrap();
     gauge
 });
 
-static TILE_CACHE_MISSES: LazyLock<IntGauge> = LazyLock::new(|| {
-    let gauge = IntGauge::new(
-        "tile_cache_misses_total",
-        "GeoTIFF tile cache misses (cumulative)",
+static TILE_CACHE_CAPACITY_BYTES: LazyLock<IntGaugeVec> = LazyLock::new(|| {
+    let gauge = IntGaugeVec::new(
+        Opts::new(
+            "tile_cache_capacity_bytes",
+            "Configured GeoTIFF tile cache capacity in bytes",
+        ),
+        &["collection"],
     )
     .unwrap();
     REGISTRY.register(Box::new(gauge.clone())).unwrap();
     gauge
 });
 
-static RENDERED_CACHE_HITS: LazyLock<IntGauge> = LazyLock::new(|| {
-    let gauge = IntGauge::new(
-        "rendered_cache_hits_total",
-        "Rendered image cache hits (cumulative)",
+static TILE_CACHE_ENTRIES: LazyLock<IntGaugeVec> = LazyLock::new(|| {
+    let gauge = IntGaugeVec::new(
+        Opts::new(
+            "tile_cache_entries",
+            "Number of entries currently in the GeoTIFF tile cache",
+        ),
+        &["collection"],
     )
     .unwrap();
     REGISTRY.register(Box::new(gauge.clone())).unwrap();
     gauge
 });
 
-static RENDERED_CACHE_MISSES: LazyLock<IntGauge> = LazyLock::new(|| {
+// Rendered image cache (global — shared across all collections that render).
+static RENDERED_CACHE_HITS: LazyLock<IntCounter> = LazyLock::new(|| {
+    let counter =
+        IntCounter::new("rendered_cache_hits_total", "Rendered image cache hits").unwrap();
+    REGISTRY.register(Box::new(counter.clone())).unwrap();
+    counter
+});
+
+static RENDERED_CACHE_MISSES: LazyLock<IntCounter> = LazyLock::new(|| {
+    let counter =
+        IntCounter::new("rendered_cache_misses_total", "Rendered image cache misses").unwrap();
+    REGISTRY.register(Box::new(counter.clone())).unwrap();
+    counter
+});
+
+static RENDERED_CACHE_BYTES: LazyLock<IntGauge> = LazyLock::new(|| {
     let gauge = IntGauge::new(
-        "rendered_cache_misses_total",
-        "Rendered image cache misses (cumulative)",
+        "rendered_cache_bytes",
+        "Bytes currently held in the rendered image cache",
     )
     .unwrap();
     REGISTRY.register(Box::new(gauge.clone())).unwrap();
     gauge
 });
 
-static GRID_CACHE_HITS: LazyLock<IntGauge> = LazyLock::new(|| {
-    let gauge =
-        IntGauge::new("grid_cache_hits_total", "GRIB grid cache hits (cumulative)").unwrap();
-    REGISTRY.register(Box::new(gauge.clone())).unwrap();
-    gauge
-});
-
-static GRID_CACHE_MISSES: LazyLock<IntGauge> = LazyLock::new(|| {
+static RENDERED_CACHE_CAPACITY_BYTES: LazyLock<IntGauge> = LazyLock::new(|| {
     let gauge = IntGauge::new(
-        "grid_cache_misses_total",
-        "GRIB grid cache misses (cumulative)",
+        "rendered_cache_capacity_bytes",
+        "Configured rendered image cache capacity in bytes",
     )
     .unwrap();
     REGISTRY.register(Box::new(gauge.clone())).unwrap();
     gauge
 });
+
+static RENDERED_CACHE_ENTRIES: LazyLock<IntGauge> = LazyLock::new(|| {
+    let gauge = IntGauge::new(
+        "rendered_cache_entries",
+        "Number of entries currently in the rendered image cache",
+    )
+    .unwrap();
+    REGISTRY.register(Box::new(gauge.clone())).unwrap();
+    gauge
+});
+
+// GRIB grid cache (per-collection).
+static GRID_CACHE_HITS: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    let counter = IntCounterVec::new(
+        Opts::new("grid_cache_hits_total", "GRIB grid cache hits"),
+        &["collection"],
+    )
+    .unwrap();
+    REGISTRY.register(Box::new(counter.clone())).unwrap();
+    counter
+});
+
+static GRID_CACHE_MISSES: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    let counter = IntCounterVec::new(
+        Opts::new("grid_cache_misses_total", "GRIB grid cache misses"),
+        &["collection"],
+    )
+    .unwrap();
+    REGISTRY.register(Box::new(counter.clone())).unwrap();
+    counter
+});
+
+static GRID_CACHE_BYTES: LazyLock<IntGaugeVec> = LazyLock::new(|| {
+    let gauge = IntGaugeVec::new(
+        Opts::new(
+            "grid_cache_bytes",
+            "Bytes currently held in the GRIB grid cache",
+        ),
+        &["collection"],
+    )
+    .unwrap();
+    REGISTRY.register(Box::new(gauge.clone())).unwrap();
+    gauge
+});
+
+static GRID_CACHE_CAPACITY_BYTES: LazyLock<IntGaugeVec> = LazyLock::new(|| {
+    let gauge = IntGaugeVec::new(
+        Opts::new(
+            "grid_cache_capacity_bytes",
+            "Configured GRIB grid cache capacity in bytes",
+        ),
+        &["collection"],
+    )
+    .unwrap();
+    REGISTRY.register(Box::new(gauge.clone())).unwrap();
+    gauge
+});
+
+static GRID_CACHE_ENTRIES: LazyLock<IntGaugeVec> = LazyLock::new(|| {
+    let gauge = IntGaugeVec::new(
+        Opts::new(
+            "grid_cache_entries",
+            "Number of entries currently in the GRIB grid cache",
+        ),
+        &["collection"],
+    )
+    .unwrap();
+    REGISTRY.register(Box::new(gauge.clone())).unwrap();
+    gauge
+});
+
+/// Tracks the last observed (hits, misses) snapshot per (cache_kind, collection)
+/// so that the metrics handler can convert cumulative cache counters into
+/// monotonically-increasing Prometheus counters via delta tracking.
+///
+/// On collection reload the underlying cache is replaced with a fresh one
+/// (hits/misses reset to 0), which we detect as a decrease and treat as the
+/// new baseline.
+static CACHE_COUNTER_STATE: LazyLock<Mutex<CacheCounterState>> =
+    LazyLock::new(|| Mutex::new(CacheCounterState::default()));
+
+#[derive(Default)]
+struct CacheCounterState {
+    tile: HashMap<String, (u64, u64)>,
+    grid: HashMap<String, (u64, u64)>,
+    rendered: (u64, u64),
+}
 
 static RENDER_SEMAPHORE_AVAILABLE: LazyLock<IntGauge> = LazyLock::new(|| {
     let gauge = IntGauge::new(
@@ -1370,54 +1496,131 @@ pub async fn metrics_handler(State(state): State<AdminState>) -> impl IntoRespon
     let wms = state.wms.load();
     RENDER_SEMAPHORE_AVAILABLE.set(wms.render_semaphore.available_permits() as i64);
 
-    let (r_hits, r_misses) = wms.rendered_cache.stats();
-    RENDERED_CACHE_HITS.set(r_hits as i64);
-    RENDERED_CACHE_MISSES.set(r_misses as i64);
+    // Delta-tracked cache counters: cache implementations expose cumulative
+    // (hits, misses) values but may be replaced on reload. Convert to
+    // monotonic Prometheus counters.
+    let mut counter_state = CACHE_COUNTER_STATE
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
 
-    // Update tile cache gauges (sum across all GeoTIFF engines)
+    // Rendered image cache: global (single cache shared across collections).
+    // Always call inc_by() (even with delta 0) to ensure the LazyLock counter
+    // is registered on the first scrape, so dashboards see the series even
+    // before any rendering has happened.
+    let (r_hits, r_misses) = wms.rendered_cache.stats();
+    let (last_h, last_m) = counter_state.rendered;
+    if r_hits < last_h || r_misses < last_m {
+        // Cache was replaced (reload) — rebaseline without emitting a spike.
+        counter_state.rendered = (r_hits, r_misses);
+        RENDERED_CACHE_HITS.inc_by(0);
+        RENDERED_CACHE_MISSES.inc_by(0);
+    } else {
+        RENDERED_CACHE_HITS.inc_by(r_hits - last_h);
+        RENDERED_CACHE_MISSES.inc_by(r_misses - last_m);
+        counter_state.rendered = (r_hits, r_misses);
+    }
+    RENDERED_CACHE_BYTES.set(wms.rendered_cache.weight() as i64);
+    RENDERED_CACHE_CAPACITY_BYTES.set(wms.rendered_cache.capacity() as i64);
+    RENDERED_CACHE_ENTRIES.set(wms.rendered_cache.len() as i64);
+
+    // Tile cache: per-collection
     if let Ok(engines) = state.geotiff_engines.read() {
-        let (mut total_hits, mut total_misses) = (0u64, 0u64);
         for engine in engines.iter() {
-            let (h, m) = engine.tile_cache_stats();
-            total_hits += h;
-            total_misses += m;
+            let collection = engine.collection_id();
+            let (hits, misses) = engine.tile_cache_stats();
+            let entry = counter_state
+                .tile
+                .entry(collection.to_string())
+                .or_insert((0, 0));
+            if hits < entry.0 || misses < entry.1 {
+                *entry = (hits, misses);
+            } else {
+                let dh = hits - entry.0;
+                let dm = misses - entry.1;
+                if dh > 0 {
+                    TILE_CACHE_HITS.with_label_values(&[collection]).inc_by(dh);
+                }
+                if dm > 0 {
+                    TILE_CACHE_MISSES
+                        .with_label_values(&[collection])
+                        .inc_by(dm);
+                }
+                *entry = (hits, misses);
+            }
+
+            let (bytes_used, capacity_bytes, entries) = engine.tile_cache_utilization();
+            TILE_CACHE_BYTES
+                .with_label_values(&[collection])
+                .set(bytes_used as i64);
+            TILE_CACHE_CAPACITY_BYTES
+                .with_label_values(&[collection])
+                .set(capacity_bytes as i64);
+            TILE_CACHE_ENTRIES
+                .with_label_values(&[collection])
+                .set(entries as i64);
 
             // Update per-collection storage bytes
             let bytes = engine.storage_bytes_read();
             if bytes > 0 {
                 STORAGE_BYTES_READ
-                    .with_label_values(&[engine.collection_id(), "geotiff"])
+                    .with_label_values(&[collection, "geotiff"])
                     .reset();
                 STORAGE_BYTES_READ
-                    .with_label_values(&[engine.collection_id(), "geotiff"])
+                    .with_label_values(&[collection, "geotiff"])
                     .inc_by(bytes);
             }
         }
-        TILE_CACHE_HITS.set(total_hits as i64);
-        TILE_CACHE_MISSES.set(total_misses as i64);
     }
 
-    // Update GRIB grid cache and storage bytes
+    // GRIB grid cache: per-collection
     if let Ok(engines) = state.grib_engines.read() {
-        let (mut total_hits, mut total_misses) = (0u64, 0u64);
         for engine in engines.iter() {
-            let (h, m) = engine.grid_cache_stats();
-            total_hits += h;
-            total_misses += m;
+            let collection = engine.collection_id();
+            let (hits, misses) = engine.grid_cache_stats();
+            let entry = counter_state
+                .grid
+                .entry(collection.to_string())
+                .or_insert((0, 0));
+            if hits < entry.0 || misses < entry.1 {
+                *entry = (hits, misses);
+            } else {
+                let dh = hits - entry.0;
+                let dm = misses - entry.1;
+                if dh > 0 {
+                    GRID_CACHE_HITS.with_label_values(&[collection]).inc_by(dh);
+                }
+                if dm > 0 {
+                    GRID_CACHE_MISSES
+                        .with_label_values(&[collection])
+                        .inc_by(dm);
+                }
+                *entry = (hits, misses);
+            }
+
+            let (bytes_used, capacity_bytes, entries) = engine.grid_cache_utilization();
+            GRID_CACHE_BYTES
+                .with_label_values(&[collection])
+                .set(bytes_used as i64);
+            GRID_CACHE_CAPACITY_BYTES
+                .with_label_values(&[collection])
+                .set(capacity_bytes as i64);
+            GRID_CACHE_ENTRIES
+                .with_label_values(&[collection])
+                .set(entries as i64);
 
             let bytes = engine.storage_bytes_read();
             if bytes > 0 {
                 STORAGE_BYTES_READ
-                    .with_label_values(&[engine.collection_id(), "grib"])
+                    .with_label_values(&[collection, "grib"])
                     .reset();
                 STORAGE_BYTES_READ
-                    .with_label_values(&[engine.collection_id(), "grib"])
+                    .with_label_values(&[collection, "grib"])
                     .inc_by(bytes);
             }
         }
-        GRID_CACHE_HITS.set(total_hits as i64);
-        GRID_CACHE_MISSES.set(total_misses as i64);
     }
+
+    drop(counter_state);
 
     let encoder = TextEncoder::new();
     let metric_families = REGISTRY.gather();

--- a/grafana/dashboards/meteocore-overview.json
+++ b/grafana/dashboards/meteocore-overview.json
@@ -263,7 +263,7 @@
       },
       "targets": [
         {
-          "expr": "tile_cache_hits_total / clamp_min(tile_cache_hits_total + tile_cache_misses_total, 1)",
+          "expr": "sum(rate(tile_cache_hits_total[5m])) / clamp_min(sum(rate(tile_cache_hits_total[5m])) + sum(rate(tile_cache_misses_total[5m])), 0.0001)",
           "legendFormat": "Hit Rate"
         }
       ]
@@ -289,7 +289,7 @@
       },
       "targets": [
         {
-          "expr": "rendered_cache_hits_total / clamp_min(rendered_cache_hits_total + rendered_cache_misses_total, 1)",
+          "expr": "rate(rendered_cache_hits_total[5m]) / clamp_min(rate(rendered_cache_hits_total[5m]) + rate(rendered_cache_misses_total[5m]), 0.0001)",
           "legendFormat": "Hit Rate"
         }
       ]
@@ -315,7 +315,7 @@
       },
       "targets": [
         {
-          "expr": "grid_cache_hits_total / clamp_min(grid_cache_hits_total + grid_cache_misses_total, 1)",
+          "expr": "sum(rate(grid_cache_hits_total[5m])) / clamp_min(sum(rate(grid_cache_hits_total[5m])) + sum(rate(grid_cache_misses_total[5m])), 0.0001)",
           "legendFormat": "Hit Rate"
         }
       ]
@@ -371,11 +371,11 @@
       },
       "targets": [
         {
-          "expr": "rate(tile_cache_hits_total[5m])",
+          "expr": "sum(rate(tile_cache_hits_total[5m]))",
           "legendFormat": "Tile Hits"
         },
         {
-          "expr": "rate(tile_cache_misses_total[5m])",
+          "expr": "sum(rate(tile_cache_misses_total[5m]))",
           "legendFormat": "Tile Misses"
         },
         {
@@ -385,6 +385,14 @@
         {
           "expr": "rate(rendered_cache_misses_total[5m])",
           "legendFormat": "Rendered Misses"
+        },
+        {
+          "expr": "sum(rate(grid_cache_hits_total[5m]))",
+          "legendFormat": "Grid Hits"
+        },
+        {
+          "expr": "sum(rate(grid_cache_misses_total[5m]))",
+          "legendFormat": "Grid Misses"
         }
       ]
     },


### PR DESCRIPTION
## Summary
- Converts the six tile/rendered/grid cache hit/miss metrics from `IntGauge` to `IntCounter`(`Vec`) so PromQL `rate()` actually works. Cache hit-rate queries need `rate(hits) / (rate(hits) + rate(misses))`, which is only valid on counters.
- Adds a `collection` label to the tile and grid hit/miss counters so a thrashing collection can be distinguished from a healthy one. Rendered cache stays unlabeled because there is a single global shared cache.
- Adds nine new utilization gauges: `{tile,rendered,grid}_cache_{bytes,capacity_bytes,entries}` — so it is now possible to see whether a cache is actually full before tuning its size.
- Counters are derived from each cache's cumulative `(hits, misses)` stats via delta tracking in the metrics handler, with reset detection for collection reloads. A force `inc_by(0)` on the rendered counter guarantees the series appears on the first scrape even before any rendering happens.
- Updates the Grafana dashboard to wrap hit-rate queries in `sum(rate(...))` so the gauges still show a single aggregate number across the now per-collection series, and adds a GRIB hit/miss trace to the "Cache Hits vs Misses" timeseries panel.

Closes #28.

## Test plan
- [x] `cargo build --workspace`
- [x] `cargo test --workspace` — 127+ tests pass
- [x] `cargo fmt --all` + `cargo clippy --workspace --all-targets` clean
- [x] Started server with a minimal CSV-only config and scraped `/metrics`; confirmed `rendered_cache_hits_total{} 0`, `rendered_cache_misses_total{} 0`, `rendered_cache_{bytes,capacity_bytes,entries}` appear on first scrape before any traffic
- [ ] Manual smoke test with GeoTIFF collection loaded: issue a WMS request, re-scrape, confirm `tile_cache_hits_total{collection="radar"}` and `rendered_cache_bytes` advance

## Compatibility note
Existing dashboards that query `tile_cache_hits_total` or `grid_cache_hits_total` without label matchers will now return multiple time series (one per collection) instead of a single aggregate. Wrap in `sum(...)` if you want the old shape; the bundled Grafana dashboard has been updated accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)