### PR TITLE
feat(api-edr): MULTIPOINT support for position query

### DIFF
--- a/crates/api-edr/src/handlers.rs
+++ b/crates/api-edr/src/handlers.rs
@@ -12,7 +12,11 @@ use ds_core::config::CollectionConfig;
 use ds_core::datetime::parse_datetime_interval;
 use ds_core::engine::Engine;
 
-use crate::params::{AreaQueryParams, LocationQueryParams, PositionQueryParams};
+use ds_core::model::AreaQueryResult;
+
+use crate::params::{
+    split_position_coords, AreaQueryParams, LocationQueryParams, PositionQueryParams,
+};
 use crate::response::{
     area_query_result_to_json, locations_to_geojson, query_result_to_coverage_json,
     LocationsContext,
@@ -283,7 +287,7 @@ pub async fn api_definition(State(state): State<AppState>) -> impl IntoResponse 
                     "in": "query",
                     "required": true,
                     "schema": {"type": "string"},
-                    "description": "WKT POINT geometry, e.g. POINT(24.94 60.17)"
+                    "description": "WKT POINT or MULTIPOINT geometry. Examples: POINT(24.94 60.17), MULTIPOINT((24.94 60.17),(23.76 61.5))"
                 },
                 "coords-polygon": {
                     "name": "coords",
@@ -480,31 +484,61 @@ pub async fn position_query(
         .as_deref()
         .map(|s| s.split(',').map(|p| p.trim().to_string()).collect());
 
-    let result = engine
-        .query_position(&params.coords, datetime, param_names.as_deref())
-        .map_err(|e| match &e {
-            ds_core::error::DataServerError::InvalidParameter(_)
-            | ds_core::error::DataServerError::InvalidBbox(_)
-            | ds_core::error::DataServerError::InvalidDatetime(_) => (
-                StatusCode::BAD_REQUEST,
-                Json(json!({ "code": "BadRequest", "description": e.to_string() })),
-            ),
-            ds_core::error::DataServerError::LocationNotFound(_)
-            | ds_core::error::DataServerError::CollectionNotFound(_)
-            | ds_core::error::DataServerError::FeatureNotFound(_) => (
-                StatusCode::NOT_FOUND,
-                Json(json!({ "code": "NotFound", "description": e.to_string() })),
-            ),
-            _ => {
-                tracing::error!("Position query error: {e}");
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(json!({ "code": "ServerError", "description": "Internal server error" })),
-                )
-            }
-        })?;
+    // Split coords into one or more POINT(lon lat) strings. A single POINT is
+    // passed through to the engine as-is; MULTIPOINT is fanned out into one
+    // query per point and assembled into a CoverageCollection.
+    let points = split_position_coords(&params.coords).map_err(|e| {
+        (
+            StatusCode::BAD_REQUEST,
+            Json(json!({ "code": "BadRequest", "description": e.to_string() })),
+        )
+    })?;
 
-    let body = serde_json::to_string(&query_result_to_coverage_json(&result)).unwrap();
+    let map_engine_error = |e: &ds_core::error::DataServerError| match e {
+        ds_core::error::DataServerError::InvalidParameter(_)
+        | ds_core::error::DataServerError::InvalidBbox(_)
+        | ds_core::error::DataServerError::InvalidDatetime(_) => (
+            StatusCode::BAD_REQUEST,
+            Json(json!({ "code": "BadRequest", "description": e.to_string() })),
+        ),
+        ds_core::error::DataServerError::LocationNotFound(_)
+        | ds_core::error::DataServerError::CollectionNotFound(_)
+        | ds_core::error::DataServerError::FeatureNotFound(_) => (
+            StatusCode::NOT_FOUND,
+            Json(json!({ "code": "NotFound", "description": e.to_string() })),
+        ),
+        _ => {
+            tracing::error!("Position query error: {e}");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({ "code": "ServerError", "description": "Internal server error" })),
+            )
+        }
+    };
+
+    if points.len() == 1 {
+        let result = engine
+            .query_position(&points[0], datetime, param_names.as_deref())
+            .map_err(|e| map_engine_error(&e))?;
+        let body = serde_json::to_string(&query_result_to_coverage_json(&result)).unwrap();
+        return Ok((
+            [(header::CONTENT_TYPE, "application/prs.coverage+json")],
+            body,
+        ));
+    }
+
+    let mut coverages = Vec::with_capacity(points.len());
+    for point in &points {
+        let qr = engine
+            .query_position(point, datetime, param_names.as_deref())
+            .map_err(|e| map_engine_error(&e))?;
+        coverages.push(qr);
+    }
+
+    let body = serde_json::to_string(&area_query_result_to_json(&AreaQueryResult::Collection(
+        coverages,
+    )))
+    .unwrap();
     Ok((
         [(header::CONTENT_TYPE, "application/prs.coverage+json")],
         body,

--- a/crates/api-edr/src/params.rs
+++ b/crates/api-edr/src/params.rs
@@ -1,3 +1,4 @@
+use ds_core::error::DataServerError;
 use serde::Deserialize;
 
 #[derive(Debug, Deserialize)]
@@ -21,4 +22,151 @@ pub struct AreaQueryParams {
     pub datetime: Option<String>,
     #[serde(rename = "parameter-name")]
     pub parameter_name: Option<String>,
+}
+
+/// Split a position-query `coords` value into one or more `POINT(lon lat)` WKT
+/// strings. Accepts either a single `POINT(lon lat)` or a
+/// `MULTIPOINT((lon lat),(lon lat),...)` (nested form) /
+/// `MULTIPOINT(lon lat, lon lat, ...)` (flat form). The returned strings are
+/// always normalized to `POINT(lon lat)` so that existing engine
+/// `query_position` implementations can be reused unchanged.
+pub fn split_position_coords(coords: &str) -> Result<Vec<String>, DataServerError> {
+    let trimmed = coords.trim();
+
+    // POINT(lon lat) — single point, passed through unchanged.
+    if starts_with_ignore_ascii_case(trimmed, "POINT") {
+        return Ok(vec![trimmed.to_string()]);
+    }
+
+    // MULTIPOINT(...) — split into individual POINT strings.
+    if let Some(rest) = strip_prefix_ignore_ascii_case(trimmed, "MULTIPOINT") {
+        let inner = rest
+            .trim_start()
+            .strip_prefix('(')
+            .and_then(|s| s.strip_suffix(')'))
+            .ok_or_else(|| {
+                DataServerError::InvalidParameter(
+                    "MULTIPOINT geometry must be wrapped in parentheses".into(),
+                )
+            })?;
+
+        let points: Vec<String> = inner
+            .split(',')
+            .map(|part| {
+                let part = part.trim();
+                // Nested form "(lon lat)" — strip the inner parens.
+                let point_body = part
+                    .strip_prefix('(')
+                    .and_then(|s| s.strip_suffix(')'))
+                    .unwrap_or(part)
+                    .trim();
+                // Validate "lon lat" so we fail fast before reaching any engine.
+                let coords: Vec<&str> = point_body.split_whitespace().collect();
+                if coords.len() != 2 {
+                    return Err(DataServerError::InvalidParameter(format!(
+                        "MULTIPOINT element '{part}' is not 'lon lat'"
+                    )));
+                }
+                coords[0].parse::<f64>().map_err(|_| {
+                    DataServerError::InvalidParameter(format!(
+                        "MULTIPOINT element '{part}' has invalid longitude"
+                    ))
+                })?;
+                coords[1].parse::<f64>().map_err(|_| {
+                    DataServerError::InvalidParameter(format!(
+                        "MULTIPOINT element '{part}' has invalid latitude"
+                    ))
+                })?;
+                Ok(format!("POINT({} {})", coords[0], coords[1]))
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        if points.is_empty() {
+            return Err(DataServerError::InvalidParameter(
+                "MULTIPOINT geometry must contain at least one point".into(),
+            ));
+        }
+
+        return Ok(points);
+    }
+
+    Err(DataServerError::InvalidParameter(
+        "Expected WKT POINT or MULTIPOINT geometry".into(),
+    ))
+}
+
+fn strip_prefix_ignore_ascii_case<'a>(s: &'a str, prefix: &str) -> Option<&'a str> {
+    if s.len() >= prefix.len() && s[..prefix.len()].eq_ignore_ascii_case(prefix) {
+        Some(&s[prefix.len()..])
+    } else {
+        None
+    }
+}
+
+fn starts_with_ignore_ascii_case(s: &str, prefix: &str) -> bool {
+    strip_prefix_ignore_ascii_case(s, prefix).is_some()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn single_point_passthrough() {
+        let points = split_position_coords("POINT(24.94 60.17)").unwrap();
+        assert_eq!(points, vec!["POINT(24.94 60.17)".to_string()]);
+    }
+
+    #[test]
+    fn point_case_insensitive() {
+        let points = split_position_coords("point(24.94 60.17)").unwrap();
+        assert_eq!(points, vec!["point(24.94 60.17)".to_string()]);
+    }
+
+    #[test]
+    fn multipoint_nested_form() {
+        let points =
+            split_position_coords("MULTIPOINT((24.94 60.17),(23.76 61.5),(27.67 62.9))").unwrap();
+        assert_eq!(
+            points,
+            vec![
+                "POINT(24.94 60.17)".to_string(),
+                "POINT(23.76 61.5)".to_string(),
+                "POINT(27.67 62.9)".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn multipoint_flat_form() {
+        let points = split_position_coords("MULTIPOINT(24.94 60.17, 23.76 61.5)").unwrap();
+        assert_eq!(
+            points,
+            vec![
+                "POINT(24.94 60.17)".to_string(),
+                "POINT(23.76 61.5)".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn multipoint_case_insensitive() {
+        let points = split_position_coords("MultiPoint((1 2),(3 4))").unwrap();
+        assert_eq!(points.len(), 2);
+    }
+
+    #[test]
+    fn multipoint_rejects_non_numeric() {
+        assert!(split_position_coords("MULTIPOINT((a b),(1 2))").is_err());
+    }
+
+    #[test]
+    fn multipoint_rejects_wrong_arity() {
+        assert!(split_position_coords("MULTIPOINT((1 2 3),(4 5))").is_err());
+    }
+
+    #[test]
+    fn rejects_polygon() {
+        assert!(split_position_coords("POLYGON((0 0,1 0,1 1,0 1,0 0))").is_err());
+    }
 }

--- a/crates/api-edr/tests/ogc_edr_api_tests.rs
+++ b/crates/api-edr/tests/ogc_edr_api_tests.rs
@@ -137,6 +137,36 @@ impl Engine for MockEngine {
         }
         Ok(AreaQueryResult::Collection(coverages))
     }
+
+    fn query_position(
+        &self,
+        coords: &str,
+        _datetime: Option<(DateTime<Utc>, DateTime<Utc>)>,
+        _parameters: Option<&[String]>,
+    ) -> Result<QueryResult, DataServerError> {
+        // Accept any well-formed POINT(lon lat). Parsing is handled here to
+        // exercise the handler's MULTIPOINT fan-out (which normalizes each
+        // sub-point to POINT before calling the engine).
+        let inner = coords
+            .trim()
+            .strip_prefix("POINT(")
+            .or_else(|| coords.trim().strip_prefix("POINT ("))
+            .and_then(|s| s.strip_suffix(')'))
+            .ok_or_else(|| DataServerError::InvalidParameter(format!("bad point: {coords}")))?;
+        let parts: Vec<&str> = inner.split_whitespace().collect();
+        if parts.len() != 2 {
+            return Err(DataServerError::InvalidParameter(format!(
+                "bad point arity: {coords}"
+            )));
+        }
+        let _lon: f64 = parts[0].parse().map_err(|_| {
+            DataServerError::InvalidParameter(format!("bad longitude: {}", parts[0]))
+        })?;
+        let _lat: f64 = parts[1].parse().map_err(|_| {
+            DataServerError::InvalidParameter(format!("bad latitude: {}", parts[1]))
+        })?;
+        Ok(Self::sample_query_result())
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -924,11 +954,55 @@ mod unimplemented_queries {
     use super::*;
 
     #[tokio::test]
-    #[ignore = "position query not yet implemented"]
-    async fn position_query() {
-        // GET /collections/{id}/position?coords=POINT(24.9384 60.1699)
-        let (status, _) = get("/collections/weather/position?coords=POINT(24.9384 60.1699)").await;
+    async fn position_query_point_returns_single_coverage() {
+        // POINT(24.9384 60.1699)
+        let (status, json) =
+            get("/collections/weather/position?coords=POINT%2824.9384%2060.1699%29").await;
         assert_eq!(status, StatusCode::OK);
+        assert_eq!(json["type"], "Coverage");
+        assert!(json["domain"].is_object());
+    }
+
+    #[tokio::test]
+    async fn position_query_multipoint_returns_coverage_collection() {
+        // MULTIPOINT((24.94 60.17),(23.76 61.5))
+        let (status, json) = get(
+            "/collections/weather/position?coords=MULTIPOINT%28%2824.94%2060.17%29%2C%2823.76%2061.5%29%29",
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(json["type"], "CoverageCollection");
+        assert_eq!(json["domainType"], "PointSeries");
+        let coverages = json["coverages"].as_array().unwrap();
+        assert_eq!(coverages.len(), 2);
+        for cov in coverages {
+            assert_eq!(cov["type"], "Coverage");
+            assert!(cov["domain"].is_object());
+        }
+        // Parameters hoisted to collection level.
+        assert!(json["parameters"].is_object());
+    }
+
+    #[tokio::test]
+    async fn position_query_multipoint_flat_form() {
+        // MULTIPOINT(24.94 60.17, 23.76 61.5, 27.67 62.9)
+        let (status, json) = get(
+            "/collections/weather/position?coords=MULTIPOINT%2824.94%2060.17%2C%2023.76%2061.5%2C%2027.67%2062.9%29",
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(json["type"], "CoverageCollection");
+        assert_eq!(json["coverages"].as_array().unwrap().len(), 3);
+    }
+
+    #[tokio::test]
+    async fn position_query_rejects_polygon() {
+        let (status, json) = get(
+            "/collections/weather/position?coords=POLYGON%28%280%200%2C1%200%2C1%201%2C0%201%2C0%200%29%29",
+        )
+        .await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert_eq!(json["code"], "BadRequest");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- Accept WKT `MULTIPOINT((lon lat),(lon lat),...)` (nested) and `MULTIPOINT(lon lat, lon lat)` (flat) on `/collections/{id}/position`, fanning out to one engine `query_position` call per point and returning a CoverageJSON `CoverageCollection`.
- Single `POINT(...)` queries still return a single `Coverage` (no behaviour change).
- Parser lives in `api-edr` (`split_position_coords`) so all engines get MULTIPOINT for free — each sub-point is normalized to `POINT(lon lat)` before the engine is called. No engine trait changes.

Closes #35.

## Test plan
- [x] `cargo test -p api-edr` — all 8 new `params::tests` pass, full crate suite green
- [x] New integration tests in `ogc_edr_api_tests.rs`:
  - single `POINT` → `Coverage`
  - nested `MULTIPOINT` → `CoverageCollection` with 2 coverages + hoisted `parameters`
  - flat `MULTIPOINT` form → 3 coverages
  - `POLYGON` → 400 `BadRequest`
- [x] Reuses existing `area_query_result_to_json` path which is already schema-validated by `covjson_validation.rs`
- [x] `cargo fmt` + `cargo clippy -p api-edr --all-targets -- -D warnings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)