### PR TITLE
ci: cancel stale workflow runs when a newer commit lands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,15 @@ on:
   pull_request:
     branches: [ "main" ]
 
+# Cancel stale runs when a newer commit lands on the same ref. PR review
+# rounds force-push frequently; multiple merges to `main` queue up runs
+# of which only the latest commit's result matters. `release.yml`
+# deliberately does *not* set this — each tag is a distinct release
+# artifact that must complete on its own.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -4,6 +4,13 @@ on:
   pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
 
+# Cancel the previous review when a new commit lands on the same PR —
+# only the latest commit's review matters, and review jobs can take
+# several minutes to complete.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   claude-review:
     runs-on: ubuntu-latest

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -10,6 +10,14 @@ on:
   pull_request_review:
     types: [submitted]
 
+# Bot only needs to act on the latest @claude trigger for a given ref.
+# `github.event.pull_request.number || github.ref` makes the group
+# stable across the comment/review event types that don't set
+# `pull_request` directly.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   claude:
     if: |


### PR DESCRIPTION
## Summary

Adds GitHub Actions `concurrency` groups with `cancel-in-progress: true` to three workflows so older runs are killed when a newer commit on the same ref starts. Saves wasted CI minutes during PR review rounds and back-to-back main merges.

## Motivation

After #137 and #148 landed seconds apart today, three CI-on-main runs stacked up — each rebuilding the whole workspace and Docker image, even though only the latest commit's result was meaningful. PR review rounds force-push frequently too; the previous run becomes moot the moment a new push arrives.

## Changes

| Workflow | Concurrency? | Why |
|---|---|---|
| `ci.yml` | **yes** | PR force-pushes + back-to-back main merges. |
| `claude-code-review.yml` | **yes** | Bot review jobs take minutes; only the latest commit's review is useful. |
| `claude.yml` | **yes** | Same — group key uses `pull_request.number || github.ref` so it stays stable across the comment/review event types that don't bind a PR ref directly. |
| `release.yml` | **no** (deliberate) | Each tag is a distinct release artifact (binary build matrix + container push + cosign sign). Cancelling could leave releases half-built. |

## Pattern

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true
```

`${{ github.ref }}` resolves to the PR head ref for PRs and `refs/heads/main` for main pushes, so both cases collapse cleanly. The `workflow` prefix keeps unrelated workflows from interfering with each other.

## Test plan

- [ ] After merge, two quick pushes to the same PR should leave only one CI run alive (the older one shows "Cancelled").
- [ ] release.yml runs on tag pushes are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)