### PR TITLE
config: rename fmi-radar → fmi-radar-composite-dbz-aws-s3

### DIFF
--- a/collections.d/fmi-radar-composite-dbz-aws-s3.toml
+++ b/collections.d/fmi-radar-composite-dbz-aws-s3.toml
@@ -1,6 +1,6 @@
-id = "fmi-radar"
-title = "FMI Radar (S3, EPSG:3067)"
-description = "Finnish radar composite from FMI S3 bucket, Transverse Mercator projection"
+id = "fmi-radar-composite-dbz-aws-s3"
+title = "FMI Radar Composite dBZ (AWS S3, EPSG:3067)"
+description = "Finnish radar reflectivity composite from FMI AWS S3 bucket COG, Transverse Mercator projection"
 engine_type = "geotiff"
 apis = ["edr", "wms", "maps", "tiles"]
 


### PR DESCRIPTION
## Summary

Long-form id + title that names the actual product (composite reflectivity in dBZ from AWS S3) rather than just the provider. Aligns with the longer-form naming pattern used by other radar collections.

## Diff

| Field | Before | After |
|---|---|---|
| `id` | `fmi-radar` | `fmi-radar-composite-dbz-aws-s3` |
| `title` | FMI Radar (S3, EPSG:3067) | FMI Radar Composite dBZ (AWS S3, EPSG:3067) |
| `description` | "Finnish radar composite from FMI S3 bucket, Transverse Mercator projection" | "Finnish radar reflectivity composite from FMI AWS S3 bucket COG, Transverse Mercator projection" |

Engine config (bucket, prefix pattern, filename template, parameter, style bundle, poll interval, nodata) is unchanged — git sees this as a 66% rename, which is just the metadata fields above.

## Caveat for operators

Anyone with a bookmark, dashboard, or external tool pointing at the old `fmi-radar` URL (e.g. `/edr/collections/fmi-radar/...`, `/tiles/collections/fmi-radar/...`) will get 404 after this lands. The new id is the canonical path.

## Test plan

- [ ] `cargo check -p server` — the config loader doesn't pin the id.
- [ ] Smoke test in the preview SPA: the collection appears once under the new title and the radar layer toggles on/off correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)