### PR TITLE
ci(release): enable cargo-workspace plugin and restore --locked

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,14 +152,18 @@ jobs:
             ${{ matrix.target }}-cargo-
 
       - name: Build release binary
-        # `--locked` deliberately omitted while release-please's
-        # `cargo-workspace` plugin is not yet configured to bump
-        # `Cargo.lock` alongside `Cargo.toml`. Without the plugin a
-        # tag built with `--locked` fails on the version drift. Restore
-        # `--locked` once #153 lands; the obligation lives there, not here.
+        # `--locked` enforces that the lockfile committed at the tag
+        # exactly matches Cargo.toml — so a release tag can't silently
+        # pick up a new transitive dep version. This works because
+        # release-please's `cargo-workspace` plugin rewrites
+        # `Cargo.lock` alongside the `Cargo.toml` version bump in the
+        # release PR (see `release-please-config.json::plugins`).
+        # If a future release PR ever lands without a matching
+        # `Cargo.lock` bump, this step fails loudly rather than
+        # producing a release built against a drifted lockfile.
         env:
           TARGET: ${{ matrix.target }}
-        run: cargo build --release --target "${TARGET}" -p server
+        run: cargo build --release --locked --target "${TARGET}" -p server
 
       - name: Package tarball
         # All inputs flow through `env:` so the shell never sees an

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,6 +5,12 @@
   "include-v-in-tag": true,
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": false,
+  "plugins": [
+    {
+      "type": "cargo-workspace",
+      "merge": true
+    }
+  ],
   "packages": {
     "crates/server": {
       "package-name": "meteocore",


### PR DESCRIPTION
## Summary

Closes #153.

#152 dropped \`--locked\` from the release-build line because release-please bumps \`crates/server/Cargo.toml\` but doesn't touch \`Cargo.lock\` — the lockfile's \`[[package]] name = \"server\"\` entry drifts from the manifest version and \`cargo build --locked\` refuses to reconcile. The drop was correct as a stopgap; the proper fix lives here.

### Changes

- **\`release-please-config.json\`**: add the \`cargo-workspace\` plugin. After the \`release-type: rust\` step bumps the per-package \`Cargo.toml\`, this plugin rewrites the workspace's \`Cargo.lock\` so the two stay in sync. \`merge: true\` keeps everything in a single release PR (we currently have one releasable package, so this is mostly future-proofing).
- **\`.github/workflows/release.yml\`**: re-add \`--locked\` to the \`cargo build\` invocation; rewrite the comment from \"deliberately omitted while #153 is pending\" to explain why \`--locked\` is now safe.

### Verification

- \`python3 -c \"import json; json.load(open('release-please-config.json'))\"\` — JSON valid.
- \`cargo build --release --locked -p server\` succeeds locally on the current main (baseline: lockfile is in sync today since no release-bump has happened since the last release).
- Post-merge: the next release-please PR will exercise the plugin. Expected diff includes both \`crates/server/Cargo.toml\` and \`Cargo.lock\`.

### Fallback path if the plugin misbehaves

If \`cargo-workspace\` proves incompatible with this monorepo shape, revert this PR and apply the issue's fallback: a \`cargo update -p server --precise \${NEW_VERSION}\` step inside the release PR's workflow (via release-please \`extra-files\`). Less clean but works.

### Why this is worth doing

Without \`--locked\` each release silently picked up changed transitive dep versions — releases were not reproducible from the lockfile. With the plugin keeping \`Cargo.lock\` in sync, \`--locked\` is both safe and the right default for a release-tag build.

## Test plan

- [x] \`json.load\` validates the config
- [x] \`cargo build --release --locked -p server\` passes locally (baseline)
- [ ] Reviewer eyeballs the plugin name + config object shape against release-please docs
- [ ] **Post-merge:** confirm the next auto-generated release-please PR includes both \`crates/server/Cargo.toml\` and \`Cargo.lock\` in its diff
- [ ] **Post-merge:** confirm the next tagged release build runs with \`--locked\` and succeeds