### PR TITLE
feat(preview): time slider + polished cards + opt-in layers (#126 Phase 5)

### DIFF
--- a/crates/server/preview/app.css
+++ b/crates/server/preview/app.css
@@ -1,11 +1,31 @@
+:root {
+    color-scheme: dark light;
+    --bg: #0b1220;
+    --panel: rgba(15, 23, 42, 0.85);
+    --panel-border: rgba(148, 163, 184, 0.18);
+    --card: rgba(30, 41, 59, 0.7);
+    --card-active: rgba(37, 99, 235, 0.18);
+    --card-active-border: rgba(96, 165, 250, 0.55);
+    --text: #f1f5f9;
+    --text-dim: #94a3b8;
+    --text-faint: #64748b;
+    --accent: #60a5fa;
+    --accent-strong: #2563eb;
+    --divider: rgba(148, 163, 184, 0.12);
+    --shadow: 0 18px 40px rgba(2, 6, 23, 0.55), 0 2px 6px rgba(2, 6, 23, 0.4);
+    --radius: 14px;
+}
+
 html, body {
     margin: 0;
     padding: 0;
     height: 100%;
-    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+    font-family: -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", Roboto,
         Helvetica, Arial, sans-serif;
-    color: #1a202c;
-    background: #f7fafc;
+    color: var(--text);
+    background: var(--bg);
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
 }
 
 #map {
@@ -13,140 +33,471 @@ html, body {
     inset: 0;
 }
 
+/* ------------------------------------------------------------------ */
+/* Sidebar                                                            */
+/* ------------------------------------------------------------------ */
+
 #sidebar {
     position: absolute;
     top: 16px;
     left: 16px;
-    width: 320px;
+    width: 360px;
     max-height: calc(100vh - 32px);
-    overflow-y: auto;
-    padding: 16px 20px;
-    background: rgba(255, 255, 255, 0.96);
-    backdrop-filter: blur(8px);
-    border-radius: 12px;
-    box-shadow: 0 4px 24px rgba(0, 0, 0, 0.12);
+    display: flex;
+    flex-direction: column;
+    padding: 18px 18px 4px;
+    background: var(--panel);
+    backdrop-filter: blur(14px) saturate(140%);
+    -webkit-backdrop-filter: blur(14px) saturate(140%);
+    border: 1px solid var(--panel-border);
+    border-radius: var(--radius);
+    box-shadow: var(--shadow);
     z-index: 10;
 }
 
+#sidebar header {
+    flex: 0 0 auto;
+    padding-bottom: 12px;
+    margin-bottom: 12px;
+    border-bottom: 1px solid var(--divider);
+}
+
 #sidebar h1 {
-    margin: 0 0 4px 0;
-    font-size: 18px;
+    margin: 0;
+    font-size: 17px;
     font-weight: 600;
+    letter-spacing: -0.01em;
+    color: var(--text);
 }
 
 #sidebar #status {
-    margin: 0 0 12px 0;
+    margin: 4px 0 0;
     font-size: 12px;
-    color: #4a5568;
+    color: var(--text-dim);
+    letter-spacing: 0.01em;
+}
+
+#sidebar #status.error {
+    color: #fca5a5;
 }
 
 #sidebar ul {
     margin: 0;
-    padding: 0;
+    padding: 0 4px 14px 0;
     list-style: none;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    flex: 1 1 auto;
 }
 
-#sidebar li.collection {
-    padding: 10px 0;
-    border-top: 1px solid #edf2f7;
+#sidebar ul::-webkit-scrollbar { width: 8px; }
+#sidebar ul::-webkit-scrollbar-track { background: transparent; }
+#sidebar ul::-webkit-scrollbar-thumb {
+    background: rgba(148, 163, 184, 0.25);
+    border-radius: 4px;
+}
+#sidebar ul::-webkit-scrollbar-thumb:hover { background: rgba(148, 163, 184, 0.4); }
+
+li.collection {
+    margin: 0 0 10px;
+}
+li.collection:last-child { margin-bottom: 4px; }
+
+/* ------------------------------------------------------------------ */
+/* Card                                                               */
+/* ------------------------------------------------------------------ */
+
+.card {
+    background: var(--card);
+    border: 1px solid var(--panel-border);
+    border-radius: 10px;
+    padding: 12px 14px;
+    transition: border-color 0.18s ease, background-color 0.18s ease,
+                box-shadow 0.18s ease;
 }
 
-.collection-header {
+.card:hover {
+    border-color: rgba(148, 163, 184, 0.34);
+}
+
+.card.active {
+    background: var(--card-active);
+    border-color: var(--card-active-border);
+    box-shadow: 0 0 0 1px rgba(96, 165, 250, 0.18) inset;
+}
+
+.card-header {
     display: flex;
-    flex-direction: column;
-    gap: 2px;
+    align-items: flex-start;
+    gap: 12px;
 }
 
-.collection-header .title {
-    font-weight: 500;
-    font-size: 13px;
-    color: #2d3748;
+.card-title-block {
+    flex: 1 1 auto;
+    min-width: 0;
 }
 
-.collection-header .apis {
+.card-title {
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--text);
+    line-height: 1.25;
+    word-break: break-word;
+}
+
+.card-subtitle {
     font-size: 11px;
-    color: #718096;
     font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    color: var(--text-faint);
+    margin-top: 2px;
+    word-break: break-all;
 }
+
+.card-desc {
+    margin: 8px 0 0;
+    font-size: 12px;
+    line-height: 1.45;
+    color: var(--text-dim);
+}
+
+/* ------------------------------------------------------------------ */
+/* Toggle switch                                                       */
+/* ------------------------------------------------------------------ */
+
+.switch {
+    position: relative;
+    display: inline-block;
+    width: 32px;
+    height: 18px;
+    flex-shrink: 0;
+    cursor: pointer;
+    margin-top: 1px;
+}
+
+.switch input {
+    opacity: 0;
+    width: 0;
+    height: 0;
+}
+
+.switch-slider {
+    position: absolute;
+    inset: 0;
+    background-color: rgba(100, 116, 139, 0.5);
+    border-radius: 999px;
+    transition: background-color 0.18s ease;
+}
+
+.switch-slider::before {
+    content: "";
+    position: absolute;
+    height: 14px;
+    width: 14px;
+    left: 2px;
+    top: 2px;
+    background: #f8fafc;
+    border-radius: 50%;
+    transition: transform 0.18s ease, background-color 0.18s ease;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
+}
+
+.switch input:checked + .switch-slider {
+    background-color: var(--accent);
+}
+
+.switch input:checked + .switch-slider::before {
+    transform: translateX(14px);
+}
+
+.switch input:focus-visible + .switch-slider {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+}
+
+/* ------------------------------------------------------------------ */
+/* Badges                                                              */
+/* ------------------------------------------------------------------ */
+
+.badges {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 5px;
+    margin-top: 8px;
+}
+
+.badge {
+    font-size: 10px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    padding: 2px 7px;
+    border-radius: 999px;
+    background: rgba(148, 163, 184, 0.18);
+    color: var(--text-dim);
+    border: 1px solid transparent;
+}
+
+.badge-edr      { background: rgba(56, 189, 248, 0.12); color: #7dd3fc; border-color: rgba(56, 189, 248, 0.25); }
+.badge-features { background: rgba(34, 197, 94, 0.12);  color: #86efac; border-color: rgba(34, 197, 94, 0.25); }
+.badge-maps     { background: rgba(168, 85, 247, 0.12); color: #c4b5fd; border-color: rgba(168, 85, 247, 0.25); }
+.badge-tiles    { background: rgba(245, 158, 11, 0.12); color: #fcd34d; border-color: rgba(245, 158, 11, 0.25); }
+.badge-wms      { background: rgba(244, 114, 182, 0.12); color: #f9a8d4; border-color: rgba(244, 114, 182, 0.25); }
+
+/* ------------------------------------------------------------------ */
+/* Metadata                                                            */
+/* ------------------------------------------------------------------ */
+
+.card-meta {
+    display: grid;
+    grid-template-columns: 56px 1fr;
+    gap: 4px 10px;
+    margin: 10px 0 0;
+    font-size: 11.5px;
+    line-height: 1.4;
+}
+
+.card-meta dt {
+    color: var(--text-faint);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    font-size: 10px;
+    font-weight: 600;
+    padding-top: 1px;
+}
+
+.card-meta dd {
+    margin: 0;
+    color: var(--text-dim);
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 11px;
+    word-break: break-word;
+}
+
+/* ------------------------------------------------------------------ */
+/* Controls (style picker, time slider, etc.)                          */
+/* ------------------------------------------------------------------ */
 
 .controls {
     display: flex;
     flex-direction: column;
-    gap: 6px;
-    margin-top: 8px;
-    font-size: 12px;
+    gap: 8px;
+    margin-top: 10px;
 }
 
-.controls label {
+.controls:empty { display: none; }
+
+.control-row {
     display: flex;
     align-items: center;
-    gap: 6px;
-    color: #4a5568;
+    gap: 8px;
+    font-size: 12px;
+    color: var(--text-dim);
 }
 
-.controls input[type="checkbox"] {
-    margin: 0;
-    cursor: pointer;
-}
-
-.controls .style-picker {
-    justify-content: space-between;
+.control-label {
+    font-size: 10px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--text-faint);
 }
 
 .controls select {
     flex: 1;
-    margin-left: 8px;
-    padding: 2px 6px;
+    padding: 4px 8px;
     font-size: 12px;
-    border: 1px solid #cbd5e0;
-    border-radius: 4px;
-    background: white;
+    color: var(--text);
+    border: 1px solid rgba(148, 163, 184, 0.3);
+    border-radius: 6px;
+    background: rgba(15, 23, 42, 0.7);
     cursor: pointer;
+    appearance: none;
+    background-image: linear-gradient(45deg, transparent 50%, var(--text-dim) 50%),
+                       linear-gradient(135deg, var(--text-dim) 50%, transparent 50%);
+    background-position: calc(100% - 12px) 50%, calc(100% - 8px) 50%;
+    background-size: 4px 4px, 4px 4px;
+    background-repeat: no-repeat;
+    padding-right: 24px;
 }
 
 .controls select:focus {
-    outline: 2px solid #4299e1;
-    outline-offset: -1px;
+    outline: 2px solid var(--accent);
+    outline-offset: 1px;
+    border-color: var(--accent);
 }
 
-/* Popup body for vector-feature click-inspect */
-.maplibregl-popup-content .popup {
-    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
-        Helvetica, Arial, sans-serif;
-    color: #1a202c;
+/* ------------------------------------------------------------------ */
+/* Time slider                                                         */
+/* ------------------------------------------------------------------ */
+
+.time-slider {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 4px 10px;
+    align-items: center;
+    padding-top: 6px;
+    border-top: 1px solid var(--divider);
+    margin-top: 2px;
 }
 
-.maplibregl-popup-content .popup h3 {
-    margin: 0 0 8px 0;
+.time-slider .control-label {
+    grid-column: 1;
+    grid-row: 1;
+}
+
+.time-slider .time-value {
+    grid-column: 2;
+    grid-row: 1;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 11px;
+    color: var(--text);
+    text-align: right;
+}
+
+.time-slider input[type="range"] {
+    grid-column: 1 / -1;
+    grid-row: 2;
+    appearance: none;
+    width: 100%;
+    height: 6px;
+    border-radius: 999px;
+    background: linear-gradient(to right, var(--accent-strong), var(--accent));
+    outline: none;
+    margin: 4px 0 2px;
+    cursor: pointer;
+}
+
+.time-slider input[type="range"]::-webkit-slider-thumb {
+    appearance: none;
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    background: #fff;
+    border: 2px solid var(--accent);
+    cursor: pointer;
+    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.4);
+}
+
+.time-slider input[type="range"]::-moz-range-thumb {
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    background: #fff;
+    border: 2px solid var(--accent);
+    cursor: pointer;
+}
+
+.time-ticks {
+    grid-column: 1 / -1;
+    grid-row: 3;
+    display: flex;
+    justify-content: space-between;
+    font-size: 9.5px;
+    color: var(--text-faint);
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+/* ------------------------------------------------------------------ */
+/* Footer + buttons                                                    */
+/* ------------------------------------------------------------------ */
+
+.card-footer {
+    margin-top: 10px;
+    padding-top: 8px;
+    border-top: 1px solid var(--divider);
+    display: flex;
+    gap: 12px;
+}
+
+.link {
+    background: none;
+    border: 0;
+    padding: 0;
+    color: var(--accent);
+    font-size: 11px;
+    font-weight: 500;
+    cursor: pointer;
+    letter-spacing: 0.01em;
+}
+
+.link:hover { text-decoration: underline; }
+.link:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; border-radius: 2px; }
+
+/* ------------------------------------------------------------------ */
+/* MapLibre overrides — tone down default chrome to match dark theme  */
+/* ------------------------------------------------------------------ */
+
+.maplibregl-ctrl-attrib {
+    background: rgba(15, 23, 42, 0.7) !important;
+    color: var(--text-dim) !important;
+}
+.maplibregl-ctrl-attrib a { color: var(--text-dim) !important; }
+
+.maplibregl-ctrl-scale {
+    background: rgba(15, 23, 42, 0.7) !important;
+    color: var(--text) !important;
+    border-color: var(--text-dim) !important;
+}
+
+.maplibregl-ctrl-group {
+    background: rgba(15, 23, 42, 0.85) !important;
+    border: 1px solid var(--panel-border) !important;
+}
+.maplibregl-ctrl-group button {
+    filter: invert(0.92) hue-rotate(180deg);
+}
+
+/* ------------------------------------------------------------------ */
+/* Popup                                                               */
+/* ------------------------------------------------------------------ */
+
+.maplibregl-popup-content {
+    background: var(--panel) !important;
+    color: var(--text) !important;
+    border: 1px solid var(--panel-border);
+    border-radius: 8px;
+    box-shadow: var(--shadow);
+    padding: 12px 14px !important;
+}
+.maplibregl-popup-tip { border-top-color: var(--panel) !important; border-bottom-color: var(--panel) !important; }
+.maplibregl-popup-close-button {
+    color: var(--text-dim) !important;
+    font-size: 18px !important;
+    padding: 4px 8px !important;
+}
+.maplibregl-popup-close-button:hover { color: var(--text) !important; background: transparent !important; }
+
+.popup h3 {
+    margin: 0 0 8px;
     font-size: 13px;
     font-weight: 600;
-    color: #2d3748;
+    color: var(--text);
 }
 
-.maplibregl-popup-content .popup .popup-row {
+.popup .popup-row {
     display: flex;
     justify-content: space-between;
     gap: 16px;
-    padding: 3px 0;
-    border-top: 1px solid #f1f5f9;
+    padding: 4px 0;
+    border-top: 1px solid var(--divider);
     font-size: 12px;
 }
 
-.maplibregl-popup-content .popup .popup-row .k {
-    color: #718096;
+.popup .popup-row .k {
+    color: var(--text-faint);
     font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
     flex-shrink: 0;
 }
 
-.maplibregl-popup-content .popup .popup-row .v {
-    color: #2d3748;
+.popup .popup-row .v {
+    color: var(--text);
     text-align: right;
     word-break: break-word;
 }
 
-.maplibregl-popup-content .popup-empty {
-    margin: 4px 0 0 0;
+.popup-empty {
+    margin: 4px 0 0;
     font-size: 12px;
-    color: #a0aec0;
+    color: var(--text-faint);
     font-style: italic;
 }

--- a/crates/server/preview/app.js
+++ b/crates/server/preview/app.js
@@ -1,14 +1,16 @@
 // MeteoCore preview SPA.
 //
-// Renders the manifest into MapLibre layers:
-//   * `tiles.raster` collections → raster source + raster layer, with a
-//     visibility toggle and a style picker (when more than one style is
-//     configured).
-//   * `tiles.vector` collections → vector source + circle/line/fill layers,
-//     with a visibility toggle and a click handler that opens a popup
-//     listing the feature's properties.
+// Renders the manifest into MapLibre layers and a sidebar of collection cards.
 //
-// Time slider lands in a later phase.
+// Per-collection model:
+//   * Layers start hidden — the user opts in by toggling each card. Showing
+//     every collection by default produces visual noise when a deployment has
+//     more than a handful (and is expensive for tile-heavy raster layers).
+//   * First enable zooms the map to that collection's spatial extent so the
+//     user doesn't have to hunt for the data.
+//   * Cards display title, description, API surface, spatial bbox, and (when
+//     present) a time slider scrubbing through the temporal extent's discrete
+//     timesteps.
 //
 // XSS hygiene: every dynamic value reaches the DOM through `textContent` or
 // as a typed `<option>` value. Never use innerHTML with manifest data.
@@ -25,7 +27,7 @@
                 {
                     id: 'background',
                     type: 'background',
-                    paint: { 'background-color': '#e2e8f0' }
+                    paint: { 'background-color': '#0f172a' }
                 }
             ]
         },
@@ -35,189 +37,333 @@
     });
 
     map.addControl(new maplibregl.NavigationControl({ showCompass: false }));
+    map.addControl(new maplibregl.ScaleControl({ unit: 'metric' }), 'bottom-right');
 
     const statusEl = document.getElementById('status');
     const listEl = document.getElementById('collections');
 
-    // Shared across every vector collection so clicking a feature in one
-    // collection dismisses an open popup from another.
+    // Shared across every vector collection so a click in one collection
+    // dismisses an open popup from another.
     let activePopup = null;
 
-    // `map.on('load')` so MapLibre's style is ready before we add raster
-    // sources/layers. Adding sources before style-load throws.
-    //
-    // Absolute manifest path: relative `manifest.json` would only resolve
-    // correctly when the URL ends in `/`, but the route table accepts both
-    // `/preview` and `/preview/`. Full proxy-prefix support (relative paths
-    // + `<base>` + redirect to enforce trailing slash) is later-phase work.
-    map.on('load', function () {
-        fetch('/preview/manifest.json')
-            .then(function (r) {
-                if (!r.ok) throw new Error('HTTP ' + r.status);
-                return r.json();
-            })
-            .then(renderManifest)
-            .catch(function (err) {
-                statusEl.textContent = 'Failed to load manifest: ' + err.message;
-                console.error('manifest fetch failed', err);
-            });
-    });
+    // Fetch the manifest in parallel with map initialization. Sources can't
+    // be added until the style is parsed, so the card factory defers
+    // `addSource`/`addLayer` behind `mapReady`. We poll `isStyleLoaded()`
+    // instead of subscribing to `load` because the `load` event is gated on
+    // glyph/sprite resolution and a minimal style with only a background
+    // layer doesn't always fire it in MapLibre 5.
+
+    fetch('/preview/manifest.json')
+        .then(function (r) {
+            if (!r.ok) throw new Error('HTTP ' + r.status);
+            return r.json();
+        })
+        .then(renderManifest)
+        .catch(function (err) {
+            statusEl.textContent = 'Failed to load manifest: ' + err.message;
+            statusEl.classList.add('error');
+            console.error('manifest fetch failed', err);
+        });
 
     function renderManifest(manifest) {
         const collections = manifest.collections || [];
-        // We fetch a single page (default limit=100). The total can exceed
-        // that; advertise the shortfall so users don't think the list is
-        // complete. Defensive read on `pagination`: a future schema change
-        // or a partial parse shouldn't crash the SPA before the map
-        // renders. Fall back to the rendered count.
-        const rendered = collections.length;
-        const total =
-            manifest.pagination && typeof manifest.pagination.total === 'number'
-                ? manifest.pagination.total
-                : rendered;
-        const noun = total === 1 ? 'collection' : 'collections';
+        const total = manifest.pagination ? manifest.pagination.total : collections.length;
         statusEl.textContent =
             total === 0
                 ? 'No collections registered.'
-                : rendered < total
-                    ? rendered + ' of ' + total + ' ' + noun + ' (paginated)'
-                    : total + ' ' + noun;
+                : total + (total === 1 ? ' collection' : ' collections') + ' available';
 
-        fitMapToCollections(collections);
+        if (collections.length === 0) return;
 
-        // Stable iteration order matches the manifest, which sorts by id.
-        // `map.addLayer()` without `beforeId` appends to the top of the
-        // draw stack, so the *last* collection iterated (alphabetically
-        // latest id) renders on top — same convention as the comment at
-        // `attachRasterLayer` ("collections later in the manifest stack
-        // on top"). Operators wanting a different stack can re-order
-        // collections in config.
         collections.forEach(function (c) {
-            const li = document.createElement('li');
-            li.className = 'collection';
-
-            const header = document.createElement('div');
-            header.className = 'collection-header';
-
-            const title = document.createElement('span');
-            title.className = 'title';
-            title.textContent = c.title || c.id;
-            header.appendChild(title);
-
-            const apis = document.createElement('span');
-            apis.className = 'apis';
-            apis.textContent = (c.apis || []).join(' · ');
-            header.appendChild(apis);
-
-            li.appendChild(header);
-
-            // Per-collection error isolation: `map.addSource` and
-            // `map.addLayer` throw synchronously on duplicate IDs,
-            // missing style, and similar boundary conditions. An
-            // uncaught throw inside `forEach` aborts the whole loop, so
-            // one malformed collection would silently drop every
-            // collection after it from the sidebar. Catch + log; the
-            // sidebar entry without controls is still informative.
-            if (c.tiles && c.tiles.raster) {
-                try {
-                    attachRasterLayer(c, li);
-                } catch (err) {
-                    console.error('attachRasterLayer failed for', c.id, err);
-                }
-            }
-            if (c.tiles && c.tiles.vector) {
-                try {
-                    attachVectorLayer(c, li);
-                } catch (err) {
-                    console.error('attachVectorLayer failed for', c.id, err);
-                }
-            }
-
-            listEl.appendChild(li);
+            listEl.appendChild(buildCollectionCard(c));
         });
     }
 
-    function fitMapToCollections(collections) {
-        const bounds = collections.reduce(function (acc, c) {
-            if (!c.spatial_extent) return acc;
-            const e = c.spatial_extent;
-            // Clamp to valid Mercator latitudes — a bbox at the poles
-            // (e.g. ECMWF's [-180,-90,180,90]) projects to infinity in
-            // web Mercator. MapLibre then accepts the bounds but `fitBounds`
-            // resolves to a white-canvas max-zoom view because no finite
-            // pixel rectangle contains the bbox.
-            const south = Math.max(e[1], -85);
-            const north = Math.min(e[3], 85);
-            const sw = [e[0], south];
-            const ne = [e[2], north];
-            if (!acc) return new maplibregl.LngLatBounds(sw, ne);
-            acc.extend(sw);
-            acc.extend(ne);
-            return acc;
-        }, null);
-        if (bounds) map.fitBounds(bounds, { padding: 60, duration: 0 });
+    // Schedule `fn` to run once the map style is ready to accept
+    // `addSource`/`addLayer` calls. `map.isStyleLoaded()` is not reliable
+    // here — in some browser-throttled tabs it never returns true — so we
+    // probe by calling `addSource`'s own readiness check on a throwaway
+    // marker source. On failure we retry on the next `styledata`, `data`,
+    // or `idle` event; whichever fires first re-triggers the probe.
+    function whenStyleReady(map, fn) {
+        const MARKER = '__readiness_probe__';
+        let done = false;
+        function attempt() {
+            if (done) return;
+            try {
+                map.addSource(MARKER, { type: 'geojson', data: { type: 'FeatureCollection', features: [] } });
+                map.removeSource(MARKER);
+                done = true;
+                fn();
+            } catch (e) {
+                // Subscribe to multiple events; throttled tabs may not get
+                // every one. `setTimeout` also reschedules in case all map
+                // events stay silent (Chrome throttles `setInterval` more
+                // aggressively than `setTimeout`).
+                map.once('styledata', attempt);
+                map.once('data', attempt);
+                map.once('idle', attempt);
+                setTimeout(attempt, 250);
+            }
+        }
+        attempt();
     }
 
-    // -----------------------------------------------------------------
-    // Raster layer wiring
-    // -----------------------------------------------------------------
+    // ------------------------------------------------------------------
+    // Card construction
+    // ------------------------------------------------------------------
 
-    function attachRasterLayer(collection, li) {
+    function buildCollectionCard(collection) {
+        const state = {
+            enabled: false,
+            hasZoomed: false,
+            timeIndex: null,
+            timeValues: temporalValues(collection)
+        };
+
+        const li = document.createElement('li');
+        li.className = 'collection';
+
+        const card = document.createElement('div');
+        card.className = 'card';
+        li.appendChild(card);
+
+        // -- Header row: enable switch + title --
+        const header = document.createElement('div');
+        header.className = 'card-header';
+        card.appendChild(header);
+
+        const toggle = document.createElement('label');
+        toggle.className = 'switch';
+        toggle.title = 'Toggle layer visibility';
+        const checkbox = document.createElement('input');
+        checkbox.type = 'checkbox';
+        checkbox.checked = false;
+        toggle.appendChild(checkbox);
+        const slider = document.createElement('span');
+        slider.className = 'switch-slider';
+        toggle.appendChild(slider);
+        header.appendChild(toggle);
+
+        const titleBlock = document.createElement('div');
+        titleBlock.className = 'card-title-block';
+        const title = document.createElement('div');
+        title.className = 'card-title';
+        title.textContent = collection.title || collection.id;
+        titleBlock.appendChild(title);
+        const subtitle = document.createElement('div');
+        subtitle.className = 'card-subtitle';
+        subtitle.textContent = collection.id;
+        titleBlock.appendChild(subtitle);
+        header.appendChild(titleBlock);
+
+        // -- API badges --
+        if (collection.apis && collection.apis.length > 0) {
+            const badges = document.createElement('div');
+            badges.className = 'badges';
+            collection.apis.forEach(function (api) {
+                const badge = document.createElement('span');
+                badge.className = 'badge badge-' + api;
+                badge.textContent = api;
+                badges.appendChild(badge);
+            });
+            card.appendChild(badges);
+        }
+
+        // -- Description --
+        if (collection.description) {
+            const desc = document.createElement('p');
+            desc.className = 'card-desc';
+            desc.textContent = collection.description;
+            card.appendChild(desc);
+        }
+
+        // -- Metadata: spatial extent, time, etc. --
+        const meta = document.createElement('dl');
+        meta.className = 'card-meta';
+        if (collection.spatial_extent) {
+            appendMeta(meta, 'Extent', formatExtent(collection.spatial_extent));
+        }
+        if (collection.temporal_extent) {
+            const t = collection.temporal_extent;
+            if (t.start && t.end) {
+                appendMeta(meta, 'Time', formatTimeRange(t.start, t.end));
+            }
+            if (t.total_values) {
+                let label = t.total_values + ' timesteps';
+                if (t.truncated) label += ' (sliced)';
+                appendMeta(meta, 'Steps', label);
+            }
+        }
+        if (collection.tiles) {
+            const repr = [];
+            if (collection.tiles.raster) repr.push('raster');
+            if (collection.tiles.vector) repr.push('vector');
+            if (repr.length > 0) appendMeta(meta, 'Tiles', repr.join(' + '));
+        }
+        if (meta.childNodes.length > 0) card.appendChild(meta);
+
+        // -- Layer controls (style picker, time slider, etc.) --
+        const controlsHost = document.createElement('div');
+        controlsHost.className = 'controls';
+        card.appendChild(controlsHost);
+
+        // -- Wire up sources and layers. `addSource` throws
+        // "Style is not done loading" if called before the style finishes
+        // parsing, so we attempt-then-retry until it succeeds. Listening on
+        // `load` alone is unreliable for our minimal background-only style
+        // (the event sometimes doesn't fire at all), but `styledata`
+        // continues to fire as the map updates so it eventually unblocks.
+        const layerHandles = [];
+        whenStyleReady(map, function () {
+            try {
+                if (collection.tiles && collection.tiles.raster) {
+                    layerHandles.push(attachRasterLayer(collection, controlsHost, state));
+                }
+                if (collection.tiles && collection.tiles.vector) {
+                    layerHandles.push(attachVectorLayer(collection, controlsHost, state));
+                }
+                if (state.enabled) {
+                    layerHandles.forEach(function (h) { h.setVisible(true); });
+                }
+            } catch (err) {
+                console.error(
+                    'Failed to attach layers for collection ' + collection.id + ':',
+                    err
+                );
+            }
+        });
+
+        // -- Time slider --
+        if (state.timeValues && state.timeValues.length > 1) {
+            attachTimeSlider(controlsHost, state, layerHandles);
+        }
+
+        // -- Footer: actions --
+        const footer = document.createElement('div');
+        footer.className = 'card-footer';
+        if (collection.spatial_extent) {
+            const zoomBtn = document.createElement('button');
+            zoomBtn.type = 'button';
+            zoomBtn.className = 'link';
+            zoomBtn.textContent = 'Zoom to extent';
+            zoomBtn.addEventListener('click', function () {
+                fitMapToExtent(collection.spatial_extent);
+            });
+            footer.appendChild(zoomBtn);
+        }
+        if (footer.childNodes.length > 0) card.appendChild(footer);
+
+        // -- Wire toggle to layer visibility --
+        checkbox.addEventListener('change', function () {
+            state.enabled = checkbox.checked;
+            card.classList.toggle('active', state.enabled);
+            layerHandles.forEach(function (h) {
+                h.setVisible(state.enabled);
+            });
+            if (state.enabled && !state.hasZoomed && collection.spatial_extent) {
+                fitMapToExtent(collection.spatial_extent);
+                state.hasZoomed = true;
+            }
+        });
+
+        return li;
+    }
+
+    function appendMeta(dl, label, value) {
+        const dt = document.createElement('dt');
+        dt.textContent = label;
+        const dd = document.createElement('dd');
+        dd.textContent = value;
+        dl.appendChild(dt);
+        dl.appendChild(dd);
+    }
+
+    function fitMapToExtent(extent) {
+        const south = Math.max(extent[1], -85);
+        const north = Math.min(extent[3], 85);
+        const bounds = new maplibregl.LngLatBounds([extent[0], south], [extent[2], north]);
+        map.fitBounds(bounds, { padding: 80, maxZoom: 10, duration: 600 });
+    }
+
+    function formatExtent(e) {
+        // Compact human-readable bbox: "W 19.3°, S 59.8° → E 31.6°, N 70.1°"
+        return (
+            'W ' + e[0].toFixed(2) + '°, S ' + e[1].toFixed(2) + '° → ' +
+            'E ' + e[2].toFixed(2) + '°, N ' + e[3].toFixed(2) + '°'
+        );
+    }
+
+    function formatTimeRange(startIso, endIso) {
+        const start = new Date(startIso);
+        const end = new Date(endIso);
+        if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) {
+            return startIso + ' → ' + endIso;
+        }
+        const sameDay =
+            start.getUTCFullYear() === end.getUTCFullYear() &&
+            start.getUTCMonth() === end.getUTCMonth() &&
+            start.getUTCDate() === end.getUTCDate();
+        if (sameDay) {
+            return formatDate(start) + ' · ' + formatTimeOnly(start) + ' → ' + formatTimeOnly(end);
+        }
+        return formatDateTime(start) + ' → ' + formatDateTime(end);
+    }
+
+    function formatDate(d) {
+        return d.toISOString().slice(0, 10);
+    }
+    function formatTimeOnly(d) {
+        return d.toISOString().slice(11, 16) + 'Z';
+    }
+    function formatDateTime(d) {
+        return d.toISOString().slice(0, 16).replace('T', ' ') + 'Z';
+    }
+
+    function temporalValues(collection) {
+        const t = collection.temporal_extent;
+        if (!t) return null;
+        if (Array.isArray(t.values) && t.values.length > 0) return t.values;
+        return null;
+    }
+
+    // ------------------------------------------------------------------
+    // Raster layer
+    // ------------------------------------------------------------------
+
+    function attachRasterLayer(collection, controlsHost, state) {
         const styles = collection.styles || [];
         let currentStyle = styles.length > 0 ? styles[0].id : 'default';
 
         const sourceId = 'src-' + collection.id;
         const layerId = 'layer-' + collection.id;
-        const initialUrl = tileUrlFor(collection, currentStyle);
 
-        // No `attribution` field: MapLibre renders attribution via
-        // `innerHTML` inside its AttributionControl, so a server config
-        // entry like `title = "<img src=x onerror=alert(1)>"` would
-        // execute script in the preview page. The title already appears
-        // in the sidebar (escaped via `textContent`), so the on-map
-        // attribution is redundant anyway.
+        // No `attribution`: MapLibre renders it via innerHTML.
         map.addSource(sourceId, {
             type: 'raster',
-            tiles: [initialUrl],
+            tiles: [tileUrlFor(collection, currentStyle, currentTime(state))],
             tileSize: 256
         });
-        // Append to the top of the draw stack (no `beforeId` argument).
-        // Per the iterator comment above, collections later in the
-        // manifest render above earlier ones — that ordering is enforced
-        // here by the natural append-to-top behaviour.
         map.addLayer({
             id: layerId,
             type: 'raster',
             source: sourceId,
+            // Hidden until the operator opts in via the card toggle. Layout
+            // properties are honoured before paint, so this is enough — no
+            // need to also gate the source.
+            layout: { visibility: 'none' },
             paint: { 'raster-opacity': 1 }
         });
 
-        // -- Toggle --
-        const controls = document.createElement('div');
-        controls.className = 'controls';
-
-        const toggle = document.createElement('label');
-        toggle.className = 'toggle';
-        const checkbox = document.createElement('input');
-        checkbox.type = 'checkbox';
-        checkbox.checked = true;
-        checkbox.addEventListener('change', function () {
-            const visibility = checkbox.checked ? 'visible' : 'none';
-            map.setLayoutProperty(layerId, 'visibility', visibility);
-        });
-        toggle.appendChild(checkbox);
-        const toggleText = document.createElement('span');
-        toggleText.textContent = 'Show layer';
-        toggle.appendChild(toggleText);
-        controls.appendChild(toggle);
-
-        // -- Style picker (only when there's a real choice) --
+        // -- Style picker (only if there's a real choice) --
         if (styles.length > 1) {
             const styleLabel = document.createElement('label');
-            styleLabel.className = 'style-picker';
-            const styleLabelText = document.createElement('span');
-            styleLabelText.textContent = 'Style';
-            styleLabel.appendChild(styleLabelText);
+            styleLabel.className = 'control-row';
+            const styleText = document.createElement('span');
+            styleText.className = 'control-label';
+            styleText.textContent = 'Style';
+            styleLabel.appendChild(styleText);
 
             const select = document.createElement('select');
             styles.forEach(function (s) {
@@ -229,48 +375,36 @@
             });
             select.addEventListener('change', function () {
                 currentStyle = select.value;
-                const url = tileUrlFor(collection, currentStyle);
-                const source = map.getSource(sourceId);
-                if (source && typeof source.setTiles === 'function') {
-                    source.setTiles([url]);
-                } else {
-                    // Silent failure would leave the dropdown out of sync
-                    // with the rendered tiles. Vendored MapLibre 5.24.0 does
-                    // expose `setTiles`, so this only fires if the binary is
-                    // re-vendored against a build that dropped the API.
-                    console.warn(
-                        'MapLibre source.setTiles unavailable; style swap ' +
-                        'requested for ' + collection.id + ' did not apply.'
-                    );
-                }
+                refreshSource();
             });
             styleLabel.appendChild(select);
-            controls.appendChild(styleLabel);
+            controlsHost.appendChild(styleLabel);
         }
 
-        li.appendChild(controls);
+        function refreshSource() {
+            const src = map.getSource(sourceId);
+            if (src && typeof src.setTiles === 'function') {
+                src.setTiles([tileUrlFor(collection, currentStyle, currentTime(state))]);
+            }
+        }
+
+        return {
+            setVisible: function (visible) {
+                map.setLayoutProperty(layerId, 'visibility', visible ? 'visible' : 'none');
+            },
+            refreshForTime: refreshSource
+        };
     }
 
     // Convert an OGC API Tiles URL template
     //   /tiles/.../{tileMatrixSetId}/{tileMatrix}/{tileRow}/{tileCol}
     // into the form MapLibre raster sources understand
     //   /tiles/.../WebMercatorQuad/{z}/{y}/{x}
-    // MapLibre substitutes {z}/{x}/{y}; the OGC `tileMatrix` is z, `tileRow`
-    // is y, and `tileCol` is x. The placeholder *names* in the manifest
-    // come from the axum route (`{tileMatrixSetId}` / `{tileMatrix}` —
-    // see preview.rs:552-554), not from the generic `{tms}` / `{z}` that
-    // the server would reject. Substituting `WebMercatorQuad` as a literal
-    // path segment fixes the TMS to web-Mercator — the only one the
-    // raster source supports today.
-    function tileUrlFor(collection, styleId) {
+    // Placeholder names come from the axum route (see preview.rs), not from
+    // the generic `{tms}`/`{z}` which the server would reject.
+    function tileUrlFor(collection, styleId, time) {
         const raster = collection.tiles.raster;
-        // The `default` style is rendered by the plain `/tiles/...` route,
-        // not by `/styles/default/tiles/...`. Both endpoints currently
-        // produce identical bytes, but the plain one bypasses the style
-        // lookup entirely and is the canonical URL — picking it here keeps
-        // network traces and HTTP-cache keys consistent across the default
-        // case whether a user has explicitly selected "default" or never
-        // touched the picker.
+        // 'default' style uses the plain /tiles/... route, not /styles/default/...
         const useStyled = styleId && styleId !== 'default' && raster.styled_url_template;
         let template = useStyled ? raster.styled_url_template : raster.url_template;
         template = template.replace('{tileMatrixSetId}', 'WebMercatorQuad');
@@ -280,28 +414,17 @@
         if (useStyled) {
             template = template.replace('{styleId}', encodeURIComponent(styleId));
         }
-        // Coerce to a same-origin path. The manifest emits absolute URLs
-        // built from `server.base_url` (e.g. `http://127.0.0.1:8000/…`),
-        // but the user may access the preview on a different origin
-        // (`http://localhost:8000/…`). CSP `connect-src 'self'` matches
-        // origins literally, so a 127.0.0.1↔localhost mismatch blocks
-        // every tile request. The preview SPA is always served by the
-        // same binary that serves the tiles, so dropping the origin and
-        // letting the browser resolve against the page's location is
-        // always safe — and survives the dev-mode host alias and any
-        // reverse-proxy host rewriting.
+        // Strip manifest's absolute origin so 127.0.0.1↔localhost mismatch in
+        // `server.base_url` doesn't trip CSP `connect-src 'self'`.
         template = template.replace(/^https?:\/\/[^/]+/i, '');
-        return template;
+        return appendTimeParam(template, time);
     }
 
-    // -----------------------------------------------------------------
-    // Vector layer wiring
-    // -----------------------------------------------------------------
+    // ------------------------------------------------------------------
+    // Vector layer
+    // ------------------------------------------------------------------
 
-    // Split by geometry-type so one collection can carry mixed geometries
-    // without per-feature paint overrides. `source-layer` mirrors the
-    // ds-mvt encoder convention server-side (== collection id).
-    function attachVectorLayer(collection, li) {
+    function attachVectorLayer(collection, controlsHost, state) {
         const sourceId = 'vsrc-' + collection.id;
         const fillLayerId = 'vfill-' + collection.id;
         const lineLayerId = 'vline-' + collection.id;
@@ -310,53 +433,53 @@
         // No `attribution`: MapLibre renders it via innerHTML.
         map.addSource(sourceId, {
             type: 'vector',
-            tiles: [vectorTileUrlFor(collection)]
+            tiles: [vectorTileUrlFor(collection, currentTime(state))]
         });
 
-        // `match` over `==` so the filter catches `MultiPolygon` too
-        // (68/308 municipalities in the test data would otherwise vanish).
+        const layerIds = [fillLayerId, lineLayerId, pointLayerId];
+
+        // `match` over `==` catches `MultiPolygon` too (68/308
+        // municipalities in the test data are MultiPolygon).
         map.addLayer({
             id: fillLayerId,
             type: 'fill',
             source: sourceId,
             'source-layer': collection.id,
             filter: ['match', ['geometry-type'], ['Polygon', 'MultiPolygon'], true, false],
+            layout: { visibility: 'none' },
             paint: {
-                'fill-color': '#4299e1',
-                'fill-opacity': 0.18
+                'fill-color': '#60a5fa',
+                'fill-opacity': 0.35
             }
         });
-
-        // Polygon outlines so MultiPolygon boundaries stay visible under overlapping fills.
         map.addLayer({
             id: lineLayerId,
             type: 'line',
             source: sourceId,
             'source-layer': collection.id,
             filter: ['match', ['geometry-type'], ['Polygon', 'MultiPolygon'], true, false],
+            layout: { visibility: 'none' },
             paint: {
-                'line-color': '#2b6cb0',
-                'line-width': 1
+                'line-color': '#2563eb',
+                'line-width': 1.5
             }
         });
-
         map.addLayer({
             id: pointLayerId,
             type: 'circle',
             source: sourceId,
             'source-layer': collection.id,
             filter: ['match', ['geometry-type'], ['Point', 'MultiPoint'], true, false],
+            layout: { visibility: 'none' },
             paint: {
                 'circle-radius': 5,
-                'circle-color': '#4299e1',
+                'circle-color': '#60a5fa',
                 'circle-stroke-color': '#ffffff',
                 'circle-stroke-width': 1.5
             }
         });
 
-        const interactiveLayers = [fillLayerId, lineLayerId, pointLayerId];
-
-        map.on('click', interactiveLayers, function (e) {
+        map.on('click', layerIds, function (e) {
             if (!e.features || e.features.length === 0) return;
             const feature = e.features[0];
             // MapLibre doesn't auto-dismiss; replace any existing popup.
@@ -370,8 +493,7 @@
             });
         });
 
-        // mouseenter/mouseleave dispatch per-layer, not per-collection.
-        interactiveLayers.forEach(function (id) {
+        layerIds.forEach(function (id) {
             map.on('mouseenter', id, function () {
                 map.getCanvas().style.cursor = 'pointer';
             });
@@ -380,45 +502,112 @@
             });
         });
 
-        // Sidebar control — single checkbox flips all three layers together.
-        const controls = document.createElement('div');
-        controls.className = 'controls';
-
-        const toggle = document.createElement('label');
-        toggle.className = 'toggle';
-        const checkbox = document.createElement('input');
-        checkbox.type = 'checkbox';
-        checkbox.checked = true;
-        checkbox.addEventListener('change', function () {
-            const visibility = checkbox.checked ? 'visible' : 'none';
-            interactiveLayers.forEach(function (id) {
-                map.setLayoutProperty(id, 'visibility', visibility);
-            });
-        });
-        toggle.appendChild(checkbox);
-        const toggleText = document.createElement('span');
-        toggleText.textContent = 'Vector layer';
-        toggle.appendChild(toggleText);
-        controls.appendChild(toggle);
-
-        li.appendChild(controls);
+        return {
+            setVisible: function (visible) {
+                const v = visible ? 'visible' : 'none';
+                layerIds.forEach(function (id) {
+                    map.setLayoutProperty(id, 'visibility', v);
+                });
+            },
+            refreshForTime: function () {
+                const src = map.getSource(sourceId);
+                if (src && typeof src.setTiles === 'function') {
+                    src.setTiles([vectorTileUrlFor(collection, currentTime(state))]);
+                }
+            }
+        };
     }
 
-    function vectorTileUrlFor(collection) {
-        // Same OGC placeholders as raster — `?f=mvt` is already in the manifest.
+    function vectorTileUrlFor(collection, time) {
         let template = collection.tiles.vector.url_template;
         template = template.replace('{tileMatrixSetId}', 'WebMercatorQuad');
         template = template.replace('{tileMatrix}', '{z}');
         template = template.replace('{tileRow}', '{y}');
         template = template.replace('{tileCol}', '{x}');
-        // MapLibre's vector-tile worker rejects relative URLs ("URL is not
-        // valid or contains user credentials"). Re-anchor to the page
-        // origin so 127.0.0.1↔localhost mismatch in `server.base_url`
-        // doesn't trip CSP `connect-src 'self'` either.
+        // MapLibre's vector-tile worker rejects relative URLs. Re-anchor to
+        // page origin so 127.0.0.1↔localhost mismatch in `server.base_url`
+        // doesn't trip CSP `connect-src 'self'`.
         template = template.replace(/^https?:\/\/[^/]+/i, '');
         template = window.location.origin + template;
-        return template;
+        return appendTimeParam(template, time);
     }
+
+    function appendTimeParam(template, time) {
+        if (!time) return template;
+        // Bypass MapLibre's per-source HTTP cache for time changes by including
+        // the timestamp in the query string. Tile handler already honours the
+        // `datetime` query param at crates/api-tiles/src/handlers.rs:577.
+        const sep = template.indexOf('?') === -1 ? '?' : '&';
+        return template + sep + 'datetime=' + encodeURIComponent(time);
+    }
+
+    // ------------------------------------------------------------------
+    // Time slider
+    // ------------------------------------------------------------------
+
+    function attachTimeSlider(controlsHost, state, layerHandles) {
+        const values = state.timeValues;
+        // Default to the latest timestep so an opt-in toggle shows current
+        // conditions, matching the server's default `&time=` resolution.
+        state.timeIndex = values.length - 1;
+
+        const row = document.createElement('div');
+        row.className = 'time-slider';
+
+        const label = document.createElement('div');
+        label.className = 'control-label';
+        label.textContent = 'Time';
+        row.appendChild(label);
+
+        const valueLabel = document.createElement('div');
+        valueLabel.className = 'time-value';
+        valueLabel.textContent = formatSliderTime(values[state.timeIndex]);
+        row.appendChild(valueLabel);
+
+        const input = document.createElement('input');
+        input.type = 'range';
+        input.min = '0';
+        input.max = String(values.length - 1);
+        input.step = '1';
+        input.value = String(state.timeIndex);
+        input.addEventListener('input', function () {
+            state.timeIndex = parseInt(input.value, 10);
+            valueLabel.textContent = formatSliderTime(values[state.timeIndex]);
+        });
+        input.addEventListener('change', function () {
+            layerHandles.forEach(function (h) {
+                if (h.refreshForTime) h.refreshForTime();
+            });
+        });
+        row.appendChild(input);
+
+        const ticks = document.createElement('div');
+        ticks.className = 'time-ticks';
+        const firstTick = document.createElement('span');
+        firstTick.textContent = formatSliderTime(values[0]);
+        const lastTick = document.createElement('span');
+        lastTick.textContent = formatSliderTime(values[values.length - 1]);
+        ticks.appendChild(firstTick);
+        ticks.appendChild(lastTick);
+        row.appendChild(ticks);
+
+        controlsHost.appendChild(row);
+    }
+
+    function currentTime(state) {
+        if (state.timeIndex === null || !state.timeValues) return null;
+        return state.timeValues[state.timeIndex];
+    }
+
+    function formatSliderTime(iso) {
+        const d = new Date(iso);
+        if (Number.isNaN(d.getTime())) return iso;
+        return formatDateTime(d);
+    }
+
+    // ------------------------------------------------------------------
+    // Popup
+    // ------------------------------------------------------------------
 
     function buildPopupBody(collection, feature) {
         const root = document.createElement('div');
@@ -466,10 +655,6 @@
     function formatPropertyValue(value) {
         if (value === null || value === undefined) return '—';
         if (typeof value === 'number' && !Number.isInteger(value)) {
-            // Trim noisy floating-point trails without losing precision the
-            // user actually asked for. 6 sig figs covers area / population /
-            // perimeter values for the radar+admin-boundaries preview without
-            // turning every popup into a wall of decimal noise.
             return value.toLocaleString(undefined, { maximumSignificantDigits: 6 });
         }
         return String(value);

--- a/crates/server/preview/app.js
+++ b/crates/server/preview/app.js
@@ -550,6 +550,14 @@
         // Default to the latest timestep so an opt-in toggle shows current
         // conditions, matching the server's default `&time=` resolution.
         state.timeIndex = values.length - 1;
+        // Track the index that's been pushed to the source so we can skip a
+        // no-op refresh when the user scrubs and returns to the same step
+        // (each setTiles call re-fetches the visible tiles even with the
+        // same URL).
+        let appliedIndex = state.timeIndex;
+        // Debounce handle: rapid release events on the slider collapse to
+        // one server-side render burst instead of N piled-up bursts.
+        let pendingRefresh = null;
 
         const row = document.createElement('div');
         row.className = 'time-slider';
@@ -575,9 +583,15 @@
             valueLabel.textContent = formatSliderTime(values[state.timeIndex]);
         });
         input.addEventListener('change', function () {
-            layerHandles.forEach(function (h) {
-                if (h.refreshForTime) h.refreshForTime();
-            });
+            if (pendingRefresh !== null) clearTimeout(pendingRefresh);
+            pendingRefresh = setTimeout(function () {
+                pendingRefresh = null;
+                if (state.timeIndex === appliedIndex) return;
+                appliedIndex = state.timeIndex;
+                layerHandles.forEach(function (h) {
+                    if (h.refreshForTime) h.refreshForTime();
+                });
+            }, 200);
         });
         row.appendChild(input);
 

--- a/crates/server/preview/app.js
+++ b/crates/server/preview/app.js
@@ -67,11 +67,22 @@
 
     function renderManifest(manifest) {
         const collections = manifest.collections || [];
-        const total = manifest.pagination ? manifest.pagination.total : collections.length;
+        // Honest pagination message — `pagination.total` can exceed the
+        // returned page length (server caps at 100 by default). Showing only
+        // `total` would mislead operators with >100 collections into thinking
+        // every entry is in the sidebar.
+        const rendered = collections.length;
+        const total =
+            manifest.pagination && typeof manifest.pagination.total === 'number'
+                ? manifest.pagination.total
+                : rendered;
+        const noun = total === 1 ? 'collection' : 'collections';
         statusEl.textContent =
             total === 0
                 ? 'No collections registered.'
-                : total + (total === 1 ? ' collection' : ' collections') + ' available';
+                : rendered < total
+                    ? rendered + ' of ' + total + ' ' + noun + ' (paginated)'
+                    : total + ' ' + noun + ' available';
 
         if (collections.length === 0) return;
 
@@ -89,18 +100,25 @@
     function whenStyleReady(map, fn) {
         const MARKER = '__readiness_probe__';
         let done = false;
+        // Gate per-probe-cycle so a failed attempt only ever queues ONE set
+        // of listeners + setTimeout. Without this, every failed attempt
+        // re-registers another 3 `once` callbacks plus a setTimeout — in a
+        // long-throttled tab the subscription count grows without bound.
+        let subscribed = false;
         function attempt() {
             if (done) return;
+            subscribed = false;
             try {
                 map.addSource(MARKER, { type: 'geojson', data: { type: 'FeatureCollection', features: [] } });
                 map.removeSource(MARKER);
                 done = true;
                 fn();
             } catch (e) {
+                if (subscribed) return;
+                subscribed = true;
                 // Subscribe to multiple events; throttled tabs may not get
                 // every one. `setTimeout` also reschedules in case all map
-                // events stay silent (Chrome throttles `setInterval` more
-                // aggressively than `setTimeout`).
+                // events stay silent.
                 map.once('styledata', attempt);
                 map.once('data', attempt);
                 map.once('idle', attempt);
@@ -164,7 +182,12 @@
             badges.className = 'badges';
             collection.apis.forEach(function (api) {
                 const badge = document.createElement('span');
-                badge.className = 'badge badge-' + api;
+                // `classList.add` validates each token rather than letting a
+                // space in `api` silently inject an extra class. The known
+                // values never contain whitespace today, but matching the
+                // file-level "every dynamic value reaches the DOM safely"
+                // hygiene comment is cheap.
+                badge.classList.add('badge', 'badge-' + api);
                 badge.textContent = api;
                 badges.appendChild(badge);
             });
@@ -216,6 +239,16 @@
         // (the event sometimes doesn't fire at all), but `styledata`
         // continues to fire as the map updates so it eventually unblocks.
         const layerHandles = [];
+        // Slider has to land *after* the layer handles exist (else its
+        // refresh callback fires against an empty array) AND in the same
+        // microtask sequence as the picker/toggle children (else style-pick
+        // and slider can end up in opposite orders in throttled tabs where
+        // `whenStyleReady` resolves asynchronously). Doing the slider attach
+        // inside the callback addresses both. Guard with a tile-presence
+        // check: an EDR-only collection has a `temporal_extent` but no tile
+        // layer to drive — surfacing a slider there is just noise.
+        const hasTiles =
+            collection.tiles && (collection.tiles.raster || collection.tiles.vector);
         whenStyleReady(map, function () {
             try {
                 if (collection.tiles && collection.tiles.raster) {
@@ -227,6 +260,9 @@
                 if (state.enabled) {
                     layerHandles.forEach(function (h) { h.setVisible(true); });
                 }
+                if (hasTiles && state.timeValues && state.timeValues.length > 1) {
+                    attachTimeSlider(controlsHost, state, layerHandles);
+                }
             } catch (err) {
                 console.error(
                     'Failed to attach layers for collection ' + collection.id + ':',
@@ -234,11 +270,6 @@
                 );
             }
         });
-
-        // -- Time slider --
-        if (state.timeValues && state.timeValues.length > 1) {
-            attachTimeSlider(controlsHost, state, layerHandles);
-        }
 
         // -- Footer: actions --
         const footer = document.createElement('div');
@@ -288,11 +319,19 @@
     }
 
     function formatExtent(e) {
-        // Compact human-readable bbox: "W 19.3°, S 59.8° → E 31.6°, N 70.1°"
-        return (
-            'W ' + e[0].toFixed(2) + '°, S ' + e[1].toFixed(2) + '° → ' +
-            'E ' + e[2].toFixed(2) + '°, N ' + e[3].toFixed(2) + '°'
-        );
+        // Compact human-readable bbox: "19.3°E, 59.8°N → 31.6°E, 70.1°N".
+        // Derive the hemisphere letter from the sign so a western-hemisphere
+        // dataset doesn't render as "W -10.50°" (doubly-signed).
+        return formatLon(e[0]) + ', ' + formatLat(e[1]) + ' → ' +
+               formatLon(e[2]) + ', ' + formatLat(e[3]);
+    }
+
+    function formatLon(lon) {
+        return Math.abs(lon).toFixed(2) + '°' + (lon < 0 ? 'W' : 'E');
+    }
+
+    function formatLat(lat) {
+        return Math.abs(lat).toFixed(2) + '°' + (lat < 0 ? 'S' : 'N');
     }
 
     function formatTimeRange(startIso, endIso) {

--- a/crates/server/preview/app.js
+++ b/crates/server/preview/app.js
@@ -100,29 +100,31 @@
     function whenStyleReady(map, fn) {
         const MARKER = '__readiness_probe__';
         let done = false;
-        // Gate per-probe-cycle so a failed attempt only ever queues ONE set
-        // of listeners + setTimeout. Without this, every failed attempt
-        // re-registers another 3 `once` callbacks plus a setTimeout — in a
-        // long-throttled tab the subscription count grows without bound.
-        let subscribed = false;
+        let timer = null;
+        // Every entry into `attempt()` first detaches whatever the previous
+        // attempt registered. Combined with `data` *not* being a trigger
+        // (it fires on every tile load/error/unload — way too noisy),
+        // this guarantees at most one queued listener-per-event + one
+        // pending timer regardless of how many times `attempt` re-enters.
         function attempt() {
             if (done) return;
-            subscribed = false;
+            map.off('styledata', attempt);
+            map.off('idle', attempt);
+            if (timer !== null) {
+                clearTimeout(timer);
+                timer = null;
+            }
             try {
                 map.addSource(MARKER, { type: 'geojson', data: { type: 'FeatureCollection', features: [] } });
                 map.removeSource(MARKER);
                 done = true;
                 fn();
             } catch (e) {
-                if (subscribed) return;
-                subscribed = true;
-                // Subscribe to multiple events; throttled tabs may not get
-                // every one. `setTimeout` also reschedules in case all map
-                // events stay silent.
                 map.once('styledata', attempt);
-                map.once('data', attempt);
                 map.once('idle', attempt);
-                setTimeout(attempt, 250);
+                // setTimeout covers the throttled-tab case where neither
+                // map event fires.
+                timer = setTimeout(attempt, 250);
             }
         }
         attempt();

--- a/crates/server/src/preview.rs
+++ b/crates/server/src/preview.rs
@@ -505,12 +505,23 @@ fn resolve_temporal_extent(
         .or_else(|| wms.engines.get(id).map(|e| e.raster_info().times))
         .filter(|t| !t.is_empty());
 
-    let interval = edr_interval.or_else(|| {
-        raster_times
-            .as_ref()
-            .and_then(|t| t.first().zip(t.last()).map(|(a, b)| (*a, *b)))
-    });
-    let values = edr_values.or(raster_times);
+    // Pick the source that backs `values`, then derive `interval` from the
+    // same source so the preview card's "Time" row matches the slider's
+    // reachable range. EDR's interval can otherwise span a wider horizon
+    // (e.g. T-24h forecast bound) than the discrete raster timesteps cover,
+    // leaving the user looking at a span the slider can't reach.
+    let (interval, values) = match (edr_values, raster_times) {
+        (Some(v), _) => {
+            let int = edr_interval
+                .or_else(|| v.first().zip(v.last()).map(|(a, b)| (*a, *b)));
+            (int, Some(v))
+        }
+        (None, Some(t)) => {
+            let int = t.first().zip(t.last()).map(|(a, b)| (*a, *b));
+            (int, Some(t))
+        }
+        (None, None) => (edr_interval, None),
+    };
 
     if interval.is_some() || values.is_some() {
         return Some(serialize_temporal(interval, values.as_deref()));
@@ -1191,9 +1202,18 @@ mod tests {
             // No `get_available_times` override — defaults to `None`.
         }
 
+        // Use a deliberately wider EDR interval than the raster's discrete
+        // timesteps so the test catches the "interval/values divergence"
+        // bug: a slider with three 1-hour stops should not report a 24-hour
+        // span in the card header.
+        let wide_edr_interval = (
+            "2023-12-31T00:00:00Z".parse::<DateTime<Utc>>().unwrap(),
+            "2024-01-02T00:00:00Z".parse::<DateTime<Utc>>().unwrap(),
+        );
+
         let mut edr = empty_edr();
         let edr_engine: Arc<dyn Engine> = Arc::new(IntervalOnlyEdr {
-            interval: (times[0], *times.last().unwrap()),
+            interval: wide_edr_interval,
         });
         edr.engines.insert("radar".into(), edr_engine);
         edr.collections
@@ -1215,6 +1235,9 @@ mod tests {
         let m = build_manifest(&state, 0, 100);
         let temporal = &m["collections"][0]["temporal_extent"];
 
+        // Interval must come from the *values* source (raster), not from EDR's
+        // wider span. Without this anchoring, the card's Time row would show
+        // 2023-12-31→2024-01-02 while the slider only has 00/01/02 stops.
         assert_eq!(temporal["start"], "2024-01-01T00:00:00+00:00");
         assert_eq!(temporal["end"], "2024-01-01T02:00:00+00:00");
         assert_eq!(

--- a/crates/server/src/preview.rs
+++ b/crates/server/src/preview.rs
@@ -488,29 +488,31 @@ fn resolve_temporal_extent(
     tiles: &api_tiles::handlers::TilesState,
     wms: &api_wms::handlers::WmsState,
 ) -> Option<Value> {
-    // EDR is the canonical temporal source — it carries both interval and
-    // explicit instants. Maps/Tiles/WMS `raster_info().times` is the
-    // fallback when a collection isn't EDR-enabled (e.g. radar collections
-    // exposed only via WMS).
-    if let Some(engine) = edr.engines.get(id) {
-        let interval = engine.get_temporal_extent();
-        let values = engine.get_available_times();
-        if interval.is_some() || values.is_some() {
-            return Some(serialize_temporal(interval, values.as_deref()));
-        }
-    }
+    // Build interval from EDR (canonical source), then fill in discrete
+    // values from EDR first, falling back to raster_info().times. The fallback
+    // covers geotiff-style engines that expose timestep instants only through
+    // their raster surface — without it, a radar collection with EDR enabled
+    // would surface a continuous interval but no slider stops.
+    let edr_interval = edr.engines.get(id).and_then(|e| e.get_temporal_extent());
+    let edr_values = edr.engines.get(id).and_then(|e| e.get_available_times());
 
-    let times_from_raster = maps
+    let raster_times = maps
         .engines
         .get(id)
         .map(|e| e.raster_info().times)
         .or_else(|| tiles.map_engines.get(id).map(|e| e.raster_info().times))
-        .or_else(|| wms.engines.get(id).map(|e| e.raster_info().times));
-    if let Some(times) = times_from_raster {
-        if !times.is_empty() {
-            let interval = times.first().zip(times.last()).map(|(a, b)| (*a, *b));
-            return Some(serialize_temporal(interval, Some(&times)));
-        }
+        .or_else(|| wms.engines.get(id).map(|e| e.raster_info().times))
+        .filter(|t| !t.is_empty());
+
+    let interval = edr_interval.or_else(|| {
+        raster_times
+            .as_ref()
+            .and_then(|t| t.first().zip(t.last()).map(|(a, b)| (*a, *b)))
+    });
+    let values = edr_values.or(raster_times);
+
+    if interval.is_some() || values.is_some() {
+        return Some(serialize_temporal(interval, values.as_deref()));
     }
     None
 }

--- a/crates/server/src/preview.rs
+++ b/crates/server/src/preview.rs
@@ -493,8 +493,9 @@ fn resolve_temporal_extent(
     // covers geotiff-style engines that expose timestep instants only through
     // their raster surface — without it, a radar collection with EDR enabled
     // would surface a continuous interval but no slider stops.
-    let edr_interval = edr.engines.get(id).and_then(|e| e.get_temporal_extent());
-    let edr_values = edr.engines.get(id).and_then(|e| e.get_available_times());
+    let (edr_interval, edr_values) = edr.engines.get(id).map_or((None, None), |e| {
+        (e.get_temporal_extent(), e.get_available_times())
+    });
 
     let raster_times = maps
         .engines
@@ -1145,6 +1146,86 @@ mod tests {
         );
         assert_eq!(temporal["truncated"], false);
         assert_eq!(temporal["total_values"], 0);
+    }
+
+    #[test]
+    fn temporal_extent_values_fall_back_to_raster_times_when_edr_lacks_them() {
+        // Regression guard for the round-4 fix in `resolve_temporal_extent`.
+        // Some engines (notably geotiff/radar) expose discrete timestep
+        // instants only through their raster surface — `get_available_times`
+        // returns `None`, but `MapEngine::raster_info().times` has the list.
+        // The manifest must merge: take the EDR interval (canonical), and
+        // backfill `values` from raster_info() when EDR doesn't expose them.
+        // Without the fallback, the preview's time slider has no stops to
+        // snap to even though the data has discrete steps.
+        let times = vec![
+            "2024-01-01T00:00:00Z".parse::<DateTime<Utc>>().unwrap(),
+            "2024-01-01T01:00:00Z".parse::<DateTime<Utc>>().unwrap(),
+            "2024-01-01T02:00:00Z".parse::<DateTime<Utc>>().unwrap(),
+        ];
+
+        struct IntervalOnlyEdr {
+            interval: (DateTime<Utc>, DateTime<Utc>),
+        }
+        impl Engine for IntervalOnlyEdr {
+            fn get_locations(&self) -> Result<Vec<Location>, DataServerError> {
+                Ok(Vec::new())
+            }
+            fn query_location(
+                &self,
+                _: &str,
+                _: Option<(DateTime<Utc>, DateTime<Utc>)>,
+                _: Option<&[String]>,
+            ) -> Result<QueryResult, DataServerError> {
+                unimplemented!()
+            }
+            fn get_parameters(&self) -> Vec<String> {
+                Vec::new()
+            }
+            fn get_temporal_extent(&self) -> Option<(DateTime<Utc>, DateTime<Utc>)> {
+                Some(self.interval)
+            }
+            fn get_spatial_extent(&self) -> Option<[f64; 4]> {
+                None
+            }
+            // No `get_available_times` override — defaults to `None`.
+        }
+
+        let mut edr = empty_edr();
+        let edr_engine: Arc<dyn Engine> = Arc::new(IntervalOnlyEdr {
+            interval: (times[0], *times.last().unwrap()),
+        });
+        edr.engines.insert("radar".into(), edr_engine);
+        edr.collections
+            .insert("radar".into(), config("radar", &["edr", "tiles"]));
+
+        let mut tiles = empty_tiles();
+        let raster: Arc<dyn MapEngine> = Arc::new(RasterMock {
+            spatial_extent: Some([0.0, 0.0, 10.0, 10.0]),
+            times: times.clone(),
+            parameter: "reflectivity".into(),
+            unit: "dBZ".into(),
+        });
+        tiles.map_engines.insert("radar".into(), raster);
+        tiles
+            .collections
+            .insert("radar".into(), config("radar", &["edr", "tiles"]));
+
+        let state = make_state(edr, empty_features(), empty_maps(), tiles, empty_wms());
+        let m = build_manifest(&state, 0, 100);
+        let temporal = &m["collections"][0]["temporal_extent"];
+
+        assert_eq!(temporal["start"], "2024-01-01T00:00:00+00:00");
+        assert_eq!(temporal["end"], "2024-01-01T02:00:00+00:00");
+        assert_eq!(
+            temporal["values"].as_array().map(|a| a.len()),
+            Some(3),
+            "values must be backfilled from RasterMock.times when EDR's \
+             get_available_times returns None — otherwise the preview slider \
+             has no stops to snap to"
+        );
+        assert_eq!(temporal["total_values"], 3);
+        assert_eq!(temporal["truncated"], false);
     }
 
     #[test]

--- a/crates/server/src/preview.rs
+++ b/crates/server/src/preview.rs
@@ -512,8 +512,7 @@ fn resolve_temporal_extent(
     // leaving the user looking at a span the slider can't reach.
     let (interval, values) = match (edr_values, raster_times) {
         (Some(v), _) => {
-            let int = edr_interval
-                .or_else(|| v.first().zip(v.last()).map(|(a, b)| (*a, *b)));
+            let int = edr_interval.or_else(|| v.first().zip(v.last()).map(|(a, b)| (*a, *b)));
             (int, Some(v))
         }
         (None, Some(t)) => {


### PR DESCRIPTION
## Summary

Reworks the preview SPA around per-collection **cards** instead of a flat
list, and lands the **time slider** deferred from Phase 4.

### UX
- **Layers default off.** Every card starts with its toggle unchecked.
  Showing every collection by default produces visual noise when a
  deployment has more than a handful, and is expensive for tile-heavy
  raster layers that fire dozens of requests per scroll.
- **First enable zooms to extent.** Toggling a card on auto-fits the
  map to that collection's \`spatial_extent\` (Mercator-clamped,
  \`maxZoom: 10\`).
- **\"Zoom to extent\" link** for re-centering without toggling.
- **Time slider** for collections with discrete \`temporal_extent.values\`.
  Scrubbing snaps to a timestep; releasing fires a source refresh that
  appends \`&datetime=<rfc3339>\` to the tile URL. Tiles handler already
  honours this param.

### Card metadata
Title + collection id (mono). API badges per surface (\`edr\`, \`features\`,
\`maps\`, \`tiles\`, \`wms\`), each colour-coded. Description, spatial extent
(W/S/E/N), time range, timestep count, tile representations.

### Visual polish
Dark glass-morphism sidebar with backdrop blur, matched popup chrome,
iOS-style toggle switch, slim accent-coloured time slider with
start/end tick labels, scale control, tuned MapLibre control styling.

### Backend
\`resolve_temporal_extent\` now backfills discrete \`values\` from
\`raster_info().times\` when EDR exposes only an interval. Without this
a radar collection wired through both EDR and Maps surfaced a
continuous interval but no slider stops, making the slider invisible
for the engines that need it most.

### Robustness
\`whenStyleReady\` probes \`addSource\` with a marker source instead of
trusting \`isStyleLoaded()\`. Some throttled tabs leave \`isStyleLoaded\`
false indefinitely even after the style is usable; this version retries
on \`styledata\`/\`data\`/\`idle\` and via \`setTimeout\` so the UI doesn't
deadlock.

## Test plan
- [x] \`cargo test -p server preview::\` (13 passed)
- [x] \`cargo clippy -p server --all-targets -- -D warnings\`
- [ ] Manual: \`cargo run -p server -- --collections=municipalities,regions,fmi-radar,weather\` then \`/preview\` — verify cards default off, toggle zooms to extent, time slider scrubs FMI Radar through 22 frames