### PR TITLE
fix: populate http_response_bytes_total from body size hint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2488,6 +2488,7 @@ dependencies = [
  "engine-geotiff",
  "engine-grib",
  "engine-querydata",
+ "http-body",
  "prometheus",
  "serde",
  "serde_json",

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -18,6 +18,7 @@ api-tiles = { path = "../api-tiles" }
 ds-render = { path = "../render" }
 arc-swap = "1"
 axum = "0.8"
+http-body = "1"
 prometheus = "0.13"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/server/src/admin.rs
+++ b/crates/server/src/admin.rs
@@ -1652,13 +1652,20 @@ pub async fn metrics_middleware(
     let duration = start.elapsed().as_secs_f64();
     let status = response.status().as_u16().to_string();
 
-    // Track response body size from content-length header if present
-    if let Some(content_length) = response.headers().get(header::CONTENT_LENGTH) {
-        if let Ok(len) = content_length.to_str().unwrap_or("0").parse::<u64>() {
-            HTTP_RESPONSE_BYTES
-                .with_label_values(&[&method, &path])
-                .inc_by(len);
-        }
+    // Track response body size. Axum handlers like `Json`, `Bytes`, and
+    // image responses return buffered bodies whose exact length is known
+    // at response-construction time and exposed via `Body::size_hint()`.
+    // The `Content-Length` HTTP header is NOT set on the response object
+    // at this point — hyper adds it later when serializing to the wire —
+    // so reading it here always returns `None`. `size_hint().exact()`
+    // works directly on the in-memory body and covers every buffered
+    // response (99% of the traffic this server serves). Streaming bodies
+    // return `None` from size_hint and are silently skipped, which is
+    // acceptable — no handler in this codebase streams.
+    if let Some(len) = http_body::Body::size_hint(response.body()).exact() {
+        HTTP_RESPONSE_BYTES
+            .with_label_values(&[&method, &path])
+            .inc_by(len);
     }
 
     HTTP_REQUESTS_TOTAL


### PR DESCRIPTION
## Summary
The **Response Throughput** and **Response Bytes Transferred** panels in the Grafana dashboard have always been empty because `metrics_middleware` read `Content-Length` from `response.headers()` at a point when that header is not yet set. Axum does not stamp `Content-Length` onto the response object — hyper only adds it later when serializing the body to the wire — so `response.headers().get(CONTENT_LENGTH)` always returned `None` and the counter was never incremented. Its `LazyLock` was never even initialized, so `http_response_bytes_total` did not appear in `/metrics` at all.

The fix reads the length from the in-memory body via `Body::size_hint().exact()`. For the `Json`, `Bytes`, `String`, `Html`, and `Vec<u8>` image responses this server returns, `size_hint()` is always exact and matches what hyper later writes as `Content-Length` on the wire. Streaming bodies return `None` and are silently skipped, which is fine — no handler in this codebase currently streams.

## Root-cause evidence
Before the fix, I added a `tracing::warn!` dumping what the middleware actually sees:
```
WARN server::admin: metrics_middleware: path=/edr/collections cl=None headers={"content-type": "application/json"}
```
Meanwhile `curl -D -` against the same endpoint shows `content-length: 2709` on the wire — confirming the header is added after the middleware runs.

## Smoke test
After the fix, on a running server:
```
http_response_bytes_total{method="GET",path="/edr/collections"}    8127
http_response_bytes_total{method="GET",path="/maps/collections"}   3702
http_response_bytes_total{method="GET",path="/tiles/collections"}  3138
http_response_bytes_total{method="GET",path="/wms"}                6948
```
`8127 / 3 ≈ 2709` — matches the per-request Content-Length exactly.

I also verified the dashboard regex filters against actual matched route templates:
```
'/wms.*'   → /wms
'/edr.*'   → /edr/collections, /edr/collections/{id}
'/maps.*'  → /maps/collections, /maps/collections/{id}/map
'/tiles.*' → /tiles/collections, /tiles/collections/{id}/tiles/{tileMatrixSetId}/{tileMatrix}/{tileRow}/{tileCol}
```
All four Response Throughput series and the 24h Response Bytes Transferred stat will now draw data.

## Test plan
- [x] `cargo build -p server`
- [x] `cargo test -p server` — 12/12 pass
- [x] `cargo fmt --all` + `cargo clippy --workspace --all-targets` clean
- [x] Manual: scrape `/metrics` after hitting multiple APIs, confirm the counter populates with realistic values per route template
- [ ] Open the Grafana dashboard after redeploy and confirm the two panels start drawing

🤖 Generated with [Claude Code](https://claude.com/claude-code)