### PR TITLE
feat(discovery): apis[] field, tileset links, MVT conformance (#127 Phase 3)

### DIFF
--- a/crates/api-edr/src/handlers.rs
+++ b/crates/api-edr/src/handlers.rs
@@ -695,6 +695,7 @@ fn build_collection_metadata(
         "id": config.id,
         "title": config.title,
         "description": config.description,
+        "apis": config.apis,
         "links": [
             {
                 "href": format!("{base_url}/edr/collections/{}", config.id),

--- a/crates/api-edr/tests/ogc_edr_api_tests.rs
+++ b/crates/api-edr/tests/ogc_edr_api_tests.rs
@@ -1106,4 +1106,11 @@ mod unimplemented_queries {
         let crs = json["crs"].as_array().unwrap();
         assert!(!crs.is_empty());
     }
+
+    #[tokio::test]
+    async fn collection_exposes_apis_array() {
+        let (_, json) = get("/collections/weather").await;
+        let apis = json["apis"].as_array().expect("apis must be present");
+        assert!(apis.iter().any(|a| a == "edr"));
+    }
 }

--- a/crates/api-edr/tests/ogc_edr_api_tests.rs
+++ b/crates/api-edr/tests/ogc_edr_api_tests.rs
@@ -556,6 +556,13 @@ mod collections {
             "locations link should have 'href'"
         );
     }
+
+    #[tokio::test]
+    async fn collection_exposes_apis_array() {
+        let (_, json) = get("/collections/weather").await;
+        let apis = json["apis"].as_array().expect("apis must be present");
+        assert!(apis.iter().any(|a| a == "edr"));
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1105,12 +1112,5 @@ mod unimplemented_queries {
         );
         let crs = json["crs"].as_array().unwrap();
         assert!(!crs.is_empty());
-    }
-
-    #[tokio::test]
-    async fn collection_exposes_apis_array() {
-        let (_, json) = get("/collections/weather").await;
-        let apis = json["apis"].as_array().expect("apis must be present");
-        assert!(apis.iter().any(|a| a == "edr"));
     }
 }

--- a/crates/api-features/src/handlers.rs
+++ b/crates/api-features/src/handlers.rs
@@ -468,19 +468,20 @@ fn build_collection_metadata(
         }),
     ];
 
-    // If this collection is also exposed through OGC API Tiles as MVT, advertise
-    // the tileset so clients can discover the vector-tile source without probing.
-    // URL template uses `?f=mvt` per the api-tiles content-negotiation route.
+    // If this collection is also exposed through OGC API Tiles, advertise the
+    // tilesets list so clients can discover the vector-tile representation
+    // without probing. Per OGC API – Tiles 1.0 §7.1, the `tilesets-vector`
+    // relation targets the tilesets list resource (`application/json`), not a
+    // tile URL template — the per-tile URL template lives one level deeper
+    // inside the tilesets-list response as `rel: item`. Linking to the list
+    // also avoids hardcoding `WebMercatorQuad`; the list enumerates every
+    // supported TileMatrixSet.
     if config.apis.iter().any(|a| a == "tiles") {
         links.push(json!({
-            "href": format!(
-                "{base_url}/tiles/collections/{}/tiles/WebMercatorQuad/{{tileMatrix}}/{{tileRow}}/{{tileCol}}?f=mvt",
-                config.id
-            ),
+            "href": format!("{base_url}/tiles/collections/{}/tiles", config.id),
             "rel": "http://www.opengis.net/def/rel/ogc/1.0/tilesets-vector",
-            "type": "application/vnd.mapbox-vector-tile",
-            "templated": true,
-            "title": "Vector tiles (MVT)"
+            "type": "application/json",
+            "title": "Vector tilesets"
         }));
     }
 

--- a/crates/api-features/src/handlers.rs
+++ b/crates/api-features/src/handlers.rs
@@ -453,29 +453,48 @@ fn build_collection_metadata(
 ) -> serde_json::Value {
     let total = engine.feature_count();
 
+    let mut links = vec![
+        json!({
+            "href": format!("{base_url}/features/collections/{}", config.id),
+            "rel": "self",
+            "type": "application/json",
+            "title": config.title
+        }),
+        json!({
+            "href": format!("{base_url}/features/collections/{}/items", config.id),
+            "rel": "items",
+            "type": "application/geo+json",
+            "title": "Items"
+        }),
+    ];
+
+    // If this collection is also exposed through OGC API Tiles as MVT, advertise
+    // the tileset so clients can discover the vector-tile source without probing.
+    // URL template uses `?f=mvt` per the api-tiles content-negotiation route.
+    if config.apis.iter().any(|a| a == "tiles") {
+        links.push(json!({
+            "href": format!(
+                "{base_url}/tiles/collections/{}/tiles/WebMercatorQuad/{{tileMatrix}}/{{tileRow}}/{{tileCol}}?f=mvt",
+                config.id
+            ),
+            "rel": "http://www.opengis.net/def/rel/ogc/1.0/tilesets-vector",
+            "type": "application/vnd.mapbox-vector-tile",
+            "templated": true,
+            "title": "Vector tiles (MVT)"
+        }));
+    }
+
     let mut metadata = json!({
         "id": config.id,
         "title": config.title,
         "description": config.description,
+        "apis": config.apis,
         "itemType": "feature",
         "crs": [
             "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
         ],
         "storageCrs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84",
-        "links": [
-            {
-                "href": format!("{base_url}/features/collections/{}", config.id),
-                "rel": "self",
-                "type": "application/json",
-                "title": config.title
-            },
-            {
-                "href": format!("{base_url}/features/collections/{}/items", config.id),
-                "rel": "items",
-                "type": "application/geo+json",
-                "title": "Items"
-            }
-        ],
+        "links": links,
         "numberItems": total
     });
 

--- a/crates/api-features/tests/ogc_features_api_tests.rs
+++ b/crates/api-features/tests/ogc_features_api_tests.rs
@@ -390,9 +390,94 @@ mod collections {
     }
 
     #[tokio::test]
+    async fn collection_detail_exposes_apis_array() {
+        let (_, json) = get("/collections/cities").await;
+        let apis = json["apis"].as_array().expect("apis must be present");
+        assert!(apis.iter().any(|a| a == "features"));
+    }
+
+    #[tokio::test]
     async fn unknown_collection_returns_404() {
         let (status, _) = get("/collections/nonexistent").await;
         assert_eq!(status, StatusCode::NOT_FOUND);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Vector-tile discovery tests
+// ---------------------------------------------------------------------------
+
+mod vector_tile_discovery {
+    use super::*;
+
+    fn build_router_with_tiles() -> axum::Router {
+        // Router seeded with a collection that advertises both Features and
+        // Tiles, mirroring how server/admin.rs would wire a real geojson
+        // collection that the operator opted into vector tiles for.
+        let engine: Arc<dyn FeatureEngine> = Arc::new(MockFeatureEngine::new());
+        let mut engines = HashMap::new();
+        let mut collections = HashMap::new();
+        engines.insert("cities".to_string(), engine);
+        collections.insert(
+            "cities".to_string(),
+            CollectionConfig {
+                id: "cities".to_string(),
+                title: "Finnish Cities".to_string(),
+                description: "City points for testing".to_string(),
+                data_path: None,
+                apis: vec!["features".to_string(), "tiles".to_string()],
+                engine_type: "mock".to_string(),
+                geotiff: None,
+                querydata: None,
+                wms: None,
+                grib: None,
+                postgis: None,
+            },
+        );
+        let state = Arc::new(ArcSwap::from_pointee(FeaturesState {
+            engines,
+            collections,
+            base_url: String::new(),
+        }));
+        api_features::router(state)
+    }
+
+    async fn fetch(uri: &str) -> Value {
+        let app = build_router_with_tiles();
+        let req = Request::builder().uri(uri).body(Body::empty()).unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        let body = resp.into_body().collect().await.unwrap().to_bytes();
+        serde_json::from_slice(&body).unwrap()
+    }
+
+    #[tokio::test]
+    async fn collection_with_tiles_api_advertises_apis_array() {
+        let json = fetch("/collections/cities").await;
+        let apis = json["apis"].as_array().expect("apis must be present");
+        assert!(apis.iter().any(|a| a == "features"));
+        assert!(apis.iter().any(|a| a == "tiles"));
+    }
+
+    #[tokio::test]
+    async fn collection_with_tiles_api_emits_tileset_link() {
+        let json = fetch("/collections/cities").await;
+        let links = json["links"].as_array().expect("links must be present");
+        let tileset_link = links
+            .iter()
+            .find(|l| {
+                l["rel"].as_str() == Some("http://www.opengis.net/def/rel/ogc/1.0/tilesets-vector")
+            })
+            .expect("collection with apis=[tiles] must advertise a vector tileset link");
+        assert_eq!(
+            tileset_link["type"].as_str().unwrap(),
+            "application/vnd.mapbox-vector-tile"
+        );
+        assert_eq!(tileset_link["templated"].as_bool(), Some(true));
+        let href = tileset_link["href"].as_str().unwrap();
+        // URL template points at the api-tiles MVT route, and the format
+        // override stays explicit so blind copy/paste into a tile client works.
+        assert!(href.contains("/tiles/collections/cities/tiles/WebMercatorQuad/"));
+        assert!(href.contains("f=mvt"));
     }
 }
 

--- a/crates/api-features/tests/ogc_features_api_tests.rs
+++ b/crates/api-features/tests/ogc_features_api_tests.rs
@@ -491,42 +491,12 @@ mod vector_tile_discovery {
 
     #[tokio::test]
     async fn collection_without_tiles_api_does_not_emit_tileset_link() {
-        // Use a fresh router whose only collection declares `apis=["features"]`
-        // — i.e. no `"tiles"`. The conditional in `build_collection_metadata`
-        // must omit the `tilesets-vector` link entirely.
-        let engine: Arc<dyn FeatureEngine> = Arc::new(MockFeatureEngine::new());
-        let mut engines = HashMap::new();
-        let mut collections = HashMap::new();
-        engines.insert("cities".to_string(), engine);
-        collections.insert(
-            "cities".to_string(),
-            CollectionConfig {
-                id: "cities".to_string(),
-                title: "Finnish Cities".to_string(),
-                description: "City points for testing".to_string(),
-                data_path: None,
-                apis: vec!["features".to_string()],
-                engine_type: "mock".to_string(),
-                geotiff: None,
-                querydata: None,
-                wms: None,
-                grib: None,
-                postgis: None,
-            },
-        );
-        let state = Arc::new(ArcSwap::from_pointee(FeaturesState {
-            engines,
-            collections,
-            base_url: String::new(),
-        }));
-        let app = api_features::router(state);
-        let req = Request::builder()
-            .uri("/collections/cities")
-            .body(Body::empty())
-            .unwrap();
-        let resp = app.oneshot(req).await.unwrap();
-        let body = resp.into_body().collect().await.unwrap().to_bytes();
-        let json: Value = serde_json::from_slice(&body).unwrap();
+        // Reuse the standard `build_router()` fixture (via `get`), which
+        // seeds `cities` with `apis: ["features"]` only — exactly the
+        // config this assertion needs. The conditional in
+        // `build_collection_metadata` must omit the `tilesets-vector`
+        // link when `tiles` is absent.
+        let (_, json) = get("/collections/cities").await;
         let links = json["links"].as_array().expect("links must be present");
         assert!(
             !links.iter().any(|l| {

--- a/crates/api-features/tests/ogc_features_api_tests.rs
+++ b/crates/api-features/tests/ogc_features_api_tests.rs
@@ -468,16 +468,72 @@ mod vector_tile_discovery {
                 l["rel"].as_str() == Some("http://www.opengis.net/def/rel/ogc/1.0/tilesets-vector")
             })
             .expect("collection with apis=[tiles] must advertise a vector tileset link");
-        assert_eq!(
-            tileset_link["type"].as_str().unwrap(),
-            "application/vnd.mapbox-vector-tile"
+        // Per OGC API – Tiles 1.0 §7.1 the `tilesets-vector` rel targets the
+        // tilesets-list resource (returns JSON), not a tile URL template, so
+        // the type is `application/json` and there is no `templated` flag.
+        assert_eq!(tileset_link["type"].as_str().unwrap(), "application/json");
+        assert!(
+            tileset_link.get("templated").is_none(),
+            "tilesets-vector link must not carry the `templated` HAL-ism: \
+             it points at a concrete tilesets-list URL, not a template"
         );
-        assert_eq!(tileset_link["templated"].as_bool(), Some(true));
         let href = tileset_link["href"].as_str().unwrap();
-        // URL template points at the api-tiles MVT route, and the format
-        // override stays explicit so blind copy/paste into a tile client works.
-        assert!(href.contains("/tiles/collections/cities/tiles/WebMercatorQuad/"));
-        assert!(href.contains("f=mvt"));
+        // No WebMercatorQuad hardcode — the list enumerates every supported
+        // TileMatrixSet, so the discovery link stays correct if another TMS
+        // is added later.
+        assert!(
+            href.ends_with("/tiles/collections/cities/tiles"),
+            "tilesets-vector href must be the tilesets-list endpoint, got: {href}"
+        );
+        assert!(!href.contains("WebMercatorQuad"));
+        assert!(!href.contains("f=mvt"));
+    }
+
+    #[tokio::test]
+    async fn collection_without_tiles_api_does_not_emit_tileset_link() {
+        // Use a fresh router whose only collection declares `apis=["features"]`
+        // — i.e. no `"tiles"`. The conditional in `build_collection_metadata`
+        // must omit the `tilesets-vector` link entirely.
+        let engine: Arc<dyn FeatureEngine> = Arc::new(MockFeatureEngine::new());
+        let mut engines = HashMap::new();
+        let mut collections = HashMap::new();
+        engines.insert("cities".to_string(), engine);
+        collections.insert(
+            "cities".to_string(),
+            CollectionConfig {
+                id: "cities".to_string(),
+                title: "Finnish Cities".to_string(),
+                description: "City points for testing".to_string(),
+                data_path: None,
+                apis: vec!["features".to_string()],
+                engine_type: "mock".to_string(),
+                geotiff: None,
+                querydata: None,
+                wms: None,
+                grib: None,
+                postgis: None,
+            },
+        );
+        let state = Arc::new(ArcSwap::from_pointee(FeaturesState {
+            engines,
+            collections,
+            base_url: String::new(),
+        }));
+        let app = api_features::router(state);
+        let req = Request::builder()
+            .uri("/collections/cities")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        let body = resp.into_body().collect().await.unwrap().to_bytes();
+        let json: Value = serde_json::from_slice(&body).unwrap();
+        let links = json["links"].as_array().expect("links must be present");
+        assert!(
+            !links.iter().any(|l| {
+                l["rel"].as_str() == Some("http://www.opengis.net/def/rel/ogc/1.0/tilesets-vector")
+            }),
+            "collection without `tiles` in apis must not emit a tilesets-vector link"
+        );
     }
 }
 

--- a/crates/api-maps/src/handlers.rs
+++ b/crates/api-maps/src/handlers.rs
@@ -123,6 +123,7 @@ fn build_collection_metadata(
         "id": config.id,
         "title": config.title,
         "description": config.description,
+        "apis": config.apis,
         "dataType": "map",
         "crs": crs_uris,
         "styles": style_list,

--- a/crates/api-maps/tests/integration.rs
+++ b/crates/api-maps/tests/integration.rs
@@ -328,6 +328,13 @@ mod collections {
     }
 
     #[tokio::test]
+    async fn collection_exposes_apis_array() {
+        let (_, json) = get("/collections/radar").await;
+        let apis = json["apis"].as_array().expect("apis must be present");
+        assert!(apis.iter().any(|a| a == "maps"));
+    }
+
+    #[tokio::test]
     async fn unknown_collection_returns_404() {
         let (status, _) = get("/collections/nonexistent").await;
         assert_eq!(status, StatusCode::NOT_FOUND);

--- a/crates/api-tiles/src/handlers.rs
+++ b/crates/api-tiles/src/handlers.rs
@@ -127,6 +127,7 @@ fn build_collection_metadata(
         "id": config.id,
         "title": config.title,
         "description": config.description,
+        "apis": config.apis,
         "dataType": "map",
         "tileMatrixSetLinks": tms_links,
         "styles": style_list,
@@ -424,7 +425,8 @@ pub async fn conformance() -> impl IntoResponse {
             "http://www.opengis.net/spec/tms/2.0/conf/tilematrixset",
             "http://www.opengis.net/spec/tms/2.0/conf/json-tilematrixset",
             "http://www.opengis.net/spec/ogcapi-tiles-1/1.0/conf/png",
-            "http://www.opengis.net/spec/ogcapi-tiles-1/1.0/conf/jpeg"
+            "http://www.opengis.net/spec/ogcapi-tiles-1/1.0/conf/jpeg",
+            "http://www.opengis.net/spec/ogcapi-tiles-1/1.0/conf/mvt"
         ]
     }))
 }

--- a/crates/api-tiles/tests/integration.rs
+++ b/crates/api-tiles/tests/integration.rs
@@ -252,6 +252,18 @@ mod conformance {
     }
 
     #[tokio::test]
+    async fn declares_mvt() {
+        let (_, json) = get("/conformance").await;
+        let classes = json["conformsTo"].as_array().unwrap();
+        assert!(
+            classes
+                .iter()
+                .any(|c| c.as_str().unwrap().ends_with("conf/mvt")),
+            "conformance must include the OGC API Tiles MVT class once ?f=mvt is wired"
+        );
+    }
+
+    #[tokio::test]
     async fn declares_tilematrixset() {
         let (_, json) = get("/conformance").await;
         let classes = json["conformsTo"].as_array().unwrap();
@@ -349,6 +361,13 @@ mod collections {
         let c = &json["collections"][0];
         assert!(c["tileMatrixSetLinks"].is_array());
         assert!(!c["tileMatrixSetLinks"].as_array().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn collection_exposes_apis_array() {
+        let (_, json) = get("/collections/radar").await;
+        let apis = json["apis"].as_array().expect("apis must be present");
+        assert!(apis.iter().any(|a| a == "tiles"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Phase 3 of #127. Originally stacked on #130 (Phase 2); now rebased onto `main` since #130 has merged.

Surfaces enough discovery metadata that a client can determine which APIs a collection supports and follow a typed link to the vector-tile representation when one exists — without N-way probing across the four api crates.

## What changed

- **`apis: Vec<String>`** added to per-collection metadata in all four APIs (`api-edr`, `api-features`, `api-maps`, `api-tiles`). Same shape, same field name, sourced from `CollectionConfig.apis`.
- **api-features** emits a typed `tilesets-vector` link on every collection that declares `tiles` in `apis`. Per OGC API – Tiles 1.0 §7.1 the relation targets the tilesets-list resource (`application/json`), not a tile URL template — the tile URL template lives one level deeper inside that resource as `rel: item`. Linking to the list also drops the `WebMercatorQuad` hardcode: the list enumerates every supported TileMatrixSet, so the discovery link stays correct if another TMS is added later.
  ```json
  {
    "href": "/tiles/collections/{id}/tiles",
    "rel": "http://www.opengis.net/def/rel/ogc/1.0/tilesets-vector",
    "type": "application/json",
    "title": "Vector tilesets"
  }
  ```
- **api-tiles `/conformance`** now advertises `http://www.opengis.net/spec/ogcapi-tiles-1/1.0/conf/mvt` so any spec-aware client knows MVT is on the table.

## Why not also advertise tile conformance from api-features?

Features doesn't itself serve tiles — it just provides a discovery link to api-tiles. The conformance classes belong on the API that actually serves the resource. Same reasoning as the existing api-maps↔api-wms split.

## Test plan

- [x] `cargo test --workspace` — green, including positive + negative `tilesets-vector` link tests in api-features, an MVT-conformance test in api-tiles, and `apis[]` tests in each of the four API crates.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] Negative test (`collection_without_tiles_api_does_not_emit_tileset_link`) asserts a collection with `apis: ["features"]` only emits **no** `tilesets-vector` link — guards the conditional in `build_collection_metadata` against future regressions.

Refs #127.

🤖 Generated with [Claude Code](https://claude.com/claude-code)