### PR TITLE
ci: speed up the check job (5min → ~1.5min)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,24 +25,23 @@ jobs:
     steps:
     - uses: actions/checkout@v6
 
-    - name: Install system dependencies
-      run: sudo apt-get update && sudo apt-get install -y cmake clang
+    # `cmake` and `clang` are pre-installed on `ubuntu-24.04`
+    # (the current `ubuntu-latest`), so no `apt-get` step is needed.
+    # The previous step spent ~3 min mostly on `apt-get update` against
+    # 30+ repo indexes for two packages that the runner image ships.
 
     - name: Install Rust toolchain
       uses: dtolnay/rust-toolchain@stable
       with:
         components: clippy, rustfmt
 
-    - name: Cache cargo registry & build
-      uses: actions/cache@v5
-      with:
-        path: |
-          ~/.cargo/registry
-          ~/.cargo/git
-          target
-        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-cargo-
+    # `Swatinem/rust-cache` is the de-facto Rust cache action — faster
+    # restore than `actions/cache`, GC's stale fingerprints/incremental
+    # artifacts before save (keeps target/ small so we hit the cache
+    # more often before the repo-wide 10 GiB limit evicts entries),
+    # keys on Cargo.lock + rustc version + workspace members.
+    - name: Rust cache
+      uses: Swatinem/rust-cache@v2
 
     - name: Check formatting
       run: cargo fmt -- --check
@@ -53,11 +52,10 @@ jobs:
     - name: Clippy
       run: cargo clippy --all-targets -- -D warnings
 
-    - name: Build
-      run: cargo build --verbose
-
+    # `cargo test` builds everything `cargo build` does, plus test
+    # binaries — a separate build step would just duplicate work.
     - name: Run tests
-      run: cargo test --verbose
+      run: cargo test
 
   docker-check:
     name: Docker Build (PR)


### PR DESCRIPTION
## Summary

Three small edits to `.github/workflows/ci.yml` that together cut the **Check, Lint & Test** job from roughly **5 min → 1.5 min** per run.

Measured against the latest passing run on `feat/preview-assets-126-phase2` (run `25754019892`, cache-hit case):

| Step | Before | After (est.) |
|---|---|---|
| Install system dependencies | **193s** | 0s (removed) |
| Cache restore | 27s | ~10s |
| Build | 12s | 0s (folded into test) |
| Run tests | 64s | ~60s |
| Other (toolchain, clippy, fmt, SQL) | ~20s | ~20s |
| **Total** | **~316s** | **~90s** |

## Changes

1. **Delete `apt-get update && apt-get install -y cmake clang`.**
   Both packages ship in the `ubuntu-24.04` runner image, so the step was a no-op install on top of a 3-min `apt-get update`. The build still needs `cmake` (via the `cmake` build-rs crate used by `libaec-sys`) and `clang` (via `bindgen`) — they're just already present in the image.

2. **Replace `actions/cache@v5` with `Swatinem/rust-cache@v2`.**
   The de-facto Rust caching action. Faster restore, GCs stale `target/` fingerprints + incremental artifacts before saving (keeps the cache below the 10 GiB repo cap so we evict less), and keys on Cargo.lock + rustc version + workspace members instead of just Cargo.lock.

3. **Fold `cargo build` into `cargo test`.**
   `cargo test` builds everything `cargo build` does plus the test binaries — running both was pure duplication. Also dropped `--verbose` (rustc command-line spam isn't useful when CI passes; one click to the log when it doesn't).

## Notes

- `Swatinem/rust-cache@v2` runs on Node 24 (`runs.using: node24` in its action.yml at the `v2` tag), so it satisfies the Node-24-or-newer floor in the global instructions.
- `release.yml`'s build/upload steps are independent and unchanged — they install their own toolchain on each matrix arch and don't share the `check`-job cache.
- The first run after merging will be a **cache miss** (cache key shape changes) and take a few minutes longer. Subsequent runs benefit.

## Test plan

- [ ] CI on this PR completes successfully and the `Run tests` step duration is ~60s (cache-hit case after the action's cache is populated by the first run).
- [ ] No build error from missing `cmake`/`clang` (verifies my "pre-installed in ubuntu-24.04" claim).

🤖 Generated with [Claude Code](https://claude.com/claude-code)