### PR TITLE
ci(release): always() to defeat transitive skip on workflow_dispatch path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,11 +104,13 @@ jobs:
   build-binary:
     name: binary ${{ matrix.target }}
     needs: resolve-target
-    # Skip cleanly if `resolve-target` was skipped (push that didn't
-    # produce a release); fail-skip cleanly if it errored. Without an
-    # explicit guard, a `resolve-target` failure cascades into job
-    # failures here instead of skips.
-    if: needs.resolve-target.result == 'success'
+    # `always() &&` is mandatory, not stylistic: on the
+    # `workflow_dispatch` backfill path `release-please` is skipped,
+    # and GitHub Actions propagates that skip *transitively* through
+    # the dependency chain. Without `always()`, this job inherits the
+    # original release-please skip even though its direct dep
+    # (`resolve-target`) succeeded — and every build job sits out.
+    if: always() && needs.resolve-target.result == 'success'
     permissions:
       contents: read
     strategy:
@@ -194,7 +196,9 @@ jobs:
   build-container:
     name: container image
     needs: resolve-target
-    if: needs.resolve-target.result == 'success'
+    # See build-binary above — `always()` defeats transitive skip
+    # propagation from the dispatch-path-skipped `release-please` job.
+    if: always() && needs.resolve-target.result == 'success'
     permissions:
       contents: read
       packages: write
@@ -257,7 +261,9 @@ jobs:
     # against ghcr.io. If the container build fails, the binaries on the
     # GitHub Release are still useful and should ship.
     needs: [resolve-target, build-binary]
-    if: needs.resolve-target.result == 'success'
+    # See build-binary above — `always()` defeats transitive skip
+    # propagation from the dispatch-path-skipped `release-please` job.
+    if: always() && needs.resolve-target.result == 'success' && needs.build-binary.result == 'success'
     permissions:
       contents: write
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Why

#152's `workflow_dispatch` backfill silently skipped every build job — verified on run [25783964899](https://github.com/mrauhala/meteocore/actions/runs/25783964899). All three build jobs (`build-binary`, `build-container`, `upload`) reported `skipped` even though `resolve-target` finished `success`.

## Root cause

GitHub Actions propagates skip status **transitively** through the dependency chain, not just from direct deps. On dispatch:

```
release-please    (skipped: if: github.event_name == 'push')
  └─ resolve-target  (if: always() && … → ran, success)
       └─ build-binary       \
       └─ build-container     } "needs: resolve-target"
       └─ upload             /
```

The build jobs' `if: needs.resolve-target.result == 'success'` evaluated to true, but Actions had already classified them as "implicitly skipped" because the chain crossed a skipped job. The `if:` is only consulted **after** the implicit-skip classification clears, which requires `always()` (or `!cancelled()`).

`resolve-target` already used this pattern; we just missed rolling it down to the children.

## Fix

Add `always() &&` to the guard on `build-binary`, `build-container`, and `upload`. Also added an explicit `build-binary.result == 'success'` check on `upload` so a binary-build failure doesn't silently ship an empty release (the implicit propagation that previously caught this is no longer reliable now that `always()` is in play).

## Test plan

- [ ] CI clean on this PR.
- [ ] After merge, re-run the v0.2.0 backfill:
  ```
  gh workflow run release.yml --field tag=v0.2.0
  ```
- [ ] Confirm tarballs attached to v0.2.0 release + `ghcr.io/mrauhala/meteocore:0.2.0`, `:0.2`, `:latest` published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)