### PR TITLE
refactor: rename Engine trait to EdrEngine

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ When completing work, close the relevant issue: `gh issue close <number>`.
 
 ## Architecture Rules
 
-- **Three core traits: `Engine` (EDR), `FeatureEngine` (Features), and `MapEngine` (Maps/WMS/Tiles).** They are separate traits — not all engines need to support all APIs. Engines return domain types, never JSON/XML. Serialization belongs in the API crates.
+- **Three core traits: `EdrEngine` (EDR), `FeatureEngine` (Features), and `MapEngine` (Maps/WMS/Tiles).** They are separate traits — not all engines need to support all APIs. Engines return domain types, never JSON/XML. Serialization belongs in the API crates.
 - **ds-core has no framework dependencies.** Only chrono, serde, thiserror, toml. Keep it that way. Use `PropertyValue` enum instead of `serde_json::Value` for feature properties.
 - **CRS and GeoTransform live in ds-core** (`ds_core::geo`), shared by all engines.
 - **ds-render has no framework dependencies.** Only ds-core and `png`.
@@ -58,8 +58,8 @@ When completing work, close the relevant issue: `gh issue close <number>`.
 - **EDR, Features, Maps, Tiles, and WMS are separate services** with separate base routes (`/edr/...`, `/features/...`, `/maps/...`, `/tiles/...`, `/wms/...`).
 - **WMS uses XML, not JSON.** All XML output in api-wms uses `quick-xml::Writer` for proper escaping. Never build XML with `format!()` or string concatenation (XML injection risk).
 - **CORS is applied at the server level**, not in individual API crates. The `CorsLayer` lives in `server/src/main.rs`.
-- **New engines** implement `Engine`, `FeatureEngine`, and/or `MapEngine` traits in their own crate, get wired up in `server/src/main.rs`.
-- **Collection routing is dynamic.** Handlers look up engines from a `HashMap<String, Arc<dyn Engine/FeatureEngine/MapEngine>>` by collection ID from the URL path. No collection IDs are hardcoded.
+- **New engines** implement `EdrEngine`, `FeatureEngine`, and/or `MapEngine` traits in their own crate, get wired up in `server/src/main.rs`.
+- **Collection routing is dynamic.** Handlers look up engines from a `HashMap<String, Arc<dyn EdrEngine/FeatureEngine/MapEngine>>` by collection ID from the URL path. No collection IDs are hardcoded.
 - **The `apis` config field is enforced.** Only collections listing a given API in their `apis` array are wired to that API's router.
 - **Tiles reuses MapEngine.** Tile z/x/y coordinates are converted to a bbox via TileMatrixSet math, then passed to `MapEngine::get_raster_tile()`. No separate tile engine trait is needed.
 
@@ -70,7 +70,7 @@ The core crate is named `ds-core` in Cargo.toml (imported as `ds_core` in Rust).
 ## Adding a New Engine
 
 1. Create `crates/engine-<name>/` with `Cargo.toml` depending on `ds-core`
-2. Implement `Engine`, `FeatureEngine`, and/or `MapEngine` traits
+2. Implement `EdrEngine`, `FeatureEngine`, and/or `MapEngine` traits
 3. Add the crate to workspace members in root `Cargo.toml`
 4. Add the crate as a dependency of `crates/server/Cargo.toml`
 5. Add a match arm for the new `engine_type` in `server/src/main.rs`
@@ -126,12 +126,12 @@ Currently implemented: `PointSeries`, `Grid`.
 
 | Engine | Traits | APIs |
 |--------|--------|------|
-| CSV | `Engine` | EDR (locations only) |
+| CSV | `EdrEngine` + `FeatureEngine` | EDR (locations only), Features |
 | GeoJSON | `FeatureEngine` | Features |
-| GeoTIFF | `Engine` + `MapEngine` | EDR (position, area), WMS, Maps, Tiles |
-| GRIB | `Engine` + `MapEngine` | EDR, WMS, Maps, Tiles |
-| QueryData | `Engine` + `MapEngine` | EDR (position only), WMS, Maps, Tiles |
-| PostGIS | `Engine` + `FeatureEngine` | EDR (position, locations, area), Features |
+| GeoTIFF | `EdrEngine` + `MapEngine` | EDR (position, area), WMS, Maps, Tiles |
+| GRIB | `EdrEngine` + `MapEngine` | EDR, WMS, Maps, Tiles |
+| QueryData | `EdrEngine` + `MapEngine` | EDR (position only), WMS, Maps, Tiles |
+| PostGIS | `EdrEngine` + `FeatureEngine` | EDR (position, locations, area), Features |
 
 ## GeoTIFF Engine Notes
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Three core traits, each corresponding to one or more APIs:
 
 | Trait | APIs | Description |
 |-------|------|-------------|
-| `Engine` | EDR | Time-series queries (position, area, locations) returning CoverageJSON |
+| `EdrEngine` | EDR | Time-series queries (position, area, locations) returning CoverageJSON |
 | `FeatureEngine` | Features | Paginated spatial feature queries returning GeoJSON |
 | `MapEngine` | Maps, WMS, Tiles | Raster tile rendering returning PNG/JPEG/WebP images |
 
@@ -77,7 +77,7 @@ Traits are separate — not all engines need to support all APIs. Engines return
 ### Collection Routing
 
 - API state is a registry of engines keyed by collection ID (`EdrState` / `FeaturesState` / `MapsState` / `WmsState`).
-- Handlers look up engines from a `HashMap<String, Arc<dyn Engine/FeatureEngine/MapEngine>>` by collection ID from the URL path.
+- Handlers look up engines from a `HashMap<String, Arc<dyn EdrEngine/FeatureEngine/MapEngine>>` by collection ID from the URL path.
 - The `apis` config field is enforced — only collections listing a given API in their `apis` array are wired to that API's router.
 - Tiles reuses MapEngine — tile z/x/y coordinates are converted to a bbox via TileMatrixSet math, then passed to `MapEngine::get_raster_tile()`.
 
@@ -302,7 +302,7 @@ ogr2ogr -f GeoJSON -t_srs EPSG:4326 output.geojson input.geojson
 
 ### GeoTIFF
 
-Cloud-Optimized GeoTIFF (COG) files with tiled layout. Implements `Engine` (EDR) for position/area queries returning CoverageJSON, and `MapEngine` (WMS/Maps/Tiles) for raster tile rendering.
+Cloud-Optimized GeoTIFF (COG) files with tiled layout. Implements `EdrEngine` (EDR) for position/area queries returning CoverageJSON, and `MapEngine` (WMS/Maps/Tiles) for raster tile rendering.
 
 **Requirements:**
 - **Must be tiled.** Strip-based TIFFs are not supported. Convert with: `gdal_translate -co TILED=YES -co COMPRESS=DEFLATE input.tif output.tif`
@@ -514,7 +514,7 @@ GRIB2 files from NWP models. The engine discovers data via JSON index sidecar fi
 1. Poll S3 prefix for `.index` files (lightweight, ~35 KB each)
 2. Parse index -> build catalog: `(reference_time, step) -> (file_url, message_offsets)`
 3. On query: HTTP Range request for the specific GRIB message (~500 KB per surface field)
-4. Decode message -> regular lat/lon grid -> serve via Engine/MapEngine
+4. Decode message -> regular lat/lon grid -> serve via EdrEngine/MapEngine
 
 **Multi-parameter collections:** Unlike GeoTIFF (one band per collection), a GRIB collection exposes all parameters from the data source. EDR queries select parameters via `parameter-name`. MapEngine uses per-parameter WMS layers.
 
@@ -586,7 +586,7 @@ max = 1050.0
 
 ### QueryData
 
-FMI QueryData (.sqd) binary format for NWP gridded data. Implements `Engine` (EDR position queries) and `MapEngine` (WMS/Maps/Tiles rendering).
+FMI QueryData (.sqd) binary format for NWP gridded data. Implements `EdrEngine` (EDR position queries) and `MapEngine` (WMS/Maps/Tiles rendering).
 
 **Key characteristics:**
 - **Binary format** with text header. Magic bytes: `@$°£Q`. Version 6.0+ only, little-endian.
@@ -1032,7 +1032,7 @@ CoverageJSON output is validated against the official [OGC CoverageJSON 1.0 sche
 - CSV/GeoJSON data loaded into memory at startup; GeoTIFF reads tiles on demand
 - CSV engine supports only the `locations` query type
 - GeoJSON engine implements `FeatureEngine` only (not EDR or WMS)
-- GeoTIFF engine implements `Engine` + `MapEngine` only (not Features)
+- GeoTIFF engine implements `EdrEngine` + `MapEngine` only (not Features)
 - GeoTIFF: one band per collection; strip-based TIFFs not supported
 - WMS: single LAYERS only, no SLD/SE styling, no GetFeatureInfo
 - WMS/Maps/Tiles: nearest-neighbor resampling only

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A high-performance modular meteorological data server built in Rust. Implements 
 
 | Crate | Description |
 |-------|-------------|
-| `ds-core` | Domain traits (`Engine`, `FeatureEngine`, `MapEngine`), shared types (CRS, GeoTransform, PropertyValue), config parsing. No framework deps. |
+| `ds-core` | Domain traits (`EdrEngine`, `FeatureEngine`, `MapEngine`), shared types (CRS, GeoTransform, PropertyValue), config parsing. No framework deps. |
 | `ds-storage` | Unified S3 / HTTP / local-filesystem object store, used by every engine that fetches remote data. |
 | `ds-render` | Raster colorization (LUT + linear gradient) and PNG encoding. No framework deps. |
 | `ds-mvt` | Mapbox Vector Tile encoder + weighted LRU cache. Used by `api-tiles` to serve `?f=mvt` from `FeatureEngine` collections. |
@@ -19,12 +19,12 @@ Each engine implements one or more of the core traits.
 
 | Crate | Traits | Source |
 |-------|--------|--------|
-| `engine-csv` | `Engine` + `FeatureEngine` | CSV files with fixed `location, latitude, longitude, time, …` columns |
+| `engine-csv` | `EdrEngine` + `FeatureEngine` | CSV files with fixed `location, latitude, longitude, time, …` columns |
 | `engine-geojson` | `FeatureEngine` | GeoJSON FeatureCollection files (WGS84 only) |
-| `engine-geotiff` | `Engine` + `MapEngine` | Cloud-Optimized GeoTIFF (local dir, S3, or STAC catalog) |
-| `engine-grib` | `Engine` + `MapEngine` | GRIB2 NWP data via JSON/wgrib2 index sidecars (ECMWF IFS, NOAA GFS) |
-| `engine-querydata` | `Engine` + `MapEngine` | FMI QueryData (`.sqd`) binary files, memory-mapped |
-| `engine-postgis` | `Engine` + `FeatureEngine` | PostgreSQL/PostGIS observation tables (TimescaleDB compatible) |
+| `engine-geotiff` | `EdrEngine` + `MapEngine` | Cloud-Optimized GeoTIFF (local dir, S3, or STAC catalog) |
+| `engine-grib` | `EdrEngine` + `MapEngine` | GRIB2 NWP data via JSON/wgrib2 index sidecars (ECMWF IFS, NOAA GFS) |
+| `engine-querydata` | `EdrEngine` + `MapEngine` | FMI QueryData (`.sqd`) binary files, memory-mapped |
+| `engine-postgis` | `EdrEngine` + `FeatureEngine` | PostgreSQL/PostGIS observation tables (TimescaleDB compatible) |
 
 ### OGC API Plugins
 

--- a/crates/api-edr/src/handlers.rs
+++ b/crates/api-edr/src/handlers.rs
@@ -10,7 +10,7 @@ use serde_json::json;
 
 use ds_core::config::CollectionConfig;
 use ds_core::datetime::parse_datetime_interval;
-use ds_core::engine::Engine;
+use ds_core::edr_engine::EdrEngine;
 
 use ds_core::model::AreaQueryResult;
 
@@ -25,7 +25,7 @@ use crate::response::{
 /// Shared state for the EDR API: a registry of collection engines + metadata.
 #[derive(Clone)]
 pub struct EdrState {
-    pub engines: HashMap<String, Arc<dyn Engine>>,
+    pub engines: HashMap<String, Arc<dyn EdrEngine>>,
     pub collections: HashMap<String, CollectionConfig>,
     /// Base URL for generating absolute links (e.g. "https://api.example.com").
     pub base_url: String,
@@ -37,7 +37,7 @@ pub type AppState = Arc<ArcSwap<EdrState>>;
 fn lookup_collection<'a>(
     state: &'a EdrState,
     id: &str,
-) -> Result<(&'a Arc<dyn Engine>, &'a CollectionConfig), (StatusCode, Json<serde_json::Value>)> {
+) -> Result<(&'a Arc<dyn EdrEngine>, &'a CollectionConfig), (StatusCode, Json<serde_json::Value>)> {
     let engine = state.engines.get(id).ok_or_else(|| {
         (
             StatusCode::NOT_FOUND,
@@ -601,7 +601,7 @@ pub async fn area_query(
 }
 
 fn build_collection_metadata(
-    engine: &dyn Engine,
+    engine: &dyn EdrEngine,
     config: &CollectionConfig,
     base_url: &str,
 ) -> serde_json::Value {

--- a/crates/api-edr/tests/ogc_edr_api_tests.rs
+++ b/crates/api-edr/tests/ogc_edr_api_tests.rs
@@ -11,7 +11,7 @@ use tower::ServiceExt;
 
 use api_edr::handlers::EdrState;
 use ds_core::config::CollectionConfig;
-use ds_core::engine::Engine;
+use ds_core::edr_engine::EdrEngine;
 use ds_core::error::DataServerError;
 use ds_core::model::*;
 
@@ -80,7 +80,7 @@ impl MockEngine {
     }
 }
 
-impl Engine for MockEngine {
+impl EdrEngine for MockEngine {
     fn get_locations(&self) -> Result<Vec<Location>, DataServerError> {
         Ok(Self::sample_locations())
     }
@@ -173,7 +173,7 @@ impl Engine for MockEngine {
 // Helpers
 // ---------------------------------------------------------------------------
 
-fn make_edr_state(engine: Arc<dyn Engine>) -> Arc<ArcSwap<EdrState>> {
+fn make_edr_state(engine: Arc<dyn EdrEngine>) -> Arc<ArcSwap<EdrState>> {
     let mut engines = HashMap::new();
     let mut collections = HashMap::new();
     engines.insert("weather".to_string(), engine);
@@ -201,7 +201,7 @@ fn make_edr_state(engine: Arc<dyn Engine>) -> Arc<ArcSwap<EdrState>> {
 }
 
 fn build_router() -> axum::Router {
-    let engine: Arc<dyn Engine> = Arc::new(MockEngine);
+    let engine: Arc<dyn EdrEngine> = Arc::new(MockEngine);
     api_edr::router(make_edr_state(engine))
 }
 

--- a/crates/api-edr/tests/performance_tests.rs
+++ b/crates/api-edr/tests/performance_tests.rs
@@ -32,8 +32,8 @@
 //    The spec allows 202 for long-running queries. All queries currently
 //    block the handler until completion.
 //
-// 5. Arc<dyn Engine> CONCURRENCY.
-//    The Engine trait requires Send + Sync, and state is shared via Arc.
+// 5. Arc<dyn EdrEngine> CONCURRENCY.
+//    The EdrEngine trait requires Send + Sync, and state is shared via Arc.
 //    This is correct for concurrent access but should be validated under load.
 //
 // =============================================================================
@@ -49,7 +49,7 @@ use tower::ServiceExt;
 
 use api_edr::handlers::EdrState;
 use ds_core::config::CollectionConfig;
-use ds_core::engine::Engine;
+use ds_core::edr_engine::EdrEngine;
 use ds_core::error::DataServerError;
 use ds_core::model::*;
 
@@ -63,7 +63,7 @@ struct ScalableEngine {
     parameter_count: usize,
 }
 
-impl Engine for ScalableEngine {
+impl EdrEngine for ScalableEngine {
     fn get_locations(&self) -> Result<Vec<Location>, DataServerError> {
         let locations = (0..self.location_count)
             .map(|i| Location {
@@ -150,7 +150,7 @@ impl Engine for ScalableEngine {
     }
 }
 
-fn make_edr_state(engine: Arc<dyn Engine>) -> Arc<ArcSwap<EdrState>> {
+fn make_edr_state(engine: Arc<dyn EdrEngine>) -> Arc<ArcSwap<EdrState>> {
     let mut engines = HashMap::new();
     let mut collections = HashMap::new();
     engines.insert("weather".to_string(), engine);
@@ -178,7 +178,7 @@ fn make_edr_state(engine: Arc<dyn Engine>) -> Arc<ArcSwap<EdrState>> {
 }
 
 fn build_app(engine: ScalableEngine) -> axum::Router {
-    let engine: Arc<dyn Engine> = Arc::new(engine);
+    let engine: Arc<dyn EdrEngine> = Arc::new(engine);
     api_edr::router(make_edr_state(engine))
 }
 
@@ -453,7 +453,7 @@ async fn error_response_has_json_content_type() {
 // 4. Filtering Efficiency Tests
 // ===========================================================================
 //
-// NOTE: The current Engine trait signature accepts datetime and parameter-name
+// NOTE: The current EdrEngine trait signature accepts datetime and parameter-name
 // filters, but the ScalableEngine mock above ignores them. In a real
 // implementation, these filters reduce the data returned by the engine. These
 // tests verify that the handler correctly passes filter parameters through to
@@ -574,11 +574,11 @@ async fn invalid_datetime_filter_returns_400() {
 // ===========================================================================
 
 /// Verify that multiple concurrent requests to the same endpoint all succeed.
-/// This validates that the Arc<dyn Engine> sharing pattern works correctly
+/// This validates that the Arc<dyn EdrEngine> sharing pattern works correctly
 /// and that no internal state causes data races or deadlocks.
 #[tokio::test]
 async fn concurrent_location_queries_all_succeed() {
-    let engine: Arc<dyn Engine> = Arc::new(ScalableEngine {
+    let engine: Arc<dyn EdrEngine> = Arc::new(ScalableEngine {
         location_count: 10,
         timestep_count: 24,
         parameter_count: 3,
@@ -618,7 +618,7 @@ async fn concurrent_location_queries_all_succeed() {
 /// Mixes locations listing, location queries, and collection metadata.
 #[tokio::test]
 async fn concurrent_mixed_endpoint_requests_all_succeed() {
-    let engine: Arc<dyn Engine> = Arc::new(ScalableEngine {
+    let engine: Arc<dyn EdrEngine> = Arc::new(ScalableEngine {
         location_count: 5,
         timestep_count: 24,
         parameter_count: 2,

--- a/crates/api-edr/tests/security_tests.rs
+++ b/crates/api-edr/tests/security_tests.rs
@@ -10,7 +10,7 @@ use tower::ServiceExt;
 
 use api_edr::handlers::EdrState;
 use ds_core::config::CollectionConfig;
-use ds_core::engine::Engine;
+use ds_core::edr_engine::EdrEngine;
 use ds_core::error::DataServerError;
 use ds_core::model::*;
 
@@ -20,7 +20,7 @@ use ds_core::model::*;
 
 struct MockEngine;
 
-impl Engine for MockEngine {
+impl EdrEngine for MockEngine {
     fn get_locations(&self) -> Result<Vec<Location>, DataServerError> {
         Ok(vec![Location {
             id: "helsinki".to_string(),
@@ -90,7 +90,7 @@ impl Engine for MockEngine {
 // Helpers
 // ---------------------------------------------------------------------------
 
-fn make_edr_state(engine: Arc<dyn Engine>) -> Arc<ArcSwap<EdrState>> {
+fn make_edr_state(engine: Arc<dyn EdrEngine>) -> Arc<ArcSwap<EdrState>> {
     let mut engines = HashMap::new();
     let mut collections = HashMap::new();
     engines.insert("weather".to_string(), engine);
@@ -118,7 +118,7 @@ fn make_edr_state(engine: Arc<dyn Engine>) -> Arc<ArcSwap<EdrState>> {
 }
 
 fn app() -> axum::Router {
-    let engine = Arc::new(MockEngine) as Arc<dyn Engine>;
+    let engine = Arc::new(MockEngine) as Arc<dyn EdrEngine>;
     api_edr::router(make_edr_state(engine))
 }
 

--- a/crates/api-edr/tests/spec_compliance_tests.rs
+++ b/crates/api-edr/tests/spec_compliance_tests.rs
@@ -21,7 +21,7 @@ use tower::util::ServiceExt;
 
 use api_edr::handlers::EdrState;
 use ds_core::config::CollectionConfig;
-use ds_core::engine::Engine;
+use ds_core::edr_engine::EdrEngine;
 use ds_core::error::DataServerError;
 use ds_core::model::*;
 
@@ -30,7 +30,7 @@ use ds_core::model::*;
 // ---------------------------------------------------------------------------
 struct MockEngine;
 
-impl Engine for MockEngine {
+impl EdrEngine for MockEngine {
     fn get_locations(&self) -> Result<Vec<Location>, DataServerError> {
         Ok(vec![
             Location {
@@ -105,7 +105,7 @@ impl Engine for MockEngine {
     }
 }
 
-fn make_edr_state(engine: Arc<dyn Engine>) -> Arc<ArcSwap<EdrState>> {
+fn make_edr_state(engine: Arc<dyn EdrEngine>) -> Arc<ArcSwap<EdrState>> {
     let mut engines = HashMap::new();
     let mut collections = HashMap::new();
     engines.insert("weather".to_string(), engine);
@@ -133,7 +133,7 @@ fn make_edr_state(engine: Arc<dyn Engine>) -> Arc<ArcSwap<EdrState>> {
 }
 
 fn app() -> axum::Router {
-    let engine: Arc<dyn Engine> = Arc::new(MockEngine);
+    let engine: Arc<dyn EdrEngine> = Arc::new(MockEngine);
     api_edr::router(make_edr_state(engine))
 }
 
@@ -549,7 +549,7 @@ async fn finding_13_error_response_format() {
 // Implementation: build_collection_metadata() only includes "type" and
 //   "observedProperty" -- no "unit" field.
 // Impact: Clients cannot discover parameter units from collection metadata.
-// Fix: Engine trait needs to expose parameter descriptions (not just names)
+// Fix: EdrEngine trait needs to expose parameter descriptions (not just names)
 //   for collection-level metadata.
 
 #[tokio::test]
@@ -757,7 +757,7 @@ async fn finding_24_items_not_implemented() {
 // Spec: bbox should be an array of arrays, where each inner array is
 //   [west, south, east, north] (2D) or [west, south, min-z, east, north, max-z].
 // Implementation: Correctly wraps bbox in an outer array: "bbox": [bbox].
-//   But the Engine returns [f64; 4] and we wrap it as [bbox], which produces
+//   But the EdrEngine returns [f64; 4] and we wrap it as [bbox], which produces
 //   [[19.0, 59.0, 32.0, 71.0]]. This is correct.
 
 #[tokio::test]

--- a/crates/core/src/edr_engine.rs
+++ b/crates/core/src/edr_engine.rs
@@ -5,7 +5,7 @@ use chrono::{DateTime, Utc};
 use crate::error::DataServerError;
 use crate::model::{AreaQueryResult, Location, ParameterDescription, QueryResult};
 
-pub trait Engine: Send + Sync {
+pub trait EdrEngine: Send + Sync {
     fn get_locations(&self) -> Result<Vec<Location>, DataServerError>;
 
     fn query_location(

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1,6 +1,6 @@
 pub mod config;
 pub mod datetime;
-pub mod engine;
+pub mod edr_engine;
 pub mod error;
 pub mod feature;
 pub mod feature_engine;

--- a/crates/core/src/map_engine.rs
+++ b/crates/core/src/map_engine.rs
@@ -44,9 +44,9 @@ pub struct RasterInfo {
     pub parameters: Vec<(String, String)>,
 }
 
-/// Engine trait for serving raster data as map images.
+/// Trait for serving raster data as map images.
 ///
-/// Separate from `Engine` (EDR) and `FeatureEngine` (Features).
+/// Separate from `EdrEngine` (EDR) and `FeatureEngine` (Features).
 /// Only raster engines (GeoTIFF, future NetCDF/GRIB) implement this.
 pub trait MapEngine: Send + Sync {
     /// Extract a raster tile for the given bbox and output dimensions.

--- a/crates/engine-csv/benches/csv_engine.rs
+++ b/crates/engine-csv/benches/csv_engine.rs
@@ -1,6 +1,6 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
-use ds_core::engine::Engine;
+use ds_core::edr_engine::EdrEngine;
 use ds_core::feature::{Bbox, FeatureQuery};
 use ds_core::feature_engine::FeatureEngine;
 use engine_csv::engine::CsvEngine;

--- a/crates/engine-csv/src/engine.rs
+++ b/crates/engine-csv/src/engine.rs
@@ -1,7 +1,7 @@
 use chrono::{DateTime, Utc};
 use std::collections::HashMap;
 
-use ds_core::engine::Engine;
+use ds_core::edr_engine::EdrEngine;
 use ds_core::error::DataServerError;
 use std::sync::Arc;
 
@@ -23,7 +23,7 @@ impl CsvEngine {
     }
 }
 
-impl Engine for CsvEngine {
+impl EdrEngine for CsvEngine {
     fn get_locations(&self) -> Result<Vec<Location>, DataServerError> {
         let mut locations = Vec::new();
         let mut seen = HashMap::new();

--- a/crates/engine-geotiff/benches/geotiff_engine.rs
+++ b/crates/engine-geotiff/benches/geotiff_engine.rs
@@ -1,7 +1,7 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
 use ds_core::config::GeoTiffConfig;
-use ds_core::engine::Engine;
+use ds_core::edr_engine::EdrEngine;
 use engine_geotiff::GeoTiffEngine;
 
 fn make_config() -> GeoTiffConfig {

--- a/crates/engine-geotiff/benches/geotiff_remote.rs
+++ b/crates/engine-geotiff/benches/geotiff_remote.rs
@@ -19,7 +19,7 @@ use std::time::Duration;
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
 
 use ds_core::config::GeoTiffConfig;
-use ds_core::engine::Engine;
+use ds_core::edr_engine::EdrEngine;
 use engine_geotiff::GeoTiffEngine;
 
 fn make_config(cache_mb: u64) -> GeoTiffConfig {

--- a/crates/engine-geotiff/src/lib.rs
+++ b/crates/engine-geotiff/src/lib.rs
@@ -26,7 +26,7 @@ use std::sync::Arc;
 use tokio::sync::watch;
 
 use ds_core::config::GeoTiffConfig;
-use ds_core::engine::Engine;
+use ds_core::edr_engine::EdrEngine;
 use ds_core::error::DataServerError;
 use ds_core::model::*;
 
@@ -1464,7 +1464,7 @@ impl ds_core::map_engine::MapEngine for GeoTiffEngine {
     }
 }
 
-impl Engine for GeoTiffEngine {
+impl EdrEngine for GeoTiffEngine {
     fn get_locations(&self) -> Result<Vec<Location>, DataServerError> {
         Ok(vec![])
     }

--- a/crates/engine-grib/src/lib.rs
+++ b/crates/engine-grib/src/lib.rs
@@ -14,7 +14,7 @@ use chrono::{DateTime, Datelike, Utc};
 use tokio::sync::watch;
 
 use ds_core::config::GribConfig;
-use ds_core::engine::Engine;
+use ds_core::edr_engine::EdrEngine;
 use ds_core::error::DataServerError;
 use ds_core::map_engine::{MapEngine, OutputCrs, RasterInfo, RasterTile};
 use ds_core::model::*;
@@ -734,7 +734,7 @@ impl GribEngine {
 // Engine trait (EDR)
 // ---------------------------------------------------------------------------
 
-impl Engine for GribEngine {
+impl EdrEngine for GribEngine {
     fn get_locations(&self) -> Result<Vec<Location>, DataServerError> {
         // Gridded data has no discrete locations
         Ok(Vec::new())

--- a/crates/engine-postgis/src/engine.rs
+++ b/crates/engine-postgis/src/engine.rs
@@ -1,4 +1,4 @@
-//! `PostgisEngine` — implements the `ds_core::engine::Engine` trait on top
+//! `PostgisEngine` — implements the `ds_core::edr_engine::EdrEngine` trait on top
 //! of a [`deadpool_postgres`] pool and a [`MetadataCache`].
 //!
 //! DB work is async; the trait is sync. The bridge is
@@ -12,7 +12,7 @@ use std::sync::Arc;
 
 use chrono::{DateTime, Utc};
 use deadpool_postgres::Pool;
-use ds_core::engine::Engine;
+use ds_core::edr_engine::EdrEngine;
 use ds_core::error::DataServerError;
 use ds_core::model::{
     AreaQueryResult, DomainDescription, Location, NdArray, ParameterDescription, QueryResult,
@@ -33,7 +33,7 @@ use crate::schema::ObservationSchema;
 type ParamSeries = Vec<(DateTime<Utc>, Option<f64>)>;
 
 /// Collection-scoped engine. Cheap to clone (Arcs inside); axum handlers
-/// hold it behind `Arc<dyn Engine>` as is done for every engine.
+/// hold it behind `Arc<dyn EdrEngine>` as is done for every engine.
 pub struct PostgisEngine {
     collection_id: String,
     config: Arc<PostgisEngineConfig>,
@@ -108,7 +108,7 @@ impl PostgisEngine {
 
 // ─── Engine trait ────────────────────────────────────────────────────────────
 
-impl Engine for PostgisEngine {
+impl EdrEngine for PostgisEngine {
     fn get_locations(&self) -> Result<Vec<Location>, DataServerError> {
         Ok((*self.load_meta().locations).clone())
     }

--- a/crates/engine-querydata/src/engine.rs
+++ b/crates/engine-querydata/src/engine.rs
@@ -7,7 +7,7 @@ use arc_swap::ArcSwap;
 use chrono::{DateTime, Utc};
 use tokio::sync::watch;
 
-use ds_core::engine::Engine;
+use ds_core::edr_engine::EdrEngine;
 use ds_core::error::DataServerError;
 use ds_core::map_engine::{MapEngine, OutputCrs, RasterInfo, RasterTile};
 use ds_core::model::{DomainDescription, Location, NdArray, ParameterDescription, QueryResult};
@@ -165,7 +165,7 @@ impl QueryDataEngine {
     }
 }
 
-impl Engine for QueryDataEngine {
+impl EdrEngine for QueryDataEngine {
     fn get_locations(&self) -> Result<Vec<Location>, DataServerError> {
         Ok(vec![])
     }

--- a/crates/server/src/admin.rs
+++ b/crates/server/src/admin.rs
@@ -372,7 +372,7 @@ pub fn load_collections(
 ) -> LoadResult {
     let bundle_index: HashMap<&str, &StyleBundle> =
         style_bundles.iter().map(|b| (b.id.as_str(), b)).collect();
-    let mut edr_engines: HashMap<String, Arc<dyn ds_core::engine::Engine>> = HashMap::new();
+    let mut edr_engines: HashMap<String, Arc<dyn ds_core::edr_engine::EdrEngine>> = HashMap::new();
     let mut edr_collections: HashMap<String, CollectionConfig> = HashMap::new();
     let mut feature_engines: HashMap<String, Arc<dyn ds_core::feature_engine::FeatureEngine>> =
         HashMap::new();
@@ -500,7 +500,7 @@ pub fn load_collections(
                 if collection.apis.contains(&"edr".to_string()) {
                     edr_engines.insert(
                         collection.id.clone(),
-                        engine.clone() as Arc<dyn ds_core::engine::Engine>,
+                        engine.clone() as Arc<dyn ds_core::edr_engine::EdrEngine>,
                     );
                     edr_collections.insert(collection.id.clone(), collection.clone());
                 }
@@ -622,7 +622,7 @@ pub fn load_collections(
                 };
 
                 if let Some((start, end)) =
-                    ds_core::engine::Engine::get_temporal_extent(engine.as_ref())
+                    ds_core::edr_engine::EdrEngine::get_temporal_extent(engine.as_ref())
                 {
                     info!(
                         "Collection '{}': temporal extent {} to {}",
@@ -635,7 +635,7 @@ pub fn load_collections(
                 if collection.apis.contains(&"edr".to_string()) {
                     edr_engines.insert(
                         collection.id.clone(),
-                        engine.clone() as Arc<dyn ds_core::engine::Engine>,
+                        engine.clone() as Arc<dyn ds_core::edr_engine::EdrEngine>,
                     );
                     edr_collections.insert(collection.id.clone(), collection.clone());
                 }
@@ -680,7 +680,7 @@ pub fn load_collections(
                 // GeoTIFF starts degraded (no data yet until first poll), unless
                 // the initial scan already found files.
                 let has_data =
-                    ds_core::engine::Engine::get_temporal_extent(engine.as_ref()).is_some();
+                    ds_core::edr_engine::EdrEngine::get_temporal_extent(engine.as_ref()).is_some();
                 health.push(CollectionHealth {
                     id: collection.id.clone(),
                     engine_type: "geotiff".into(),
@@ -746,7 +746,7 @@ pub fn load_collections(
                 if collection.apis.contains(&"edr".to_string()) {
                     edr_engines.insert(
                         collection.id.clone(),
-                        engine.clone() as Arc<dyn ds_core::engine::Engine>,
+                        engine.clone() as Arc<dyn ds_core::edr_engine::EdrEngine>,
                     );
                     edr_collections.insert(collection.id.clone(), collection.clone());
                 }
@@ -862,7 +862,7 @@ pub fn load_collections(
                 };
 
                 if let Some((start, end)) =
-                    ds_core::engine::Engine::get_temporal_extent(engine.as_ref())
+                    ds_core::edr_engine::EdrEngine::get_temporal_extent(engine.as_ref())
                 {
                     info!(
                         "Collection '{}': temporal extent {} to {}",
@@ -875,7 +875,7 @@ pub fn load_collections(
                 if collection.apis.contains(&"edr".to_string()) {
                     edr_engines.insert(
                         collection.id.clone(),
-                        engine.clone() as Arc<dyn ds_core::engine::Engine>,
+                        engine.clone() as Arc<dyn ds_core::edr_engine::EdrEngine>,
                     );
                     edr_collections.insert(collection.id.clone(), collection.clone());
                 }
@@ -939,7 +939,7 @@ pub fn load_collections(
                 }
 
                 let has_data =
-                    ds_core::engine::Engine::get_temporal_extent(engine.as_ref()).is_some();
+                    ds_core::edr_engine::EdrEngine::get_temporal_extent(engine.as_ref()).is_some();
                 health.push(CollectionHealth {
                     id: collection.id.clone(),
                     engine_type: "grib".into(),
@@ -1048,7 +1048,7 @@ pub fn load_collections(
 
                 let (status, status_err) = match &refresh_result {
                     Ok(()) => {
-                        use ds_core::engine::Engine as _;
+                        use ds_core::edr_engine::EdrEngine as _;
                         info!(
                             "Collection '{}': postgis engine ready ({} stations, {} parameters)",
                             collection.id,
@@ -1070,7 +1070,7 @@ pub fn load_collections(
                 if collection.apis.contains(&"edr".to_string()) {
                     edr_engines.insert(
                         collection.id.clone(),
-                        engine.clone() as Arc<dyn ds_core::engine::Engine>,
+                        engine.clone() as Arc<dyn ds_core::edr_engine::EdrEngine>,
                     );
                     edr_collections.insert(collection.id.clone(), collection.clone());
                 }
@@ -1648,8 +1648,8 @@ pub async fn health_handler(State(state): State<AdminState>) -> impl IntoRespons
     let mut data_ages: HashMap<String, i64> = HashMap::new();
     let mut temporal_info: HashMap<String, serde_json::Value> = HashMap::new();
 
-    // Helper: build temporal extent from any Engine
-    fn build_temporal(engine: &dyn ds_core::engine::Engine) -> Option<serde_json::Value> {
+    // Helper: build temporal extent from any EdrEngine
+    fn build_temporal(engine: &dyn ds_core::edr_engine::EdrEngine) -> Option<serde_json::Value> {
         let (start, end) = engine.get_temporal_extent()?;
         let mut obj = serde_json::Map::new();
         obj.insert(

--- a/crates/server/src/preview.rs
+++ b/crates/server/src/preview.rs
@@ -540,7 +540,7 @@ fn serialize_temporal(
     // Always emit `values` / `truncated` / `total_values`, even when the
     // engine doesn't override `get_available_times()`. This keeps the
     // manifest shape stable so UI clients don't have to null-guard each
-    // field individually. The `Engine` trait's default impl returns
+    // field individually. The `EdrEngine` trait's default impl returns
     // `None` for several engines (CSV, PostGIS, QueryData) — without
     // this fallback those collections would emit only `start`/`end`.
     let (slice, truncated, total): (&[_], bool, usize) = match values {
@@ -663,7 +663,7 @@ mod tests {
 
     use arc_swap::ArcSwap;
     use chrono::{DateTime, Utc};
-    use ds_core::engine::Engine;
+    use ds_core::edr_engine::EdrEngine;
     use ds_core::error::DataServerError;
     use ds_core::feature::{Feature, FeaturePage, FeatureQuery};
     use ds_core::feature_engine::FeatureEngine;
@@ -679,7 +679,7 @@ mod tests {
         times: Vec<DateTime<Utc>>,
     }
 
-    impl Engine for EdrMock {
+    impl EdrEngine for EdrMock {
         fn get_locations(&self) -> Result<Vec<Location>, DataServerError> {
             Ok(Vec::new())
         }
@@ -874,7 +874,7 @@ mod tests {
     #[test]
     fn manifest_aggregates_edr_collection_with_temporal_extent() {
         let mut edr = empty_edr();
-        let engine: Arc<dyn Engine> = Arc::new(EdrMock {
+        let engine: Arc<dyn EdrEngine> = Arc::new(EdrMock {
             extent: Some([10.0, 55.0, 30.0, 70.0]),
             times: vec![t("2024-01-01T00:00:00Z"), t("2024-01-02T00:00:00Z")],
         });
@@ -914,7 +914,7 @@ mod tests {
         let times: Vec<DateTime<Utc>> = (0..MAX_TEMPORAL_VALUES + 50)
             .map(|i| DateTime::<Utc>::from_timestamp(1_700_000_000 + i as i64 * 60, 0).unwrap())
             .collect();
-        let engine: Arc<dyn Engine> = Arc::new(EdrMock {
+        let engine: Arc<dyn EdrEngine> = Arc::new(EdrMock {
             extent: None,
             times: times.clone(),
         });
@@ -1105,7 +1105,7 @@ mod tests {
         struct IntervalOnlyMock {
             interval: (DateTime<Utc>, DateTime<Utc>),
         }
-        impl Engine for IntervalOnlyMock {
+        impl EdrEngine for IntervalOnlyMock {
             fn get_locations(&self) -> Result<Vec<Location>, DataServerError> {
                 Ok(Vec::new())
             }
@@ -1129,7 +1129,7 @@ mod tests {
             // Note: no `get_available_times` override — falls back to default `None`.
         }
         let mut edr = empty_edr();
-        let engine: Arc<dyn Engine> = Arc::new(IntervalOnlyMock {
+        let engine: Arc<dyn EdrEngine> = Arc::new(IntervalOnlyMock {
             interval: (
                 "2024-01-01T00:00:00Z".parse().unwrap(),
                 "2024-01-02T00:00:00Z".parse().unwrap(),
@@ -1177,7 +1177,7 @@ mod tests {
         struct IntervalOnlyEdr {
             interval: (DateTime<Utc>, DateTime<Utc>),
         }
-        impl Engine for IntervalOnlyEdr {
+        impl EdrEngine for IntervalOnlyEdr {
             fn get_locations(&self) -> Result<Vec<Location>, DataServerError> {
                 Ok(Vec::new())
             }
@@ -1211,7 +1211,7 @@ mod tests {
         );
 
         let mut edr = empty_edr();
-        let edr_engine: Arc<dyn Engine> = Arc::new(IntervalOnlyEdr {
+        let edr_engine: Arc<dyn EdrEngine> = Arc::new(IntervalOnlyEdr {
             interval: wide_edr_interval,
         });
         edr.engines.insert("radar".into(), edr_engine);


### PR DESCRIPTION
## Summary

- The trait was named `Engine` but is specifically the EDR-shaped time-series-at-locations contract.
- Renamed to `EdrEngine` to match its peers `FeatureEngine` and `MapEngine` and stop misleading readers into thinking it's the workspace's generic engine trait.
- Pure rename — no behavior change. Module file `crates/core/src/engine.rs` → `edr_engine.rs`.

## Why

The engine-capability table read like CSV implements "the engine" (singular) while GeoTIFF implements "Engine + MapEngine" (compound). `EdrEngine` makes it self-evident which API each engine targets, and removes the "wait, what's just `Engine`?" beat when reading the trait list.

`DataServerError::Engine(String)` variant is intentionally unchanged — it's a generic "engine-layer error", not a reference to the trait.

## Test plan

- [x] `cargo fmt -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --workspace` (43 test binaries green)
- [ ] CI green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)