### PR TITLE
fix(wms): honour image/webp on GetLegendGraphic and reject unknown formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -912,7 +912,6 @@ PNG/WebP responses are always RGBA (transparent for empty tiles). JPEG is RGB. E
 - `bbox` is always lon/lat (no CRS-dependent axis swap)
 - Multi-parameter selection uses `?parameter-name=`, not `LAYERS=collection/param`
 - Errors are JSON, not `ServiceExceptionReport` XML
-- WebP is a first-class output format on every endpoint
 
 ### Conformance Classes
 

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ The render semaphore (sized to 2× available CPU cores, minimum 8) and rendered 
 
 /wms/?SERVICE=WMS&REQUEST=GetCapabilities      WMS 1.3.0 GetCapabilities (XML)
 /wms/?SERVICE=WMS&REQUEST=GetMap&...           WMS 1.3.0 GetMap (PNG/JPEG/WebP)
-/wms/?SERVICE=WMS&REQUEST=GetLegendGraphic&... WMS 1.3.0 GetLegendGraphic (PNG/JPEG)
+/wms/?SERVICE=WMS&REQUEST=GetLegendGraphic&... WMS 1.3.0 GetLegendGraphic (PNG/JPEG/WebP)
 
 /preview                                       Built-in MapLibre SPA (cards + map for every collection)
 /preview/manifest.json                         Aggregated discovery JSON consumed by the SPA
@@ -777,7 +777,7 @@ Internally the handler normalizes everything to WGS84 `[west, south, east, north
 | `STYLES` | no | `default` | Style name. Note: only the plural form works on this endpoint, unlike GetMap which accepts both. Tracked in #165. |
 | `WIDTH` | no | `40` | Pixels, capped at 256 |
 | `HEIGHT` | no | `200` | Pixels, capped at 1024 |
-| `FORMAT` | no | `image/png` | `image/png` or `image/jpeg`. Any other value (including the `image/webp` that capabilities advertises) silently falls back to PNG with `Content-Type: image/png` — no error is raised. Tracked in #161. |
+| `FORMAT` | no | `image/png` | `image/png`, `image/jpeg`, or `image/webp`. Any other value returns `InvalidFormat`. |
 
 Legends are static — they always carry `Cache-Control: public, max-age=86400, immutable`.
 
@@ -863,7 +863,7 @@ Or attach a reusable `[[style_bundles]]` block defined in top-level `config.toml
 | `LAYERS` count | exactly 1 |
 | Supported CRS | `CRS:84`, `EPSG:4326`, `EPSG:3857`, `EPSG:3067`, `EPSG:3035` |
 | Supported `FORMAT` (GetMap) | `image/png`, `image/jpeg`, `image/webp` |
-| Supported `FORMAT` (GetLegendGraphic) | `image/png`, `image/jpeg` |
+| Supported `FORMAT` (GetLegendGraphic) | `image/png`, `image/jpeg`, `image/webp` |
 
 ## OGC API - Maps
 
@@ -912,7 +912,7 @@ PNG/WebP responses are always RGBA (transparent for empty tiles). JPEG is RGB. E
 - `bbox` is always lon/lat (no CRS-dependent axis swap)
 - Multi-parameter selection uses `?parameter-name=`, not `LAYERS=collection/param`
 - Errors are JSON, not `ServiceExceptionReport` XML
-- WebP is a first-class output format (WMS accepts it on GetMap but not on GetLegendGraphic)
+- WebP is a first-class output format on every endpoint
 
 ### Conformance Classes
 

--- a/crates/api-wms/src/capabilities.rs
+++ b/crates/api-wms/src/capabilities.rs
@@ -88,21 +88,17 @@ fn write_request(writer: &mut Writer<Vec<u8>>, base_url: &str) {
     write_dcp_type(writer, base_url);
     let _ = writer.write_event(Event::End(BytesEnd::new("GetCapabilities")));
 
-    // GetMap
-    let _ = writer.write_event(Event::Start(BytesStart::new("GetMap")));
-    write_format(writer, "image/png");
-    write_format(writer, "image/jpeg");
-    write_format(writer, "image/webp");
-    write_dcp_type(writer, base_url);
-    let _ = writer.write_event(Event::End(BytesEnd::new("GetMap")));
-
-    // GetLegendGraphic
-    let _ = writer.write_event(Event::Start(BytesStart::new("GetLegendGraphic")));
-    write_format(writer, "image/png");
-    write_format(writer, "image/jpeg");
-    write_format(writer, "image/webp");
-    write_dcp_type(writer, base_url);
-    let _ = writer.write_event(Event::End(BytesEnd::new("GetLegendGraphic")));
+    // GetMap and GetLegendGraphic accept the same image formats — iterate
+    // SUPPORTED_FORMATS so the advertised list can't drift from what the
+    // handlers actually serve.
+    for op in ["GetMap", "GetLegendGraphic"] {
+        let _ = writer.write_event(Event::Start(BytesStart::new(op)));
+        for format in params::SUPPORTED_FORMATS {
+            write_format(writer, format);
+        }
+        write_dcp_type(writer, base_url);
+        let _ = writer.write_event(Event::End(BytesEnd::new(op)));
+    }
 
     let _ = writer.write_event(Event::End(BytesEnd::new("Request")));
 }

--- a/crates/api-wms/src/error.rs
+++ b/crates/api-wms/src/error.rs
@@ -43,7 +43,8 @@ impl WmsError {
 
     pub fn invalid_format(format: &str) -> Self {
         WmsError::InvalidFormat(format!(
-            "Format '{format}' is not supported. Use image/png, image/jpeg, or image/webp."
+            "Format '{format}' is not supported. Use {}.",
+            crate::params::SUPPORTED_FORMATS.join(", ")
         ))
     }
 
@@ -216,5 +217,22 @@ mod tests {
             !xml_str.contains("10.0.0.5"),
             "body must not echo internal connection detail, got {xml_str}"
         );
+    }
+
+    /// Lock the `InvalidFormat` message to `params::SUPPORTED_FORMATS` so a
+    /// future format addition can't leave the error hint stale. The
+    /// drift-guard test in params.rs only asserts the slice round-trips
+    /// through `parse_image_format`; the rejection message lives here.
+    #[test]
+    fn invalid_format_message_lists_every_supported_format() {
+        let WmsError::InvalidFormat(msg) = WmsError::invalid_format("image/gif") else {
+            panic!("invalid_format() must produce InvalidFormat");
+        };
+        for fmt in crate::params::SUPPORTED_FORMATS {
+            assert!(
+                msg.contains(fmt),
+                "InvalidFormat message {msg:?} should mention {fmt:?}"
+            );
+        }
     }
 }

--- a/crates/api-wms/src/error.rs
+++ b/crates/api-wms/src/error.rs
@@ -43,7 +43,7 @@ impl WmsError {
 
     pub fn invalid_format(format: &str) -> Self {
         WmsError::InvalidFormat(format!(
-            "Format '{format}' is not supported. Use image/png."
+            "Format '{format}' is not supported. Use image/png, image/jpeg, or image/webp."
         ))
     }
 

--- a/crates/api-wms/src/handlers.rs
+++ b/crates/api-wms/src/handlers.rs
@@ -312,8 +312,10 @@ pub async fn wms_handler(
             let height = height.min(1024);
 
             let format = match query.format.as_deref() {
+                None | Some("image/png") => ds_render::ImageFormat::Png,
                 Some("image/jpeg") => ds_render::ImageFormat::Jpeg,
-                _ => ds_render::ImageFormat::Png,
+                Some("image/webp") => ds_render::ImageFormat::Webp,
+                Some(other) => return Err(WmsError::invalid_format(other)),
             };
 
             let colormap = style_info.colormap.clone();

--- a/crates/api-wms/src/handlers.rs
+++ b/crates/api-wms/src/handlers.rs
@@ -311,12 +311,7 @@ pub async fn wms_handler(
             let width = width.min(256);
             let height = height.min(1024);
 
-            let format = match query.format.as_deref() {
-                None | Some("image/png") => ds_render::ImageFormat::Png,
-                Some("image/jpeg") => ds_render::ImageFormat::Jpeg,
-                Some("image/webp") => ds_render::ImageFormat::Webp,
-                Some(other) => return Err(WmsError::invalid_format(other)),
-            };
+            let format = crate::params::parse_image_format(query.format.as_deref())?;
 
             let colormap = style_info.colormap.clone();
             let min = style_info.min;

--- a/crates/api-wms/src/params.rs
+++ b/crates/api-wms/src/params.rs
@@ -16,8 +16,27 @@ pub const MAX_MAP_DIMENSION: u32 = 8000;
 /// Supported CRS identifiers.
 const SUPPORTED_CRS: &[&str] = &["CRS:84", "EPSG:4326", "EPSG:3857", "EPSG:3067", "EPSG:3035"];
 
-/// Supported output formats.
-const SUPPORTED_FORMATS: &[&str] = &["image/png", "image/jpeg", "image/webp"];
+/// Supported output formats for `GetMap` and `GetLegendGraphic`.
+///
+/// Single source of truth: capabilities iterates this slice when emitting
+/// `<Format>` children, and `parse_image_format` mirrors it. If you add a
+/// format here, extend the match in `parse_image_format` to match.
+pub const SUPPORTED_FORMATS: &[&str] = &["image/png", "image/jpeg", "image/webp"];
+
+/// Parse a WMS `FORMAT=` query parameter into the corresponding `ImageFormat`.
+///
+/// `None` (parameter omitted) defaults to PNG, matching the WMS 1.3.0
+/// convention. Any value outside `SUPPORTED_FORMATS` yields
+/// `WmsError::InvalidFormat`. Used by both `validate_get_map` and the
+/// `GetLegendGraphic` handler so the two paths can't drift.
+pub fn parse_image_format(format: Option<&str>) -> Result<ds_render::ImageFormat, WmsError> {
+    match format {
+        None | Some("image/png") => Ok(ds_render::ImageFormat::Png),
+        Some("image/jpeg") => Ok(ds_render::ImageFormat::Jpeg),
+        Some("image/webp") => Ok(ds_render::ImageFormat::Webp),
+        Some(other) => Err(WmsError::invalid_format(other)),
+    }
+}
 
 /// Raw WMS query parameters (case-insensitive keys handled by axum).
 #[derive(Debug, Deserialize)]
@@ -162,10 +181,7 @@ impl WmsQuery {
         }
 
         // FORMAT
-        let format = self.format.as_deref().unwrap_or("image/png");
-        if !SUPPORTED_FORMATS.contains(&format) {
-            return Err(WmsError::invalid_format(format));
-        }
+        let image_format = parse_image_format(self.format.as_deref())?;
 
         // TRANSPARENT
         let transparent = self
@@ -192,12 +208,6 @@ impl WmsQuery {
             "default".to_string()
         } else {
             style.to_string()
-        };
-
-        let image_format = match format {
-            "image/jpeg" => ds_render::ImageFormat::Jpeg,
-            "image/webp" => ds_render::ImageFormat::Webp,
-            _ => ds_render::ImageFormat::Png,
         };
 
         Ok(GetMapParams {
@@ -366,5 +376,64 @@ mod tests {
         assert!(parse_time("2024-01-01T00:00:00+00:00").is_ok());
         assert!(parse_time("2024-01-01T00:00").is_ok());
         assert!(parse_time("not-a-time").is_err());
+    }
+
+    #[test]
+    fn parse_image_format_accepts_all_supported_types() {
+        assert!(matches!(
+            parse_image_format(Some("image/png")).unwrap(),
+            ds_render::ImageFormat::Png
+        ));
+        assert!(matches!(
+            parse_image_format(Some("image/jpeg")).unwrap(),
+            ds_render::ImageFormat::Jpeg
+        ));
+        assert!(matches!(
+            parse_image_format(Some("image/webp")).unwrap(),
+            ds_render::ImageFormat::Webp
+        ));
+    }
+
+    #[test]
+    fn parse_image_format_defaults_to_png_when_absent() {
+        assert!(matches!(
+            parse_image_format(None).unwrap(),
+            ds_render::ImageFormat::Png
+        ));
+    }
+
+    #[test]
+    fn parse_image_format_rejects_unknown_with_invalid_format() {
+        // Locks in the fix for #161: any value outside SUPPORTED_FORMATS
+        // must return InvalidFormat, not silently fall back to PNG. The
+        // pre-fix handler returned PNG for image/gif and any other typo
+        // with no error, leaving capabilities-trusting clients confused.
+        for bogus in ["image/gif", "image/avif", "", "png", "image/webp;q=1"] {
+            let err = parse_image_format(Some(bogus)).expect_err(bogus);
+            assert!(
+                matches!(err, WmsError::InvalidFormat(_)),
+                "expected InvalidFormat for {bogus:?}, got {err:?}"
+            );
+        }
+    }
+
+    /// Pin SUPPORTED_FORMATS to the match arms in `parse_image_format` so
+    /// a future format addition can't land in one place but not the other
+    /// (the divergence flagged on #166). If you add an entry to
+    /// SUPPORTED_FORMATS, extend `parse_image_format` to handle it and
+    /// this test will start passing again.
+    #[test]
+    fn parse_image_format_covers_every_supported_format() {
+        for fmt in SUPPORTED_FORMATS {
+            let parsed = parse_image_format(Some(fmt)).unwrap_or_else(|_| {
+                panic!("SUPPORTED_FORMATS entry {fmt:?} not handled by parse_image_format")
+            });
+            assert_eq!(
+                parsed.content_type(),
+                *fmt,
+                "parse_image_format({fmt:?}) → ImageFormat with wrong content_type {}",
+                parsed.content_type()
+            );
+        }
     }
 }

--- a/crates/api-wms/src/params.rs
+++ b/crates/api-wms/src/params.rs
@@ -417,11 +417,10 @@ mod tests {
         }
     }
 
-    /// Pin SUPPORTED_FORMATS to the match arms in `parse_image_format` so
-    /// a future format addition can't land in one place but not the other
-    /// (the divergence flagged on #166). If you add an entry to
-    /// SUPPORTED_FORMATS, extend `parse_image_format` to handle it and
-    /// this test will start passing again.
+    /// Adding an entry to `SUPPORTED_FORMATS` without extending the match in
+    /// `parse_image_format` will cause this test to fail — update both
+    /// together. (Introduced to prevent the same capabilities-vs-handler
+    /// drift that caused #161.)
     #[test]
     fn parse_image_format_covers_every_supported_format() {
         for fmt in SUPPORTED_FORMATS {


### PR DESCRIPTION
## Summary

Closes #161.

The GetLegendGraphic handler matched only \`image/jpeg\` and fell through to PNG for everything else — including \`image/webp\`, which is *advertised* in \`<GetLegendGraphic>\` capabilities. Clients trusting capabilities and requesting WebP got PNG bytes back with \`Content-Type: image/png\` and no error.

\`ds_render::render_legend\` already supports \`ImageFormat::Webp\` (the encoder path exists for GetMap), so this is purely a handler-side routing fix:

\`\`\`rust
let format = match query.format.as_deref() {
    None | Some(\"image/png\") => ds_render::ImageFormat::Png,
    Some(\"image/jpeg\")       => ds_render::ImageFormat::Jpeg,
    Some(\"image/webp\")       => ds_render::ImageFormat::Webp,
    Some(other)              => return Err(WmsError::invalid_format(other)),
};
\`\`\`

The same change tightens the unknown-format hole: any unsupported \`FORMAT\` (e.g. \`image/gif\`) now returns \`ServiceException InvalidFormat\` instead of silently downgrading to PNG. That closes the same class of silent-fallback bug surfaced by reviewer on #159 for non-WebP formats.

\`WmsError::invalid_format\` now lists all three supported types in the error message.

## Files changed

- \`crates/api-wms/src/handlers.rs\` — match expanded to four arms
- \`crates/api-wms/src/error.rs\` — error message updated
- \`README.md\` — drop the \`Tracked in #161\` note on the FORMAT row, list WebP under GetLegendGraphic in the limits table and the routing summary, and update the differences-from-WMS bullet

## Test plan

- [x] \`cargo check -p api-wms\`
- [x] \`cargo test -p api-wms\` — all 8 tests pass (existing tests don't assert the old error string)
- [x] \`cargo fmt -p api-wms --check\` clean
- [x] \`cargo clippy -p api-wms\` clean
- [ ] Manual: \`curl '...REQUEST=GetLegendGraphic&FORMAT=image/webp'\` returns a valid WebP image with \`Content-Type: image/webp\`
- [ ] Manual: \`curl '...REQUEST=GetLegendGraphic&FORMAT=image/gif'\` returns a \`ServiceException InvalidFormat\` XML body with HTTP 400