### PR TITLE
feat(preview): vector tile layers + click popups (#126 Phase 4)

### DIFF
--- a/collections.d/municipalities.toml
+++ b/collections.d/municipalities.toml
@@ -3,4 +3,4 @@ title = "Finnish Municipalities"
 description = "Municipality boundaries from Statistics Finland (1:1M scale)"
 data_path = "testdata/municipalities.geojson"
 engine_type = "geojson"
-apis = ["features"]
+apis = ["features", "tiles"]

--- a/collections.d/regions.toml
+++ b/collections.d/regions.toml
@@ -3,4 +3,4 @@ title = "Finnish Regions"
 description = "Regional boundaries (maakunta) from Statistics Finland (1:1M scale)"
 data_path = "testdata/regions.geojson"
 engine_type = "geojson"
-apis = ["features"]
+apis = ["features", "tiles"]

--- a/crates/server/preview/app.css
+++ b/crates/server/preview/app.css
@@ -108,3 +108,45 @@ html, body {
     outline: 2px solid #4299e1;
     outline-offset: -1px;
 }
+
+/* Popup body for vector-feature click-inspect */
+.maplibregl-popup-content .popup {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+        Helvetica, Arial, sans-serif;
+    color: #1a202c;
+}
+
+.maplibregl-popup-content .popup h3 {
+    margin: 0 0 8px 0;
+    font-size: 13px;
+    font-weight: 600;
+    color: #2d3748;
+}
+
+.maplibregl-popup-content .popup .popup-row {
+    display: flex;
+    justify-content: space-between;
+    gap: 16px;
+    padding: 3px 0;
+    border-top: 1px solid #f1f5f9;
+    font-size: 12px;
+}
+
+.maplibregl-popup-content .popup .popup-row .k {
+    color: #718096;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    flex-shrink: 0;
+}
+
+.maplibregl-popup-content .popup .popup-row .v {
+    color: #2d3748;
+    text-align: right;
+    word-break: break-word;
+}
+
+.maplibregl-popup-content .popup-empty {
+    margin: 4px 0 0 0;
+    font-size: 12px;
+    color: #a0aec0;
+    font-style: italic;
+}

--- a/crates/server/preview/app.js
+++ b/crates/server/preview/app.js
@@ -39,6 +39,10 @@
     const statusEl = document.getElementById('status');
     const listEl = document.getElementById('collections');
 
+    // Shared across every vector collection so clicking a feature in one
+    // collection dismisses an open popup from another.
+    let activePopup = null;
+
     // `map.on('load')` so MapLibre's style is ready before we add raster
     // sources/layers. Adding sources before style-load throws.
     //
@@ -294,33 +298,23 @@
     // Vector layer wiring
     // -----------------------------------------------------------------
 
-    // Three style layers per source — split by geometry-type so the same
-    // collection can carry mixed geometries without per-feature paint
-    // overrides. The MVT layer name (`source-layer`) equals the collection
-    // id; the ds-mvt encoder uses the same convention server-side.
+    // Split by geometry-type so one collection can carry mixed geometries
+    // without per-feature paint overrides. `source-layer` mirrors the
+    // ds-mvt encoder convention server-side (== collection id).
     function attachVectorLayer(collection, li) {
         const sourceId = 'vsrc-' + collection.id;
         const fillLayerId = 'vfill-' + collection.id;
         const lineLayerId = 'vline-' + collection.id;
         const pointLayerId = 'vpoint-' + collection.id;
 
-        // No `attribution` field: MapLibre renders attribution via
-        // `innerHTML` inside its AttributionControl — a server config
-        // title like `<img src=x onerror=alert(1)>` would execute
-        // script in the preview page. Mirrors the raster source.
+        // No `attribution`: MapLibre renders it via innerHTML.
         map.addSource(sourceId, {
             type: 'vector',
             tiles: [vectorTileUrlFor(collection)]
         });
 
-        // `match` (not `==`) so the filter catches Multi-variants too.
-        // The MVT decoder bundled in MapLibre reconstructs a
-        // `Geometry::MultiPolygon` as GeoJSON `MultiPolygon`, so the
-        // expression `['geometry-type']` returns `'MultiPolygon'` —
-        // an `== 'Polygon'` filter silently drops every multi-feature.
-        // In the test data being opted in here, 68/308 municipalities
-        // and 9/19 regions are MultiPolygon, so the bug would render
-        // a third of the dataset invisible.
+        // `match` over `==` so the filter catches `MultiPolygon` too
+        // (68/308 municipalities in the test data would otherwise vanish).
         map.addLayer({
             id: fillLayerId,
             type: 'fill',
@@ -333,22 +327,13 @@
             }
         });
 
-        // Lines double as polygon outlines so MultiPolygon boundaries stay
-        // visible even when fills overlap. `LineString`/`MultiLineString`
-        // arms are dead today (ds-core's `Geometry` enum has no LineString
-        // variant), but harmless future-proofing.
+        // Polygon outlines so MultiPolygon boundaries stay visible under overlapping fills.
         map.addLayer({
             id: lineLayerId,
             type: 'line',
             source: sourceId,
             'source-layer': collection.id,
-            filter: [
-                'match',
-                ['geometry-type'],
-                ['Polygon', 'MultiPolygon', 'LineString', 'MultiLineString'],
-                true,
-                false
-            ],
+            filter: ['match', ['geometry-type'], ['Polygon', 'MultiPolygon'], true, false],
             paint: {
                 'line-color': '#2b6cb0',
                 'line-width': 1
@@ -371,15 +356,10 @@
 
         const interactiveLayers = [fillLayerId, lineLayerId, pointLayerId];
 
-        // Track the currently-open popup so successive clicks replace
-        // rather than stack. MapLibre does not auto-dismiss existing
-        // popups when a new one is added, so without this, clicking
-        // municipality A then municipality B would leave both panels
-        // open. `null` after `.remove()` keeps the check simple.
-        let activePopup = null;
         map.on('click', interactiveLayers, function (e) {
             if (!e.features || e.features.length === 0) return;
             const feature = e.features[0];
+            // MapLibre doesn't auto-dismiss; replace any existing popup.
             if (activePopup) activePopup.remove();
             activePopup = new maplibregl.Popup({ closeButton: true, maxWidth: '320px' })
                 .setLngLat(e.lngLat)
@@ -390,8 +370,7 @@
             });
         });
 
-        // Cursor feedback. Tracked separately per layer because MapLibre
-        // dispatches mouseenter/mouseleave per-layer, not per-collection.
+        // mouseenter/mouseleave dispatch per-layer, not per-collection.
         interactiveLayers.forEach(function (id) {
             map.on('mouseenter', id, function () {
                 map.getCanvas().style.cursor = 'pointer';
@@ -426,27 +405,16 @@
     }
 
     function vectorTileUrlFor(collection) {
-        // Same placeholder rewrite as `tileUrlFor()` for rasters — same
-        // four OGC placeholder names emitted by the manifest
-        // (`{tileMatrixSetId}` / `{tileMatrix}` / `{tileRow}` / `{tileCol}`,
-        // not the generic `{tms}` / `{z}`). Plus the URL already carries
-        // `?f=mvt` from the manifest, so MapLibre fetches MVT-encoded
-        // bytes.
+        // Same OGC placeholders as raster — `?f=mvt` is already in the manifest.
         let template = collection.tiles.vector.url_template;
         template = template.replace('{tileMatrixSetId}', 'WebMercatorQuad');
         template = template.replace('{tileMatrix}', '{z}');
         template = template.replace('{tileRow}', '{y}');
         template = template.replace('{tileCol}', '{x}');
-        // Vector tiles are loaded inside a MapLibre Web Worker, which
-        // has no `document` base to resolve relative URLs against and
-        // rejects them with "URL is not valid or contains user
-        // credentials". Re-anchor to `window.location.origin` so:
-        //   (a) the worker receives a fully-qualified URL it can parse,
-        //   (b) the host always matches the page's origin, sidestepping
-        //       any 127.0.0.1↔localhost mismatch from `server.base_url`,
-        //       which CSP `connect-src 'self'` would otherwise refuse.
-        // Strip whatever origin the manifest emitted, then prefix the
-        // page's. Idempotent on path-only manifests.
+        // MapLibre's vector-tile worker rejects relative URLs ("URL is not
+        // valid or contains user credentials"). Re-anchor to the page
+        // origin so 127.0.0.1↔localhost mismatch in `server.base_url`
+        // doesn't trip CSP `connect-src 'self'` either.
         template = template.replace(/^https?:\/\/[^/]+/i, '');
         template = window.location.origin + template;
         return template;

--- a/crates/server/preview/app.js
+++ b/crates/server/preview/app.js
@@ -122,7 +122,11 @@
                 }
             }
             if (c.tiles && c.tiles.vector) {
-                attachVectorLayer(c, li);
+                try {
+                    attachVectorLayer(c, li);
+                } catch (err) {
+                    console.error('attachVectorLayer failed for', c.id, err);
+                }
             }
 
             listEl.appendChild(li);
@@ -309,12 +313,20 @@
             tiles: [vectorTileUrlFor(collection)]
         });
 
+        // `match` (not `==`) so the filter catches Multi-variants too.
+        // The MVT decoder bundled in MapLibre reconstructs a
+        // `Geometry::MultiPolygon` as GeoJSON `MultiPolygon`, so the
+        // expression `['geometry-type']` returns `'MultiPolygon'` —
+        // an `== 'Polygon'` filter silently drops every multi-feature.
+        // In the test data being opted in here, 68/308 municipalities
+        // and 9/19 regions are MultiPolygon, so the bug would render
+        // a third of the dataset invisible.
         map.addLayer({
             id: fillLayerId,
             type: 'fill',
             source: sourceId,
             'source-layer': collection.id,
-            filter: ['==', ['geometry-type'], 'Polygon'],
+            filter: ['match', ['geometry-type'], ['Polygon', 'MultiPolygon'], true, false],
             paint: {
                 'fill-color': '#4299e1',
                 'fill-opacity': 0.18
@@ -322,16 +334,20 @@
         });
 
         // Lines double as polygon outlines so MultiPolygon boundaries stay
-        // visible even when fills overlap.
+        // visible even when fills overlap. `LineString`/`MultiLineString`
+        // arms are dead today (ds-core's `Geometry` enum has no LineString
+        // variant), but harmless future-proofing.
         map.addLayer({
             id: lineLayerId,
             type: 'line',
             source: sourceId,
             'source-layer': collection.id,
             filter: [
-                'any',
-                ['==', ['geometry-type'], 'Polygon'],
-                ['==', ['geometry-type'], 'LineString']
+                'match',
+                ['geometry-type'],
+                ['Polygon', 'MultiPolygon', 'LineString', 'MultiLineString'],
+                true,
+                false
             ],
             paint: {
                 'line-color': '#2b6cb0',
@@ -344,7 +360,7 @@
             type: 'circle',
             source: sourceId,
             'source-layer': collection.id,
-            filter: ['==', ['geometry-type'], 'Point'],
+            filter: ['match', ['geometry-type'], ['Point', 'MultiPoint'], true, false],
             paint: {
                 'circle-radius': 5,
                 'circle-color': '#4299e1',
@@ -463,7 +479,9 @@
         if (value === null || value === undefined) return '—';
         if (typeof value === 'number' && !Number.isInteger(value)) {
             // Trim noisy floating-point trails without losing precision the
-            // user actually asked for; 4 sig figs covers most preview cases.
+            // user actually asked for. 6 sig figs covers area / population /
+            // perimeter values for the radar+admin-boundaries preview without
+            // turning every popup into a wall of decimal noise.
             return value.toLocaleString(undefined, { maximumSignificantDigits: 6 });
         }
         return String(value);

--- a/crates/server/preview/app.js
+++ b/crates/server/preview/app.js
@@ -1,12 +1,17 @@
 // MeteoCore preview SPA.
 //
-// Phase 3 scope: render every `tiles.raster` collection as a MapLibre raster
-// layer, with a sidebar checkbox to toggle visibility and (when more than one
-// style exists) a dropdown to swap styles live. Vector tiles + time slider
-// land in later phases.
+// Renders the manifest into MapLibre layers:
+//   * `tiles.raster` collections → raster source + raster layer, with a
+//     visibility toggle and a style picker (when more than one style is
+//     configured).
+//   * `tiles.vector` collections → vector source + circle/line/fill layers,
+//     with a visibility toggle and a click handler that opens a popup
+//     listing the feature's properties.
 //
-// XSS hygiene: every dynamic value reaches the DOM through `textContent` only.
-// Never use innerHTML with manifest data.
+// Time slider lands in a later phase.
+//
+// XSS hygiene: every dynamic value reaches the DOM through `textContent` or
+// as a typed `<option>` value. Never use innerHTML with manifest data.
 
 (function () {
     'use strict';
@@ -115,6 +120,9 @@
                 } catch (err) {
                     console.error('attachRasterLayer failed for', c.id, err);
                 }
+            }
+            if (c.tiles && c.tiles.vector) {
+                attachVectorLayer(c, li);
             }
 
             listEl.appendChild(li);
@@ -276,5 +284,188 @@
         // reverse-proxy host rewriting.
         template = template.replace(/^https?:\/\/[^/]+/i, '');
         return template;
+    }
+
+    // -----------------------------------------------------------------
+    // Vector layer wiring
+    // -----------------------------------------------------------------
+
+    // Three style layers per source — split by geometry-type so the same
+    // collection can carry mixed geometries without per-feature paint
+    // overrides. The MVT layer name (`source-layer`) equals the collection
+    // id; the ds-mvt encoder uses the same convention server-side.
+    function attachVectorLayer(collection, li) {
+        const sourceId = 'vsrc-' + collection.id;
+        const fillLayerId = 'vfill-' + collection.id;
+        const lineLayerId = 'vline-' + collection.id;
+        const pointLayerId = 'vpoint-' + collection.id;
+
+        // No `attribution` field: MapLibre renders attribution via
+        // `innerHTML` inside its AttributionControl — a server config
+        // title like `<img src=x onerror=alert(1)>` would execute
+        // script in the preview page. Mirrors the raster source.
+        map.addSource(sourceId, {
+            type: 'vector',
+            tiles: [vectorTileUrlFor(collection)]
+        });
+
+        map.addLayer({
+            id: fillLayerId,
+            type: 'fill',
+            source: sourceId,
+            'source-layer': collection.id,
+            filter: ['==', ['geometry-type'], 'Polygon'],
+            paint: {
+                'fill-color': '#4299e1',
+                'fill-opacity': 0.18
+            }
+        });
+
+        // Lines double as polygon outlines so MultiPolygon boundaries stay
+        // visible even when fills overlap.
+        map.addLayer({
+            id: lineLayerId,
+            type: 'line',
+            source: sourceId,
+            'source-layer': collection.id,
+            filter: [
+                'any',
+                ['==', ['geometry-type'], 'Polygon'],
+                ['==', ['geometry-type'], 'LineString']
+            ],
+            paint: {
+                'line-color': '#2b6cb0',
+                'line-width': 1
+            }
+        });
+
+        map.addLayer({
+            id: pointLayerId,
+            type: 'circle',
+            source: sourceId,
+            'source-layer': collection.id,
+            filter: ['==', ['geometry-type'], 'Point'],
+            paint: {
+                'circle-radius': 5,
+                'circle-color': '#4299e1',
+                'circle-stroke-color': '#ffffff',
+                'circle-stroke-width': 1.5
+            }
+        });
+
+        const interactiveLayers = [fillLayerId, lineLayerId, pointLayerId];
+
+        map.on('click', interactiveLayers, function (e) {
+            if (!e.features || e.features.length === 0) return;
+            const feature = e.features[0];
+            new maplibregl.Popup({ closeButton: true, maxWidth: '320px' })
+                .setLngLat(e.lngLat)
+                .setDOMContent(buildPopupBody(collection, feature))
+                .addTo(map);
+        });
+
+        // Cursor feedback. Tracked separately per layer because MapLibre
+        // dispatches mouseenter/mouseleave per-layer, not per-collection.
+        interactiveLayers.forEach(function (id) {
+            map.on('mouseenter', id, function () {
+                map.getCanvas().style.cursor = 'pointer';
+            });
+            map.on('mouseleave', id, function () {
+                map.getCanvas().style.cursor = '';
+            });
+        });
+
+        // Sidebar control — single checkbox flips all three layers together.
+        const controls = document.createElement('div');
+        controls.className = 'controls';
+
+        const toggle = document.createElement('label');
+        toggle.className = 'toggle';
+        const checkbox = document.createElement('input');
+        checkbox.type = 'checkbox';
+        checkbox.checked = true;
+        checkbox.addEventListener('change', function () {
+            const visibility = checkbox.checked ? 'visible' : 'none';
+            interactiveLayers.forEach(function (id) {
+                map.setLayoutProperty(id, 'visibility', visibility);
+            });
+        });
+        toggle.appendChild(checkbox);
+        const toggleText = document.createElement('span');
+        toggleText.textContent = 'Vector layer';
+        toggle.appendChild(toggleText);
+        controls.appendChild(toggle);
+
+        li.appendChild(controls);
+    }
+
+    function vectorTileUrlFor(collection) {
+        // Same placeholder rewrite as `tileUrlFor()` for rasters — same
+        // four OGC placeholder names emitted by the manifest
+        // (`{tileMatrixSetId}` / `{tileMatrix}` / `{tileRow}` / `{tileCol}`,
+        // not the generic `{tms}` / `{z}`). Plus the URL already carries
+        // `?f=mvt` from the manifest, so MapLibre fetches MVT-encoded
+        // bytes. Finally, strip the absolute origin so a 127.0.0.1↔
+        // localhost mismatch doesn't trip CSP `connect-src 'self'`.
+        let template = collection.tiles.vector.url_template;
+        template = template.replace('{tileMatrixSetId}', 'WebMercatorQuad');
+        template = template.replace('{tileMatrix}', '{z}');
+        template = template.replace('{tileRow}', '{y}');
+        template = template.replace('{tileCol}', '{x}');
+        template = template.replace(/^https?:\/\/[^/]+/i, '');
+        return template;
+    }
+
+    function buildPopupBody(collection, feature) {
+        const root = document.createElement('div');
+        root.className = 'popup';
+
+        const heading = document.createElement('h3');
+        heading.textContent = collection.title || collection.id;
+        root.appendChild(heading);
+
+        const rows = [];
+        if (feature.id !== undefined && feature.id !== null && feature.id !== '') {
+            rows.push(['id', String(feature.id)]);
+        }
+        const props = feature.properties || {};
+        Object.keys(props)
+            .sort()
+            .forEach(function (key) {
+                rows.push([key, formatPropertyValue(props[key])]);
+            });
+
+        if (rows.length === 0) {
+            const empty = document.createElement('p');
+            empty.className = 'popup-empty';
+            empty.textContent = 'No properties.';
+            root.appendChild(empty);
+            return root;
+        }
+
+        rows.forEach(function (kv) {
+            const row = document.createElement('div');
+            row.className = 'popup-row';
+            const k = document.createElement('span');
+            k.className = 'k';
+            k.textContent = kv[0];
+            const v = document.createElement('span');
+            v.className = 'v';
+            v.textContent = kv[1];
+            row.appendChild(k);
+            row.appendChild(v);
+            root.appendChild(row);
+        });
+        return root;
+    }
+
+    function formatPropertyValue(value) {
+        if (value === null || value === undefined) return '—';
+        if (typeof value === 'number' && !Number.isInteger(value)) {
+            // Trim noisy floating-point trails without losing precision the
+            // user actually asked for; 4 sig figs covers most preview cases.
+            return value.toLocaleString(undefined, { maximumSignificantDigits: 6 });
+        }
+        return String(value);
     }
 })();

--- a/crates/server/preview/app.js
+++ b/crates/server/preview/app.js
@@ -431,14 +431,24 @@
         // (`{tileMatrixSetId}` / `{tileMatrix}` / `{tileRow}` / `{tileCol}`,
         // not the generic `{tms}` / `{z}`). Plus the URL already carries
         // `?f=mvt` from the manifest, so MapLibre fetches MVT-encoded
-        // bytes. Finally, strip the absolute origin so a 127.0.0.1↔
-        // localhost mismatch doesn't trip CSP `connect-src 'self'`.
+        // bytes.
         let template = collection.tiles.vector.url_template;
         template = template.replace('{tileMatrixSetId}', 'WebMercatorQuad');
         template = template.replace('{tileMatrix}', '{z}');
         template = template.replace('{tileRow}', '{y}');
         template = template.replace('{tileCol}', '{x}');
+        // Vector tiles are loaded inside a MapLibre Web Worker, which
+        // has no `document` base to resolve relative URLs against and
+        // rejects them with "URL is not valid or contains user
+        // credentials". Re-anchor to `window.location.origin` so:
+        //   (a) the worker receives a fully-qualified URL it can parse,
+        //   (b) the host always matches the page's origin, sidestepping
+        //       any 127.0.0.1↔localhost mismatch from `server.base_url`,
+        //       which CSP `connect-src 'self'` would otherwise refuse.
+        // Strip whatever origin the manifest emitted, then prefix the
+        // page's. Idempotent on path-only manifests.
         template = template.replace(/^https?:\/\/[^/]+/i, '');
+        template = window.location.origin + template;
         return template;
     }
 

--- a/crates/server/preview/app.js
+++ b/crates/server/preview/app.js
@@ -371,13 +371,23 @@
 
         const interactiveLayers = [fillLayerId, lineLayerId, pointLayerId];
 
+        // Track the currently-open popup so successive clicks replace
+        // rather than stack. MapLibre does not auto-dismiss existing
+        // popups when a new one is added, so without this, clicking
+        // municipality A then municipality B would leave both panels
+        // open. `null` after `.remove()` keeps the check simple.
+        let activePopup = null;
         map.on('click', interactiveLayers, function (e) {
             if (!e.features || e.features.length === 0) return;
             const feature = e.features[0];
-            new maplibregl.Popup({ closeButton: true, maxWidth: '320px' })
+            if (activePopup) activePopup.remove();
+            activePopup = new maplibregl.Popup({ closeButton: true, maxWidth: '320px' })
                 .setLngLat(e.lngLat)
                 .setDOMContent(buildPopupBody(collection, feature))
                 .addTo(map);
+            activePopup.on('close', function () {
+                activePopup = null;
+            });
         });
 
         // Cursor feedback. Tracked separately per layer because MapLibre


### PR DESCRIPTION
## Summary

Phase 4 of #126. Stacked on top of #134. For every manifest entry with `tiles.vector`, the SPA now adds three MapLibre style layers (circle for points, fill for polygons, line for outlines + linestrings) over one vector source backed by `?f=mvt`. Click → popup with the feature's id + sorted properties. One sidebar checkbox flips all three layers together.

## Embedded bugfixes

This PR also fixes two real issues that surfaced during the smoke test — both pre-existing, both shipped in the same commit because each was a blocker for verifying Phase 4:

1. **`api-tiles` MVT handler bug (introduced #127 Phase 2):** the handler passed `FeatureQuery { limit: 0 }`. `PostgisEngine` reads that as "unlimited"; `GeoJsonEngine` reads it as "return zero". Every MVT tile from a geojson collection was a 23-byte empty layer header. Fixed by passing `MAX_FEATURES_PER_TILE + 1` instead — density guard already catches anything beyond the cap. The api-tiles integration test's mock was also tightened to mirror `GeoJsonEngine` semantics so this regresses if reintroduced.

2. **Asset cache headers (introduced #126 Phase 2):** `Cache-Control: public, max-age=86400, immutable` made the browser ignore upstream binary bumps without a forced refresh. Replaced with `public, max-age=0, must-revalidate` + ETag derived from rust-embed's content sha256. Browser sends `If-None-Match`; server returns 304 on match. New asset bytes propagate on the next navigation without manual cache-clear.

## Files

- `crates/server/preview/app.js` — `attachVectorLayer`, `vectorTileUrlFor`, `buildPopupBody`, `formatPropertyValue`.
- `crates/server/preview/app.css` — `.popup` and `.popup-row` styling.
- `crates/server/src/preview.rs` — ETag handler + revalidating Cache-Control.
- `crates/api-tiles/src/handlers.rs` — `limit` fix.
- `crates/api-tiles/tests/integration.rs` — tightened mock.
- `collections.d/{municipalities,regions}.toml` — opted into `apis = ["features", "tiles"]` so the existing deployment exercises the path.

## XSS hygiene

Every dynamic value (feature id, property key, property value) reaches the DOM via `.textContent`. No `innerHTML` use anywhere.

## Manual smoke (live deployment)

- 12 collections in sidebar: 2 vector-toggleable (municipalities, regions) + 9 raster-toggleable + 1 features-only.
- MVT bytes: 51 KB at z=0/0/0 (world), 79 KB at z=5/9/18 (Finland), 9.6 KB at z=9/147/291 (Helsinki). All were 23 B empty before the limit fix.
- MapLibre `sourcedata` events confirm `vsrc-municipalities` + `vsrc-regions` tiles loading at z=9 in `state: 'loaded'`.
- Visible-feature query at Helsinki returns polygons from `vfill-municipalities`; click handler fires popup with municipality properties.

## Test plan

- [x] `cargo test --workspace` — 26 groups, all green (includes the updated cache-header test).
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.

## What's next

- **Phase 5** — time slider for time-aware collections.
- **Phase 6** — polish + README/ARCHITECTURE notes.

Refs #126.

🤖 Generated with [Claude Code](https://claude.com/claude-code)