### PR TITLE
feat: JSON logging and X-Request-ID correlation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,6 +53,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
 name = "api-edr"
 version = "0.1.0"
 dependencies = [
@@ -800,6 +806,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -938,9 +950,22 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -1029,6 +1054,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
 dependencies = [
  "byteorder",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
 ]
 
 [[package]]
@@ -1286,6 +1320,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1313,7 +1353,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1425,6 +1467,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
 name = "libaec-sys"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1492,6 +1540,15 @@ name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
 
 [[package]]
 name = "matchit"
@@ -1915,7 +1972,7 @@ checksum = "5a70b1b8b47e31d0498ecbc3c5470bb931399a8bfed1fd79d1717a61ce7f96e3"
 dependencies = [
  "ahash",
  "equivalent",
- "hashbrown",
+ "hashbrown 0.16.1",
  "parking_lot",
 ]
 
@@ -1988,6 +2045,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
@@ -2327,6 +2390,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2427,6 +2496,7 @@ dependencies = [
  "tower-http",
  "tracing",
  "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]
@@ -2874,17 +2944,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -2910,6 +2997,12 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "untrusted"
@@ -2941,6 +3034,7 @@ version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
 dependencies = [
+ "getrandom 0.4.2",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -3009,6 +3103,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3068,6 +3171,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
 name = "wasm-streams"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3078,6 +3203,18 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags 2.11.0",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
 ]
 
 [[package]]
@@ -3371,6 +3508,88 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags 2.11.0",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "writeable"

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -25,4 +25,5 @@ tokio = { version = "1", features = ["full"] }
 tower = "0.5"
 tower-http = { version = "0.6", features = ["cors", "normalize-path"] }
 tracing = "0.1"
-tracing-subscriber = "0.3"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
+uuid = { version = "1", features = ["v4"] }

--- a/crates/server/src/admin.rs
+++ b/crates/server/src/admin.rs
@@ -1509,11 +1509,67 @@ fn classify_route<'a>(
     (api, collection_id, query_type)
 }
 
+/// Request ID attached to an incoming request via extensions so that
+/// downstream middleware and handlers can correlate logs with the wire
+/// `X-Request-ID` header.
+#[derive(Clone, Debug)]
+pub struct RequestId(pub String);
+
+/// Maximum length of an incoming `X-Request-ID` header we will trust.
+/// Anything longer is replaced with a fresh UUID to bound log-line size.
+const MAX_REQUEST_ID_LEN: usize = 128;
+
+/// Returns true if the string is a plausible request ID — only printable
+/// ASCII, no control characters, bounded length. This keeps malicious
+/// clients from injecting newlines or other log-forgery payloads through
+/// the `X-Request-ID` header.
+fn is_safe_request_id(s: &str) -> bool {
+    !s.is_empty()
+        && s.len() <= MAX_REQUEST_ID_LEN
+        && s.chars()
+            .all(|c| c.is_ascii_graphic() || c == ' ' || c == '-' || c == '_')
+}
+
+/// Middleware that assigns a correlation ID to every request.
+///
+/// - Reads `X-Request-ID` from the incoming headers if present and safe;
+///   otherwise generates a fresh UUIDv4.
+/// - Stores the ID in request extensions as [`RequestId`] so downstream
+///   middleware and handlers can attach it to logs.
+/// - Wraps the downstream future in a tracing span carrying the ID, so
+///   any log events emitted from inside the request inherit it.
+/// - Echoes the final ID back to the client as `X-Request-ID`.
+pub async fn correlation_id_middleware(
+    mut req: axum::extract::Request,
+    next: axum::middleware::Next,
+) -> axum::response::Response {
+    use tracing::Instrument;
+
+    let request_id = req
+        .headers()
+        .get("x-request-id")
+        .and_then(|v| v.to_str().ok())
+        .filter(|s| is_safe_request_id(s))
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
+
+    req.extensions_mut().insert(RequestId(request_id.clone()));
+
+    let span = tracing::info_span!("http_request", request_id = %request_id);
+    let mut response = next.run(req).instrument(span).await;
+
+    if let Ok(header_value) = request_id.parse() {
+        response.headers_mut().insert("x-request-id", header_value);
+    }
+
+    response
+}
+
 /// Middleware that emits one structured INFO log line per HTTP request.
 ///
-/// Fields: method, path, route (template), api, collection, query_type,
-/// query (raw query string), status, duration_ms, result_size (bytes from
-/// Content-Length header if present).
+/// Fields: request_id, method, path, route (template), api, collection,
+/// query_type, query (raw query string), status, duration_ms, result_size
+/// (bytes from Content-Length header if present).
 pub async fn request_logging_middleware(
     matched_path: Option<MatchedPath>,
     req: axum::extract::Request,
@@ -1524,6 +1580,11 @@ pub async fn request_logging_middleware(
     let uri_path = req.uri().path().to_string();
     let query = req.uri().query().map(|q| q.to_string());
     let matched = matched_path.as_ref().map(|p| p.as_str().to_string());
+    let request_id = req
+        .extensions()
+        .get::<RequestId>()
+        .map(|id| id.0.clone())
+        .unwrap_or_default();
 
     let response = next.run(req).await;
 
@@ -1538,6 +1599,7 @@ pub async fn request_logging_middleware(
     let (api, collection_id, query_type) = classify_route(&uri_path, matched.as_deref());
 
     tracing::info!(
+        request_id = %request_id,
         method = %method,
         path = %uri_path,
         route = matched.as_deref().unwrap_or(""),
@@ -1556,7 +1618,38 @@ pub async fn request_logging_middleware(
 
 #[cfg(test)]
 mod tests {
-    use super::classify_route;
+    use super::{classify_route, is_safe_request_id};
+
+    #[test]
+    fn accepts_typical_uuid() {
+        assert!(is_safe_request_id("550e8400-e29b-41d4-a716-446655440000"));
+    }
+
+    #[test]
+    fn accepts_alphanumeric_with_underscores() {
+        assert!(is_safe_request_id("trace_12345"));
+        assert!(is_safe_request_id("req-abc-xyz"));
+    }
+
+    #[test]
+    fn rejects_empty() {
+        assert!(!is_safe_request_id(""));
+    }
+
+    #[test]
+    fn rejects_newlines_and_control_chars() {
+        // Prevents log forgery via CRLF injection.
+        assert!(!is_safe_request_id("abc\ndef"));
+        assert!(!is_safe_request_id("abc\rdef"));
+        assert!(!is_safe_request_id("abc\tdef"));
+        assert!(!is_safe_request_id("abc\x00def"));
+    }
+
+    #[test]
+    fn rejects_oversized_ids() {
+        let huge = "a".repeat(256);
+        assert!(!is_safe_request_id(&huge));
+    }
 
     #[test]
     fn classifies_edr_position_query() {

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -14,12 +14,37 @@ use tower::Layer;
 use tower_http::cors::CorsLayer;
 use tower_http::normalize_path::NormalizePathLayer;
 use tracing::info;
+use tracing_subscriber::EnvFilter;
 
 use admin::{AdminState, ServerState};
 
+/// Initialize tracing based on the `LOG_FORMAT` env var.
+///
+/// * `LOG_FORMAT=json` — newline-delimited JSON, one object per event.
+///   Use this in production so Alloy / Promtail / Loki can parse fields
+///   without regex stages.
+/// * anything else (or unset) — human-readable ANSI output for dev.
+///
+/// Filter is controlled by `RUST_LOG` (defaults to `info`).
+fn init_tracing() {
+    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
+    let format = std::env::var("LOG_FORMAT").unwrap_or_default();
+    if format.eq_ignore_ascii_case("json") {
+        tracing_subscriber::fmt()
+            .with_env_filter(filter)
+            .json()
+            .flatten_event(true)
+            .with_current_span(true)
+            .with_span_list(false)
+            .init();
+    } else {
+        tracing_subscriber::fmt().with_env_filter(filter).init();
+    }
+}
+
 #[tokio::main]
 async fn main() {
-    tracing_subscriber::fmt::init();
+    init_tracing();
 
     let config_path = std::env::var("CONFIG_PATH").unwrap_or_else(|_| "config.toml".to_string());
     let config = match ds_core::config::ServerConfig::from_file(&config_path) {
@@ -155,6 +180,7 @@ async fn main() {
         .merge(admin_routes)
         .layer(middleware::from_fn(admin::metrics_middleware))
         .layer(middleware::from_fn(admin::request_logging_middleware))
+        .layer(middleware::from_fn(admin::correlation_id_middleware))
         .layer(CorsLayer::permissive());
 
     // Normalize trailing slashes (e.g., /wms/ → /wms) before routing


### PR DESCRIPTION
## Summary
- Adds `LOG_FORMAT` env var. Default (`pretty` / unset) keeps the current human-readable ANSI logs for dev. `LOG_FORMAT=json` switches to newline-delimited JSON with flattened fields, ready for direct Loki / Alloy / Promtail ingestion without regex parse stages.
- Adds a `correlation_id_middleware` that reads `X-Request-ID` from incoming headers (validating it is printable, short ASCII to prevent log forgery via CRLF injection), falls back to a fresh UUIDv4, stores the ID in request extensions as `RequestId`, wraps the downstream future in a tracing span carrying the ID so inner log events inherit it, and echoes the final ID in the response header.
- Updates `request_logging_middleware` from #47 to read the `RequestId` extension and include `request_id` as a top-level field in its structured log line.
- Uses `EnvFilter` so log level is now configurable via `RUST_LOG`.

Closes #15.

## Example output

### `LOG_FORMAT=json`
```json
{"timestamp":"2026-04-08T15:55:52.404889Z","level":"INFO","message":"request","request_id":"my-trace-12345","method":"GET","path":"/edr/collections/weather","route":"/edr/collections/{id}","api":"edr","collection":"weather","query_type":"collections","query":"","status":200,"duration_ms":"5.958","target":"server::admin","span":{"request_id":"my-trace-12345","name":"http_request"}}
```

### Response header
```
< HTTP/1.1 200 OK
< x-request-id: my-trace-12345
```

When no `X-Request-ID` is supplied, the server generates a UUIDv4 and echoes that instead.

## Test plan
- [x] `cargo build -p server`
- [x] `cargo test -p server` — 12 tests pass, including 5 new tests for `is_safe_request_id` covering UUID, alphanumeric+underscore, empty, CRLF/control-char rejection, and length bound
- [x] `cargo fmt --all` + `cargo clippy --workspace --all-targets` clean
- [x] Manual smoke test: pretty mode with `/health` — confirmed `X-Request-ID` generated and echoed, log line shows `http_request{request_id=...}` span + flattened fields
- [x] Manual smoke test: `LOG_FORMAT=json` with client-supplied `X-Request-ID: my-trace-12345` — confirmed ID preserved round-trip and appears as both top-level `request_id` and under `span.request_id`
- [ ] Manual smoke test: malicious `X-Request-ID: foo\r\nBAD: injected` → expect the header to be rejected and a fresh UUID generated

## Followups (not in this PR)
Once this lands the Loki/Grafana integration I described in chat becomes a drop-in exercise: run Alloy next to the server, point it at stdout, and apply the label strategy in the docs (low-cardinality labels = `api`, `query_type`, `status_class`; keep `collection`, `path`, `query` as body fields only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)