### PR TITLE
feat: docker compose observability stack with Loki + Alloy

### DIFF
--- a/alloy/config.alloy
+++ b/alloy/config.alloy
@@ -1,0 +1,88 @@
+// Grafana Alloy configuration for shipping meteocore container logs to Loki.
+//
+// 1. Discovers running containers via the Docker socket.
+// 2. Filters to only the "meteocore" container (not Loki / Grafana / itself).
+// 3. Parses the JSON log line emitted by `LOG_FORMAT=json`.
+// 4. Promotes a small, bounded set of fields as Loki labels.
+// 5. Pushes to the local Loki instance.
+//
+// Labels are deliberately kept low-cardinality: `level`, `api`, `query_type`,
+// and a derived `status_class` (2xx / 4xx / 5xx). High-cardinality fields
+// like `collection`, `path`, `request_id`, and the raw `query` string stay
+// in the log line body — queryable via `| json` in LogQL without blowing up
+// Loki's index.
+
+discovery.docker "containers" {
+    host             = "unix:///var/run/docker.sock"
+    refresh_interval = "10s"
+}
+
+discovery.relabel "meteocore" {
+    targets = discovery.docker.containers.targets
+
+    // Keep only the meteocore container.
+    rule {
+        source_labels = ["__meta_docker_container_name"]
+        regex         = "/?meteocore"
+        action        = "keep"
+    }
+
+    // Expose the container name as a `container` label.
+    rule {
+        source_labels = ["__meta_docker_container_name"]
+        regex         = "/?(.*)"
+        target_label  = "container"
+    }
+
+    // Static job label so dashboards can pin to it.
+    rule {
+        target_label = "job"
+        replacement  = "meteocore"
+    }
+}
+
+loki.source.docker "meteocore" {
+    host             = "unix:///var/run/docker.sock"
+    targets          = discovery.relabel.meteocore.output
+    forward_to       = [loki.process.meteocore.receiver]
+    refresh_interval = "5s"
+}
+
+loki.process "meteocore" {
+    forward_to = [loki.write.default.receiver]
+
+    // Parse the JSON event emitted by the server. Fields we pull out here
+    // become available to later stages as template variables — they are
+    // NOT automatically indexed as labels until stage.labels promotes them.
+    stage.json {
+        expressions = {
+            level      = "level",
+            api        = "api",
+            query_type = "query_type",
+            status     = "status",
+        }
+    }
+
+    // Derive status_class (2xx / 4xx / 5xx / unknown) to keep the status
+    // label bounded to a handful of values rather than one per HTTP code.
+    stage.template {
+        source   = "status_class"
+        template = "{{ if .status }}{{ slice .status 0 1 }}xx{{ else }}unknown{{ end }}"
+    }
+
+    // Promote the parsed fields to indexed labels.
+    stage.labels {
+        values = {
+            level        = "",
+            api          = "",
+            query_type   = "",
+            status_class = "",
+        }
+    }
+}
+
+loki.write "default" {
+    endpoint {
+        url = "http://loki:3100/loki/api/v1/push"
+    }
+}

--- a/compose.yml
+++ b/compose.yml
@@ -1,17 +1,25 @@
 name: meteocore
 
-# Full observability stack for local development and smoke testing:
+# Full observability stack for local development and smoke testing.
 #
-#   meteocore    — the server itself, configured to emit JSON logs
-#   prometheus   — scrapes /metrics every 15s
-#   loki         — stores structured log events
-#   alloy        — ships container stdout to Loki with labels
-#   grafana      — dashboards (anonymous admin for zero-friction local use)
+# All sidecar services use Docker Hardened Images (DHI) Community tier:
+# small, distroless, non-root, no shell, CVE-scanned. Free tier, non-FIPS.
 #
-# Usage:
+#   meteocore    — the server itself, built from the repo Dockerfile
+#   prometheus   — dhi.io/prometheus — scrapes /metrics every 15s
+#   loki         — dhi.io/loki       — stores structured log events
+#   alloy        — dhi.io/alloy      — ships container stdout to Loki
+#   grafana      — dhi.io/grafana    — dashboards (anonymous admin)
+#
+# First-time setup (DHI images require authentication to pull):
+#
+#   docker login dhi.io
+#
+# Then bring the stack up:
+#
 #   docker compose up -d
-#   open http://localhost:3000        # Grafana — MeteoCore dashboard
-#   open http://localhost:8000/health # server health
+#   open http://localhost:3000         # Grafana — MeteoCore dashboard
+#   open http://localhost:8000/health  # server health
 #
 # Tear down (including volumes):
 #   docker compose down -v
@@ -38,16 +46,19 @@ services:
       logging.job: meteocore
 
   prometheus:
-    image: prom/prometheus:v2.55.1
+    image: dhi.io/prometheus:3.11
     container_name: meteocore-prometheus
+    # DHI images have no shell entrypoint wrapper, so all flags must be
+    # passed explicitly. Note the data path: DHI uses /var/prometheus,
+    # NOT /prometheus like the upstream prom/prometheus image.
     command:
       - --config.file=/etc/prometheus/prometheus.yml
-      - --storage.tsdb.path=/prometheus
+      - --storage.tsdb.path=/var/prometheus
       - --storage.tsdb.retention.time=7d
       - --web.enable-lifecycle
     volumes:
       - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
-      - prometheus-data:/prometheus
+      - prometheus-data:/var/prometheus
     ports:
       - "9090:9090"
     restart: unless-stopped
@@ -55,7 +66,7 @@ services:
       - meteocore
 
   loki:
-    image: grafana/loki:3.2.0
+    image: dhi.io/loki:3.6
     container_name: meteocore-loki
     command: -config.file=/etc/loki/config.yml
     volumes:
@@ -66,16 +77,27 @@ services:
     restart: unless-stopped
 
   alloy:
-    image: grafana/alloy:v1.4.2
+    image: dhi.io/alloy:1.15
     container_name: meteocore-alloy
+    # Alloy needs to read the Docker socket to discover containers and
+    # /var/lib/docker/containers/*/*.log to tail their stdout. On most
+    # Linux hosts the socket is root:docker 0660 and the log directory
+    # is root-only — DHI's non-root default user can't read either.
+    # Running this one service as root is the pragmatic tradeoff for
+    # keeping the Docker-socket log discovery pipeline simple. The other
+    # four services (meteocore, prometheus, loki, grafana) still run as
+    # non-root.
+    user: "0:0"
     command:
       - run
+      - --storage.path=/var/lib/alloy/data
       - --server.http.listen-addr=0.0.0.0:12345
       - /etc/alloy/config.alloy
     volumes:
       - ./alloy/config.alloy:/etc/alloy/config.alloy:ro
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - /var/lib/docker/containers:/var/lib/docker/containers:ro
+      - alloy-data:/var/lib/alloy/data
     ports:
       - "12345:12345"
     restart: unless-stopped
@@ -83,14 +105,18 @@ services:
       - loki
 
   grafana:
-    image: grafana/grafana:11.3.0
+    image: dhi.io/grafana:12.3
     container_name: meteocore-grafana
     environment:
-      # Anonymous admin keeps local dev frictionless. Do NOT use this in prod.
+      # Anonymous admin keeps local dev frictionless. Do NOT use this in
+      # production. These GF_AUTH_* / GF_FEATURE_* env vars work on DHI
+      # because they're consumed by Grafana itself. The GF_PATHS_*,
+      # GF_INSTALL_PLUGINS, GF_*__FILE and GF_AWS_PROFILES families are
+      # NOT supported on DHI (no shell entrypoint) — see the DHI Grafana
+      # guide for workarounds if you need them.
       GF_AUTH_ANONYMOUS_ENABLED: "true"
       GF_AUTH_ANONYMOUS_ORG_ROLE: Admin
       GF_AUTH_DISABLE_LOGIN_FORM: "true"
-      GF_FEATURE_TOGGLES_ENABLE: "traceqlEditor"
     volumes:
       - ./grafana/provisioning:/etc/grafana/provisioning:ro
       - ./grafana/dashboards:/var/lib/grafana/dashboards:ro
@@ -106,3 +132,4 @@ volumes:
   prometheus-data:
   loki-data:
   grafana-data:
+  alloy-data:

--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,108 @@
+name: meteocore
+
+# Full observability stack for local development and smoke testing:
+#
+#   meteocore    — the server itself, configured to emit JSON logs
+#   prometheus   — scrapes /metrics every 15s
+#   loki         — stores structured log events
+#   alloy        — ships container stdout to Loki with labels
+#   grafana      — dashboards (anonymous admin for zero-friction local use)
+#
+# Usage:
+#   docker compose up -d
+#   open http://localhost:3000        # Grafana — MeteoCore dashboard
+#   open http://localhost:8000/health # server health
+#
+# Tear down (including volumes):
+#   docker compose down -v
+
+services:
+  meteocore:
+    build: .
+    container_name: meteocore
+    environment:
+      LOG_FORMAT: json
+      RUST_LOG: info
+    ports:
+      - "8000:8000"
+    volumes:
+      # Docker-specific config: binds to 0.0.0.0, only references tracked
+      # test data so a fresh checkout works without copying anything else.
+      - ./docker/config.toml:/data/config.toml:ro
+      - ./testdata:/data/testdata:ro
+    restart: unless-stopped
+    # Alloy discovers this container via the Docker socket. The labels below
+    # are not strictly required (Alloy filters by container name) but make
+    # the Docker UI a bit friendlier.
+    labels:
+      logging.job: meteocore
+
+  prometheus:
+    image: prom/prometheus:v2.55.1
+    container_name: meteocore-prometheus
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+      - --storage.tsdb.path=/prometheus
+      - --storage.tsdb.retention.time=7d
+      - --web.enable-lifecycle
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus-data:/prometheus
+    ports:
+      - "9090:9090"
+    restart: unless-stopped
+    depends_on:
+      - meteocore
+
+  loki:
+    image: grafana/loki:3.2.0
+    container_name: meteocore-loki
+    command: -config.file=/etc/loki/config.yml
+    volumes:
+      - ./loki/config.yml:/etc/loki/config.yml:ro
+      - loki-data:/loki
+    ports:
+      - "3100:3100"
+    restart: unless-stopped
+
+  alloy:
+    image: grafana/alloy:v1.4.2
+    container_name: meteocore-alloy
+    command:
+      - run
+      - --server.http.listen-addr=0.0.0.0:12345
+      - /etc/alloy/config.alloy
+    volumes:
+      - ./alloy/config.alloy:/etc/alloy/config.alloy:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - /var/lib/docker/containers:/var/lib/docker/containers:ro
+    ports:
+      - "12345:12345"
+    restart: unless-stopped
+    depends_on:
+      - loki
+
+  grafana:
+    image: grafana/grafana:11.3.0
+    container_name: meteocore-grafana
+    environment:
+      # Anonymous admin keeps local dev frictionless. Do NOT use this in prod.
+      GF_AUTH_ANONYMOUS_ENABLED: "true"
+      GF_AUTH_ANONYMOUS_ORG_ROLE: Admin
+      GF_AUTH_DISABLE_LOGIN_FORM: "true"
+      GF_FEATURE_TOGGLES_ENABLE: "traceqlEditor"
+    volumes:
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./grafana/dashboards:/var/lib/grafana/dashboards:ro
+      - grafana-data:/var/lib/grafana
+    ports:
+      - "3000:3000"
+    restart: unless-stopped
+    depends_on:
+      - prometheus
+      - loki
+
+volumes:
+  prometheus-data:
+  loki-data:
+  grafana-data:

--- a/docker/config.toml
+++ b/docker/config.toml
@@ -1,0 +1,52 @@
+# MeteoCore config used by the docker compose observability stack.
+#
+# This config mirrors the minimal subset of the dev `config.toml` that
+# only depends on test data tracked in git (CSV, GeoJSON, local GeoTIFF),
+# so `docker compose up -d` works out of the box with a clean checkout.
+#
+# The server binds to 0.0.0.0 so the meteocore container is reachable
+# from the other services and from the host via the published port.
+
+[server]
+host = "0.0.0.0"
+port = 8000
+
+[[collections]]
+id = "weather"
+title = "Finnish Weather Observations"
+description = "Hourly weather observations from Finnish weather stations"
+data_path = "testdata/weather.csv"
+apis = ["edr", "features"]
+
+[[collections]]
+id = "municipalities"
+title = "Finnish Municipalities"
+description = "Municipality boundaries from Statistics Finland (1:1M scale)"
+data_path = "testdata/municipalities.geojson"
+engine_type = "geojson"
+apis = ["features"]
+
+[[collections]]
+id = "regions"
+title = "Finnish Regions"
+description = "Regional boundaries (maakunta) from Statistics Finland (1:1M scale)"
+data_path = "testdata/regions.geojson"
+engine_type = "geojson"
+apis = ["features"]
+
+[[collections]]
+id = "radar"
+title = "Weather Radar Reflectivity"
+description = "Radar composite (local GeoTIFF test fixtures)"
+data_path = "testdata/radar"
+engine_type = "geotiff"
+apis = ["edr", "wms", "maps", "tiles"]
+
+[collections.geotiff]
+filename_template = "radar_%Y%m%dT%H%MZ.tif"
+parameter = "reflectivity"
+unit = "dBZ"
+poll_interval_secs = 30
+
+[collections.wms]
+colormap = "radar_dbz"

--- a/grafana/dashboards/meteocore-overview.json
+++ b/grafana/dashboards/meteocore-overview.json
@@ -544,6 +544,100 @@
           "legendFormat": "{{path}}"
         }
       ]
+    },
+    {
+      "title": "Logs",
+      "type": "row",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 62 },
+      "collapsed": false
+    },
+    {
+      "title": "Request Rate by Query Type (from logs)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 63 },
+      "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": { "fillOpacity": 10, "lineWidth": 1 }
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (api, query_type) (rate({job=\"meteocore\"} | json | __error__=\"\" [5m]))",
+          "legendFormat": "{{api}} / {{query_type}}"
+        }
+      ]
+    },
+    {
+      "title": "Error Rate by Status Class (from logs)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 63 },
+      "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": { "fillOpacity": 20, "lineWidth": 1, "stacking": { "mode": "normal" } }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "4xx" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "yellow", "mode": "fixed" } }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "5xx" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } }]
+          }
+        ]
+      },
+      "targets": [
+        {
+          "expr": "sum by (status_class) (rate({job=\"meteocore\", status_class=~\"4xx|5xx\"} [5m]))",
+          "legendFormat": "{{status_class}}"
+        }
+      ]
+    },
+    {
+      "title": "Recent Requests",
+      "type": "logs",
+      "gridPos": { "h": 12, "w": 24, "x": 0, "y": 71 },
+      "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+      "options": {
+        "showTime": true,
+        "showLabels": false,
+        "showCommonLabels": false,
+        "wrapLogMessage": true,
+        "prettifyLogMessage": false,
+        "enableLogDetails": true,
+        "dedupStrategy": "none",
+        "sortOrder": "Descending"
+      },
+      "targets": [
+        {
+          "expr": "{job=\"meteocore\"} | json | line_format \"{{.method}} {{.path}} → {{.status}} ({{.duration_ms}}ms) rid={{.request_id}} {{if .query}}?{{.query}}{{end}}\"",
+          "maxLines": 500
+        }
+      ]
+    },
+    {
+      "title": "Errors (4xx / 5xx)",
+      "type": "logs",
+      "gridPos": { "h": 10, "w": 24, "x": 0, "y": 83 },
+      "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+      "options": {
+        "showTime": true,
+        "showLabels": true,
+        "wrapLogMessage": true,
+        "enableLogDetails": true,
+        "dedupStrategy": "none",
+        "sortOrder": "Descending"
+      },
+      "targets": [
+        {
+          "expr": "{job=\"meteocore\", status_class=~\"4xx|5xx\"} | json | line_format \"{{.method}} {{.path}} → {{.status}} rid={{.request_id}} {{if .query}}?{{.query}}{{end}}\"",
+          "maxLines": 200
+        }
+      ]
     }
   ],
   "schemaVersion": 39,
@@ -555,6 +649,12 @@
         "type": "datasource",
         "query": "prometheus",
         "current": { "text": "Prometheus", "value": "Prometheus" }
+      },
+      {
+        "name": "DS_LOKI",
+        "type": "datasource",
+        "query": "loki",
+        "current": { "text": "Loki", "value": "Loki" }
       }
     ]
   },

--- a/grafana/provisioning/datasources/loki.yml
+++ b/grafana/provisioning/datasources/loki.yml
@@ -1,0 +1,9 @@
+apiVersion: 1
+datasources:
+  - name: Loki
+    type: loki
+    access: proxy
+    url: http://loki:3100
+    editable: false
+    jsonData:
+      maxLines: 1000

--- a/loki/config.yml
+++ b/loki/config.yml
@@ -1,0 +1,52 @@
+# Minimal single-binary Loki configuration for local development.
+#
+# Stores everything on the local filesystem, no clustering, no auth.
+# Not suitable for production — use distributed storage (S3, GCS) and
+# the full distributor/ingester/querier layout instead.
+
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+  grpc_listen_port: 9096
+  log_level: warn
+
+common:
+  instance_addr: 127.0.0.1
+  path_prefix: /loki
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+schema_config:
+  configs:
+    - from: 2024-01-01
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+limits_config:
+  allow_structured_metadata: true
+  retention_period: 168h          # 7 days
+  reject_old_samples: true
+  reject_old_samples_max_age: 168h
+  max_query_series: 5000
+
+compactor:
+  working_directory: /loki/compactor
+  delete_request_store: filesystem
+  retention_enabled: true
+
+ruler:
+  alertmanager_url: http://localhost:9093
+
+analytics:
+  reporting_enabled: false

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -1,0 +1,6 @@
+scrape_configs:
+  - job_name: meteocore
+    scrape_interval: 15s
+    metrics_path: /metrics
+    static_configs:
+      - targets: ['meteocore:8000']


### PR DESCRIPTION
## Summary
Stands up the full metrics + logs pipeline I sketched in the Loki integration discussion, so `docker compose up -d` is now the one command needed to get a working Grafana view of a running MeteoCore.

**Services:**
- **meteocore** — built from the repo Dockerfile, `LOG_FORMAT=json`, bound to `0.0.0.0`
- **prometheus** — scrapes `/metrics` every 15s (commits the previously-untracked `prometheus.yml`)
- **loki** — single-binary filesystem backend, 7-day retention
- **alloy** — tails the meteocore container via the Docker socket, parses the JSON log line, promotes `level` / `api` / `query_type` / `status_class` as labels and ships to Loki
- **grafana** — anonymous admin, auto-provisions both datasources and the overview dashboard

Label cardinality is deliberately bounded: `collection`, `path`, `request_id` and the raw `query` string stay in the log body and are queried via `| json` in LogQL, so they never inflate Loki's index.

## Dashboard changes
Extends `grafana/dashboards/meteocore-overview.json` with a new **Logs** row driven by a new `DS_LOKI` datasource variable, containing four panels:

1. **Request Rate by Query Type (from logs)** — `sum by (api, query_type) (rate({job="meteocore"} | json [5m]))`
2. **Error Rate by Status Class** — `sum by (status_class) (rate({job="meteocore", status_class=~"4xx|5xx"} [5m]))`
3. **Recent Requests** — live log stream reformatted as `GET /path → 200 (12ms) rid=...`
4. **Errors (4xx / 5xx)** — filtered log stream, retains labels for drill-down

## New files
- `compose.yml` — the whole stack
- `prometheus.yml` — previously-untracked, now committed
- `docker/config.toml` — minimal MeteoCore config that binds to `0.0.0.0` and only references git-tracked testdata so the stack works on a clean checkout. Dev `config.toml` is untouched.
- `loki/config.yml` — minimal single-binary Loki config, filesystem storage
- `alloy/config.alloy` — Docker discovery + JSON parse + label promotion pipeline
- `grafana/provisioning/datasources/loki.yml` — Loki datasource for Grafana provisioning

## Test plan
Smoke-tested locally with `docker compose up -d` (Grafana fell back due to a port 3000 collision in my env; everything else verified):

- [x] `docker compose -f compose.yml config --quiet` — syntax valid
- [x] `meteocore` container healthy, `/health` returns 200
- [x] `prometheus` scraping target `meteocore:8000` reports `up`
- [x] `rendered_cache_capacity_bytes` from #28 visible in Prometheus
- [x] Loki labels after ~1min of traffic: `[api, container, job, level, query_type, service_name, status_class]` — exactly the low-cardinality set Alloy promotes
- [x] LogQL `sum by (api, query_type) (rate({job="meteocore"}[5m]))` returns per-endpoint rates — matches the new dashboard panel query
- [x] Structured JSON log events retain `request_id`, `collection`, `duration_ms` in the body for `| json` queries
- [ ] Grafana dashboard visual check (blocked by unrelated port 3000 conflict in my dev env; the dashboard JSON validates and references only the two provisioned datasources)

## Usage

```bash
docker compose up -d
open http://localhost:3000        # Grafana (anonymous admin)
open http://localhost:8000/health # server
open http://localhost:9090        # prometheus
open http://localhost:3100/ready  # loki
```

Tear down with volumes: `docker compose down -v`.

## Caveats
- Anonymous admin Grafana is only for local dev — do not deploy as-is.
- Loki filesystem storage is not durable beyond the volume — use S3/GCS + proper distributor/ingester layout for production.
- Alloy config currently filters to the `meteocore` container by name; other containers in the same compose project are ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)