### PR TITLE
fix(ci): drop illegal '..' from release-please changelog-path

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,8 +8,7 @@
   "packages": {
     "crates/server": {
       "package-name": "meteocore",
-      "component": "meteocore",
-      "changelog-path": "../../CHANGELOG.md"
+      "component": "meteocore"
     }
   }
 }


### PR DESCRIPTION
## Why

Third release-please failure on main (after #140 and #141):

> ##[error]release-please failed: illegal pathing characters in path: crates/server/../../CHANGELOG.md
> https://github.com/mrauhala/meteocore/actions/runs/25749959522

release-please refuses any path segment containing \`..\` as a security measure. The \`../../CHANGELOG.md\` override #141 added (to keep the changelog at the repo root) is the offending value.

## What

Drop the \`changelog-path\` override entirely. release-please will now write \`crates/server/CHANGELOG.md\` (the package-default location).

That's not the canonical repo-root \`CHANGELOG.md\`, but the contents are identical and there's no way to convince release-please to accept a \`..\` traversal — the validator is hard-coded. If/when an unambiguous repo-root path becomes important, a follow-up could either:

- promote the workspace root to a non-Rust release-please package (\`release-type: simple\`) and have it list \`crates/server\` via \`extra-files\`, or
- symlink \`CHANGELOG.md\` → \`crates/server/CHANGELOG.md\` at the repo root.

Both are out of scope for unblocking the pipeline.

## Test plan

- [ ] After merge: next push to main should re-fire \`release.yml\`. The \`release-please\` job should reach the "open release PR" step (vs. failing on changelog-path validation) and propose the first real release PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)