### PR TITLE
Shared WMS style bundles referenced by collections

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,6 +172,18 @@ port = 8000
 # base_url = "https://api.example.com"  # optional, for absolute links behind a proxy
 # collections_dir = "collections.d"     # optional, directory of per-collection .toml files
 
+# Optional shared WMS style bundles. MUST live in top-level config.toml —
+# a [[style_bundles]] block inside a collections_dir file is silently
+# dropped by serde and any collection referencing it will fail validation.
+[[style_bundles]]
+id = "radar_multi"
+[style_bundles.default]
+colormap = "radar_dbz"
+[[style_bundles.extras]]
+name = "radar_fmi"
+title = "FMI Radar"
+colormap = "radar_fmi"
+
 [[collections]]
 id = "weather"
 title = "Finnish Weather Observations"
@@ -197,7 +209,10 @@ time_window = "-PT2H"
 max_files = 24
 
 [collections.wms]
-colormap = "radar_dbz"
+# Either attach a named style_bundle (defined above), or set colormap/styles
+# inline — mixing the two in one [wms] block is rejected at config load.
+style_bundle = "radar_multi"
+# colormap = "radar_dbz"
 ```
 
 See config struct definitions in each engine crate and `ds-core/src/config.rs` for all fields.
@@ -237,6 +252,7 @@ colormap = "radar_dbz"
 - Non-recursive: only files directly in the directory, no subdirectory traversal.
 - Hot-reload (`POST /admin/collections/reload`) picks up added, removed, and changed files automatically.
 - A single invalid file rejects the entire config (no partial loads).
+- `[[style_bundles]]` blocks are NOT allowed in per-collection files — only in `config.toml`. Referencing a bundle from a per-collection `[wms]` is fine; defining one here is silently dropped.
 
 ## Admin & Operations
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -253,7 +253,8 @@ colormap = "radar_dbz"
 - Hot-reload (`POST /admin/collections/reload`) picks up added, removed, and changed files automatically.
 - A single invalid file rejects the entire config (no partial loads).
 - `[[style_bundles]]` blocks are NOT allowed in per-collection files — only in `config.toml`. Referencing a bundle from a per-collection `[wms]` is fine; defining one here is rejected with an explicit error.
-- A `style_bundle` cannot coexist with `[[wms.parameters]]` on the same collection. Bundle-backed multi-parameter collections (e.g. QueryData with several parameters) use the bundle's default colormap for every parameter layer — per-parameter overrides are not available while a bundle is attached.
+- A `style_bundle` cannot coexist with `[[wms.parameters]]` on the same collection — inline per-parameter *defaults* are rejected at config load when a bundle is attached.
+- Inside a bundle, each `[[style_bundles.extras]]` entry may carry an optional `parameter` field. Extras with a `parameter` are scoped to that layer only (e.g. `parameter = "wind_speed"` surfaces only under `collection/wind_speed`); untagged extras are shared across every parameter layer.
 
 ## Admin & Operations
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -252,7 +252,8 @@ colormap = "radar_dbz"
 - Non-recursive: only files directly in the directory, no subdirectory traversal.
 - Hot-reload (`POST /admin/collections/reload`) picks up added, removed, and changed files automatically.
 - A single invalid file rejects the entire config (no partial loads).
-- `[[style_bundles]]` blocks are NOT allowed in per-collection files — only in `config.toml`. Referencing a bundle from a per-collection `[wms]` is fine; defining one here is silently dropped.
+- `[[style_bundles]]` blocks are NOT allowed in per-collection files — only in `config.toml`. Referencing a bundle from a per-collection `[wms]` is fine; defining one here is rejected with an explicit error.
+- A `style_bundle` cannot coexist with `[[wms.parameters]]` on the same collection. Bundle-backed multi-parameter collections (e.g. QueryData with several parameters) use the bundle's default colormap for every parameter layer — per-parameter overrides are not available while a bundle is attached.
 
 ## Admin & Operations
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2550,6 +2550,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "toml",
  "tower",
  "tower-http",
  "tracing",

--- a/collections.d/fmi-radar.toml
+++ b/collections.d/fmi-radar.toml
@@ -16,4 +16,4 @@ poll_interval_secs = 300
 nodata = 255
 
 [wms]
-colormap = "radar_dbz"
+style_bundle = "radar_multi"

--- a/collections.d/met-norway-radar.toml
+++ b/collections.d/met-norway-radar.toml
@@ -13,4 +13,4 @@ unit = "dBZ"
 poll_interval_secs = 300
 
 [wms]
-colormap = "radar_dbz"
+style_bundle = "radar_multi"

--- a/collections.d/opera-reflectivity.toml
+++ b/collections.d/opera-reflectivity.toml
@@ -15,4 +15,4 @@ unit = "dBZ"
 poll_interval_secs = 300
 
 [wms]
-colormap = "radar_dbz"
+style_bundle = "radar_multi"

--- a/collections.d/radar-norway.toml
+++ b/collections.d/radar-norway.toml
@@ -12,4 +12,4 @@ unit = "dBZ"
 poll_interval_secs = 60
 
 [wms]
-colormap = "radar_dbz"
+style_bundle = "radar_multi"

--- a/config.toml
+++ b/config.toml
@@ -2,3 +2,33 @@
 host = "127.0.0.1"
 port = 8000
 collections_dir = "collections.d"
+
+# Shared WMS style bundles. Collections reference these by id from their
+# [wms] style_bundle field to avoid duplicating the same default + extras
+# block across multiple radar configs.
+
+[[style_bundles]]
+id = "radar_multi"
+
+[style_bundles.default]
+colormap = "radar_dbz"
+
+[[style_bundles.extras]]
+name = "radar_dbz"
+title = "MeteoCore Radar"
+colormap = "radar_dbz"
+
+[[style_bundles.extras]]
+name = "radar_fmi"
+title = "FMI Radar"
+colormap = "radar_fmi"
+
+[[style_bundles.extras]]
+name = "radar_bookbinder"
+title = "Bookbinder Radar"
+colormap = "radar_bookbinder"
+
+[[style_bundles.extras]]
+name = "radar_smhi"
+title = "SMHI Radar"
+colormap = "radar_smhi"

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -5,6 +5,11 @@ pub struct ServerConfig {
     pub server: ServerSettings,
     #[serde(default)]
     pub collections: Vec<CollectionConfig>,
+    /// Reusable named style bundles referenced from collection configs via
+    /// `[wms] style_bundle = "..."`. Each bundle defines one default style
+    /// plus zero or more named extras that apply to every collection referencing it.
+    #[serde(default)]
+    pub style_bundles: Vec<StyleBundle>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -64,10 +69,14 @@ pub struct CollectionConfig {
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct WmsConfig {
+    /// Reference to a named bundle declared under top-level `[[style_bundles]]`.
+    /// When set, the bundle's default + extras provide all styles for this
+    /// collection and the other fields below (colormap/color_stops/styles/
+    /// parameters/min/max) must be absent — mixing is rejected at config load.
+    pub style_bundle: Option<String>,
     /// Built-in colormap name for the default style (e.g., "radar_dbz", "viridis").
-    /// Ignored if color_stops are provided.
-    #[serde(default = "default_colormap")]
-    pub colormap: String,
+    /// Ignored if color_stops are provided. Falls back to "viridis" if not set.
+    pub colormap: Option<String>,
     /// Inline color stops for the default style. Overrides the built-in colormap.
     #[serde(default)]
     pub color_stops: Vec<ColorStop>,
@@ -131,12 +140,51 @@ pub struct ColorStop {
     pub color: String,
 }
 
-fn default_colormap() -> String {
-    "viridis".to_string()
-}
-
 fn default_rendered_cache_mb() -> u64 {
     512
+}
+
+/// A reusable named style bundle declared at top level of `config.toml` and
+/// referenced by collections via `[wms] style_bundle = "..."`. Replaces the
+/// per-collection `colormap` + `[[wms.styles]]` block when many collections
+/// share the same set of styles (e.g. radar collections that all offer the
+/// same four dBZ palettes).
+#[derive(Debug, Clone, Deserialize)]
+pub struct StyleBundle {
+    /// Unique identifier referenced from `WmsConfig::style_bundle`.
+    pub id: String,
+    /// The default style (served when no STYLES= is given, or STYLES=default).
+    pub default: StyleBundleDefault,
+    /// Named extras — each becomes an additional WMS style for every
+    /// collection that references this bundle.
+    #[serde(default)]
+    pub extras: Vec<StyleBundleExtra>,
+}
+
+/// Default style inside a `StyleBundle`. Same fields as a `WmsConfig` default
+/// style, minus references and per-parameter bits.
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct StyleBundleDefault {
+    pub colormap: Option<String>,
+    #[serde(default)]
+    pub color_stops: Vec<ColorStop>,
+    pub min: Option<f64>,
+    pub max: Option<f64>,
+}
+
+/// Named extra style inside a `StyleBundle`. Mirrors `WmsStyle` — the fields
+/// are intentionally identical so bundle expansion maps 1:1 to the existing
+/// `StyleInfo` builder path.
+#[derive(Debug, Clone, Deserialize)]
+pub struct StyleBundleExtra {
+    pub name: String,
+    pub title: Option<String>,
+    pub colormap: Option<String>,
+    #[serde(default)]
+    pub color_stops: Vec<ColorStop>,
+    pub min: Option<f64>,
+    pub max: Option<f64>,
+    pub parameter: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -406,6 +454,22 @@ impl ServerConfig {
 
     /// Validate configuration for common errors before starting the server.
     pub fn validate(&self) -> Result<(), crate::error::DataServerError> {
+        // Check for duplicate style_bundle IDs
+        let mut bundle_ids: std::collections::HashSet<&str> = std::collections::HashSet::new();
+        for bundle in &self.style_bundles {
+            if bundle.id.is_empty() {
+                return Err(crate::error::DataServerError::Config(
+                    "Style bundle has an empty 'id' field".to_string(),
+                ));
+            }
+            if !bundle_ids.insert(bundle.id.as_str()) {
+                return Err(crate::error::DataServerError::Config(format!(
+                    "Duplicate style_bundle ID '{}'",
+                    bundle.id
+                )));
+            }
+        }
+
         // Check for duplicate collection IDs
         let mut seen: std::collections::HashMap<&str, usize> = std::collections::HashMap::new();
         for (i, collection) in self.collections.iter().enumerate() {
@@ -464,6 +528,30 @@ impl ServerConfig {
                         return Err(crate::error::DataServerError::Config(format!(
                             "Collection '{id}': invalid grib index_format '{fmt}', \
                              expected 'ecmwf-json' or 'wgrib2'"
+                        )));
+                    }
+                }
+            }
+
+            // style_bundle: reference must resolve, must not mix with inline WMS style fields
+            if let Some(wms) = &collection.wms {
+                if let Some(bundle_ref) = &wms.style_bundle {
+                    if !bundle_ids.contains(bundle_ref.as_str()) {
+                        return Err(crate::error::DataServerError::Config(format!(
+                            "Collection '{id}': style_bundle '{bundle_ref}' is not defined \
+                             in [[style_bundles]]"
+                        )));
+                    }
+                    if wms.colormap.is_some()
+                        || !wms.color_stops.is_empty()
+                        || !wms.styles.is_empty()
+                        || !wms.parameters.is_empty()
+                        || wms.min.is_some()
+                        || wms.max.is_some()
+                    {
+                        return Err(crate::error::DataServerError::Config(format!(
+                            "Collection '{id}': style_bundle cannot be combined with inline \
+                             colormap/color_stops/min/max/styles/parameters in [wms]"
                         )));
                     }
                 }
@@ -799,5 +887,262 @@ collections_dir = "collections.d"
         let (config, _) = ServerConfig::from_file(path.to_str().unwrap()).unwrap();
         let ids: Vec<&str> = config.collections.iter().map(|c| c.id.as_str()).collect();
         assert_eq!(ids, vec!["alpha", "beta", "gamma"]);
+    }
+
+    // ---- style_bundles ------------------------------------------------------
+
+    fn radar_bundle_toml() -> &'static str {
+        r#"
+[[style_bundles]]
+id = "radar_multi"
+
+[style_bundles.default]
+colormap = "radar_bookbinder"
+
+[[style_bundles.extras]]
+name = "radar_dbz"
+title = "MeteoCore Radar"
+colormap = "radar_dbz"
+
+[[style_bundles.extras]]
+name = "radar_fmi"
+title = "FMI Radar"
+colormap = "radar_fmi"
+"#
+    }
+
+    #[test]
+    fn style_bundle_parses_and_collection_reference_resolves() {
+        let tmp = TempDir::new().unwrap();
+        let config_toml = format!(
+            r#"
+[server]
+host = "127.0.0.1"
+port = 8000
+
+{bundle}
+
+[[collections]]
+id = "radar-dwd"
+title = "DWD"
+description = "DWD"
+engine_type = "geotiff"
+
+[collections.geotiff]
+filename_template = "radar_%Y%m%dT%H%MZ.tif"
+parameter = "reflectivity"
+unit = "dBZ"
+data_path = "/tmp"
+
+[collections.wms]
+style_bundle = "radar_multi"
+"#,
+            bundle = radar_bundle_toml()
+        );
+        let path = write_config(tmp.path(), "config.toml", &config_toml);
+        let (config, _) = ServerConfig::from_file(path.to_str().unwrap()).unwrap();
+        assert_eq!(config.style_bundles.len(), 1);
+        assert_eq!(config.style_bundles[0].id, "radar_multi");
+        assert_eq!(config.style_bundles[0].extras.len(), 2);
+        assert_eq!(
+            config.collections[0]
+                .wms
+                .as_ref()
+                .unwrap()
+                .style_bundle
+                .as_deref(),
+            Some("radar_multi")
+        );
+    }
+
+    #[test]
+    fn duplicate_style_bundle_id_rejected() {
+        let tmp = TempDir::new().unwrap();
+        let config_toml = r#"
+[server]
+host = "127.0.0.1"
+port = 8000
+
+[[style_bundles]]
+id = "dup"
+[style_bundles.default]
+colormap = "viridis"
+
+[[style_bundles]]
+id = "dup"
+[style_bundles.default]
+colormap = "grayscale"
+"#;
+        let path = write_config(tmp.path(), "config.toml", config_toml);
+        let err = ServerConfig::from_file(path.to_str().unwrap())
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("Duplicate style_bundle ID 'dup'"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn unknown_style_bundle_reference_rejected() {
+        let tmp = TempDir::new().unwrap();
+        let config_toml = r#"
+[server]
+host = "127.0.0.1"
+port = 8000
+
+[[collections]]
+id = "radar-dwd"
+title = "DWD"
+description = "DWD"
+engine_type = "geotiff"
+
+[collections.geotiff]
+filename_template = "radar_%Y%m%dT%H%MZ.tif"
+parameter = "reflectivity"
+unit = "dBZ"
+data_path = "/tmp"
+
+[collections.wms]
+style_bundle = "missing"
+"#;
+        let path = write_config(tmp.path(), "config.toml", config_toml);
+        let err = ServerConfig::from_file(path.to_str().unwrap())
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("style_bundle 'missing' is not defined"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn style_bundle_cannot_be_mixed_with_inline_wms_fields() {
+        let tmp = TempDir::new().unwrap();
+        let config_toml = format!(
+            r#"
+[server]
+host = "127.0.0.1"
+port = 8000
+
+{bundle}
+
+[[collections]]
+id = "radar-dwd"
+title = "DWD"
+description = "DWD"
+engine_type = "geotiff"
+
+[collections.geotiff]
+filename_template = "radar_%Y%m%dT%H%MZ.tif"
+parameter = "reflectivity"
+unit = "dBZ"
+data_path = "/tmp"
+
+[collections.wms]
+style_bundle = "radar_multi"
+colormap = "viridis"
+"#,
+            bundle = radar_bundle_toml()
+        );
+        let path = write_config(tmp.path(), "config.toml", &config_toml);
+        let err = ServerConfig::from_file(path.to_str().unwrap())
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("style_bundle cannot be combined with inline"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn style_bundle_cannot_be_mixed_with_inline_styles_array() {
+        let tmp = TempDir::new().unwrap();
+        let config_toml = format!(
+            r#"
+[server]
+host = "127.0.0.1"
+port = 8000
+
+{bundle}
+
+[[collections]]
+id = "radar-dwd"
+title = "DWD"
+description = "DWD"
+engine_type = "geotiff"
+
+[collections.geotiff]
+filename_template = "radar_%Y%m%dT%H%MZ.tif"
+parameter = "reflectivity"
+unit = "dBZ"
+data_path = "/tmp"
+
+[collections.wms]
+style_bundle = "radar_multi"
+
+[[collections.wms.styles]]
+name = "extra"
+colormap = "viridis"
+"#,
+            bundle = radar_bundle_toml()
+        );
+        let path = write_config(tmp.path(), "config.toml", &config_toml);
+        let err = ServerConfig::from_file(path.to_str().unwrap())
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("style_bundle cannot be combined with inline"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn empty_style_bundle_id_rejected() {
+        let tmp = TempDir::new().unwrap();
+        let config_toml = r#"
+[server]
+host = "127.0.0.1"
+port = 8000
+
+[[style_bundles]]
+id = ""
+[style_bundles.default]
+colormap = "viridis"
+"#;
+        let path = write_config(tmp.path(), "config.toml", config_toml);
+        let err = ServerConfig::from_file(path.to_str().unwrap())
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("Style bundle has an empty 'id' field"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn wms_without_colormap_or_bundle_defaults_to_none() {
+        // Verifies the Option<String> migration: omitting `colormap` no longer
+        // forces a default at parse time — the default "viridis" is applied
+        // later by build_colormap_from_wms_config. Previously this field was a
+        // required String with a serde default.
+        let tmp = TempDir::new().unwrap();
+        let config_toml = r#"
+[server]
+host = "127.0.0.1"
+port = 8000
+
+[[collections]]
+id = "x"
+title = "X"
+description = "X"
+
+[collections.wms]
+"#;
+        let path = write_config(tmp.path(), "config.toml", config_toml);
+        let (config, _) = ServerConfig::from_file(path.to_str().unwrap()).unwrap();
+        let wms = config.collections[0].wms.as_ref().unwrap();
+        assert_eq!(wms.colormap, None);
+        assert_eq!(wms.style_bundle, None);
     }
 }

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -468,9 +468,12 @@ impl ServerConfig {
                     bundle.id
                 )));
             }
-            // Extras must have non-empty, non-"default" names. "default" is
-            // reserved for the bundle's default style; an extra using that
-            // name would silently overwrite it in admin::build_styles.
+            // Extras must have non-empty, non-"default", unique names.
+            // "default" is reserved for the bundle's default style; an extra
+            // using that name would silently overwrite it in
+            // admin::build_styles. Duplicate names within the same bundle
+            // would silently overwrite each other in the same HashMap.
+            let mut extra_names: std::collections::HashSet<&str> = std::collections::HashSet::new();
             for extra in &bundle.extras {
                 if extra.name.is_empty() {
                     return Err(crate::error::DataServerError::Config(format!(
@@ -483,6 +486,12 @@ impl ServerConfig {
                         "Style bundle '{}': extra cannot be named 'default' \
                          (reserved for the bundle's default style)",
                         bundle.id
+                    )));
+                }
+                if !extra_names.insert(extra.name.as_str()) {
+                    return Err(crate::error::DataServerError::Config(format!(
+                        "Style bundle '{}': duplicate extra name '{}'",
+                        bundle.id, extra.name
                     )));
                 }
             }
@@ -1161,6 +1170,39 @@ colormap = "radar_fmi"
             .to_string();
         assert!(
             err.contains("Style bundle 'radar_multi': extra has an empty 'name' field"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn duplicate_extra_name_within_bundle_rejected() {
+        // Two extras with the same name would silently overwrite each other
+        // in build_styles' HashMap; catch at config load instead.
+        let tmp = TempDir::new().unwrap();
+        let config_toml = r#"
+[server]
+host = "127.0.0.1"
+port = 8000
+
+[[style_bundles]]
+id = "radar_multi"
+[style_bundles.default]
+colormap = "radar_dbz"
+
+[[style_bundles.extras]]
+name = "radar_fmi"
+colormap = "radar_fmi"
+
+[[style_bundles.extras]]
+name = "radar_fmi"
+colormap = "radar_bookbinder"
+"#;
+        let path = write_config(tmp.path(), "config.toml", config_toml);
+        let err = ServerConfig::from_file(path.to_str().unwrap())
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("Style bundle 'radar_multi': duplicate extra name 'radar_fmi'"),
             "got: {err}"
         );
     }

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -421,20 +421,19 @@ impl ServerConfig {
                 crate::error::DataServerError::Config(format!("Failed to read {filename}: {e}"))
             })?;
 
-            // Reject style_bundles declared in per-collection files — serde
-            // drops them silently on CollectionConfig, which makes the later
-            // "style_bundle '...' is not defined" error confusing.
             let raw: toml::Table = toml::from_str(&content).map_err(|e| {
                 crate::error::DataServerError::Config(format!("Failed to parse {filename}: {e}"))
             })?;
+            // style_bundles must live in config.toml; serde silently drops
+            // them on CollectionConfig, which makes the later "not defined"
+            // error confusing.
             if raw.contains_key("style_bundles") {
                 return Err(crate::error::DataServerError::Config(format!(
                     "{filename}: [[style_bundles]] is not allowed in per-collection files — \
                      move the block to the top-level config.toml"
                 )));
             }
-
-            let collection: CollectionConfig = toml::from_str(&content).map_err(|e| {
+            let collection: CollectionConfig = raw.try_into().map_err(|e| {
                 crate::error::DataServerError::Config(format!("Failed to parse {filename}: {e}"))
             })?;
 

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -495,6 +495,12 @@ impl ServerConfig {
                         bundle.id, extra.name
                     )));
                 }
+                if extra.parameter.as_deref() == Some("") {
+                    return Err(crate::error::DataServerError::Config(format!(
+                        "Style bundle '{}': extra '{}' has an empty 'parameter' field",
+                        bundle.id, extra.name
+                    )));
+                }
             }
         }
 
@@ -1171,6 +1177,36 @@ colormap = "radar_fmi"
             .to_string();
         assert!(
             err.contains("Style bundle 'radar_multi': extra has an empty 'name' field"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn extra_with_empty_parameter_rejected() {
+        let tmp = TempDir::new().unwrap();
+        let config_toml = r#"
+[server]
+host = "127.0.0.1"
+port = 8000
+
+[[style_bundles]]
+id = "radar_multi"
+[style_bundles.default]
+colormap = "radar_dbz"
+
+[[style_bundles.extras]]
+name = "radar_fmi"
+colormap = "radar_fmi"
+parameter = ""
+"#;
+        let path = write_config(tmp.path(), "config.toml", config_toml);
+        let err = ServerConfig::from_file(path.to_str().unwrap())
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains(
+                "Style bundle 'radar_multi': extra 'radar_fmi' has an empty 'parameter' field"
+            ),
             "got: {err}"
         );
     }

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -163,7 +163,7 @@ pub struct StyleBundle {
 
 /// Default style inside a `StyleBundle`. Same fields as a `WmsConfig` default
 /// style, minus references and per-parameter bits.
-#[derive(Debug, Clone, Deserialize, Default)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct StyleBundleDefault {
     pub colormap: Option<String>,
     #[serde(default)]
@@ -454,7 +454,7 @@ impl ServerConfig {
 
     /// Validate configuration for common errors before starting the server.
     pub fn validate(&self) -> Result<(), crate::error::DataServerError> {
-        // Check for duplicate style_bundle IDs
+        // Check for duplicate style_bundle IDs + validate each bundle's extras.
         let mut bundle_ids: std::collections::HashSet<&str> = std::collections::HashSet::new();
         for bundle in &self.style_bundles {
             if bundle.id.is_empty() {
@@ -467,6 +467,24 @@ impl ServerConfig {
                     "Duplicate style_bundle ID '{}'",
                     bundle.id
                 )));
+            }
+            // Extras must have non-empty, non-"default" names. "default" is
+            // reserved for the bundle's default style; an extra using that
+            // name would silently overwrite it in admin::build_styles.
+            for extra in &bundle.extras {
+                if extra.name.is_empty() {
+                    return Err(crate::error::DataServerError::Config(format!(
+                        "Style bundle '{}': extra has an empty 'name' field",
+                        bundle.id
+                    )));
+                }
+                if extra.name == "default" {
+                    return Err(crate::error::DataServerError::Config(format!(
+                        "Style bundle '{}': extra cannot be named 'default' \
+                         (reserved for the bundle's default style)",
+                        bundle.id
+                    )));
+                }
             }
         }
 
@@ -1116,6 +1134,62 @@ colormap = "viridis"
             .to_string();
         assert!(
             err.contains("Style bundle has an empty 'id' field"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn extra_with_empty_name_rejected() {
+        let tmp = TempDir::new().unwrap();
+        let config_toml = r#"
+[server]
+host = "127.0.0.1"
+port = 8000
+
+[[style_bundles]]
+id = "radar_multi"
+[style_bundles.default]
+colormap = "radar_dbz"
+
+[[style_bundles.extras]]
+name = ""
+colormap = "radar_fmi"
+"#;
+        let path = write_config(tmp.path(), "config.toml", config_toml);
+        let err = ServerConfig::from_file(path.to_str().unwrap())
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("Style bundle 'radar_multi': extra has an empty 'name' field"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn extra_named_default_rejected() {
+        // Without this check, an extra named "default" would silently clobber
+        // the bundle's default style when build_styles inserts the extras.
+        let tmp = TempDir::new().unwrap();
+        let config_toml = r#"
+[server]
+host = "127.0.0.1"
+port = 8000
+
+[[style_bundles]]
+id = "radar_multi"
+[style_bundles.default]
+colormap = "radar_dbz"
+
+[[style_bundles.extras]]
+name = "default"
+colormap = "radar_fmi"
+"#;
+        let path = write_config(tmp.path(), "config.toml", config_toml);
+        let err = ServerConfig::from_file(path.to_str().unwrap())
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("extra cannot be named 'default'"),
             "got: {err}"
         );
     }

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -5,9 +5,7 @@ pub struct ServerConfig {
     pub server: ServerSettings,
     #[serde(default)]
     pub collections: Vec<CollectionConfig>,
-    /// Reusable named style bundles referenced from collection configs via
-    /// `[wms] style_bundle = "..."`. Each bundle defines one default style
-    /// plus zero or more named extras that apply to every collection referencing it.
+    /// Shared style bundles referenced by collections via `[wms] style_bundle`.
     #[serde(default)]
     pub style_bundles: Vec<StyleBundle>,
 }
@@ -69,10 +67,7 @@ pub struct CollectionConfig {
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct WmsConfig {
-    /// Reference to a named bundle declared under top-level `[[style_bundles]]`.
-    /// When set, the bundle's default + extras provide all styles for this
-    /// collection and the other fields below (colormap/color_stops/styles/
-    /// parameters/min/max) must be absent — mixing is rejected at config load.
+    /// Named bundle; mixing with inline colormap/styles/etc. is a config error.
     pub style_bundle: Option<String>,
     /// Built-in colormap name for the default style (e.g., "radar_dbz", "viridis").
     /// Ignored if color_stops are provided. Falls back to "viridis" if not set.
@@ -144,11 +139,7 @@ fn default_rendered_cache_mb() -> u64 {
     512
 }
 
-/// A reusable named style bundle declared at top level of `config.toml` and
-/// referenced by collections via `[wms] style_bundle = "..."`. Replaces the
-/// per-collection `colormap` + `[[wms.styles]]` block when many collections
-/// share the same set of styles (e.g. radar collections that all offer the
-/// same four dBZ palettes).
+/// Shared WMS style set: one default + zero or more named extras.
 #[derive(Debug, Clone, Deserialize)]
 pub struct StyleBundle {
     /// Unique identifier referenced from `WmsConfig::style_bundle`.
@@ -161,8 +152,7 @@ pub struct StyleBundle {
     pub extras: Vec<StyleBundleExtra>,
 }
 
-/// Default style inside a `StyleBundle`. Same fields as a `WmsConfig` default
-/// style, minus references and per-parameter bits.
+/// Default style inside a `StyleBundle`.
 #[derive(Debug, Clone, Deserialize)]
 pub struct StyleBundleDefault {
     pub colormap: Option<String>,
@@ -172,9 +162,7 @@ pub struct StyleBundleDefault {
     pub max: Option<f64>,
 }
 
-/// Named extra style inside a `StyleBundle`. Mirrors `WmsStyle` — the fields
-/// are intentionally identical so bundle expansion maps 1:1 to the existing
-/// `StyleInfo` builder path.
+/// Named extra style inside a `StyleBundle`.
 #[derive(Debug, Clone, Deserialize)]
 pub struct StyleBundleExtra {
     pub name: String,

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -421,6 +421,19 @@ impl ServerConfig {
                 crate::error::DataServerError::Config(format!("Failed to read {filename}: {e}"))
             })?;
 
+            // Reject style_bundles declared in per-collection files — serde
+            // drops them silently on CollectionConfig, which makes the later
+            // "style_bundle '...' is not defined" error confusing.
+            let raw: toml::Table = toml::from_str(&content).map_err(|e| {
+                crate::error::DataServerError::Config(format!("Failed to parse {filename}: {e}"))
+            })?;
+            if raw.contains_key("style_bundles") {
+                return Err(crate::error::DataServerError::Config(format!(
+                    "{filename}: [[style_bundles]] is not allowed in per-collection files — \
+                     move the block to the top-level config.toml"
+                )));
+            }
+
             let collection: CollectionConfig = toml::from_str(&content).map_err(|e| {
                 crate::error::DataServerError::Config(format!("Failed to parse {filename}: {e}"))
             })?;
@@ -1220,6 +1233,47 @@ colormap = "radar_fmi"
             .to_string();
         assert!(
             err.contains("extra cannot be named 'default'"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn style_bundles_in_per_collection_file_rejected() {
+        // [[style_bundles]] inside a collections_dir file is dropped silently
+        // by CollectionConfig (no field). Without this hard error the user
+        // would see a confusing "not defined" validation failure instead.
+        let tmp = TempDir::new().unwrap();
+        let collections_dir = tmp.path().join("collections.d");
+        fs::create_dir(&collections_dir).unwrap();
+
+        let config_toml = r#"
+[server]
+host = "127.0.0.1"
+port = 8000
+collections_dir = "collections.d"
+"#;
+        write_config(tmp.path(), "config.toml", config_toml);
+        write_config(
+            &collections_dir,
+            "radar.toml",
+            r#"
+id = "radar"
+title = "Radar"
+description = "Radar"
+
+[[style_bundles]]
+id = "radar_multi"
+[style_bundles.default]
+colormap = "radar_dbz"
+"#,
+        );
+
+        let path = tmp.path().join("config.toml");
+        let err = ServerConfig::from_file(path.to_str().unwrap())
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("radar.toml: [[style_bundles]] is not allowed in per-collection files"),
             "got: {err}"
         );
     }

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -32,4 +32,5 @@ uuid = { version = "1", features = ["v4"] }
 [dev-dependencies]
 chrono = "0.4"
 http-body-util = "0.1"
+toml = "0.8"
 tower = { version = "0.5", features = ["util"] }

--- a/crates/server/src/admin.rs
+++ b/crates/server/src/admin.rs
@@ -20,7 +20,7 @@ use api_features::handlers::FeaturesState;
 use api_maps::MapsState;
 use api_tiles::TilesState;
 use api_wms::WmsState;
-use ds_core::config::CollectionConfig;
+use ds_core::config::{CollectionConfig, StyleBundle};
 
 // ---------------------------------------------------------------------------
 // Prometheus metrics (global)
@@ -367,7 +367,13 @@ pub struct LoadResult {
     pub grib_engines: Vec<Arc<engine_grib::GribEngine>>,
 }
 
-pub fn load_collections(collections: &[CollectionConfig], base_url: &str) -> LoadResult {
+pub fn load_collections(
+    collections: &[CollectionConfig],
+    style_bundles: &[StyleBundle],
+    base_url: &str,
+) -> LoadResult {
+    let bundle_index: HashMap<&str, &StyleBundle> =
+        style_bundles.iter().map(|b| (b.id.as_str(), b)).collect();
     let mut edr_engines: HashMap<String, Arc<dyn ds_core::engine::Engine>> = HashMap::new();
     let mut edr_collections: HashMap<String, CollectionConfig> = HashMap::new();
     let mut feature_engines: HashMap<String, Arc<dyn ds_core::feature_engine::FeatureEngine>> =
@@ -621,7 +627,7 @@ pub fn load_collections(collections: &[CollectionConfig], base_url: &str) -> Loa
                     map_collections.insert(collection.id.clone(), collection.clone());
 
                     // Build styles from config
-                    let styles = build_styles(collection);
+                    let styles = build_styles(collection, &bundle_index);
                     map_styles.insert(collection.id.clone(), styles);
 
                     info!("Collection '{}': wired to WMS API", collection.id);
@@ -633,7 +639,7 @@ pub fn load_collections(collections: &[CollectionConfig], base_url: &str) -> Loa
                     );
                     maps_collections.insert(collection.id.clone(), collection.clone());
 
-                    let styles = build_styles(collection);
+                    let styles = build_styles(collection, &bundle_index);
                     maps_styles.insert(collection.id.clone(), styles);
 
                     info!("Collection '{}': wired to Maps API", collection.id);
@@ -645,7 +651,7 @@ pub fn load_collections(collections: &[CollectionConfig], base_url: &str) -> Loa
                     );
                     tiles_collections.insert(collection.id.clone(), collection.clone());
 
-                    let styles = build_styles(collection);
+                    let styles = build_styles(collection, &bundle_index);
                     tiles_styles.insert(collection.id.clone(), styles);
 
                     info!("Collection '{}': wired to Tiles API", collection.id);
@@ -734,13 +740,14 @@ pub fn load_collections(collections: &[CollectionConfig], base_url: &str) -> Loa
                         engine.clone() as Arc<dyn ds_core::map_engine::MapEngine>,
                     );
                     map_collections.insert(collection.id.clone(), collection.clone());
-                    let styles = build_styles(collection);
+                    let styles = build_styles(collection, &bundle_index);
                     map_styles.insert(collection.id.clone(), styles);
                     if !raster_params.is_empty() {
                         register_parameter_layer_styles(
                             collection,
                             &raster_params,
                             &mut map_styles,
+                            &bundle_index,
                         );
                     }
                     info!("Collection '{}': wired to WMS API", collection.id);
@@ -751,13 +758,14 @@ pub fn load_collections(collections: &[CollectionConfig], base_url: &str) -> Loa
                         engine.clone() as Arc<dyn ds_core::map_engine::MapEngine>,
                     );
                     maps_collections.insert(collection.id.clone(), collection.clone());
-                    let styles = build_styles(collection);
+                    let styles = build_styles(collection, &bundle_index);
                     maps_styles.insert(collection.id.clone(), styles);
                     if !raster_params.is_empty() {
                         register_parameter_layer_styles(
                             collection,
                             &raster_params,
                             &mut maps_styles,
+                            &bundle_index,
                         );
                     }
                     info!("Collection '{}': wired to Maps API", collection.id);
@@ -768,13 +776,14 @@ pub fn load_collections(collections: &[CollectionConfig], base_url: &str) -> Loa
                         engine.clone() as Arc<dyn ds_core::map_engine::MapEngine>,
                     );
                     tiles_collections.insert(collection.id.clone(), collection.clone());
-                    let styles = build_styles(collection);
+                    let styles = build_styles(collection, &bundle_index);
                     tiles_styles.insert(collection.id.clone(), styles);
                     if !raster_params.is_empty() {
                         register_parameter_layer_styles(
                             collection,
                             &raster_params,
                             &mut tiles_styles,
+                            &bundle_index,
                         );
                     }
                     info!("Collection '{}': wired to Tiles API", collection.id);
@@ -860,13 +869,14 @@ pub fn load_collections(collections: &[CollectionConfig], base_url: &str) -> Loa
                         engine.clone() as Arc<dyn ds_core::map_engine::MapEngine>,
                     );
                     map_collections.insert(collection.id.clone(), collection.clone());
-                    let styles = build_styles(collection);
+                    let styles = build_styles(collection, &bundle_index);
                     map_styles.insert(collection.id.clone(), styles);
                     if !raster_params.is_empty() {
                         register_parameter_layer_styles(
                             collection,
                             &raster_params,
                             &mut map_styles,
+                            &bundle_index,
                         );
                     }
                     info!("Collection '{}': wired to WMS API", collection.id);
@@ -877,13 +887,14 @@ pub fn load_collections(collections: &[CollectionConfig], base_url: &str) -> Loa
                         engine.clone() as Arc<dyn ds_core::map_engine::MapEngine>,
                     );
                     maps_collections.insert(collection.id.clone(), collection.clone());
-                    let styles = build_styles(collection);
+                    let styles = build_styles(collection, &bundle_index);
                     maps_styles.insert(collection.id.clone(), styles);
                     if !raster_params.is_empty() {
                         register_parameter_layer_styles(
                             collection,
                             &raster_params,
                             &mut maps_styles,
+                            &bundle_index,
                         );
                     }
                     info!("Collection '{}': wired to Maps API", collection.id);
@@ -894,13 +905,14 @@ pub fn load_collections(collections: &[CollectionConfig], base_url: &str) -> Loa
                         engine.clone() as Arc<dyn ds_core::map_engine::MapEngine>,
                     );
                     tiles_collections.insert(collection.id.clone(), collection.clone());
-                    let styles = build_styles(collection);
+                    let styles = build_styles(collection, &bundle_index);
                     tiles_styles.insert(collection.id.clone(), styles);
                     if !raster_params.is_empty() {
                         register_parameter_layer_styles(
                             collection,
                             &raster_params,
                             &mut tiles_styles,
+                            &bundle_index,
                         );
                     }
                     info!("Collection '{}': wired to Tiles API", collection.id);
@@ -1006,12 +1018,20 @@ pub fn load_collections(collections: &[CollectionConfig], base_url: &str) -> Loa
 }
 
 /// Build all styles for a WMS-enabled collection from its config.
-fn build_styles(collection: &CollectionConfig) -> HashMap<String, ds_render::StyleInfo> {
+///
+/// If the collection's `[wms] style_bundle` is set, the bundle's default +
+/// extras are used verbatim and inline WMS style fields are ignored
+/// (validation rejects mixing at config load time). Otherwise the inline
+/// `colormap` / `[[wms.styles]]` behavior applies.
+fn build_styles(
+    collection: &CollectionConfig,
+    bundles: &HashMap<&str, &StyleBundle>,
+) -> HashMap<String, ds_render::StyleInfo> {
     let mut styles = HashMap::new();
 
-    // Build default style from top-level wms config
+    // Build default style (either from a bundle or from inline wms config)
     let (default_colormap, default_min, default_max) =
-        build_collection_default_colormap(collection);
+        build_collection_default_colormap(collection, bundles);
     styles.insert(
         "default".to_string(),
         ds_render::StyleInfo {
@@ -1024,8 +1044,28 @@ fn build_styles(collection: &CollectionConfig) -> HashMap<String, ds_render::Sty
         },
     );
 
-    // Build additional named styles
-    if let Some(wms_config) = &collection.wms {
+    // Build additional named styles — prefer bundle extras when bound
+    if let Some(bundle) = resolve_bundle(collection, bundles) {
+        for extra in &bundle.extras {
+            let (colormap, min, max) = build_colormap_from_wms_config(
+                extra.colormap.as_deref(),
+                &extra.color_stops,
+                extra.min,
+                extra.max,
+            );
+            styles.insert(
+                extra.name.clone(),
+                ds_render::StyleInfo {
+                    name: extra.name.clone(),
+                    title: extra.title.clone().unwrap_or_else(|| extra.name.clone()),
+                    colormap,
+                    min,
+                    max,
+                    parameter: extra.parameter.clone(),
+                },
+            );
+        }
+    } else if let Some(wms_config) = &collection.wms {
         for style_config in &wms_config.styles {
             let (colormap, min, max) = build_colormap_from_wms_config(
                 style_config.colormap.as_deref(),
@@ -1053,12 +1093,33 @@ fn build_styles(collection: &CollectionConfig) -> HashMap<String, ds_render::Sty
     styles
 }
 
-/// Build the collection-level default colormap (from top-level [collections.wms]).
+/// Look up a collection's bound style bundle, if any. Returns None when the
+/// collection has no `[wms]` section, no `style_bundle` ref, or — defensively —
+/// the ref didn't resolve (validation should catch that earlier).
+fn resolve_bundle<'a>(
+    collection: &CollectionConfig,
+    bundles: &'a HashMap<&str, &'a StyleBundle>,
+) -> Option<&'a StyleBundle> {
+    let bundle_ref = collection.wms.as_ref()?.style_bundle.as_deref()?;
+    bundles.get(bundle_ref).copied()
+}
+
+/// Build the collection-level default colormap (from a bound style bundle if
+/// any, otherwise from the inline `[wms]` fields).
 fn build_collection_default_colormap(
     collection: &CollectionConfig,
+    bundles: &HashMap<&str, &StyleBundle>,
 ) -> (Arc<dyn ds_render::ColorMap>, f64, f64) {
+    if let Some(bundle) = resolve_bundle(collection, bundles) {
+        return build_colormap_from_wms_config(
+            bundle.default.colormap.as_deref(),
+            &bundle.default.color_stops,
+            bundle.default.min,
+            bundle.default.max,
+        );
+    }
     build_colormap_from_wms_config(
-        collection.wms.as_ref().map(|w| w.colormap.as_str()),
+        collection.wms.as_ref().and_then(|w| w.colormap.as_deref()),
         collection
             .wms
             .as_ref()
@@ -1080,6 +1141,7 @@ fn register_parameter_layer_styles(
     collection: &CollectionConfig,
     param_names: &[(String, String)],
     style_map: &mut HashMap<String, HashMap<String, ds_render::StyleInfo>>,
+    bundles: &HashMap<&str, &StyleBundle>,
 ) {
     let wms_config = match &collection.wms {
         Some(c) => c,
@@ -1087,9 +1149,11 @@ fn register_parameter_layer_styles(
     };
 
     // Build named styles (shared across all param layers)
-    let shared_named_styles = build_styles(collection);
+    let shared_named_styles = build_styles(collection, bundles);
 
-    // Index per-parameter configs by name
+    // Index per-parameter configs by name. When a bundle is bound, inline
+    // per-parameter overrides are disallowed by validation, so this map is
+    // effectively empty in that case.
     let param_configs: HashMap<&str, &ds_core::config::WmsParameterConfig> = wms_config
         .parameters
         .iter()
@@ -1098,7 +1162,7 @@ fn register_parameter_layer_styles(
 
     // Collection-level default colormap (fallback)
     let (fallback_colormap, fallback_min, fallback_max) =
-        build_collection_default_colormap(collection);
+        build_collection_default_colormap(collection, bundles);
 
     for (short_name, _title) in param_names {
         let layer_key = format!("{}/{}", collection.id, short_name);
@@ -1295,7 +1359,7 @@ pub async fn reload_handler(
         }
     }
 
-    let result = load_collections(&config.collections, &base_url);
+    let result = load_collections(&config.collections, &config.style_bundles, &base_url);
 
     let loaded = result
         .health
@@ -1832,7 +1896,9 @@ pub async fn request_logging_middleware(
 
 #[cfg(test)]
 mod tests {
-    use super::{classify_route, is_safe_request_id};
+    use super::{build_styles, classify_route, is_safe_request_id};
+    use ds_core::config::{CollectionConfig, StyleBundle};
+    use std::collections::HashMap;
 
     #[test]
     fn accepts_typical_uuid() {
@@ -1933,5 +1999,95 @@ mod tests {
         assert_eq!(api, "edr");
         assert_eq!(coll, Some("weather"));
         assert_eq!(qt, "position");
+    }
+
+    #[test]
+    fn build_styles_expands_bundle_into_default_plus_extras() {
+        let collection: CollectionConfig = toml::from_str(
+            r#"
+id = "radar-dwd"
+title = "DWD"
+description = "DWD"
+engine_type = "geotiff"
+
+[geotiff]
+filename_template = "radar_%Y%m%dT%H%MZ.tif"
+parameter = "reflectivity"
+unit = "dBZ"
+data_path = "/tmp"
+
+[wms]
+style_bundle = "radar_multi"
+"#,
+        )
+        .unwrap();
+
+        let bundle: StyleBundle = toml::from_str(
+            r#"
+id = "radar_multi"
+
+[default]
+colormap = "radar_bookbinder"
+
+[[extras]]
+name = "radar_dbz"
+title = "MeteoCore Radar"
+colormap = "radar_dbz"
+
+[[extras]]
+name = "radar_fmi"
+title = "FMI Radar"
+colormap = "radar_fmi"
+"#,
+        )
+        .unwrap();
+
+        let bundles = [bundle];
+        let index: HashMap<&str, &StyleBundle> =
+            bundles.iter().map(|b| (b.id.as_str(), b)).collect();
+
+        let styles = build_styles(&collection, &index);
+        assert_eq!(styles.len(), 3, "default + 2 extras expected");
+        assert!(styles.contains_key("default"));
+        assert_eq!(styles["default"].name, "default");
+        assert!(styles.contains_key("radar_dbz"));
+        assert_eq!(styles["radar_dbz"].title, "MeteoCore Radar");
+        assert!(styles.contains_key("radar_fmi"));
+        assert_eq!(styles["radar_fmi"].title, "FMI Radar");
+    }
+
+    #[test]
+    fn build_styles_falls_back_to_inline_when_no_bundle_referenced() {
+        let collection: CollectionConfig = toml::from_str(
+            r#"
+id = "radar-fmi"
+title = "FMI"
+description = "FMI"
+engine_type = "geotiff"
+
+[geotiff]
+filename_template = "radar_%Y%m%dT%H%MZ.tif"
+parameter = "reflectivity"
+unit = "dBZ"
+data_path = "/tmp"
+
+[wms]
+colormap = "radar_dbz"
+
+[[wms.styles]]
+name = "alt"
+title = "Alt"
+colormap = "grayscale"
+"#,
+        )
+        .unwrap();
+
+        let index: HashMap<&str, &StyleBundle> = HashMap::new();
+
+        let styles = build_styles(&collection, &index);
+        assert_eq!(styles.len(), 2);
+        assert!(styles.contains_key("default"));
+        assert!(styles.contains_key("alt"));
+        assert_eq!(styles["alt"].title, "Alt");
     }
 }

--- a/crates/server/src/admin.rs
+++ b/crates/server/src/admin.rs
@@ -1027,11 +1027,12 @@ fn build_styles(
     collection: &CollectionConfig,
     bundles: &HashMap<&str, &StyleBundle>,
 ) -> HashMap<String, ds_render::StyleInfo> {
+    let bundle = resolve_bundle(collection, bundles);
     let mut styles = HashMap::new();
 
-    // Build default style (either from a bundle or from inline wms config)
+    // Build default style (either from the bundle or from inline wms config)
     let (default_colormap, default_min, default_max) =
-        build_collection_default_colormap(collection, bundles);
+        build_collection_default_colormap(collection, bundle);
     styles.insert(
         "default".to_string(),
         ds_render::StyleInfo {
@@ -1045,7 +1046,7 @@ fn build_styles(
     );
 
     // Build additional named styles — prefer bundle extras when bound
-    if let Some(bundle) = resolve_bundle(collection, bundles) {
+    if let Some(bundle) = bundle {
         for extra in &bundle.extras {
             let (colormap, min, max) = build_colormap_from_wms_config(
                 extra.colormap.as_deref(),
@@ -1105,12 +1106,13 @@ fn resolve_bundle<'a>(
 }
 
 /// Build the collection-level default colormap (from a bound style bundle if
-/// any, otherwise from the inline `[wms]` fields).
+/// any, otherwise from the inline `[wms]` fields). The caller passes the
+/// already-resolved bundle so the HashMap lookup happens once per collection.
 fn build_collection_default_colormap(
     collection: &CollectionConfig,
-    bundles: &HashMap<&str, &StyleBundle>,
+    bundle: Option<&StyleBundle>,
 ) -> (Arc<dyn ds_render::ColorMap>, f64, f64) {
-    if let Some(bundle) = resolve_bundle(collection, bundles) {
+    if let Some(bundle) = bundle {
         return build_colormap_from_wms_config(
             bundle.default.colormap.as_deref(),
             &bundle.default.color_stops,
@@ -1150,6 +1152,7 @@ fn register_parameter_layer_styles(
 
     // Build named styles (shared across all param layers)
     let shared_named_styles = build_styles(collection, bundles);
+    let bundle = resolve_bundle(collection, bundles);
 
     // Index per-parameter configs by name. When a bundle is bound, inline
     // per-parameter overrides are disallowed by validation, so this map is
@@ -1162,7 +1165,7 @@ fn register_parameter_layer_styles(
 
     // Collection-level default colormap (fallback)
     let (fallback_colormap, fallback_min, fallback_max) =
-        build_collection_default_colormap(collection, bundles);
+        build_collection_default_colormap(collection, bundle);
 
     for (short_name, _title) in param_names {
         let layer_key = format!("{}/{}", collection.id, short_name);

--- a/crates/server/src/admin.rs
+++ b/crates/server/src/admin.rs
@@ -1101,7 +1101,20 @@ fn resolve_bundle<'a>(
     bundles: &'a HashMap<&str, &'a StyleBundle>,
 ) -> Option<&'a StyleBundle> {
     let bundle_ref = collection.wms.as_ref()?.style_bundle.as_deref()?;
-    bundles.get(bundle_ref).copied()
+    match bundles.get(bundle_ref).copied() {
+        Some(b) => Some(b),
+        None => {
+            // validate() rejects unresolved refs, so this is defensive: log
+            // so the inline-fallback path is observable if a caller somehow
+            // bypasses validation.
+            tracing::warn!(
+                "Collection '{}': style_bundle '{}' not found in index — falling back to inline config",
+                collection.id,
+                bundle_ref
+            );
+            None
+        }
+    }
 }
 
 /// Build the collection-level default colormap from the bundle or inline `[wms]` fields.

--- a/crates/server/src/admin.rs
+++ b/crates/server/src/admin.rs
@@ -1022,10 +1022,10 @@ fn build_styles(
     collection: &CollectionConfig,
     bundles: &HashMap<&str, &StyleBundle>,
 ) -> HashMap<String, ds_render::StyleInfo> {
-    build_styles_with_bundle(collection, resolve_bundle(collection, bundles))
+    build_styles_inner(collection, resolve_bundle(collection, bundles))
 }
 
-fn build_styles_with_bundle(
+fn build_styles_inner(
     collection: &CollectionConfig,
     bundle: Option<&StyleBundle>,
 ) -> HashMap<String, ds_render::StyleInfo> {
@@ -1148,7 +1148,7 @@ fn register_parameter_layer_styles(
     };
 
     let bundle = resolve_bundle(collection, bundles);
-    let shared_named_styles = build_styles_with_bundle(collection, bundle);
+    let shared_named_styles = build_styles_inner(collection, bundle);
 
     // When a bundle is bound, inline per-parameter overrides are rejected by validation.
     let param_configs: HashMap<&str, &ds_core::config::WmsParameterConfig> = wms_config

--- a/crates/server/src/admin.rs
+++ b/crates/server/src/admin.rs
@@ -1196,11 +1196,20 @@ fn register_parameter_layer_styles(
             },
         );
 
-        // Add shared named styles (excluding "default" which we just built)
+        // Add shared named styles (excluding "default" which we just built).
+        // Styles tagged with a specific `parameter` are scoped to that layer only —
+        // otherwise a bundle extra with `parameter = "wind_speed"` would leak into
+        // every parameter layer's style map.
         for (name, style) in &shared_named_styles {
-            if name != "default" {
-                layer_styles.insert(name.clone(), style.clone());
+            if name == "default" {
+                continue;
             }
+            if let Some(p) = style.parameter.as_deref() {
+                if p != short_name {
+                    continue;
+                }
+            }
+            layer_styles.insert(name.clone(), style.clone());
         }
 
         style_map.insert(layer_key, layer_styles);
@@ -2098,5 +2107,87 @@ colormap = "grayscale"
         assert!(styles.contains_key("default"));
         assert!(styles.contains_key("alt"));
         assert_eq!(styles["alt"].title, "Alt");
+    }
+
+    #[test]
+    fn build_styles_falls_back_when_bundle_ref_unknown() {
+        // Exercises the defensive path in resolve_bundle: validate() normally
+        // rejects unresolved refs, but if a caller skips validation the
+        // collection must still load with the inline default (viridis) rather
+        // than panic.
+        let collection: CollectionConfig = toml::from_str(
+            r#"
+id = "radar-x"
+title = "X"
+description = "X"
+engine_type = "geotiff"
+
+[geotiff]
+filename_template = "radar_%Y%m%dT%H%MZ.tif"
+parameter = "reflectivity"
+unit = "dBZ"
+data_path = "/tmp"
+
+[wms]
+style_bundle = "does_not_exist"
+"#,
+        )
+        .unwrap();
+
+        let index: HashMap<&str, &StyleBundle> = HashMap::new();
+        let styles = build_styles(&collection, &index);
+
+        // Only the default; no extras; the bundle was silently skipped.
+        assert_eq!(styles.len(), 1);
+        assert!(styles.contains_key("default"));
+    }
+
+    #[test]
+    fn build_styles_parameter_tagged_extras_stay_in_map() {
+        // build_styles itself returns every extra — scoping by parameter
+        // happens downstream in register_parameter_layer_styles. This test
+        // locks the current behaviour so the bundle surface stays stable.
+        let collection: CollectionConfig = toml::from_str(
+            r#"
+id = "multi"
+title = "Multi"
+description = "Multi"
+engine_type = "querydata"
+
+[querydata]
+
+[wms]
+style_bundle = "mixed"
+"#,
+        )
+        .unwrap();
+
+        let bundle: StyleBundle = toml::from_str(
+            r#"
+id = "mixed"
+
+[default]
+colormap = "viridis"
+
+[[extras]]
+name = "wind_only"
+colormap = "wind_speed"
+parameter = "wind_speed"
+
+[[extras]]
+name = "global"
+colormap = "grayscale"
+"#,
+        )
+        .unwrap();
+
+        let bundles = [bundle];
+        let index: HashMap<&str, &StyleBundle> =
+            bundles.iter().map(|b| (b.id.as_str(), b)).collect();
+        let styles = build_styles(&collection, &index);
+
+        assert_eq!(styles.len(), 3);
+        assert_eq!(styles["wind_only"].parameter.as_deref(), Some("wind_speed"));
+        assert!(styles["global"].parameter.is_none());
     }
 }

--- a/crates/server/src/admin.rs
+++ b/crates/server/src/admin.rs
@@ -1017,17 +1017,18 @@ pub fn load_collections(
     }
 }
 
-/// Build all styles for a WMS-enabled collection from its config.
-///
-/// If the collection's `[wms] style_bundle` is set, the bundle's default +
-/// extras are used verbatim and inline WMS style fields are ignored
-/// (validation rejects mixing at config load time). Otherwise the inline
-/// `colormap` / `[[wms.styles]]` behavior applies.
+/// Build all styles for a WMS-enabled collection (bundle if bound, inline otherwise).
 fn build_styles(
     collection: &CollectionConfig,
     bundles: &HashMap<&str, &StyleBundle>,
 ) -> HashMap<String, ds_render::StyleInfo> {
-    let bundle = resolve_bundle(collection, bundles);
+    build_styles_with_bundle(collection, resolve_bundle(collection, bundles))
+}
+
+fn build_styles_with_bundle(
+    collection: &CollectionConfig,
+    bundle: Option<&StyleBundle>,
+) -> HashMap<String, ds_render::StyleInfo> {
     let mut styles = HashMap::new();
 
     // Build default style (either from the bundle or from inline wms config)
@@ -1094,9 +1095,7 @@ fn build_styles(
     styles
 }
 
-/// Look up a collection's bound style bundle, if any. Returns None when the
-/// collection has no `[wms]` section, no `style_bundle` ref, or — defensively —
-/// the ref didn't resolve (validation should catch that earlier).
+/// Resolve a collection's bound bundle; None if unset (validation rejects unresolved refs).
 fn resolve_bundle<'a>(
     collection: &CollectionConfig,
     bundles: &'a HashMap<&str, &'a StyleBundle>,
@@ -1105,9 +1104,7 @@ fn resolve_bundle<'a>(
     bundles.get(bundle_ref).copied()
 }
 
-/// Build the collection-level default colormap (from a bound style bundle if
-/// any, otherwise from the inline `[wms]` fields). The caller passes the
-/// already-resolved bundle so the HashMap lookup happens once per collection.
+/// Build the collection-level default colormap from the bundle or inline `[wms]` fields.
 fn build_collection_default_colormap(
     collection: &CollectionConfig,
     bundle: Option<&StyleBundle>,
@@ -1150,20 +1147,16 @@ fn register_parameter_layer_styles(
         None => return,
     };
 
-    // Build named styles (shared across all param layers)
-    let shared_named_styles = build_styles(collection, bundles);
     let bundle = resolve_bundle(collection, bundles);
+    let shared_named_styles = build_styles_with_bundle(collection, bundle);
 
-    // Index per-parameter configs by name. When a bundle is bound, inline
-    // per-parameter overrides are disallowed by validation, so this map is
-    // effectively empty in that case.
+    // When a bundle is bound, inline per-parameter overrides are rejected by validation.
     let param_configs: HashMap<&str, &ds_core::config::WmsParameterConfig> = wms_config
         .parameters
         .iter()
         .map(|p| (p.name.as_str(), p))
         .collect();
 
-    // Collection-level default colormap (fallback)
     let (fallback_colormap, fallback_min, fallback_max) =
         build_collection_default_colormap(collection, bundle);
 

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -159,7 +159,7 @@ async fn main() {
     let base_url = config.server.base_url();
     info!("Base URL: {base_url}");
 
-    let result = admin::load_collections(&config.collections, &base_url);
+    let result = admin::load_collections(&config.collections, &config.style_bundles, &base_url);
 
     let loaded = result
         .health

--- a/docker/config.toml
+++ b/docker/config.toml
@@ -11,6 +11,36 @@
 host = "0.0.0.0"
 port = 8000
 
+# Shared WMS style bundles — see config.toml for the same definition used by
+# the dev environment. Declared here so the docker-compose radar collection
+# can attach it via `style_bundle = "radar_multi"`.
+
+[[style_bundles]]
+id = "radar_multi"
+
+[style_bundles.default]
+colormap = "radar_dbz"
+
+[[style_bundles.extras]]
+name = "radar_dbz"
+title = "MeteoCore Radar"
+colormap = "radar_dbz"
+
+[[style_bundles.extras]]
+name = "radar_fmi"
+title = "FMI Radar"
+colormap = "radar_fmi"
+
+[[style_bundles.extras]]
+name = "radar_bookbinder"
+title = "Bookbinder Radar"
+colormap = "radar_bookbinder"
+
+[[style_bundles.extras]]
+name = "radar_smhi"
+title = "SMHI Radar"
+colormap = "radar_smhi"
+
 [[collections]]
 id = "weather"
 title = "Finnish Weather Observations"
@@ -49,4 +79,4 @@ unit = "dBZ"
 poll_interval_secs = 30
 
 [collections.wms]
-colormap = "radar_dbz"
+style_bundle = "radar_multi"


### PR DESCRIPTION
## Summary

- New top-level `[[style_bundles]]` block — one default style + extras, referenced from collections via `[wms] style_bundle = "<id>"`.
- Strict rules: unknown refs, duplicate IDs, and mixing bundle with inline `colormap`/`styles`/etc. are hard errors at config load and on `POST /admin/collections/reload`.
- Additive: every existing config keeps parsing unchanged. No changes to api-wms, api-maps, api-tiles, render, or engine crates — the single choke point is `admin::build_styles`.
- Migrates 4 single-colormap radar collections (`fmi-radar`, `met-norway-radar`, `radar-norway`, `opera-reflectivity`, plus the docker-compose `radar` demo) to the shared `radar_multi` bundle. Default remains `radar_dbz`; clients additionally gain `radar_fmi`/`radar_bookbinder`/`radar_smhi` style options.

Closes #95.

## Example

```toml
# config.toml
[[style_bundles]]
id = "radar_multi"
[style_bundles.default]
colormap = "radar_dbz"
[[style_bundles.extras]]
name = "radar_fmi"
title = "FMI Radar"
colormap = "radar_fmi"
# ... more extras

# collections.d/fmi-radar.toml
[wms]
style_bundle = "radar_multi"
```

Replaces a 14-line `[wms]` + `[[wms.styles]]` block that was duplicated across every radar provider on the production server.

## Out of scope for this PR

SLD import, per-request bundle overrides, hot file-watching, style inheritance/composition, theme variables, per-parameter bundle refs, bundles declared in a `styles.d/` directory.

## Test plan

- [x] `cargo fmt --all` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace` — all existing tests pass
- [x] New config tests: bundle parses, duplicate ID rejected, unresolved ref rejected, mixing rejected (two variants), empty ID rejected, `Option<String>` colormap migration covered
- [x] New admin tests: `build_styles` expands bundle to default + extras; falls back to inline config when no bundle is referenced
- [x] Smoke: `cargo run -p server -- --collections radar,radar-norway` → "Loaded 2/2 collections successfully" with a bundle-backed collection and an inline-config collection loading side by side
- [x] Manual: hit `/wms?REQUEST=GetCapabilities` and confirm four extra `<Style>` elements appear under the layer — verified on `radar-norway`, 5 Style elements (default + 4 extras)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
