### PR TITLE
fix(ci): revert workspace.package inheritance for release-please

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,11 +20,11 @@ members = [
 ]
 exclude = ["fuzz"]
 
-# Shared package metadata. Every member crate inherits `version` and
-# `edition` via `version.workspace = true` / `edition.workspace = true`,
-# so release-please can bump the whole workspace by editing this one
-# block. Adding repository/license/etc. here later only requires
-# adding one matching `<field>.workspace = true` line per crate.
-[workspace.package]
-version = "0.1.0"
-edition = "2021"
+# Per-crate `version` + `edition` are declared inline in each member's
+# `[package]` block on purpose. We tried hoisting them to
+# `[workspace.package]` (Rust's canonical inheritance shape) but
+# `release-please-action`'s Rust updater can't parse
+# `package.version.workspace = true` — it expects a literal string and
+# fails the release-PR with `value at path package.version is not tagged`.
+# Until that's fixed upstream, leaving versions inline lets release-please
+# walk the workspace members and bump each one to the same value.

--- a/crates/api-edr/Cargo.toml
+++ b/crates/api-edr/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "api-edr"
-version.workspace = true
-edition.workspace = true
+version = "0.1.0"
+edition = "2021"
 
 [dependencies]
 ds-core = { path = "../core" }

--- a/crates/api-features/Cargo.toml
+++ b/crates/api-features/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "api-features"
-version.workspace = true
-edition.workspace = true
+version = "0.1.0"
+edition = "2021"
 
 [dependencies]
 ds-core = { path = "../core" }

--- a/crates/api-maps/Cargo.toml
+++ b/crates/api-maps/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "api-maps"
-version.workspace = true
-edition.workspace = true
+version = "0.1.0"
+edition = "2021"
 
 [dependencies]
 ds-core = { path = "../core" }

--- a/crates/api-tiles/Cargo.toml
+++ b/crates/api-tiles/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "api-tiles"
-version.workspace = true
-edition.workspace = true
+version = "0.1.0"
+edition = "2021"
 
 [dependencies]
 ds-core = { path = "../core" }

--- a/crates/api-wms/Cargo.toml
+++ b/crates/api-wms/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "api-wms"
-version.workspace = true
-edition.workspace = true
+version = "0.1.0"
+edition = "2021"
 
 [dependencies]
 ds-core = { path = "../core" }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ds-core"
-version.workspace = true
-edition.workspace = true
+version = "0.1.0"
+edition = "2021"
 
 [dependencies]
 chrono = { version = "0.4", features = ["serde"] }

--- a/crates/ds-mvt/Cargo.toml
+++ b/crates/ds-mvt/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ds-mvt"
-version.workspace = true
-edition.workspace = true
+version = "0.1.0"
+edition = "2021"
 
 [dependencies]
 ds-core = { path = "../core" }

--- a/crates/engine-csv/Cargo.toml
+++ b/crates/engine-csv/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "engine-csv"
-version.workspace = true
-edition.workspace = true
+version = "0.1.0"
+edition = "2021"
 
 [dependencies]
 ds-core = { path = "../core" }

--- a/crates/engine-geojson/Cargo.toml
+++ b/crates/engine-geojson/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "engine-geojson"
-version.workspace = true
-edition.workspace = true
+version = "0.1.0"
+edition = "2021"
 
 [dependencies]
 ds-core = { path = "../core" }

--- a/crates/engine-geotiff/Cargo.toml
+++ b/crates/engine-geotiff/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "engine-geotiff"
-version.workspace = true
-edition.workspace = true
+version = "0.1.0"
+edition = "2021"
 
 [features]
 fuzz = []

--- a/crates/engine-grib/Cargo.toml
+++ b/crates/engine-grib/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "engine-grib"
-version.workspace = true
-edition.workspace = true
+version = "0.1.0"
+edition = "2021"
 
 [dependencies]
 ds-core = { path = "../core" }

--- a/crates/engine-postgis/Cargo.toml
+++ b/crates/engine-postgis/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "engine-postgis"
-version.workspace = true
-edition.workspace = true
+version = "0.1.0"
+edition = "2021"
 
 [dependencies]
 ds-core = { path = "../core" }

--- a/crates/engine-querydata/Cargo.toml
+++ b/crates/engine-querydata/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "engine-querydata"
-version.workspace = true
-edition.workspace = true
+version = "0.1.0"
+edition = "2021"
 
 [dependencies]
 ds-core = { path = "../core" }

--- a/crates/render/Cargo.toml
+++ b/crates/render/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ds-render"
-version.workspace = true
-edition.workspace = true
+version = "0.1.0"
+edition = "2021"
 
 [dependencies]
 ds-core = { path = "../core" }

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "server"
-version.workspace = true
-edition.workspace = true
+version = "0.1.0"
+edition = "2021"
 
 [dependencies]
 ds-core = { path = "../core" }

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ds-storage"
-version.workspace = true
-edition.workspace = true
+version = "0.1.0"
+edition = "2021"
 
 [dependencies]
 ds-core = { path = "../core" }


### PR DESCRIPTION
## Why

The first run of `release.yml` on main after #139 merged failed:

> ##[error]release-please failed: value at path package.version is not tagged
> (https://github.com/mrauhala/meteocore/actions/runs/25746329334)

release-please-action v5's Rust updater walks workspace members and tries to update each crate's `[package].version` as a literal string. It can't handle `version.workspace = true` — that's a TOML table reference, not a string, so the updater bails before opening the release PR.

`[workspace.package]` inheritance is the canonical Rust idiom and worked locally, but it's incompatible with release-please as long as that upstream limitation stands.

## What

Revert just the inheritance hoist. Each of 16 crates gets its inline `version = "0.1.0"` + `edition = "2021"` back. No code changes — only `Cargo.toml`s.

A comment in the root `Cargo.toml` explains the constraint so the next reader doesn't try to re-hoist it.

## Test plan

- [x] `cargo test --workspace` — green (43 `ok` results, 0 failures).
- [x] `cargo fmt --check` — clean.
- [ ] Once merged: next push to main should re-run `release.yml` → `release-please` job opens the first release PR (proposed `v0.2.0` based on the feat:/fix: commits since v0.1.0 manifest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)