### PR TITLE
feat(preview): parameter dropdown + bounded time slider

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -231,6 +231,13 @@ max_files = 24
 # inline — mixing the two in one [wms] block is rejected at config load.
 style_bundle = "radar_multi"
 # colormap = "radar_dbz"
+
+# Optional /preview SPA tuning. Cap the time slider's `values[]` to the most
+# recent ISO 8601 duration before the latest timestep. Useful for STAC-backed
+# collections whose archive spans years but whose useful scrub range is the
+# last few hours. Does NOT constrain the underlying engine — only the manifest.
+[collections.preview]
+time_window = "PT12H"
 ```
 
 See config struct definitions in each engine crate and `ds-core/src/config.rs` for all fields.

--- a/README.md
+++ b/README.md
@@ -278,6 +278,13 @@ unit = "dBZ"
 
 [wms]
 colormap = "radar_dbz"
+
+# Optional: bound the /preview SPA's time slider for collections whose
+# archive is far wider than the useful scrubbing range (e.g. a STAC
+# catalogue spanning years of 5-min mosaics). ISO 8601 positive duration.
+# Only affects the preview manifest — the underlying engine is unchanged.
+[preview]
+time_window = "PT12H"
 ```
 
 **Key behaviors:**
@@ -830,6 +837,7 @@ REST-based map image API. Maps and WMS share the `MapEngine` trait but have sepa
 | `crs` | no | `CRS:84` | Output CRS |
 | `datetime` | no | latest | ISO 8601 timestamp |
 | `f` | no | `image/png` | `image/png`, `image/jpeg`, `image/webp` |
+| `parameter-name` | no | engine default | Select a parameter on multi-parameter raster engines (GRIB, multi-param QueryData). Mirrors EDR's `parameter-name=` convention; non-OGC for OGC API - Maps today, but the `/preview` SPA dropdown depends on it. Single-parameter engines ignore the value. Unknown names against a multi-param engine return 400. |
 
 ### Key Differences from WMS
 
@@ -859,6 +867,7 @@ Serves raster data as tiled map images. Tiles reuses the same rendering pipeline
 |-----------|----------|---------|-------------|
 | `datetime` | no | latest | ISO 8601 timestamp |
 | `f` | no | `image/png` | Raster: `image/png`, `image/jpeg`, `image/webp`. Vector: `mvt` or `application/vnd.mapbox-vector-tile`. |
+| `parameter-name` | no | engine default | Same semantics as the Maps `parameter-name` parameter above. Ignored for `?f=mvt`. |
 
 ### Vector Tiles (MVT)
 

--- a/collections.d/met-norway-radar.toml
+++ b/collections.d/met-norway-radar.toml
@@ -14,3 +14,11 @@ poll_interval_secs = 300
 
 [wms]
 style_bundle = "radar_multi"
+
+# Bound the /preview SPA's time slider to the last 12 hours. The STAC archive
+# covers >1 year of 5-minute mosaics; without this cap the slider becomes a
+# 1000-stop bar covering ~83h that's unusable for scrubbing recent radar.
+# Only affects the preview manifest — the underlying engine still loads
+# whatever the STAC catalogue advertises.
+[preview]
+time_window = "PT12H"

--- a/crates/api-edr/tests/ogc_edr_api_tests.rs
+++ b/crates/api-edr/tests/ogc_edr_api_tests.rs
@@ -191,6 +191,7 @@ fn make_edr_state(engine: Arc<dyn EdrEngine>) -> Arc<ArcSwap<EdrState>> {
             wms: None,
             grib: None,
             postgis: None,
+            preview: None,
         },
     );
     Arc::new(ArcSwap::from_pointee(EdrState {

--- a/crates/api-edr/tests/performance_tests.rs
+++ b/crates/api-edr/tests/performance_tests.rs
@@ -168,6 +168,7 @@ fn make_edr_state(engine: Arc<dyn EdrEngine>) -> Arc<ArcSwap<EdrState>> {
             wms: None,
             grib: None,
             postgis: None,
+            preview: None,
         },
     );
     Arc::new(ArcSwap::from_pointee(EdrState {

--- a/crates/api-edr/tests/security_tests.rs
+++ b/crates/api-edr/tests/security_tests.rs
@@ -108,6 +108,7 @@ fn make_edr_state(engine: Arc<dyn EdrEngine>) -> Arc<ArcSwap<EdrState>> {
             wms: None,
             grib: None,
             postgis: None,
+            preview: None,
         },
     );
     Arc::new(ArcSwap::from_pointee(EdrState {

--- a/crates/api-edr/tests/spec_compliance_tests.rs
+++ b/crates/api-edr/tests/spec_compliance_tests.rs
@@ -123,6 +123,7 @@ fn make_edr_state(engine: Arc<dyn EdrEngine>) -> Arc<ArcSwap<EdrState>> {
             wms: None,
             grib: None,
             postgis: None,
+            preview: None,
         },
     );
     Arc::new(ArcSwap::from_pointee(EdrState {

--- a/crates/api-features/tests/ogc_features_api_tests.rs
+++ b/crates/api-features/tests/ogc_features_api_tests.rs
@@ -145,6 +145,7 @@ fn build_router() -> axum::Router {
             wms: None,
             grib: None,
             postgis: None,
+            preview: None,
         },
     );
 
@@ -432,6 +433,7 @@ mod vector_tile_discovery {
                 wms: None,
                 grib: None,
                 postgis: None,
+                preview: None,
             },
         );
         let state = Arc::new(ArcSwap::from_pointee(FeaturesState {

--- a/crates/api-maps/src/handlers.rs
+++ b/crates/api-maps/src/handlers.rs
@@ -703,6 +703,29 @@ async fn render_map(
         }
     };
 
+    // Parameter selection precedence: ?parameter-name= wins over style.parameter.
+    // Validate against the engine's advertised list when the query supplied one
+    // — passing through unrecognised names produces a confusing "default
+    // parameter rendered with wrong colormap" rather than a clear 400.
+    // `raster_info().parameters` is empty for single-parameter engines (GeoTIFF);
+    // in that case we just accept the query value and let the engine ignore it,
+    // matching `get_raster_tile`'s documented behavior.
+    if let Some(pname) = validated.parameter_name.as_deref() {
+        let info = engine.raster_info();
+        if !info.parameters.is_empty() && !info.parameters.iter().any(|(name, _)| name == pname) {
+            let supported: Vec<&str> = info.parameters.iter().map(|(n, _)| n.as_str()).collect();
+            return Err(MapsError::BadRequest(format!(
+                "parameter-name '{pname}' is not available for collection '{collection_id}'. \
+                 Available: {}",
+                supported.join(", ")
+            )));
+        }
+    }
+    let effective_parameter = validated
+        .parameter_name
+        .clone()
+        .or_else(|| style_info.parameter.clone());
+
     // Build cache key
     let cache_key = CacheKey {
         layer: collection_id.to_string(),
@@ -717,6 +740,7 @@ async fn render_map(
         width: validated.width,
         height: validated.height,
         time,
+        parameter: effective_parameter.clone(),
     };
 
     let etag = cache_key.etag();
@@ -769,7 +793,7 @@ async fn render_map(
     let format = validated.format;
     let rendered_cache = state.rendered_cache.clone();
 
-    let style_parameter = style_info.parameter.as_deref().map(String::from);
+    let render_parameter = effective_parameter;
 
     let render_result = tokio::task::spawn_blocking(move || {
         let tile = engine.get_raster_tile(
@@ -778,7 +802,7 @@ async fn render_map(
             height,
             time,
             &output_crs,
-            style_parameter.as_deref(),
+            render_parameter.as_deref(),
         )?;
         // If every pixel is nodata, skip colorization + encoding entirely.
         if tile.is_empty() {

--- a/crates/api-maps/src/handlers.rs
+++ b/crates/api-maps/src/handlers.rs
@@ -712,11 +712,17 @@ async fn render_map(
         if !raster_info.parameters.is_empty()
             && !raster_info.parameters.iter().any(|(name, _)| name == pname)
         {
-            let supported: Vec<&str> = raster_info
+            let mut supported: Vec<&str> = raster_info
                 .parameters
                 .iter()
                 .map(|(n, _)| n.as_str())
                 .collect();
+            // Sort so the error message is deterministic. `raster_info()`
+            // returns parameters in engine-defined order — fine for GRIB
+            // today but a future HashMap-backed engine would surface a
+            // different ordering per request, confusing both log greppers
+            // and clients that try to match against the hint.
+            supported.sort_unstable();
             return Err(MapsError::BadRequest(format!(
                 "parameter-name '{pname}' is not available for collection '{collection_id}'. \
                  Available: {}",

--- a/crates/api-maps/src/handlers.rs
+++ b/crates/api-maps/src/handlers.rs
@@ -694,14 +694,12 @@ async fn render_map(
     let has_explicit_time = validated.time.is_some();
     let content_crs = crs_to_uri(&validated.crs);
 
-    // Resolve time: use explicit or default to latest
-    let time = match validated.time {
-        Some(t) => Some(t),
-        None => {
-            let info = engine.raster_info();
-            info.times.last().copied()
-        }
-    };
+    // Single `raster_info()` call covers both default-time resolution and
+    // parameter-name validation. The trait now documents this as O(1), but
+    // hoisting still saves one Arc-clone-sized allocation per request on
+    // engines that materialise `RasterInfo` lazily.
+    let raster_info = engine.raster_info();
+    let time = validated.time.or_else(|| raster_info.times.last().copied());
 
     // Parameter selection precedence: ?parameter-name= wins over style.parameter.
     // Validate against the engine's advertised list when the query supplied one
@@ -711,9 +709,14 @@ async fn render_map(
     // in that case we just accept the query value and let the engine ignore it,
     // matching `get_raster_tile`'s documented behavior.
     if let Some(pname) = validated.parameter_name.as_deref() {
-        let info = engine.raster_info();
-        if !info.parameters.is_empty() && !info.parameters.iter().any(|(name, _)| name == pname) {
-            let supported: Vec<&str> = info.parameters.iter().map(|(n, _)| n.as_str()).collect();
+        if !raster_info.parameters.is_empty()
+            && !raster_info.parameters.iter().any(|(name, _)| name == pname)
+        {
+            let supported: Vec<&str> = raster_info
+                .parameters
+                .iter()
+                .map(|(n, _)| n.as_str())
+                .collect();
             return Err(MapsError::BadRequest(format!(
                 "parameter-name '{pname}' is not available for collection '{collection_id}'. \
                  Available: {}",

--- a/crates/api-maps/src/params.rs
+++ b/crates/api-maps/src/params.rs
@@ -31,6 +31,11 @@ pub struct MapQueryParams {
     pub format: Option<String>,
     #[serde(rename = "bbox-crs")]
     pub bbox_crs: Option<String>,
+    /// EDR-style parameter selector for multi-parameter raster engines
+    /// (GRIB, multi-param QueryData). Non-OGC for now — a standardised
+    /// path/query form is on the OGC Maps roadmap and will replace this.
+    #[serde(rename = "parameter-name")]
+    pub parameter_name: Option<String>,
 }
 
 /// Validated map request parameters.
@@ -42,6 +47,7 @@ pub struct ValidatedMapParams {
     pub time: Option<DateTime<Utc>>,
     pub output_crs: ds_core::map_engine::OutputCrs,
     pub format: ds_render::ImageFormat,
+    pub parameter_name: Option<String>,
 }
 
 impl MapQueryParams {
@@ -122,6 +128,16 @@ impl MapQueryParams {
             _ => ds_core::map_engine::OutputCrs::Wgs84,
         };
 
+        // parameter-name — validation that the name is in the engine's list
+        // happens in the handler (we don't have the engine here). Just trim and
+        // reject empty/blank to keep handler logic simple.
+        let parameter_name = self
+            .parameter_name
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(str::to_string);
+
         Ok(ValidatedMapParams {
             bbox,
             width,
@@ -130,6 +146,7 @@ impl MapQueryParams {
             time,
             output_crs,
             format,
+            parameter_name,
         })
     }
 }

--- a/crates/api-maps/tests/integration.rs
+++ b/crates/api-maps/tests/integration.rs
@@ -476,6 +476,152 @@ mod get_map {
         let (status, _) = get("/collections/radar/map?bbox=10,55,30,70&width=9000").await;
         assert_eq!(status, StatusCode::BAD_REQUEST);
     }
+
+    #[tokio::test]
+    async fn parameter_name_query_is_accepted_for_single_param_engine() {
+        // `MockMapEngine.raster_info().parameters` is empty (single-band).
+        // The handler accepts any `parameter-name=` and forwards it; the
+        // engine ignores the value at render time per the trait contract.
+        let (status, _, body) =
+            get_raw("/collections/radar/map?bbox=10,55,30,70&parameter-name=anything").await;
+        assert_eq!(status, StatusCode::OK);
+        assert!(body.starts_with(&[0x89, b'P', b'N', b'G']));
+    }
+
+    #[tokio::test]
+    async fn parameter_name_changes_etag() {
+        // Different parameter-name values must produce different rendered-cache
+        // entries (and thus different ETags) — otherwise a client switching
+        // parameters would get a stale 304.
+        let (_, headers_a, _) =
+            get_raw("/collections/radar/map?bbox=10,55,30,70&parameter-name=2t").await;
+        let (_, headers_b, _) =
+            get_raw("/collections/radar/map?bbox=10,55,30,70&parameter-name=10u").await;
+        assert_ne!(
+            headers_a.get("etag").unwrap(),
+            headers_b.get("etag").unwrap(),
+            "ETags must differ across parameter-name values"
+        );
+    }
+
+    #[tokio::test]
+    async fn unknown_parameter_name_returns_400_for_multi_param_engine() {
+        let app = build_multi_param_router();
+        let req = Request::builder()
+            .uri("/collections/wx/map?bbox=10,55,30,70&parameter-name=nope")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let body = resp.into_body().collect().await.unwrap().to_bytes();
+        let text = std::str::from_utf8(&body).unwrap();
+        assert!(
+            text.contains("Available: 2t, 10u") || text.contains("Available: 10u, 2t"),
+            "error body should list available parameters; got: {text}"
+        );
+    }
+
+    #[tokio::test]
+    async fn known_parameter_name_is_accepted_by_multi_param_engine() {
+        let app = build_multi_param_router();
+        let req = Request::builder()
+            .uri("/collections/wx/map?bbox=10,55,30,70&parameter-name=2t")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+}
+
+struct MultiParamMockEngine;
+
+impl MapEngine for MultiParamMockEngine {
+    fn get_raster_tile(
+        &self,
+        _bbox: [f64; 4],
+        width: u32,
+        height: u32,
+        _time: Option<chrono::DateTime<chrono::Utc>>,
+        _output_crs: &ds_core::map_engine::OutputCrs,
+        _parameter: Option<&str>,
+    ) -> Result<ds_core::map_engine::RasterTile, ds_core::error::DataServerError> {
+        let pixel_count = (width * height) as usize;
+        let values: Vec<Option<f64>> = (0..pixel_count).map(|i| Some(i as f64)).collect();
+        Ok(ds_core::map_engine::RasterTile {
+            width,
+            height,
+            values,
+        })
+    }
+
+    fn raster_info(&self) -> ds_core::map_engine::RasterInfo {
+        ds_core::map_engine::RasterInfo {
+            native_crs: "EPSG:4326".into(),
+            spatial_extent: Some([0.0, 0.0, 10.0, 10.0]),
+            times: vec![],
+            parameter: "2t".into(),
+            unit: "K".into(),
+            parameters: vec![
+                ("2t".into(), "Temperature".into()),
+                ("10u".into(), "U Wind".into()),
+            ],
+        }
+    }
+}
+
+fn build_multi_param_router() -> axum::Router {
+    let engine: Arc<dyn MapEngine> = Arc::new(MultiParamMockEngine);
+    let mut engines = HashMap::new();
+    let mut collections = HashMap::new();
+    let mut styles_map = HashMap::new();
+
+    engines.insert("wx".to_string(), engine);
+    collections.insert(
+        "wx".to_string(),
+        CollectionConfig {
+            id: "wx".to_string(),
+            title: "Forecast".to_string(),
+            description: "Test multi-param".to_string(),
+            data_path: None,
+            apis: vec!["maps".to_string()],
+            engine_type: "grib".to_string(),
+            geotiff: None,
+            querydata: None,
+            wms: None,
+            grib: None,
+            postgis: None,
+            preview: None,
+        },
+    );
+
+    let cmap = Arc::new(LutColorMap::from_builtin(
+        BuiltinColormap::Viridis,
+        0.0,
+        1.0,
+    ));
+    let mut layer_styles = HashMap::new();
+    layer_styles.insert(
+        "default".to_string(),
+        StyleInfo {
+            name: "default".to_string(),
+            title: "Default".to_string(),
+            colormap: cmap,
+            min: 0.0,
+            max: 1.0,
+            parameter: None,
+        },
+    );
+    styles_map.insert("wx".to_string(), layer_styles);
+
+    let state = Arc::new(ArcSwap::from_pointee(MapsState {
+        engines,
+        collections,
+        styles: styles_map,
+        render_semaphore: Arc::new(tokio::sync::Semaphore::new(4)),
+        rendered_cache: Arc::new(RenderedCache::new(16)),
+        base_url: String::new(),
+    }));
+    api_maps::router(state)
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/api-maps/tests/integration.rs
+++ b/crates/api-maps/tests/integration.rs
@@ -95,6 +95,7 @@ fn build_router() -> axum::Router {
             wms: None,
             grib: None,
             postgis: None,
+            preview: None,
         },
     );
 

--- a/crates/api-maps/tests/integration.rs
+++ b/crates/api-maps/tests/integration.rs
@@ -515,9 +515,10 @@ mod get_map {
         assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
         let body = resp.into_body().collect().await.unwrap().to_bytes();
         let text = std::str::from_utf8(&body).unwrap();
+        // Sorted alphabetically — "10u" < "2t" by lexicographic comparison.
         assert!(
-            text.contains("Available: 2t, 10u") || text.contains("Available: 10u, 2t"),
-            "error body should list available parameters; got: {text}"
+            text.contains("Available: 10u, 2t"),
+            "error body should list available parameters in sorted order; got: {text}"
         );
     }
 

--- a/crates/api-tiles/src/handlers.rs
+++ b/crates/api-tiles/src/handlers.rs
@@ -1040,14 +1040,11 @@ async fn render_tile(
         _ => crs_to_uri("CRS:84"),
     };
 
-    // Resolve time: use explicit or default to latest
-    let time = match validated.time {
-        Some(t) => Some(t),
-        None => {
-            let info = engine.raster_info();
-            info.times.last().copied()
-        }
-    };
+    // Single `raster_info()` call covers both default-time resolution and
+    // parameter-name validation. Trait contract is O(1) but we still avoid
+    // the redundant call.
+    let raster_info = engine.raster_info();
+    let time = validated.time.or_else(|| raster_info.times.last().copied());
 
     let tile_size = params::TILE_SIZE;
 
@@ -1057,9 +1054,14 @@ async fn render_tile(
     // with an empty `raster_info().parameters` list (single-band GeoTIFF)
     // ignore the parameter at render time — we still accept the query.
     if let Some(pname) = validated.parameter_name.as_deref() {
-        let info = engine.raster_info();
-        if !info.parameters.is_empty() && !info.parameters.iter().any(|(name, _)| name == pname) {
-            let supported: Vec<&str> = info.parameters.iter().map(|(n, _)| n.as_str()).collect();
+        if !raster_info.parameters.is_empty()
+            && !raster_info.parameters.iter().any(|(name, _)| name == pname)
+        {
+            let supported: Vec<&str> = raster_info
+                .parameters
+                .iter()
+                .map(|(n, _)| n.as_str())
+                .collect();
             return Err(TilesError::BadRequest(format!(
                 "parameter-name '{pname}' is not available for collection '{collection_id}'. \
                  Available: {}",

--- a/crates/api-tiles/src/handlers.rs
+++ b/crates/api-tiles/src/handlers.rs
@@ -1057,11 +1057,12 @@ async fn render_tile(
         if !raster_info.parameters.is_empty()
             && !raster_info.parameters.iter().any(|(name, _)| name == pname)
         {
-            let supported: Vec<&str> = raster_info
+            let mut supported: Vec<&str> = raster_info
                 .parameters
                 .iter()
                 .map(|(n, _)| n.as_str())
                 .collect();
+            supported.sort_unstable();
             return Err(TilesError::BadRequest(format!(
                 "parameter-name '{pname}' is not available for collection '{collection_id}'. \
                  Available: {}",

--- a/crates/api-tiles/src/handlers.rs
+++ b/crates/api-tiles/src/handlers.rs
@@ -1051,6 +1051,27 @@ async fn render_tile(
 
     let tile_size = params::TILE_SIZE;
 
+    // Parameter selection: ?parameter-name= wins over style.parameter. Mirror
+    // the precedence and validation used by api-maps + api-wms so the SPA
+    // dropdown works identically across all three raster routes. Engines
+    // with an empty `raster_info().parameters` list (single-band GeoTIFF)
+    // ignore the parameter at render time — we still accept the query.
+    if let Some(pname) = validated.parameter_name.as_deref() {
+        let info = engine.raster_info();
+        if !info.parameters.is_empty() && !info.parameters.iter().any(|(name, _)| name == pname) {
+            let supported: Vec<&str> = info.parameters.iter().map(|(n, _)| n.as_str()).collect();
+            return Err(TilesError::BadRequest(format!(
+                "parameter-name '{pname}' is not available for collection '{collection_id}'. \
+                 Available: {}",
+                supported.join(", ")
+            )));
+        }
+    }
+    let effective_parameter = validated
+        .parameter_name
+        .clone()
+        .or_else(|| style_info.parameter.clone());
+
     // Build cache key
     let cache_key = CacheKey {
         layer: collection_id.to_string(),
@@ -1065,6 +1086,7 @@ async fn render_tile(
         width: tile_size,
         height: tile_size,
         time,
+        parameter: effective_parameter.clone(),
     };
 
     let etag = cache_key.etag();
@@ -1115,7 +1137,7 @@ async fn render_tile(
 
     // The blocking closure returns Ok(None) for empty (all-nodata) tiles,
     // or Ok(Some(bytes)) for tiles with data.
-    let style_parameter = style_info.parameter.as_deref().map(String::from);
+    let render_parameter = effective_parameter;
 
     let render_result = tokio::task::spawn_blocking(move || {
         let tile = engine.get_raster_tile(
@@ -1124,7 +1146,7 @@ async fn render_tile(
             tile_size,
             time,
             &output_crs,
-            style_parameter.as_deref(),
+            render_parameter.as_deref(),
         )?;
 
         // If every pixel is nodata, skip colorization + encoding entirely.

--- a/crates/api-tiles/src/params.rs
+++ b/crates/api-tiles/src/params.rs
@@ -33,6 +33,11 @@ pub struct TileQueryParams {
     pub datetime: Option<String>,
     #[serde(rename = "f")]
     pub format: Option<String>,
+    /// EDR-style parameter selector for multi-parameter raster engines.
+    /// Non-OGC for now; a standardised form is on the OGC Tiles roadmap.
+    /// Ignored for MVT (`?f=mvt`) responses.
+    #[serde(rename = "parameter-name")]
+    pub parameter_name: Option<String>,
 }
 
 impl TileQueryParams {
@@ -49,6 +54,7 @@ impl TileQueryParams {
 pub struct ValidatedTileParams {
     pub time: Option<DateTime<Utc>>,
     pub format: ds_render::ImageFormat,
+    pub parameter_name: Option<String>,
 }
 
 impl TileQueryParams {
@@ -68,7 +74,18 @@ impl TileQueryParams {
 
         let time = self.datetime.as_deref().map(parse_time).transpose()?;
 
-        Ok(ValidatedTileParams { time, format })
+        let parameter_name = self
+            .parameter_name
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(str::to_string);
+
+        Ok(ValidatedTileParams {
+            time,
+            format,
+            parameter_name,
+        })
     }
 }
 
@@ -100,6 +117,7 @@ mod tests {
         let params = TileQueryParams {
             datetime: None,
             format: None,
+            parameter_name: None,
         };
         let validated = params.validate().unwrap();
         assert!(matches!(validated.format, ds_render::ImageFormat::Png));
@@ -110,6 +128,7 @@ mod tests {
         let params = TileQueryParams {
             datetime: None,
             format: Some("image/jpeg".to_string()),
+            parameter_name: None,
         };
         let validated = params.validate().unwrap();
         assert!(matches!(validated.format, ds_render::ImageFormat::Jpeg));
@@ -120,6 +139,7 @@ mod tests {
         let params = TileQueryParams {
             datetime: None,
             format: Some("text/html".to_string()),
+            parameter_name: None,
         };
         assert!(params.validate().is_err());
     }

--- a/crates/api-tiles/tests/integration.rs
+++ b/crates/api-tiles/tests/integration.rs
@@ -96,6 +96,7 @@ fn build_router() -> axum::Router {
             wms: None,
             grib: None,
             postgis: None,
+            preview: None,
         },
     );
 
@@ -485,6 +486,160 @@ mod get_tile {
         assert_eq!(status, StatusCode::OK);
         assert!(body.starts_with(&[0x89, b'P', b'N', b'G']));
     }
+
+    #[tokio::test]
+    async fn parameter_name_query_is_accepted_for_single_param_engine() {
+        // `MockMapEngine.raster_info().parameters` is empty (single-band
+        // engine convention). The handler must accept any `parameter-name=`
+        // and forward it to the engine, which is free to ignore it.
+        let (status, _, body) =
+            get_raw("/collections/radar/tiles/WebMercatorQuad/0/0/0?parameter-name=anything").await;
+        assert_eq!(status, StatusCode::OK);
+        assert!(body.starts_with(&[0x89, b'P', b'N', b'G']));
+    }
+
+    #[tokio::test]
+    async fn parameter_name_changes_etag() {
+        // Different parameter-name values must produce different cache
+        // entries (and thus different ETags) — otherwise a client switching
+        // from "2t" to "10u" would get a 304 against the stale parameter.
+        let (_, headers_a, _) =
+            get_raw("/collections/radar/tiles/WebMercatorQuad/0/0/0?parameter-name=2t").await;
+        let (_, headers_b, _) =
+            get_raw("/collections/radar/tiles/WebMercatorQuad/0/0/0?parameter-name=10u").await;
+        let etag_a = headers_a.get("etag").unwrap();
+        let etag_b = headers_b.get("etag").unwrap();
+        assert_ne!(
+            etag_a, etag_b,
+            "ETags must differ across parameter-name values"
+        );
+    }
+
+    #[tokio::test]
+    async fn unknown_parameter_name_returns_400_for_multi_param_engine() {
+        // When the engine advertises a non-empty `parameters` list, the
+        // handler must validate against it and reject unknown names with a
+        // helpful error rather than rendering the default with a confusing
+        // colormap.
+        let app = build_multi_param_router();
+        let req = Request::builder()
+            .uri("/collections/wx/tiles/WebMercatorQuad/0/0/0?parameter-name=nope")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let body = resp.into_body().collect().await.unwrap().to_bytes();
+        let text = std::str::from_utf8(&body).unwrap();
+        assert!(
+            text.contains("Available: 2t, 10u") || text.contains("Available: 10u, 2t"),
+            "error body should list available parameters; got: {text}"
+        );
+    }
+
+    #[tokio::test]
+    async fn known_parameter_name_is_accepted_by_multi_param_engine() {
+        let app = build_multi_param_router();
+        let req = Request::builder()
+            .uri("/collections/wx/tiles/WebMercatorQuad/0/0/0?parameter-name=2t")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+}
+
+struct MultiParamMockEngine;
+
+impl MapEngine for MultiParamMockEngine {
+    fn get_raster_tile(
+        &self,
+        _bbox: [f64; 4],
+        width: u32,
+        height: u32,
+        _time: Option<chrono::DateTime<chrono::Utc>>,
+        _output_crs: &OutputCrs,
+        _parameter: Option<&str>,
+    ) -> Result<RasterTile, DataServerError> {
+        let pixel_count = (width * height) as usize;
+        let values: Vec<Option<f64>> = (0..pixel_count).map(|i| Some(i as f64)).collect();
+        Ok(RasterTile {
+            width,
+            height,
+            values,
+        })
+    }
+
+    fn raster_info(&self) -> RasterInfo {
+        RasterInfo {
+            native_crs: "EPSG:4326".into(),
+            spatial_extent: Some([0.0, 0.0, 10.0, 10.0]),
+            times: vec![],
+            parameter: "2t".into(),
+            unit: "K".into(),
+            parameters: vec![
+                ("2t".into(), "Temperature".into()),
+                ("10u".into(), "U Wind".into()),
+            ],
+        }
+    }
+}
+
+fn build_multi_param_router() -> axum::Router {
+    let engine: Arc<dyn MapEngine> = Arc::new(MultiParamMockEngine);
+    let mut engines = HashMap::new();
+    let mut collections = HashMap::new();
+    let mut styles_map = HashMap::new();
+
+    engines.insert("wx".to_string(), engine);
+    collections.insert(
+        "wx".to_string(),
+        CollectionConfig {
+            id: "wx".to_string(),
+            title: "Forecast".to_string(),
+            description: "Test multi-param".to_string(),
+            data_path: None,
+            apis: vec!["tiles".to_string()],
+            engine_type: "grib".to_string(),
+            geotiff: None,
+            querydata: None,
+            wms: None,
+            grib: None,
+            postgis: None,
+            preview: None,
+        },
+    );
+
+    let cmap = Arc::new(LutColorMap::from_builtin(
+        BuiltinColormap::Viridis,
+        0.0,
+        1.0,
+    ));
+    let mut layer_styles = HashMap::new();
+    layer_styles.insert(
+        "default".to_string(),
+        StyleInfo {
+            name: "default".to_string(),
+            title: "Default".to_string(),
+            colormap: cmap,
+            min: 0.0,
+            max: 1.0,
+            parameter: None,
+        },
+    );
+    styles_map.insert("wx".to_string(), layer_styles);
+
+    let state = Arc::new(ArcSwap::from_pointee(TilesState {
+        map_engines: engines,
+        collections,
+        styles: styles_map,
+        feature_engines: HashMap::new(),
+        feature_collections: HashMap::new(),
+        render_semaphore: Arc::new(tokio::sync::Semaphore::new(4)),
+        rendered_cache: Arc::new(RenderedCache::new(16)),
+        vector_tile_cache: Arc::new(VectorTileCache::new(16)),
+        base_url: String::new(),
+    }));
+    api_tiles::router(state)
 }
 
 // ---------------------------------------------------------------------------
@@ -663,6 +818,7 @@ mod mvt {
                 wms: None,
                 grib: None,
                 postgis: None,
+                preview: None,
             },
         );
 
@@ -744,6 +900,7 @@ mod mvt {
                 wms: None,
                 grib: None,
                 postgis: None,
+                preview: None,
             },
         );
 

--- a/crates/api-tiles/tests/integration.rs
+++ b/crates/api-tiles/tests/integration.rs
@@ -530,9 +530,10 @@ mod get_tile {
         assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
         let body = resp.into_body().collect().await.unwrap().to_bytes();
         let text = std::str::from_utf8(&body).unwrap();
+        // Sorted alphabetically — "10u" < "2t" by lexicographic comparison.
         assert!(
-            text.contains("Available: 2t, 10u") || text.contains("Available: 10u, 2t"),
-            "error body should list available parameters; got: {text}"
+            text.contains("Available: 10u, 2t"),
+            "error body should list available parameters in sorted order; got: {text}"
         );
     }
 

--- a/crates/api-wms/src/handlers.rs
+++ b/crates/api-wms/src/handlers.rs
@@ -111,6 +111,26 @@ pub async fn wms_handler(
                 ))
             })?;
 
+            // Validate `LAYERS=collection/parameter` against the engine's
+            // advertised list (mirroring Maps + Tiles). Without this, an
+            // unknown parameter would silently render whatever the engine
+            // defaults to and cache that result under the invalid name —
+            // ServiceException is the correct OGC response here.
+            if let Some(pname) = layer_parameter.as_deref() {
+                let info = engine.raster_info();
+                if !info.parameters.is_empty()
+                    && !info.parameters.iter().any(|(name, _)| name == pname)
+                {
+                    let supported: Vec<&str> =
+                        info.parameters.iter().map(|(n, _)| n.as_str()).collect();
+                    return Err(WmsError::LayerNotDefined(format!(
+                        "Parameter '{pname}' is not available for layer \
+                         '{collection_id}'. Available: {}",
+                        supported.join(", ")
+                    )));
+                }
+            }
+
             let colormap = style_info.colormap.clone();
             let content_type = params.format.content_type();
             let has_explicit_time = params.time.is_some();

--- a/crates/api-wms/src/handlers.rs
+++ b/crates/api-wms/src/handlers.rs
@@ -121,8 +121,9 @@ pub async fn wms_handler(
                 if !info.parameters.is_empty()
                     && !info.parameters.iter().any(|(name, _)| name == pname)
                 {
-                    let supported: Vec<&str> =
+                    let mut supported: Vec<&str> =
                         info.parameters.iter().map(|(n, _)| n.as_str()).collect();
+                    supported.sort_unstable();
                     return Err(WmsError::LayerNotDefined(format!(
                         "Parameter '{pname}' is not available for layer \
                          '{collection_id}'. Available: {}",

--- a/crates/api-wms/src/handlers.rs
+++ b/crates/api-wms/src/handlers.rs
@@ -129,6 +129,13 @@ pub async fn wms_handler(
                 width: params.width,
                 height: params.height,
                 time: params.time,
+                // WMS picks the parameter via `LAYERS=collection/param`
+                // (parsed into layer_parameter) and then `style_info.parameter`.
+                // Both are already folded into `style_parameter` below; mirror
+                // that here so the rendered-cache distinguishes parameters.
+                parameter: layer_parameter
+                    .clone()
+                    .or_else(|| style_info.parameter.clone()),
             };
 
             let etag = cache_key.etag();

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -65,6 +65,20 @@ pub struct CollectionConfig {
     pub wms: Option<WmsConfig>,
     /// PostGIS-specific configuration. Required when engine_type = "postgis".
     pub postgis: Option<PostgisConfig>,
+    /// Preview-SPA-specific tuning (e.g. bound the time slider). Optional.
+    pub preview: Option<PreviewConfig>,
+}
+
+/// Preview-SPA tuning knobs. Only affects what `/preview/manifest.json`
+/// emits — does NOT constrain the underlying engine.
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct PreviewConfig {
+    /// ISO 8601 positive duration (e.g. `"PT12H"`, `"P1D"`). When set, the
+    /// manifest's `temporal_extent.values` is filtered to entries within
+    /// `[max(values) - duration, max(values)]`. Useful for STAC-backed
+    /// collections whose archive spans years but whose useful slider range
+    /// is the most recent few hours.
+    pub time_window: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/crates/core/src/datetime.rs
+++ b/crates/core/src/datetime.rs
@@ -31,8 +31,16 @@ pub fn parse_iso8601_duration(s: &str) -> Result<Duration, DataServerError> {
     }
 
     if !date_part.is_empty() {
-        // Weeks (`P1W`) — natural unit for meteorological archives; reject the
-        // ambiguous combination `P1W2D` which mixes weeks with other date units.
+        // Mixed week-and-day forms (`P1W2D`) are unsupported. Catch them
+        // explicitly here — otherwise the parser falls into the days branch
+        // below, fails on `"1W2".parse::<i64>()`, and surfaces a misleading
+        // "Invalid days" message that hides the real issue.
+        if date_part.contains('W') && date_part.contains('D') {
+            return Err(DataServerError::Config(format!(
+                "Invalid ISO 8601 duration '{s}': cannot mix 'W' with other date units"
+            )));
+        }
+        // Weeks (`P1W`) — natural unit for meteorological archives.
         if let Some(stripped) = date_part.strip_suffix('W') {
             let weeks: i64 = stripped.parse().map_err(|_| {
                 DataServerError::Config(format!("Invalid weeks in ISO 8601 duration '{s}'"))
@@ -215,8 +223,15 @@ mod tests {
             parse_iso8601_duration("P2W").unwrap(),
             Duration::seconds(14 * 86_400)
         );
-        // `P1W2D` mixes weeks with other date units — not supported.
-        assert!(parse_iso8601_duration("P1W2D").is_err());
+        // `P1W2D` mixes weeks with other date units — surface a message that
+        // names the actual problem, not "Invalid days" (which is what we
+        // got before the explicit guard; an operator reading logs would have
+        // started staring at the days value, not the structure).
+        let err = parse_iso8601_duration("P1W2D").unwrap_err().to_string();
+        assert!(
+            err.contains("cannot mix 'W'"),
+            "Expected 'cannot mix W' message, got: {err}"
+        );
     }
 
     #[test]

--- a/crates/core/src/datetime.rs
+++ b/crates/core/src/datetime.rs
@@ -82,6 +82,16 @@ pub fn parse_iso8601_duration(s: &str) -> Result<Duration, DataServerError> {
                 DataServerError::Config(format!("Invalid seconds in ISO 8601 duration '{s}'"))
             })?;
             total_seconds += v as i64;
+            remaining = &remaining[pos + 1..];
+        }
+        // Anything left in `remaining` is unparsed — a trailing number with
+        // no unit (`PT12H30` for `PT12H30M`) would otherwise be silently
+        // dropped, returning a shorter window than the operator intended.
+        if !remaining.is_empty() {
+            return Err(DataServerError::Config(format!(
+                "Invalid ISO 8601 duration '{s}': trailing characters '{remaining}' after time \
+                 components"
+            )));
         }
     }
 
@@ -207,5 +217,25 @@ mod tests {
         );
         // `P1W2D` mixes weeks with other date units — not supported.
         assert!(parse_iso8601_duration("P1W2D").is_err());
+    }
+
+    #[test]
+    fn iso8601_duration_rejects_trailing_digits_without_unit() {
+        // Without the trailing-content check, `PT12H30` (operator typo for
+        // `PT12H30M`) silently parsed as 12h, dropping the 30. The
+        // surrounding behaviour — start with PT, end with a unit suffix —
+        // would otherwise hide the typo.
+        assert!(parse_iso8601_duration("PT12H30").is_err());
+        assert!(parse_iso8601_duration("PT30M5").is_err());
+        assert!(parse_iso8601_duration("PT1H2M3").is_err());
+        // The valid forms are still accepted.
+        assert_eq!(
+            parse_iso8601_duration("PT12H30M").unwrap(),
+            Duration::seconds(12 * 3600 + 30 * 60)
+        );
+        assert_eq!(
+            parse_iso8601_duration("PT1H2M3S").unwrap(),
+            Duration::seconds(3600 + 120 + 3)
+        );
     }
 }

--- a/crates/core/src/datetime.rs
+++ b/crates/core/src/datetime.rs
@@ -20,6 +20,16 @@ pub fn parse_iso8601_duration(s: &str) -> Result<Duration, DataServerError> {
 
     let mut total_seconds: i64 = 0;
 
+    // Reject any sign character anywhere in `rest` up front. ISO 8601 doesn't
+    // permit negative components within a positive duration, and without this
+    // check `P1DT-2H` parses as 22h because `i64::parse("-2")` succeeds — a
+    // config typo would produce a surprising window length, not an error.
+    if rest.contains('-') || rest.contains('+') {
+        return Err(DataServerError::Config(format!(
+            "Invalid ISO 8601 duration '{s}': signed components are not permitted"
+        )));
+    }
+
     if !date_part.is_empty() {
         // Weeks (`P1W`) — natural unit for meteorological archives; reject the
         // ambiguous combination `P1W2D` which mixes weeks with other date units.
@@ -54,24 +64,24 @@ pub fn parse_iso8601_duration(s: &str) -> Result<Duration, DataServerError> {
     if !time_part.is_empty() {
         let mut remaining = time_part;
         if let Some(pos) = remaining.find('H') {
-            let v: i64 = remaining[..pos].parse().map_err(|_| {
+            let v: u64 = remaining[..pos].parse().map_err(|_| {
                 DataServerError::Config(format!("Invalid hours in ISO 8601 duration '{s}'"))
             })?;
-            total_seconds += v * 3600;
+            total_seconds += (v as i64) * 3600;
             remaining = &remaining[pos + 1..];
         }
         if let Some(pos) = remaining.find('M') {
-            let v: i64 = remaining[..pos].parse().map_err(|_| {
+            let v: u64 = remaining[..pos].parse().map_err(|_| {
                 DataServerError::Config(format!("Invalid minutes in ISO 8601 duration '{s}'"))
             })?;
-            total_seconds += v * 60;
+            total_seconds += (v as i64) * 60;
             remaining = &remaining[pos + 1..];
         }
         if let Some(pos) = remaining.find('S') {
-            let v: i64 = remaining[..pos].parse().map_err(|_| {
+            let v: u64 = remaining[..pos].parse().map_err(|_| {
                 DataServerError::Config(format!("Invalid seconds in ISO 8601 duration '{s}'"))
             })?;
-            total_seconds += v;
+            total_seconds += v as i64;
         }
     }
 
@@ -172,6 +182,17 @@ mod tests {
         // Empty T segment is technically invalid; surface the typo.
         assert!(parse_iso8601_duration("P1DT").is_err());
         assert!(parse_iso8601_duration("PT").is_err());
+    }
+
+    #[test]
+    fn iso8601_duration_rejects_signed_components() {
+        // Pre-fix, `P1DT-2H` parsed as 22h because `i64::parse("-2")` succeeds
+        // and `86400 - 7200 > 0` passed the zero-check. A config typo would
+        // produce a window of surprising length, not an error.
+        assert!(parse_iso8601_duration("P1DT-2H").is_err());
+        assert!(parse_iso8601_duration("P-1DT2H").is_err());
+        assert!(parse_iso8601_duration("PT2H-30M").is_err());
+        assert!(parse_iso8601_duration("PT+2H").is_err());
     }
 
     #[test]

--- a/crates/core/src/datetime.rs
+++ b/crates/core/src/datetime.rs
@@ -21,13 +21,34 @@ pub fn parse_iso8601_duration(s: &str) -> Result<Duration, DataServerError> {
     let mut total_seconds: i64 = 0;
 
     if !date_part.is_empty() {
-        let stripped = date_part.strip_suffix('D').ok_or_else(|| {
-            DataServerError::Config(format!("Invalid date component in ISO 8601 duration '{s}'"))
-        })?;
-        let days: i64 = stripped.parse().map_err(|_| {
-            DataServerError::Config(format!("Invalid days in ISO 8601 duration '{s}'"))
-        })?;
-        total_seconds += days * 86_400;
+        // Weeks (`P1W`) — natural unit for meteorological archives; reject the
+        // ambiguous combination `P1W2D` which mixes weeks with other date units.
+        if let Some(stripped) = date_part.strip_suffix('W') {
+            let weeks: i64 = stripped.parse().map_err(|_| {
+                DataServerError::Config(format!("Invalid weeks in ISO 8601 duration '{s}'"))
+            })?;
+            total_seconds += weeks * 7 * 86_400;
+        } else {
+            let stripped = date_part.strip_suffix('D').ok_or_else(|| {
+                DataServerError::Config(format!(
+                    "Invalid date component in ISO 8601 duration '{s}': supported units are 'D' \
+                     (days) and 'W' (weeks)"
+                ))
+            })?;
+            let days: i64 = stripped.parse().map_err(|_| {
+                DataServerError::Config(format!("Invalid days in ISO 8601 duration '{s}'"))
+            })?;
+            total_seconds += days * 86_400;
+        }
+    }
+
+    // `PnDT` with no time components is not valid ISO 8601 — the `T` separator
+    // must be followed by at least one of H/M/S. Reject explicitly so config
+    // typos surface at load rather than silently parsing as `PnD`.
+    if rest.contains('T') && time_part.is_empty() {
+        return Err(DataServerError::Config(format!(
+            "Invalid ISO 8601 duration '{s}': 'T' separator present but no time components follow"
+        )));
     }
 
     if !time_part.is_empty() {
@@ -148,5 +169,22 @@ mod tests {
         assert!(parse_iso8601_duration("PT0H").is_err());
         assert!(parse_iso8601_duration("P0D").is_err());
         assert!(parse_iso8601_duration("-PT2H").is_err());
+        // Empty T segment is technically invalid; surface the typo.
+        assert!(parse_iso8601_duration("P1DT").is_err());
+        assert!(parse_iso8601_duration("PT").is_err());
+    }
+
+    #[test]
+    fn iso8601_duration_supports_weeks() {
+        assert_eq!(
+            parse_iso8601_duration("P1W").unwrap(),
+            Duration::seconds(7 * 86_400)
+        );
+        assert_eq!(
+            parse_iso8601_duration("P2W").unwrap(),
+            Duration::seconds(14 * 86_400)
+        );
+        // `P1W2D` mixes weeks with other date units — not supported.
+        assert!(parse_iso8601_duration("P1W2D").is_err());
     }
 }

--- a/crates/core/src/datetime.rs
+++ b/crates/core/src/datetime.rs
@@ -1,6 +1,67 @@
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, Duration, Utc};
 
 use crate::error::DataServerError;
+
+/// Parse an ISO 8601 positive duration (e.g. `"PT12H"`, `"P1D"`, `"P1DT6H"`)
+/// into a `chrono::Duration`. Rejects zero-length and signed durations —
+/// callers that need signed offsets should layer on top of this.
+pub fn parse_iso8601_duration(s: &str) -> Result<Duration, DataServerError> {
+    let rest = s.strip_prefix('P').ok_or_else(|| {
+        DataServerError::Config(format!(
+            "Invalid ISO 8601 duration '{s}': must start with 'P'"
+        ))
+    })?;
+
+    let (date_part, time_part) = if let Some(t_pos) = rest.find('T') {
+        (&rest[..t_pos], &rest[t_pos + 1..])
+    } else {
+        (rest, "")
+    };
+
+    let mut total_seconds: i64 = 0;
+
+    if !date_part.is_empty() {
+        let stripped = date_part.strip_suffix('D').ok_or_else(|| {
+            DataServerError::Config(format!("Invalid date component in ISO 8601 duration '{s}'"))
+        })?;
+        let days: i64 = stripped.parse().map_err(|_| {
+            DataServerError::Config(format!("Invalid days in ISO 8601 duration '{s}'"))
+        })?;
+        total_seconds += days * 86_400;
+    }
+
+    if !time_part.is_empty() {
+        let mut remaining = time_part;
+        if let Some(pos) = remaining.find('H') {
+            let v: i64 = remaining[..pos].parse().map_err(|_| {
+                DataServerError::Config(format!("Invalid hours in ISO 8601 duration '{s}'"))
+            })?;
+            total_seconds += v * 3600;
+            remaining = &remaining[pos + 1..];
+        }
+        if let Some(pos) = remaining.find('M') {
+            let v: i64 = remaining[..pos].parse().map_err(|_| {
+                DataServerError::Config(format!("Invalid minutes in ISO 8601 duration '{s}'"))
+            })?;
+            total_seconds += v * 60;
+            remaining = &remaining[pos + 1..];
+        }
+        if let Some(pos) = remaining.find('S') {
+            let v: i64 = remaining[..pos].parse().map_err(|_| {
+                DataServerError::Config(format!("Invalid seconds in ISO 8601 duration '{s}'"))
+            })?;
+            total_seconds += v;
+        }
+    }
+
+    if total_seconds <= 0 {
+        return Err(DataServerError::Config(format!(
+            "Invalid ISO 8601 duration '{s}': zero or negative duration"
+        )));
+    }
+
+    Ok(Duration::seconds(total_seconds))
+}
 
 /// Parses an OGC datetime interval string like "2024-01-01T00:00:00Z/2024-01-01T06:00:00Z"
 /// or a single instant "2024-01-01T00:00:00Z" (treated as a zero-width interval).
@@ -58,5 +119,34 @@ mod tests {
         let (start, end) = parse_datetime_interval("../2024-01-01T06:00:00Z").unwrap();
         assert_eq!(start, DateTime::<Utc>::MIN_UTC);
         assert_eq!(end.to_rfc3339(), "2024-01-01T06:00:00+00:00");
+    }
+
+    #[test]
+    fn iso8601_duration_basic() {
+        assert_eq!(
+            parse_iso8601_duration("PT12H").unwrap(),
+            Duration::seconds(12 * 3600)
+        );
+        assert_eq!(
+            parse_iso8601_duration("P1D").unwrap(),
+            Duration::seconds(86_400)
+        );
+        assert_eq!(
+            parse_iso8601_duration("P1DT6H").unwrap(),
+            Duration::seconds(86_400 + 6 * 3600)
+        );
+        assert_eq!(
+            parse_iso8601_duration("PT30M").unwrap(),
+            Duration::seconds(1800)
+        );
+    }
+
+    #[test]
+    fn iso8601_duration_rejects_bad_input() {
+        assert!(parse_iso8601_duration("").is_err());
+        assert!(parse_iso8601_duration("12H").is_err());
+        assert!(parse_iso8601_duration("PT0H").is_err());
+        assert!(parse_iso8601_duration("P0D").is_err());
+        assert!(parse_iso8601_duration("-PT2H").is_err());
     }
 }

--- a/crates/core/src/map_engine.rs
+++ b/crates/core/src/map_engine.rs
@@ -74,5 +74,12 @@ pub trait MapEngine: Send + Sync {
     ) -> Result<RasterTile, DataServerError>;
 
     /// Return metadata for capabilities documents.
+    ///
+    /// **Expected complexity: O(1) (or as close as practical).** Callers
+    /// invoke this on the hot tile/map path to validate `?parameter-name=`
+    /// against `parameters`, before acquiring the render semaphore. Engines
+    /// should serve from an `ArcSwap`/`RwLock` snapshot, not recompute on
+    /// every call. If your engine genuinely needs to derive metadata
+    /// per-request, cache it.
     fn raster_info(&self) -> RasterInfo;
 }

--- a/crates/render/src/lib.rs
+++ b/crates/render/src/lib.rs
@@ -68,6 +68,10 @@ pub struct CacheKey {
     pub width: u32,
     pub height: u32,
     pub time: Option<DateTime<Utc>>,
+    /// Optional parameter name override (e.g. `parameter-name=temperature`).
+    /// Distinct cache entries for the same (layer, style, bbox, time) when
+    /// the caller asks for a different parameter than the style's default.
+    pub parameter: Option<String>,
 }
 
 /// FNV-1a 64-bit mix. Fixed algorithm — safe to serialise into HTTP `ETag`
@@ -112,6 +116,13 @@ impl CacheKey {
                     .timestamp_nanos_opt()
                     .unwrap_or_else(|| t.timestamp_millis().saturating_mul(1_000_000));
                 fnv1a_mix(&mut h, &ts.to_le_bytes());
+            }
+            None => fnv1a_mix(&mut h, &[0u8]),
+        }
+        match &self.parameter {
+            Some(p) => {
+                fnv1a_mix(&mut h, &[1u8]);
+                fnv1a_mix(&mut h, p.as_bytes());
             }
             None => fnv1a_mix(&mut h, &[0u8]),
         }
@@ -433,6 +444,7 @@ mod tests {
                     .unwrap()
                     .with_timezone(&chrono::Utc),
             ),
+            parameter: None,
         };
         let mut later = base.clone();
         later.time = Some(
@@ -441,6 +453,28 @@ mod tests {
                 .with_timezone(&chrono::Utc),
         );
         assert_ne!(base.etag(), later.etag());
+    }
+
+    #[test]
+    fn cache_key_etag_changes_when_parameter_changes() {
+        let base = CacheKey {
+            layer: "ecmwf-fc".into(),
+            style: "default".into(),
+            format: 0,
+            crs: "EPSG:3857".into(),
+            bbox: [0, 0, 1, 1],
+            width: 256,
+            height: 256,
+            time: None,
+            parameter: Some("2t".into()),
+        };
+        let mut other = base.clone();
+        other.parameter = Some("10u".into());
+        assert_ne!(base.etag(), other.etag());
+
+        let mut absent = base.clone();
+        absent.parameter = None;
+        assert_ne!(base.etag(), absent.etag());
     }
 
     #[test]
@@ -458,7 +492,9 @@ mod tests {
             width: 256,
             height: 256,
             time: None,
+            parameter: None,
         };
-        assert_eq!(key.etag(), "\"c4df9fcd1a7f44aa\"");
+        // Pinned after introducing the `parameter` field (cache-bust event).
+        assert_eq!(key.etag(), "\"074133840641acde\"");
     }
 }

--- a/crates/server/preview/app.js
+++ b/crates/server/preview/app.js
@@ -139,7 +139,16 @@
             enabled: false,
             hasZoomed: false,
             timeIndex: null,
-            timeValues: temporalValues(collection)
+            timeValues: temporalValues(collection),
+            // Selected parameter name for multi-parameter raster collections.
+            // null = use the server's default. The dropdown is only rendered
+            // when `parameters.length > 1`, but state holds the first entry's
+            // name unconditionally so URL builders can append it without an
+            // extra null-check.
+            parameter:
+                Array.isArray(collection.parameters) && collection.parameters.length > 0
+                    ? collection.parameters[0].name
+                    : null
         };
 
         const li = document.createElement('li');
@@ -383,7 +392,7 @@
         // No `attribution`: MapLibre renders it via innerHTML.
         map.addSource(sourceId, {
             type: 'raster',
-            tiles: [tileUrlFor(collection, currentStyle, currentTime(state))],
+            tiles: [tileUrlFor(collection, currentStyle, currentTime(state), state.parameter)],
             tileSize: 256
         });
         map.addLayer({
@@ -396,6 +405,37 @@
             layout: { visibility: 'none' },
             paint: { 'raster-opacity': 1 }
         });
+
+        // -- Parameter picker (multi-parameter raster engines only). Rendered
+        //    above the style picker so the controls flow top-to-bottom in a
+        //    "narrow my view" order: parameter → style → time.
+        if (Array.isArray(collection.parameters) && collection.parameters.length > 1) {
+            const paramLabel = document.createElement('label');
+            paramLabel.className = 'control-row';
+            const paramText = document.createElement('span');
+            paramText.className = 'control-label';
+            paramText.textContent = 'Parameter';
+            paramLabel.appendChild(paramText);
+
+            const paramSelect = document.createElement('select');
+            collection.parameters.forEach(function (p) {
+                const opt = document.createElement('option');
+                opt.value = p.name;
+                const titleText = p.title && p.title !== p.name
+                    ? p.name + ' — ' + p.title
+                    : p.name;
+                opt.textContent = p.unit ? titleText + ' (' + p.unit + ')' : titleText;
+                if (p.name === state.parameter) opt.selected = true;
+                paramSelect.appendChild(opt);
+            });
+            paramSelect.addEventListener('change', function () {
+                if (state.parameter === paramSelect.value) return;
+                state.parameter = paramSelect.value;
+                refreshSource();
+            });
+            paramLabel.appendChild(paramSelect);
+            controlsHost.appendChild(paramLabel);
+        }
 
         // -- Style picker (only if there's a real choice) --
         if (styles.length > 1) {
@@ -425,7 +465,7 @@
         function refreshSource() {
             const src = map.getSource(sourceId);
             if (src && typeof src.setTiles === 'function') {
-                src.setTiles([tileUrlFor(collection, currentStyle, currentTime(state))]);
+                src.setTiles([tileUrlFor(collection, currentStyle, currentTime(state), state.parameter)]);
             }
         }
 
@@ -443,7 +483,7 @@
     //   /tiles/.../WebMercatorQuad/{z}/{y}/{x}
     // Placeholder names come from the axum route (see preview.rs), not from
     // the generic `{tms}`/`{z}` which the server would reject.
-    function tileUrlFor(collection, styleId, time) {
+    function tileUrlFor(collection, styleId, time, parameter) {
         const raster = collection.tiles.raster;
         // 'default' style uses the plain /tiles/... route, not /styles/default/...
         const useStyled = styleId && styleId !== 'default' && raster.styled_url_template;
@@ -458,7 +498,8 @@
         // Strip manifest's absolute origin so 127.0.0.1↔localhost mismatch in
         // `server.base_url` doesn't trip CSP `connect-src 'self'`.
         template = template.replace(/^https?:\/\/[^/]+/i, '');
-        return appendTimeParam(template, time);
+        template = appendTimeParam(template, time);
+        return appendParameterName(template, parameter);
     }
 
     // ------------------------------------------------------------------
@@ -580,6 +621,14 @@
         // `datetime` query param at crates/api-tiles/src/handlers.rs:577.
         const sep = template.indexOf('?') === -1 ? '?' : '&';
         return template + sep + 'datetime=' + encodeURIComponent(time);
+    }
+
+    function appendParameterName(template, parameter) {
+        if (!parameter) return template;
+        // Matches EDR's `parameter-name=` convention; api-maps + api-tiles
+        // accept this as a non-OGC bridge until the standardised form lands.
+        const sep = template.indexOf('?') === -1 ? '?' : '&';
+        return template + sep + 'parameter-name=' + encodeURIComponent(parameter);
     }
 
     // ------------------------------------------------------------------

--- a/crates/server/src/preview.rs
+++ b/crates/server/src/preview.rs
@@ -374,7 +374,7 @@ fn build_entry(
         entry["spatial_extent"] = json!(extent);
     }
 
-    if let Some(temporal) = resolve_temporal_extent(id, edr, maps, tiles, wms) {
+    if let Some(temporal) = resolve_temporal_extent(id, config, edr, maps, tiles, wms) {
         entry["temporal_extent"] = temporal;
     }
 
@@ -403,6 +403,7 @@ fn build_entry(
             raster_tile_descriptor(id, base_url, effective_styles),
         );
     }
+    let has_raster_tiles = tile_block.contains_key("raster");
     if !tile_block.is_empty() {
         entry["tiles"] = Value::Object(tile_block);
     }
@@ -411,7 +412,83 @@ fn build_entry(
         entry["styles"] = json!(style_list(styles));
     }
 
+    // Parameter list for the per-collection dropdown in /preview. Only emit
+    // for raster-tile-backed collections — FeatureEngine is not parameterised,
+    // and there's no rendering pathway today for switching parameters on a
+    // pure-EDR collection from the SPA.
+    if has_raster_tiles {
+        if let Some(params) = collection_parameters(id, edr, maps, tiles, wms) {
+            entry["parameters"] = json!(params);
+        }
+    }
+
     entry
+}
+
+/// Parameter list emitted as `parameters: [{name, title, unit}]` in the
+/// per-collection manifest entry. Sorted by name for stable ordering.
+///
+/// Source precedence:
+/// 1. `EdrEngine::get_parameter_descriptions()` — richest (per-param unit + label).
+/// 2. `MapEngine::raster_info().parameters` — fallback for raster-only multi-
+///    parameter collections that aren't wired into EDR. No per-param unit
+///    metadata is available at this layer, so `unit` is left empty.
+fn collection_parameters(
+    id: &str,
+    edr: &api_edr::handlers::EdrState,
+    maps: &api_maps::handlers::MapsState,
+    tiles: &api_tiles::handlers::TilesState,
+    wms: &api_wms::handlers::WmsState,
+) -> Option<Vec<Value>> {
+    if let Some(engine) = edr.engines.get(id) {
+        let descs = engine.get_parameter_descriptions();
+        if !descs.is_empty() {
+            let mut out: Vec<Value> = descs
+                .into_iter()
+                .map(|(name, desc)| {
+                    json!({
+                        "name": name,
+                        "title": desc.label,
+                        "unit": desc.unit,
+                    })
+                })
+                .collect();
+            out.sort_by(|a, b| {
+                a.get("name")
+                    .and_then(Value::as_str)
+                    .unwrap_or("")
+                    .cmp(b.get("name").and_then(Value::as_str).unwrap_or(""))
+            });
+            return Some(out);
+        }
+    }
+    let map_engine = maps
+        .engines
+        .get(id)
+        .or_else(|| tiles.map_engines.get(id))
+        .or_else(|| wms.engines.get(id))?;
+    let info = map_engine.raster_info();
+    if info.parameters.is_empty() {
+        return None;
+    }
+    let mut out: Vec<Value> = info
+        .parameters
+        .into_iter()
+        .map(|(name, title)| {
+            json!({
+                "name": name,
+                "title": title,
+                "unit": "",
+            })
+        })
+        .collect();
+    out.sort_by(|a, b| {
+        a.get("name")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .cmp(b.get("name").and_then(Value::as_str).unwrap_or(""))
+    });
+    Some(out)
 }
 
 fn first_config<'a>(
@@ -483,6 +560,7 @@ fn resolve_spatial_extent(
 
 fn resolve_temporal_extent(
     id: &str,
+    config: Option<&CollectionConfig>,
     edr: &api_edr::handlers::EdrState,
     maps: &api_maps::handlers::MapsState,
     tiles: &api_tiles::handlers::TilesState,
@@ -510,7 +588,7 @@ fn resolve_temporal_extent(
     // reachable range. EDR's interval can otherwise span a wider horizon
     // (e.g. T-24h forecast bound) than the discrete raster timesteps cover,
     // leaving the user looking at a span the slider can't reach.
-    let (interval, values) = match (edr_values, raster_times) {
+    let (mut interval, mut values) = match (edr_values, raster_times) {
         (Some(v), _) => {
             let int = edr_interval.or_else(|| v.first().zip(v.last()).map(|(a, b)| (*a, *b)));
             (int, Some(v))
@@ -521,6 +599,33 @@ fn resolve_temporal_extent(
         }
         (None, None) => (edr_interval, None),
     };
+
+    // Preview-only window filter: when [collections.preview].time_window is
+    // set, drop entries older than `max(values) - duration` and re-derive
+    // start/end from the survivors. The engine sees its full range
+    // unchanged; this only shrinks what the SPA slider exposes (useful for
+    // STAC archives spanning years of 5-min radar items).
+    if let (Some(cfg), Some(vs)) = (config, values.as_mut()) {
+        if let Some(window_str) = cfg.preview.as_ref().and_then(|p| p.time_window.as_deref()) {
+            match ds_core::datetime::parse_iso8601_duration(window_str) {
+                Ok(duration) => {
+                    if let Some(latest) = vs.iter().max().copied() {
+                        let cutoff = latest - duration;
+                        vs.retain(|t| *t >= cutoff);
+                        interval = vs.first().zip(vs.last()).map(|(a, b)| (*a, *b));
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        collection = id,
+                        time_window = window_str,
+                        error = %e,
+                        "preview.time_window is invalid; ignoring"
+                    );
+                }
+            }
+        }
+    }
 
     if interval.is_some() || values.is_some() {
         return Some(serialize_temporal(interval, values.as_deref()));
@@ -847,6 +952,7 @@ mod tests {
             wms: None,
             grib: None,
             postgis: None,
+            preview: None,
         }
     }
 
@@ -1316,6 +1422,259 @@ mod tests {
         // route exists). Worth asserting because a future refactor might
         // accidentally synthesise one.
         assert!(c.get("tiles").is_none());
+    }
+
+    // -----------------------------------------------------------------------
+    // [collections.preview] tests
+    // -----------------------------------------------------------------------
+
+    fn config_with_window(id: &str, apis: &[&str], window: &str) -> CollectionConfig {
+        let mut c = config(id, apis);
+        c.preview = Some(ds_core::config::PreviewConfig {
+            time_window: Some(window.into()),
+        });
+        c
+    }
+
+    #[test]
+    fn preview_time_window_filters_values_to_recent_slice() {
+        // 100 timesteps spanning 50h at 30-min cadence. `time_window = "PT12H"`
+        // should retain only the last ~24 entries (12h × 2/hour) plus the
+        // anchor itself.
+        let start = "2026-05-13T00:00:00Z".parse::<DateTime<Utc>>().unwrap();
+        let times: Vec<DateTime<Utc>> = (0..100)
+            .map(|i| start + chrono::Duration::minutes(30 * i as i64))
+            .collect();
+        let latest = *times.last().unwrap();
+
+        let mut tiles = empty_tiles();
+        let raster: Arc<dyn MapEngine> = Arc::new(RasterMock {
+            spatial_extent: Some([0.0, 0.0, 1.0, 1.0]),
+            times: times.clone(),
+            parameter: "reflectivity".into(),
+            unit: "dBZ".into(),
+        });
+        tiles.map_engines.insert("radar".into(), raster);
+        tiles.collections.insert(
+            "radar".into(),
+            config_with_window("radar", &["tiles"], "PT12H"),
+        );
+
+        let state = make_state(
+            empty_edr(),
+            empty_features(),
+            empty_maps(),
+            tiles,
+            empty_wms(),
+        );
+        let m = build_manifest(&state, 0, 100);
+        let temporal = &m["collections"][0]["temporal_extent"];
+        let values = temporal["values"].as_array().expect("values present");
+
+        // 12h window over a 30-min cadence = 24 entries plus the anchor = 25.
+        assert_eq!(values.len(), 25, "12h × 2/hour + anchor = 25 entries");
+        let cutoff = latest - chrono::Duration::hours(12);
+        for v in values {
+            let parsed: DateTime<Utc> = v.as_str().unwrap().parse().unwrap();
+            assert!(
+                parsed >= cutoff,
+                "value {v} is older than the 12h cutoff {cutoff}"
+            );
+        }
+        // Interval must re-anchor to the filtered slice — otherwise the card
+        // header reports a 50h span while the slider only reaches 12h.
+        assert_eq!(&temporal["start"], values.first().unwrap());
+        assert_eq!(&temporal["end"], values.last().unwrap());
+        // `truncated` follows the post-filter length vs MAX_TEMPORAL_VALUES.
+        assert_eq!(temporal["truncated"], false);
+    }
+
+    #[test]
+    fn preview_time_window_unset_returns_unfiltered_values() {
+        let start = "2026-05-13T00:00:00Z".parse::<DateTime<Utc>>().unwrap();
+        let times: Vec<DateTime<Utc>> = (0..6)
+            .map(|i| start + chrono::Duration::hours(i as i64))
+            .collect();
+
+        let mut tiles = empty_tiles();
+        let raster: Arc<dyn MapEngine> = Arc::new(RasterMock {
+            spatial_extent: None,
+            times: times.clone(),
+            parameter: "reflectivity".into(),
+            unit: "dBZ".into(),
+        });
+        tiles.map_engines.insert("radar".into(), raster);
+        tiles
+            .collections
+            .insert("radar".into(), config("radar", &["tiles"]));
+
+        let state = make_state(
+            empty_edr(),
+            empty_features(),
+            empty_maps(),
+            tiles,
+            empty_wms(),
+        );
+        let m = build_manifest(&state, 0, 100);
+        let temporal = &m["collections"][0]["temporal_extent"];
+        assert_eq!(temporal["values"].as_array().map(|a| a.len()), Some(6));
+    }
+
+    #[test]
+    fn preview_time_window_invalid_is_warning_not_error() {
+        // A bad duration string should not 500 the request — the manifest
+        // should fall back to the unfiltered values and the operator gets
+        // a `WARN` line. This protects against the manifest endpoint
+        // becoming a config-error tripwire when an operator typos.
+        let start = "2026-05-13T00:00:00Z".parse::<DateTime<Utc>>().unwrap();
+        let times: Vec<DateTime<Utc>> = (0..4)
+            .map(|i| start + chrono::Duration::hours(i as i64))
+            .collect();
+
+        let mut tiles = empty_tiles();
+        let raster: Arc<dyn MapEngine> = Arc::new(RasterMock {
+            spatial_extent: None,
+            times: times.clone(),
+            parameter: "reflectivity".into(),
+            unit: "dBZ".into(),
+        });
+        tiles.map_engines.insert("radar".into(), raster);
+        tiles.collections.insert(
+            "radar".into(),
+            config_with_window("radar", &["tiles"], "not-a-duration"),
+        );
+
+        let state = make_state(
+            empty_edr(),
+            empty_features(),
+            empty_maps(),
+            tiles,
+            empty_wms(),
+        );
+        let m = build_manifest(&state, 0, 100);
+        let temporal = &m["collections"][0]["temporal_extent"];
+        assert_eq!(
+            temporal["values"].as_array().map(|a| a.len()),
+            Some(4),
+            "invalid time_window must be ignored, not applied"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // `parameters` array tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn manifest_emits_parameters_for_multi_param_raster() {
+        use ds_core::model::ParameterDescription;
+        // Mock EdrEngine returning three parameters; RasterMock supplies the
+        // tile descriptor so the dropdown surfaces in the SPA.
+        struct MultiParamEdr;
+        impl EdrEngine for MultiParamEdr {
+            fn get_locations(&self) -> Result<Vec<Location>, DataServerError> {
+                Ok(Vec::new())
+            }
+            fn query_location(
+                &self,
+                _: &str,
+                _: Option<(DateTime<Utc>, DateTime<Utc>)>,
+                _: Option<&[String]>,
+            ) -> Result<QueryResult, DataServerError> {
+                unimplemented!()
+            }
+            fn get_parameters(&self) -> Vec<String> {
+                vec!["2t".into(), "msl".into(), "10u".into()]
+            }
+            fn get_parameter_descriptions(&self) -> HashMap<String, ParameterDescription> {
+                let mut m = HashMap::new();
+                m.insert(
+                    "2t".into(),
+                    ParameterDescription {
+                        label: "2 metre temperature".into(),
+                        unit: "K".into(),
+                        observed_property: "2t".into(),
+                    },
+                );
+                m.insert(
+                    "msl".into(),
+                    ParameterDescription {
+                        label: "Mean sea level pressure".into(),
+                        unit: "Pa".into(),
+                        observed_property: "msl".into(),
+                    },
+                );
+                m.insert(
+                    "10u".into(),
+                    ParameterDescription {
+                        label: "10 metre U wind".into(),
+                        unit: "m/s".into(),
+                        observed_property: "10u".into(),
+                    },
+                );
+                m
+            }
+            fn get_temporal_extent(&self) -> Option<(DateTime<Utc>, DateTime<Utc>)> {
+                None
+            }
+            fn get_spatial_extent(&self) -> Option<[f64; 4]> {
+                None
+            }
+        }
+
+        let mut edr = empty_edr();
+        let edr_engine: Arc<dyn EdrEngine> = Arc::new(MultiParamEdr);
+        edr.engines.insert("ecmwf-fc".into(), edr_engine);
+        edr.collections
+            .insert("ecmwf-fc".into(), config("ecmwf-fc", &["edr", "tiles"]));
+
+        let mut tiles = empty_tiles();
+        let raster: Arc<dyn MapEngine> = Arc::new(RasterMock {
+            spatial_extent: None,
+            times: Vec::new(),
+            parameter: "2t".into(),
+            unit: "K".into(),
+        });
+        tiles.map_engines.insert("ecmwf-fc".into(), raster);
+        tiles
+            .collections
+            .insert("ecmwf-fc".into(), config("ecmwf-fc", &["edr", "tiles"]));
+
+        let state = make_state(edr, empty_features(), empty_maps(), tiles, empty_wms());
+        let m = build_manifest(&state, 0, 100);
+        let params = m["collections"][0]["parameters"]
+            .as_array()
+            .expect("parameters array");
+        assert_eq!(params.len(), 3);
+        // Sorted by name → 10u, 2t, msl
+        assert_eq!(params[0]["name"], "10u");
+        assert_eq!(params[1]["name"], "2t");
+        assert_eq!(params[2]["name"], "msl");
+        assert_eq!(params[1]["unit"], "K");
+        assert_eq!(params[1]["title"], "2 metre temperature");
+    }
+
+    #[test]
+    fn manifest_omits_parameters_for_vector_only_collection() {
+        // FeatureEngine collections aren't parameterised; emitting the array
+        // would just clutter the manifest and confuse the SPA dropdown.
+        let mut tiles = empty_tiles();
+        let feature: Arc<dyn FeatureEngine> = Arc::new(PointFeatureMock {
+            extent: Some([0.0, 0.0, 1.0, 1.0]),
+        });
+        tiles.feature_engines.insert("stations".into(), feature);
+        tiles
+            .feature_collections
+            .insert("stations".into(), config("stations", &["tiles"]));
+
+        let state = make_state(
+            empty_edr(),
+            empty_features(),
+            empty_maps(),
+            tiles,
+            empty_wms(),
+        );
+        let m = build_manifest(&state, 0, 100);
+        assert!(m["collections"][0].get("parameters").is_none());
     }
 
     // -----------------------------------------------------------------------

--- a/crates/server/src/preview.rs
+++ b/crates/server/src/preview.rs
@@ -428,21 +428,19 @@ fn build_entry(
 /// Parameter list emitted as `parameters: [{name, title, unit}]` in the
 /// per-collection manifest entry. Sorted by name for stable ordering.
 ///
-/// Selection rules — the manifest must only advertise parameters the Tiles /
-/// Maps handlers will actually render, so that the SPA dropdown can't pick a
-/// value that either 400s OR (worse) is silently ignored at render time:
+/// **Caller invariant:** this is only invoked when the collection has
+/// raster tiles (see `build_entry`'s `if has_raster_tiles` guard), so a
+/// `MapEngine` is always registered. Two branches:
 ///
-/// 1. `MapEngine` registered AND `raster_info().parameters` non-empty: that
-///    list is the source of truth. Names also present in EDR are enriched
-///    with EDR's richer `(label, unit)`; names absent from EDR fall back to
-///    raster-side `(short_name, title)` with an empty unit.
-/// 2. `MapEngine` registered with an *empty* `parameters` list signals a
-///    single-band engine (single-band GeoTIFF). The tile handler ignores
-///    `?parameter-name=` regardless of the value passed — so emitting any
-///    dropdown options would lie about what the SPA can actually do. No
-///    `parameters` field in the manifest, even if EDR exposes more than one.
-/// 3. Pure-EDR collection (no raster engine at all): surface EDR's full
-///    list. No tile-rendering path exists, so there's no mismatch risk.
+/// 1. `raster_info().parameters` non-empty (multi-parameter engines like
+///    GRIB / multi-param QueryData): that list is the renderable source of
+///    truth. Names also present in EDR are enriched with EDR's richer
+///    `(label, unit)`; names absent from EDR fall back to the raster-side
+///    `(short_name, title)` with an empty unit.
+/// 2. `raster_info().parameters` empty (single-band engines like
+///    single-band GeoTIFF): the tile handler ignores `?parameter-name=`
+///    regardless of value — emitting dropdown options would lie about what
+///    the SPA can do. Suppress, even if EDR is multi-param.
 fn collection_parameters(
     id: &str,
     edr: &api_edr::handlers::EdrState,
@@ -450,51 +448,34 @@ fn collection_parameters(
     tiles: &api_tiles::handlers::TilesState,
     wms: &api_wms::handlers::WmsState,
 ) -> Option<Vec<Value>> {
-    let edr_descs = edr
-        .engines
-        .get(id)
-        .map(|engine| engine.get_parameter_descriptions());
-
-    let raster_params: Option<Vec<(String, String)>> = maps
+    let raster_params: Vec<(String, String)> = maps
         .engines
         .get(id)
         .or_else(|| tiles.map_engines.get(id))
         .or_else(|| wms.engines.get(id))
-        .map(|engine| engine.raster_info().parameters);
+        .map(|engine| engine.raster_info().parameters)?;
 
-    let mut out: Vec<Value> = match (raster_params, edr_descs) {
-        (Some(raster), edr_opt) if !raster.is_empty() => {
-            // Raster-side is the renderable set; intersect EDR descriptions on
-            // top so the dropdown shows units when the EDR engine has them.
-            let edr = edr_opt.unwrap_or_default();
-            raster
-                .into_iter()
-                .map(|(name, title)| {
-                    let (label, unit) = edr
-                        .get(&name)
-                        .map(|d| (d.label.clone(), d.unit.clone()))
-                        .unwrap_or((title, String::new()));
-                    json!({ "name": name, "title": label, "unit": unit })
-                })
-                .collect()
-        }
-        // Raster engine is present but reports no parameters → single-band.
-        // Even if EDR is multi-param the tile handler will ignore the
-        // selection, so showing a dropdown would mislead users into thinking
-        // they can switch parameters. Suppress unconditionally.
-        (Some(_), _) => return None,
-        (None, Some(edr)) if !edr.is_empty() => edr
-            .into_iter()
-            .map(|(name, desc)| {
-                json!({
-                    "name": name,
-                    "title": desc.label,
-                    "unit": desc.unit,
-                })
-            })
-            .collect(),
-        _ => return None,
-    };
+    // Single-band engine → no meaningful per-request selection.
+    if raster_params.is_empty() {
+        return None;
+    }
+
+    let edr_descs = edr
+        .engines
+        .get(id)
+        .map(|engine| engine.get_parameter_descriptions())
+        .unwrap_or_default();
+
+    let mut out: Vec<Value> = raster_params
+        .into_iter()
+        .map(|(name, title)| {
+            let (label, unit) = edr_descs
+                .get(&name)
+                .map(|d| (d.label.clone(), d.unit.clone()))
+                .unwrap_or((title, String::new()));
+            json!({ "name": name, "title": label, "unit": unit })
+        })
+        .collect();
 
     out.sort_by(|a, b| {
         a.get("name")

--- a/crates/server/src/preview.rs
+++ b/crates/server/src/preview.rs
@@ -429,21 +429,20 @@ fn build_entry(
 /// per-collection manifest entry. Sorted by name for stable ordering.
 ///
 /// Selection rules — the manifest must only advertise parameters the Tiles /
-/// Maps handlers will actually accept, so that the SPA dropdown can't pick a
-/// value that immediately 400s at render time:
+/// Maps handlers will actually render, so that the SPA dropdown can't pick a
+/// value that either 400s OR (worse) is silently ignored at render time:
 ///
-/// 1. If a `MapEngine` is registered AND its `raster_info().parameters` is
-///    non-empty, that list is the source of truth (it's what the raster route
-///    validates against). Names absent from EDR fall back to the raster-side
-///    `(short_name, title)` with an empty unit.
-/// 2. When the matching `EdrEngine` is also present, its richer
-///    `get_parameter_descriptions()` (per-param `unit` + `label`) is preferred
-///    for each name that survived (1).
-/// 3. Pure-EDR fallback: no raster engine OR `raster_info().parameters` empty
-///    (single-band collections like single-parameter GeoTIFF) — surface EDR's
-///    full list. The dropdown still renders, but the tile handler's
-///    "single-param engine ignores `parameter-name`" branch keeps everything
-///    consistent.
+/// 1. `MapEngine` registered AND `raster_info().parameters` non-empty: that
+///    list is the source of truth. Names also present in EDR are enriched
+///    with EDR's richer `(label, unit)`; names absent from EDR fall back to
+///    raster-side `(short_name, title)` with an empty unit.
+/// 2. `MapEngine` registered with an *empty* `parameters` list signals a
+///    single-band engine (single-band GeoTIFF). The tile handler ignores
+///    `?parameter-name=` regardless of the value passed — so emitting any
+///    dropdown options would lie about what the SPA can actually do. No
+///    `parameters` field in the manifest, even if EDR exposes more than one.
+/// 3. Pure-EDR collection (no raster engine at all): surface EDR's full
+///    list. No tile-rendering path exists, so there's no mismatch risk.
 fn collection_parameters(
     id: &str,
     edr: &api_edr::handlers::EdrState,
@@ -479,7 +478,12 @@ fn collection_parameters(
                 })
                 .collect()
         }
-        (_, Some(edr)) if !edr.is_empty() => edr
+        // Raster engine is present but reports no parameters → single-band.
+        // Even if EDR is multi-param the tile handler will ignore the
+        // selection, so showing a dropdown would mislead users into thinking
+        // they can switch parameters. Suppress unconditionally.
+        (Some(_), _) => return None,
+        (None, Some(edr)) if !edr.is_empty() => edr
             .into_iter()
             .map(|(name, desc)| {
                 json!({
@@ -826,6 +830,22 @@ mod tests {
         times: Vec<DateTime<Utc>>,
         parameter: String,
         unit: String,
+        /// `parameters` returned by `raster_info()`. Empty by default
+        /// (single-band convention). Tests for multi-parameter raster
+        /// behaviour set this explicitly.
+        parameters: Vec<(String, String)>,
+    }
+
+    impl Default for RasterMock {
+        fn default() -> Self {
+            Self {
+                spatial_extent: None,
+                times: Vec::new(),
+                parameter: "value".into(),
+                unit: String::new(),
+                parameters: Vec::new(),
+            }
+        }
     }
 
     impl MapEngine for RasterMock {
@@ -847,7 +867,7 @@ mod tests {
                 times: self.times.clone(),
                 parameter: self.parameter.clone(),
                 unit: self.unit.clone(),
-                parameters: vec![],
+                parameters: self.parameters.clone(),
             }
         }
     }
@@ -1068,6 +1088,7 @@ mod tests {
             times: vec![],
             parameter: "reflectivity".into(),
             unit: "dBZ".into(),
+            parameters: vec![],
         });
         let feature_engine: Arc<dyn FeatureEngine> = Arc::new(PointFeatureMock {
             extent: Some([20.0, 60.0, 30.0, 70.0]),
@@ -1340,6 +1361,7 @@ mod tests {
             times: times.clone(),
             parameter: "reflectivity".into(),
             unit: "dBZ".into(),
+            parameters: vec![],
         });
         tiles.map_engines.insert("radar".into(), raster);
         tiles
@@ -1382,6 +1404,7 @@ mod tests {
             times: times.clone(),
             parameter: "reflectivity".into(),
             unit: "dBZ".into(),
+            parameters: vec![],
         });
         wms.engines.insert("radar-wms".into(), engine);
         wms.collections
@@ -1463,6 +1486,7 @@ mod tests {
             times: times.clone(),
             parameter: "reflectivity".into(),
             unit: "dBZ".into(),
+            parameters: vec![],
         });
         tiles.map_engines.insert("radar".into(), raster);
         tiles.collections.insert(
@@ -1512,6 +1536,7 @@ mod tests {
             times: times.clone(),
             parameter: "reflectivity".into(),
             unit: "dBZ".into(),
+            parameters: vec![],
         });
         tiles.map_engines.insert("radar".into(), raster);
         tiles
@@ -1547,6 +1572,7 @@ mod tests {
             times: times.clone(),
             parameter: "reflectivity".into(),
             unit: "dBZ".into(),
+            parameters: vec![],
         });
         tiles.map_engines.insert("radar".into(), raster);
         tiles.collections.insert(
@@ -1639,10 +1665,15 @@ mod tests {
 
         let mut tiles = empty_tiles();
         let raster: Arc<dyn MapEngine> = Arc::new(RasterMock {
-            spatial_extent: None,
-            times: Vec::new(),
             parameter: "2t".into(),
             unit: "K".into(),
+            // GRIB shape: raster exposes the same param set as EDR.
+            parameters: vec![
+                ("2t".into(), "Temperature".into()),
+                ("msl".into(), "Pressure".into()),
+                ("10u".into(), "Wind U".into()),
+            ],
+            ..RasterMock::default()
         });
         tiles.map_engines.insert("ecmwf-fc".into(), raster);
         tiles
@@ -1661,6 +1692,81 @@ mod tests {
         assert_eq!(params[2]["name"], "msl");
         assert_eq!(params[1]["unit"], "K");
         assert_eq!(params[1]["title"], "2 metre temperature");
+    }
+
+    #[test]
+    fn manifest_omits_parameters_when_raster_is_single_band_even_if_edr_multi_param() {
+        // Reviewer scenario: single-band raster engine (empty
+        // `raster_info().parameters`) shares a collection ID with a
+        // multi-param EDR engine. The tile handler ignores `parameter-name=`
+        // for single-band engines, so emitting EDR's multi-param list would
+        // give the user a dropdown whose selections are silently ignored at
+        // render time. The manifest must instead drop the `parameters` field
+        // so the SPA shows no dropdown.
+        use ds_core::model::ParameterDescription;
+
+        struct MultiParamEdrShim;
+        impl EdrEngine for MultiParamEdrShim {
+            fn get_locations(&self) -> Result<Vec<Location>, DataServerError> {
+                Ok(Vec::new())
+            }
+            fn query_location(
+                &self,
+                _: &str,
+                _: Option<(DateTime<Utc>, DateTime<Utc>)>,
+                _: Option<&[String]>,
+            ) -> Result<QueryResult, DataServerError> {
+                unimplemented!()
+            }
+            fn get_parameters(&self) -> Vec<String> {
+                vec!["a".into(), "b".into()]
+            }
+            fn get_parameter_descriptions(&self) -> HashMap<String, ParameterDescription> {
+                let mut m = HashMap::new();
+                for n in ["a", "b"] {
+                    m.insert(
+                        n.to_string(),
+                        ParameterDescription {
+                            label: n.to_string(),
+                            unit: String::new(),
+                            observed_property: n.into(),
+                        },
+                    );
+                }
+                m
+            }
+            fn get_temporal_extent(&self) -> Option<(DateTime<Utc>, DateTime<Utc>)> {
+                None
+            }
+            fn get_spatial_extent(&self) -> Option<[f64; 4]> {
+                None
+            }
+        }
+
+        let mut edr = empty_edr();
+        edr.engines
+            .insert("single-band".into(), Arc::new(MultiParamEdrShim));
+        edr.collections.insert(
+            "single-band".into(),
+            config("single-band", &["edr", "tiles"]),
+        );
+
+        let mut tiles = empty_tiles();
+        let raster: Arc<dyn MapEngine> = Arc::new(RasterMock::default());
+        tiles.map_engines.insert("single-band".into(), raster);
+        tiles.collections.insert(
+            "single-band".into(),
+            config("single-band", &["edr", "tiles"]),
+        );
+
+        let state = make_state(edr, empty_features(), empty_maps(), tiles, empty_wms());
+        let m = build_manifest(&state, 0, 100);
+        assert!(
+            m["collections"][0].get("parameters").is_none(),
+            "single-band raster + multi-param EDR must NOT emit a parameters \
+             dropdown — the tile handler silently ignores parameter-name for \
+             single-band engines"
+        );
     }
 
     #[test]

--- a/crates/server/src/preview.rs
+++ b/crates/server/src/preview.rs
@@ -428,11 +428,22 @@ fn build_entry(
 /// Parameter list emitted as `parameters: [{name, title, unit}]` in the
 /// per-collection manifest entry. Sorted by name for stable ordering.
 ///
-/// Source precedence:
-/// 1. `EdrEngine::get_parameter_descriptions()` — richest (per-param unit + label).
-/// 2. `MapEngine::raster_info().parameters` — fallback for raster-only multi-
-///    parameter collections that aren't wired into EDR. No per-param unit
-///    metadata is available at this layer, so `unit` is left empty.
+/// Selection rules — the manifest must only advertise parameters the Tiles /
+/// Maps handlers will actually accept, so that the SPA dropdown can't pick a
+/// value that immediately 400s at render time:
+///
+/// 1. If a `MapEngine` is registered AND its `raster_info().parameters` is
+///    non-empty, that list is the source of truth (it's what the raster route
+///    validates against). Names absent from EDR fall back to the raster-side
+///    `(short_name, title)` with an empty unit.
+/// 2. When the matching `EdrEngine` is also present, its richer
+///    `get_parameter_descriptions()` (per-param `unit` + `label`) is preferred
+///    for each name that survived (1).
+/// 3. Pure-EDR fallback: no raster engine OR `raster_info().parameters` empty
+///    (single-band collections like single-parameter GeoTIFF) — surface EDR's
+///    full list. The dropdown still renders, but the tile handler's
+///    "single-param engine ignores `parameter-name`" branch keeps everything
+///    consistent.
 fn collection_parameters(
     id: &str,
     edr: &api_edr::handlers::EdrState,
@@ -440,48 +451,47 @@ fn collection_parameters(
     tiles: &api_tiles::handlers::TilesState,
     wms: &api_wms::handlers::WmsState,
 ) -> Option<Vec<Value>> {
-    if let Some(engine) = edr.engines.get(id) {
-        let descs = engine.get_parameter_descriptions();
-        if !descs.is_empty() {
-            let mut out: Vec<Value> = descs
-                .into_iter()
-                .map(|(name, desc)| {
-                    json!({
-                        "name": name,
-                        "title": desc.label,
-                        "unit": desc.unit,
-                    })
-                })
-                .collect();
-            out.sort_by(|a, b| {
-                a.get("name")
-                    .and_then(Value::as_str)
-                    .unwrap_or("")
-                    .cmp(b.get("name").and_then(Value::as_str).unwrap_or(""))
-            });
-            return Some(out);
-        }
-    }
-    let map_engine = maps
+    let edr_descs = edr
+        .engines
+        .get(id)
+        .map(|engine| engine.get_parameter_descriptions());
+
+    let raster_params: Option<Vec<(String, String)>> = maps
         .engines
         .get(id)
         .or_else(|| tiles.map_engines.get(id))
-        .or_else(|| wms.engines.get(id))?;
-    let info = map_engine.raster_info();
-    if info.parameters.is_empty() {
-        return None;
-    }
-    let mut out: Vec<Value> = info
-        .parameters
-        .into_iter()
-        .map(|(name, title)| {
-            json!({
-                "name": name,
-                "title": title,
-                "unit": "",
+        .or_else(|| wms.engines.get(id))
+        .map(|engine| engine.raster_info().parameters);
+
+    let mut out: Vec<Value> = match (raster_params, edr_descs) {
+        (Some(raster), edr_opt) if !raster.is_empty() => {
+            // Raster-side is the renderable set; intersect EDR descriptions on
+            // top so the dropdown shows units when the EDR engine has them.
+            let edr = edr_opt.unwrap_or_default();
+            raster
+                .into_iter()
+                .map(|(name, title)| {
+                    let (label, unit) = edr
+                        .get(&name)
+                        .map(|d| (d.label.clone(), d.unit.clone()))
+                        .unwrap_or((title, String::new()));
+                    json!({ "name": name, "title": label, "unit": unit })
+                })
+                .collect()
+        }
+        (_, Some(edr)) if !edr.is_empty() => edr
+            .into_iter()
+            .map(|(name, desc)| {
+                json!({
+                    "name": name,
+                    "title": desc.label,
+                    "unit": desc.unit,
+                })
             })
-        })
-        .collect();
+            .collect(),
+        _ => return None,
+    };
+
     out.sort_by(|a, b| {
         a.get("name")
             .and_then(Value::as_str)
@@ -1675,6 +1685,124 @@ mod tests {
         );
         let m = build_manifest(&state, 0, 100);
         assert!(m["collections"][0].get("parameters").is_none());
+    }
+
+    #[test]
+    fn manifest_parameters_intersect_with_raster_renderable_set() {
+        // Reviewer scenario: EDR advertises a param the raster engine can't
+        // render (a derived/queryable-only field). The dropdown must be the
+        // intersection so a user can never select a value that 400s at the
+        // tile route.
+        use ds_core::model::ParameterDescription;
+
+        struct WideEdr;
+        impl EdrEngine for WideEdr {
+            fn get_locations(&self) -> Result<Vec<Location>, DataServerError> {
+                Ok(Vec::new())
+            }
+            fn query_location(
+                &self,
+                _: &str,
+                _: Option<(DateTime<Utc>, DateTime<Utc>)>,
+                _: Option<&[String]>,
+            ) -> Result<QueryResult, DataServerError> {
+                unimplemented!()
+            }
+            fn get_parameters(&self) -> Vec<String> {
+                vec!["2t".into(), "msl".into(), "derived_index".into()]
+            }
+            fn get_parameter_descriptions(&self) -> HashMap<String, ParameterDescription> {
+                let mut m = HashMap::new();
+                m.insert(
+                    "2t".into(),
+                    ParameterDescription {
+                        label: "Temperature".into(),
+                        unit: "K".into(),
+                        observed_property: "2t".into(),
+                    },
+                );
+                m.insert(
+                    "msl".into(),
+                    ParameterDescription {
+                        label: "Mean SLP".into(),
+                        unit: "Pa".into(),
+                        observed_property: "msl".into(),
+                    },
+                );
+                m.insert(
+                    "derived_index".into(),
+                    ParameterDescription {
+                        label: "Derived index".into(),
+                        unit: "1".into(),
+                        observed_property: "derived_index".into(),
+                    },
+                );
+                m
+            }
+            fn get_temporal_extent(&self) -> Option<(DateTime<Utc>, DateTime<Utc>)> {
+                None
+            }
+            fn get_spatial_extent(&self) -> Option<[f64; 4]> {
+                None
+            }
+        }
+
+        /// MapEngine that only exposes 2 of the EDR's 3 parameters.
+        struct PartialRaster;
+        impl MapEngine for PartialRaster {
+            fn get_raster_tile(
+                &self,
+                _: [f64; 4],
+                _: u32,
+                _: u32,
+                _: Option<DateTime<Utc>>,
+                _: &OutputCrs,
+                _: Option<&str>,
+            ) -> Result<RasterTile, DataServerError> {
+                unimplemented!()
+            }
+            fn raster_info(&self) -> RasterInfo {
+                RasterInfo {
+                    native_crs: "EPSG:4326".into(),
+                    spatial_extent: None,
+                    times: vec![],
+                    parameter: "2t".into(),
+                    unit: "K".into(),
+                    // Note: "derived_index" is intentionally absent.
+                    parameters: vec![
+                        ("2t".into(), "Temperature".into()),
+                        ("msl".into(), "Mean SLP".into()),
+                    ],
+                }
+            }
+        }
+
+        let mut edr = empty_edr();
+        let e: Arc<dyn EdrEngine> = Arc::new(WideEdr);
+        edr.engines.insert("ecmwf-fc".into(), e);
+        edr.collections
+            .insert("ecmwf-fc".into(), config("ecmwf-fc", &["edr", "tiles"]));
+
+        let mut tiles = empty_tiles();
+        let r: Arc<dyn MapEngine> = Arc::new(PartialRaster);
+        tiles.map_engines.insert("ecmwf-fc".into(), r);
+        tiles
+            .collections
+            .insert("ecmwf-fc".into(), config("ecmwf-fc", &["edr", "tiles"]));
+
+        let state = make_state(edr, empty_features(), empty_maps(), tiles, empty_wms());
+        let m = build_manifest(&state, 0, 100);
+        let params = m["collections"][0]["parameters"]
+            .as_array()
+            .expect("parameters array");
+        // Only the renderable subset. EDR's rich "Temperature" label + "K"
+        // unit should still propagate for the surviving "2t" entry.
+        assert_eq!(params.len(), 2);
+        let names: Vec<&str> = params.iter().map(|p| p["name"].as_str().unwrap()).collect();
+        assert_eq!(names, vec!["2t", "msl"]);
+        assert!(!names.contains(&"derived_index"));
+        assert_eq!(params[0]["unit"], "K");
+        assert_eq!(params[0]["title"], "Temperature");
     }
 
     // -----------------------------------------------------------------------

--- a/crates/server/tests/middleware.rs
+++ b/crates/server/tests/middleware.rs
@@ -74,6 +74,7 @@ fn make_collection(id: &str) -> CollectionConfig {
         wms: None,
         grib: None,
         postgis: None,
+        preview: None,
     }
 }
 


### PR DESCRIPTION
## Summary

Two enhancements to the embedded `/preview` MapLibre SPA:

1. **Parameter dropdown** for multi-parameter raster collections (GRIB, multi-param QueryData). The SPA renders a `<select>` above the style picker; on change it switches the raster tile source to `?parameter-name=<name>`. The manifest carries the full parameter list (name, title, unit) — intersected with the raster engine's `raster_info().parameters` so the dropdown only advertises renderable names.

2. **Bounded time slider** for wide-extent collections via a new optional `[collections.preview] time_window = "PT12H"` block. Filters the manifest's `temporal_extent.values` to entries within `(latest - duration, latest]` and re-anchors `start`/`end`. Real motivation: MET Norway STAC radar archive is years of 5-min mosaics; before this the slider was a 1000-stop bar over ~83h that nobody could use.

## Implicit bug fix (worth calling out)

WMS `CacheKey` now scopes by parameter. This silently fixes a pre-existing bug where `LAYERS=collection/temperature` and `LAYERS=collection/wind_speed` would collide in the rendered cache for multi-parameter WMS collections.

## API surface

| Surface | Change |
|---|---|
| Tiles | `?parameter-name=NAME` query — accepted on raw + styled tile routes, ignored for `?f=mvt` |
| Maps | `?parameter-name=NAME` query — accepted on default + styled map routes |
| WMS | unchanged externally; `CacheKey` scopes by parameter (see implicit fix above) |
| Manifest | new `parameters: [{name, title, unit}]` per collection (raster-tile-backed only) |
| Config | new `[collections.preview] time_window = "PT12H"` block (ISO 8601 positive duration) |

`parameter-name` mirrors EDR's convention — explicitly non-OGC for Maps/Tiles today. A standardised path/query form is on the OGC Maps/Tiles roadmap and will replace this.

## Backwards compatibility

- Collections without `[preview]`: no value filtering, no behaviour change.
- Tiles/Maps URLs without `?parameter-name=`: identical to before.
- Single-parameter engines (single-band GeoTIFF): accept and ignore `?parameter-name=`, preserving `MapEngine::get_raster_tile`'s documented contract. The manifest also withholds the `parameters` array in this case so the SPA doesn't show a dropdown whose selections would be silently ignored.
- Multi-parameter engines: validate against `raster_info().parameters` and return `400 Bad Request` with the available list on unknown names.
- `CacheKey` grew a `parameter: Option<String>` field — this is a deliberate cache-bust event for v0.3; the pinned-ETag test was rotated.

## ISO 8601 duration parser

`ds_core::datetime::parse_iso8601_duration` is the shared positive-duration parser for `[preview]`. Strict by design:
- accepts `P1D`, `P1W`, `P1DT6H`, `PT12H`, `PT30M`, `PT15S`
- rejects signed durations (`-PT2H`), signed components (`P1DT-2H`), trailing-T with empty time (`P1DT`), mixed weeks+days (`P1W2D`), zero-length, unsupported units

Signed durations / past-window arithmetic live in `engine-geotiff::time_window` and are out of scope here.

## Test plan

- [x] `cargo fmt -- --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test -p ds-core` (datetime + 6 new duration tests)
- [x] `cargo test -p server preview::` (29 tests including 3 manifest filter tests, 3 parameter tests, plus the new `manifest_omits_parameters_when_raster_is_single_band_even_if_edr_multi_param` defensive guard)
- [x] `cargo test -p api-tiles --test integration parameter_name` (4 tests)
- [x] `cargo test -p api-maps --test integration parameter_name` (4 tests, mirroring api-tiles)
- [x] `cargo test -p ds-render` (cache_key_etag_changes_when_parameter_changes)
- [ ] Manual: launch with the updated `collections.d/met-norway-radar.toml` and confirm the slider now shows ~144 stops not 1000; launch with a GRIB collection and confirm the dropdown switches parameters

🤖 Generated with [Claude Code](https://claude.com/claude-code)