### PR TITLE
fix(wms,maps,tiles): emit image/png Content-Type for empty-tile fallback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,9 +137,11 @@ dependencies = [
  "chrono",
  "ds-core",
  "ds-render",
+ "http-body-util",
  "quick-xml",
  "serde",
  "tokio",
+ "tower",
  "tracing",
 ]
 

--- a/README.md
+++ b/README.md
@@ -960,7 +960,7 @@ Raster requests resolve a style (the `default` style for the unstyled route, or 
 1. TMS → bbox conversion (Mercator math for `WebMercatorQuad`, linear lon/lat for `WorldCRS84Quad`).
 2. ETag check / rendered-cache check.
 3. On miss: acquire render permit (timed out → 503), call `MapEngine::get_raster_tile()` with the TMS-derived `output_crs`, colorize, encode.
-4. Empty (all-nodata) tiles return a pre-generated transparent PNG with `X-Cache: EMPTY` regardless of the requested format — no engine call, no cache insert.
+4. Empty (all-nodata) tiles return a pre-generated transparent PNG with `X-Cache: EMPTY` and `Content-Type: image/png` regardless of the requested format — no engine call, no cache insert. Clients that strictly need JPEG/WebP output should check `X-Cache: EMPTY` and refetch only if needed; the alternative would be re-encoding a known-uniform buffer on every empty tile.
 
 Successful responses include `Content-Type`, `Content-Crs` (OGC URI for the TMS's CRS), `ETag`, `Cache-Control` (`max-age=86400, immutable` when `datetime` is set, `max-age=60, must-revalidate` otherwise), and `X-Cache: HIT|MISS|EMPTY`.
 

--- a/crates/api-maps/src/handlers.rs
+++ b/crates/api-maps/src/handlers.rs
@@ -822,18 +822,23 @@ async fn render_map(
     .await
     .map_err(|e| MapsError::Internal(format!("Render task failed: {e}")))?;
 
-    let (image_bytes, x_cache) = match render_result {
+    // The EMPTY fast path skips the format-aware encoder and emits PNG
+    // bytes directly. Track the actual Content-Type per branch so the
+    // header never lies about the payload — previously an `f=image/jpeg`
+    // request that hit an empty tile got PNG bytes with
+    // `Content-Type: image/jpeg`, breaking decoders that trust the type.
+    let (image_bytes, x_cache, response_content_type) = match render_result {
         Ok(Some(bytes)) => {
             let image_bytes = bytes::Bytes::from(bytes);
             rendered_cache.insert(cache_key, image_bytes.clone());
-            (image_bytes, "MISS")
+            (image_bytes, "MISS", content_type)
         }
         Ok(None) => {
-            // Empty tile: return transparent PNG without caching
+            // Empty tile: return transparent PNG without caching.
             let rgba = vec![0u8; (width * height * 4) as usize];
             let png = ds_render::encode_png(&rgba, width, height)
                 .map_err(|e| MapsError::Internal(format!("Failed to encode empty tile: {e}")))?;
-            (bytes::Bytes::from(png), "EMPTY")
+            (bytes::Bytes::from(png), "EMPTY", "image/png")
         }
         Err(e) => {
             tracing::warn!("Maps render error for collection '{}': {e}", collection_id);
@@ -842,7 +847,7 @@ async fn render_map(
     };
 
     Ok(axum::response::Response::builder()
-        .header(header::CONTENT_TYPE, content_type)
+        .header(header::CONTENT_TYPE, response_content_type)
         .header(header::ETAG, &etag)
         .header(header::CACHE_CONTROL, cache_control)
         .header(header::HeaderName::from_static("content-crs"), content_crs)

--- a/crates/api-maps/tests/integration.rs
+++ b/crates/api-maps/tests/integration.rs
@@ -532,6 +532,137 @@ mod get_map {
         let resp = app.oneshot(req).await.unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
     }
+
+    /// Regression for #162: when the engine produces an all-nodata tile,
+    /// the fast path emits PNG bytes without going through the
+    /// format-aware encoder. Before this fix the response carried the
+    /// *requested* Content-Type (e.g. image/jpeg) over PNG bytes,
+    /// breaking decoders that trust the header. Both header and body
+    /// must agree.
+    #[tokio::test]
+    async fn empty_tile_forces_png_content_type_even_when_jpeg_requested() {
+        let app = build_empty_router();
+        let req = Request::builder()
+            .uri("/collections/empty/map?bbox=10,55,30,70&f=image/jpeg")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let headers = resp.headers().clone();
+        assert_eq!(
+            headers.get("content-type").unwrap(),
+            "image/png",
+            "empty-tile response must self-declare PNG, not the requested image/jpeg"
+        );
+        assert_eq!(headers.get("x-cache").unwrap(), "EMPTY");
+        let body = resp.into_body().collect().await.unwrap().to_bytes();
+        assert!(
+            body.starts_with(&[0x89, b'P', b'N', b'G']),
+            "body must be a real PNG, got first bytes {:?}",
+            &body[..4.min(body.len())]
+        );
+    }
+
+    #[tokio::test]
+    async fn empty_tile_forces_png_content_type_even_when_webp_requested() {
+        // Same regression as above, second format for symmetry — WebP
+        // takes a different `ImageFormat::Webp` branch in the cache
+        // key, so this exercises a distinct code path.
+        let app = build_empty_router();
+        let req = Request::builder()
+            .uri("/collections/empty/map?bbox=10,55,30,70&f=image/webp")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let headers = resp.headers().clone();
+        assert_eq!(headers.get("content-type").unwrap(), "image/png");
+        assert_eq!(headers.get("x-cache").unwrap(), "EMPTY");
+    }
+}
+
+/// Mock engine that returns an all-`None` (all-nodata) `RasterTile`.
+/// Used to exercise the empty-tile fast path that bypasses the
+/// format-aware encoder. The regression test for #162 lives in
+/// `mod get_map` above.
+struct EmptyMockMapEngine;
+
+impl MapEngine for EmptyMockMapEngine {
+    fn get_raster_tile(
+        &self,
+        _bbox: [f64; 4],
+        width: u32,
+        height: u32,
+        _time: Option<chrono::DateTime<chrono::Utc>>,
+        _output_crs: &OutputCrs,
+        _parameter: Option<&str>,
+    ) -> Result<RasterTile, DataServerError> {
+        let pixel_count = (width * height) as usize;
+        Ok(RasterTile {
+            width,
+            height,
+            values: vec![None; pixel_count],
+        })
+    }
+
+    fn raster_info(&self) -> RasterInfo {
+        MockMapEngine::make_info()
+    }
+}
+
+fn build_empty_router() -> axum::Router {
+    let engine: Arc<dyn MapEngine> = Arc::new(EmptyMockMapEngine);
+    let mut engines = HashMap::new();
+    let mut collections = HashMap::new();
+    let mut styles_map = HashMap::new();
+
+    engines.insert("empty".to_string(), engine);
+    collections.insert(
+        "empty".to_string(),
+        CollectionConfig {
+            id: "empty".to_string(),
+            title: "Empty".to_string(),
+            description: "All-nodata fixture for #162".to_string(),
+            data_path: None,
+            apis: vec!["maps".to_string()],
+            engine_type: "geotiff".to_string(),
+            geotiff: None,
+            querydata: None,
+            wms: None,
+            grib: None,
+            postgis: None,
+            preview: None,
+        },
+    );
+
+    let cmap = Arc::new(LutColorMap::from_builtin(
+        BuiltinColormap::Viridis,
+        0.0,
+        1.0,
+    ));
+    let mut layer_styles = HashMap::new();
+    layer_styles.insert(
+        "default".to_string(),
+        StyleInfo {
+            name: "default".to_string(),
+            title: "Default".to_string(),
+            colormap: cmap,
+            min: 0.0,
+            max: 1.0,
+            parameter: None,
+        },
+    );
+    styles_map.insert("empty".to_string(), layer_styles);
+
+    let state = Arc::new(ArcSwap::from_pointee(MapsState {
+        engines,
+        collections,
+        styles: styles_map,
+        render_semaphore: Arc::new(tokio::sync::Semaphore::new(4)),
+        rendered_cache: Arc::new(RenderedCache::new(16)),
+        base_url: String::new(),
+    }));
+    api_maps::router(state)
 }
 
 struct MultiParamMockEngine;

--- a/crates/api-tiles/src/handlers.rs
+++ b/crates/api-tiles/src/handlers.rs
@@ -1167,18 +1167,22 @@ async fn render_tile(
         TilesError::Internal(format!("Render failed: {e}"))
     })?;
 
-    // Empty tiles: return the pre-generated transparent PNG without caching.
-    let (image_bytes, x_cache) = match maybe_bytes {
-        None => (EMPTY_TILE_PNG.clone(), "EMPTY"),
+    // Empty tiles return the pre-generated transparent PNG without caching.
+    // Track the actual Content-Type per branch so the header never lies
+    // about the payload — previously a `?f=image/jpeg` request that hit an
+    // empty tile got PNG bytes with `Content-Type: image/jpeg`, breaking
+    // decoders that trust the type.
+    let (image_bytes, x_cache, response_content_type) = match maybe_bytes {
+        None => (EMPTY_TILE_PNG.clone(), "EMPTY", "image/png"),
         Some(bytes) => {
             let image_bytes = bytes::Bytes::from(bytes);
             rendered_cache.insert(cache_key, image_bytes.clone());
-            (image_bytes, "MISS")
+            (image_bytes, "MISS", content_type)
         }
     };
 
     Ok(axum::response::Response::builder()
-        .header(header::CONTENT_TYPE, content_type)
+        .header(header::CONTENT_TYPE, response_content_type)
         .header(header::ETAG, &etag)
         .header(header::CACHE_CONTROL, cache_control)
         .header(header::HeaderName::from_static("content-crs"), content_crs)

--- a/crates/api-tiles/tests/integration.rs
+++ b/crates/api-tiles/tests/integration.rs
@@ -547,6 +547,136 @@ mod get_tile {
         let resp = app.oneshot(req).await.unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
     }
+
+    /// Regression for #162: when the engine produces an all-nodata tile,
+    /// the handler short-circuits to the pre-generated `EMPTY_TILE_PNG`
+    /// global without going through the format-aware encoder. Before
+    /// the fix the response carried the *requested* Content-Type (e.g.
+    /// image/jpeg) over PNG bytes, breaking decoders that trust the
+    /// header. Both header and body must agree.
+    #[tokio::test]
+    async fn empty_tile_forces_png_content_type_even_when_jpeg_requested() {
+        let app = build_empty_router();
+        let req = Request::builder()
+            .uri("/collections/empty/tiles/WebMercatorQuad/0/0/0?f=image/jpeg")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let headers = resp.headers().clone();
+        assert_eq!(
+            headers.get("content-type").unwrap(),
+            "image/png",
+            "empty-tile response must self-declare PNG, not the requested image/jpeg"
+        );
+        assert_eq!(headers.get("x-cache").unwrap(), "EMPTY");
+        let body = resp.into_body().collect().await.unwrap().to_bytes();
+        assert!(
+            body.starts_with(&[0x89, b'P', b'N', b'G']),
+            "body must be a real PNG, got first bytes {:?}",
+            &body[..4.min(body.len())]
+        );
+    }
+
+    #[tokio::test]
+    async fn empty_tile_forces_png_content_type_even_when_webp_requested() {
+        let app = build_empty_router();
+        let req = Request::builder()
+            .uri("/collections/empty/tiles/WebMercatorQuad/0/0/0?f=image/webp")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let headers = resp.headers().clone();
+        assert_eq!(headers.get("content-type").unwrap(), "image/png");
+        assert_eq!(headers.get("x-cache").unwrap(), "EMPTY");
+    }
+}
+
+/// Mock engine that returns an all-`None` (all-nodata) `RasterTile` —
+/// drives the empty-tile fast path that bypasses the format-aware
+/// encoder. The regression test for #162 lives in `mod get_tile` above.
+struct EmptyMockMapEngine;
+
+impl MapEngine for EmptyMockMapEngine {
+    fn get_raster_tile(
+        &self,
+        _bbox: [f64; 4],
+        width: u32,
+        height: u32,
+        _time: Option<chrono::DateTime<chrono::Utc>>,
+        _output_crs: &OutputCrs,
+        _parameter: Option<&str>,
+    ) -> Result<RasterTile, DataServerError> {
+        let pixel_count = (width * height) as usize;
+        Ok(RasterTile {
+            width,
+            height,
+            values: vec![None; pixel_count],
+        })
+    }
+
+    fn raster_info(&self) -> RasterInfo {
+        MockMapEngine::make_info()
+    }
+}
+
+fn build_empty_router() -> axum::Router {
+    let engine: Arc<dyn MapEngine> = Arc::new(EmptyMockMapEngine);
+    let mut engines = HashMap::new();
+    let mut collections = HashMap::new();
+    let mut styles_map = HashMap::new();
+
+    engines.insert("empty".to_string(), engine);
+    collections.insert(
+        "empty".to_string(),
+        CollectionConfig {
+            id: "empty".to_string(),
+            title: "Empty".to_string(),
+            description: "All-nodata fixture for #162".to_string(),
+            data_path: None,
+            apis: vec!["tiles".to_string()],
+            engine_type: "geotiff".to_string(),
+            geotiff: None,
+            querydata: None,
+            wms: None,
+            grib: None,
+            postgis: None,
+            preview: None,
+        },
+    );
+
+    let cmap = Arc::new(LutColorMap::from_builtin(
+        BuiltinColormap::Viridis,
+        0.0,
+        1.0,
+    ));
+    let mut layer_styles = HashMap::new();
+    layer_styles.insert(
+        "default".to_string(),
+        StyleInfo {
+            name: "default".to_string(),
+            title: "Default".to_string(),
+            colormap: cmap,
+            min: 0.0,
+            max: 1.0,
+            parameter: None,
+        },
+    );
+    styles_map.insert("empty".to_string(), layer_styles);
+
+    let state = Arc::new(ArcSwap::from_pointee(TilesState {
+        map_engines: engines,
+        collections,
+        styles: styles_map,
+        feature_engines: HashMap::new(),
+        feature_collections: HashMap::new(),
+        render_semaphore: Arc::new(tokio::sync::Semaphore::new(4)),
+        rendered_cache: Arc::new(RenderedCache::new(16)),
+        vector_tile_cache: Arc::new(VectorTileCache::new(16)),
+        base_url: String::new(),
+    }));
+    api_tiles::router(state)
 }
 
 struct MultiParamMockEngine;

--- a/crates/api-wms/Cargo.toml
+++ b/crates/api-wms/Cargo.toml
@@ -14,3 +14,8 @@ quick-xml = "0.37"
 serde = { version = "1", features = ["derive"] }
 tokio = { version = "1", features = ["sync"] }
 tracing = "0.1"
+
+[dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+tower = { version = "0.5", features = ["util"] }
+http-body-util = "0.1"

--- a/crates/api-wms/src/handlers.rs
+++ b/crates/api-wms/src/handlers.rs
@@ -234,32 +234,39 @@ pub async fn wms_handler(
             .await
             .map_err(|e| WmsError::Internal(format!("Render task failed: {e}")))?;
 
-            let (image_bytes, x_cache) = match render_result {
+            // The EMPTY and ERROR fast paths skip the format-aware encoder and
+            // emit PNG bytes directly. Track the *actual* Content-Type per
+            // branch so the header never lies about the payload — previously
+            // a FORMAT=image/jpeg request that hit an empty tile got PNG
+            // bytes with `Content-Type: image/jpeg`, breaking decoders that
+            // trust the Content-Type.
+            let (image_bytes, x_cache, response_content_type) = match render_result {
                 Ok(Some(bytes)) => {
                     let image_bytes = bytes::Bytes::from(bytes);
                     rendered_cache.insert(cache_key, image_bytes.clone());
-                    (image_bytes, "MISS")
+                    (image_bytes, "MISS", content_type)
                 }
                 Ok(None) => {
-                    // Empty tile: return transparent PNG without caching
+                    // Empty tile: return transparent PNG without caching.
                     let rgba = vec![0u8; (params.width * params.height * 4) as usize];
                     let png =
                         ds_render::encode_png(&rgba, params.width, params.height).map_err(|e| {
                             WmsError::Internal(format!("Failed to encode empty tile: {e}"))
                         })?;
-                    (bytes::Bytes::from(png), "EMPTY")
+                    (bytes::Bytes::from(png), "EMPTY", "image/png")
                 }
                 Err(e) => {
                     tracing::warn!("WMS render error for layer '{}': {e}", params.layer);
                     (
                         bytes::Bytes::from(render_error_tile(params.width, params.height)?),
                         "ERROR",
+                        "image/png",
                     )
                 }
             };
 
             Ok(axum::response::Response::builder()
-                .header(header::CONTENT_TYPE, content_type)
+                .header(header::CONTENT_TYPE, response_content_type)
                 .header(header::ETAG, &etag)
                 .header(header::CACHE_CONTROL, cache_control)
                 .header(

--- a/crates/api-wms/tests/integration.rs
+++ b/crates/api-wms/tests/integration.rs
@@ -170,3 +170,129 @@ async fn empty_tile_forces_png_content_type_even_when_webp_requested() {
     assert_eq!(headers.get("content-type").unwrap(), "image/png");
     assert_eq!(headers.get("x-cache").unwrap(), "EMPTY");
 }
+
+/// Mock engine whose `get_raster_tile` always fails. Drives the WMS
+/// `Err(e)` branch that emits the red `render_error_tile` PNG with
+/// `X-Cache: ERROR`. WMS is the only handler that does this — Maps
+/// and Tiles propagate engine errors as JSON 500.
+struct FailingMockMapEngine;
+
+impl MapEngine for FailingMockMapEngine {
+    fn get_raster_tile(
+        &self,
+        _bbox: [f64; 4],
+        _width: u32,
+        _height: u32,
+        _time: Option<chrono::DateTime<chrono::Utc>>,
+        _output_crs: &OutputCrs,
+        _parameter: Option<&str>,
+    ) -> Result<RasterTile, DataServerError> {
+        Err(DataServerError::Engine("intentional render failure".into()))
+    }
+
+    fn raster_info(&self) -> RasterInfo {
+        RasterInfo {
+            native_crs: "EPSG:4326".into(),
+            spatial_extent: Some([10.0, 55.0, 30.0, 70.0]),
+            times: vec![chrono::DateTime::parse_from_rfc3339("2024-01-01T00:00:00Z")
+                .unwrap()
+                .with_timezone(&chrono::Utc)],
+            parameter: "reflectivity".into(),
+            unit: "dBZ".into(),
+            parameters: vec![],
+        }
+    }
+}
+
+/// WMS variant of [`build_empty_router`] for the engine-error path.
+fn build_failing_router() -> axum::Router {
+    let engine: Arc<dyn MapEngine> = Arc::new(FailingMockMapEngine);
+    let mut engines = HashMap::new();
+    let mut collections = HashMap::new();
+    let mut styles_map = HashMap::new();
+
+    engines.insert("broken".to_string(), engine);
+    collections.insert(
+        "broken".to_string(),
+        CollectionConfig {
+            id: "broken".to_string(),
+            title: "Broken".to_string(),
+            description: "Engine that always errors — for ERROR-path coverage".into(),
+            data_path: None,
+            apis: vec!["wms".to_string()],
+            engine_type: "geotiff".to_string(),
+            geotiff: None,
+            querydata: None,
+            wms: None,
+            grib: None,
+            postgis: None,
+            preview: None,
+        },
+    );
+
+    let cmap = Arc::new(LutColorMap::from_builtin(
+        BuiltinColormap::Viridis,
+        0.0,
+        1.0,
+    ));
+    let mut layer_styles = HashMap::new();
+    layer_styles.insert(
+        "default".to_string(),
+        StyleInfo {
+            name: "default".to_string(),
+            title: "Default".to_string(),
+            colormap: cmap,
+            min: 0.0,
+            max: 1.0,
+            parameter: None,
+        },
+    );
+    styles_map.insert("broken".to_string(), layer_styles);
+
+    let state = Arc::new(ArcSwap::from_pointee(WmsState {
+        engines,
+        collections,
+        styles: styles_map,
+        render_semaphore: Arc::new(tokio::sync::Semaphore::new(4)),
+        rendered_cache: Arc::new(RenderedCache::new(16)),
+        base_url: String::new(),
+    }));
+    api_wms::router(state)
+}
+
+/// Regression for #162 (WMS error-tile branch): when the engine
+/// returns `Err`, the handler swallows it and serves a red
+/// `render_error_tile` PNG with `X-Cache: ERROR`. The PR also fixed
+/// this branch to emit `Content-Type: image/png` instead of the
+/// requested-but-misleading `image/jpeg`/`image/webp`.
+#[tokio::test]
+async fn error_tile_forces_png_content_type_even_when_jpeg_requested() {
+    let app = build_failing_router();
+    let req = Request::builder()
+        .uri(
+            "/?SERVICE=WMS&REQUEST=GetMap&VERSION=1.3.0&LAYERS=broken\
+             &CRS=CRS:84&BBOX=10,55,30,70&WIDTH=64&HEIGHT=64\
+             &FORMAT=image/jpeg",
+        )
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "WMS swallows engine errors into a 200 + error-tile"
+    );
+    let headers = resp.headers().clone();
+    assert_eq!(
+        headers.get("content-type").unwrap(),
+        "image/png",
+        "error-tile response must self-declare PNG, not the requested image/jpeg"
+    );
+    assert_eq!(headers.get("x-cache").unwrap(), "ERROR");
+    let body = resp.into_body().collect().await.unwrap().to_bytes();
+    assert!(
+        body.starts_with(&[0x89, b'P', b'N', b'G']),
+        "body must be a real PNG, got first bytes {:?}",
+        &body[..4.min(body.len())]
+    );
+}

--- a/crates/api-wms/tests/integration.rs
+++ b/crates/api-wms/tests/integration.rs
@@ -1,0 +1,172 @@
+//! Integration tests for the WMS endpoint.
+//!
+//! The crate ships with handler-level unit tests in `src/error.rs` and
+//! `src/params.rs`. This file covers behaviours that only emerge once
+//! the router, mock engine, and full state are wired together — the
+//! seed test is the regression for #162 (empty-tile Content-Type
+//! mismatch when a non-PNG format is requested).
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use arc_swap::ArcSwap;
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use http_body_util::BodyExt;
+use tower::ServiceExt;
+
+use api_wms::WmsState;
+use ds_core::config::CollectionConfig;
+use ds_core::error::DataServerError;
+use ds_core::map_engine::{MapEngine, OutputCrs, RasterInfo, RasterTile};
+use ds_render::{BuiltinColormap, LutColorMap, RenderedCache, StyleInfo};
+
+/// Mock engine that returns an all-`None` (all-nodata) `RasterTile`.
+/// Drives the empty-tile fast path that bypasses the format-aware
+/// encoder and emits PNG bytes directly — the code path that #162
+/// fixed.
+struct EmptyMockMapEngine;
+
+impl MapEngine for EmptyMockMapEngine {
+    fn get_raster_tile(
+        &self,
+        _bbox: [f64; 4],
+        width: u32,
+        height: u32,
+        _time: Option<chrono::DateTime<chrono::Utc>>,
+        _output_crs: &OutputCrs,
+        _parameter: Option<&str>,
+    ) -> Result<RasterTile, DataServerError> {
+        let pixel_count = (width * height) as usize;
+        Ok(RasterTile {
+            width,
+            height,
+            values: vec![None; pixel_count],
+        })
+    }
+
+    fn raster_info(&self) -> RasterInfo {
+        RasterInfo {
+            native_crs: "EPSG:4326".into(),
+            spatial_extent: Some([10.0, 55.0, 30.0, 70.0]),
+            times: vec![chrono::DateTime::parse_from_rfc3339("2024-01-01T00:00:00Z")
+                .unwrap()
+                .with_timezone(&chrono::Utc)],
+            parameter: "reflectivity".into(),
+            unit: "dBZ".into(),
+            parameters: vec![],
+        }
+    }
+}
+
+/// Build a WMS router whose only collection (`empty`) is backed by
+/// `EmptyMockMapEngine`. Used by the empty-tile regression tests.
+fn build_empty_router() -> axum::Router {
+    let engine: Arc<dyn MapEngine> = Arc::new(EmptyMockMapEngine);
+    let mut engines = HashMap::new();
+    let mut collections = HashMap::new();
+    let mut styles_map = HashMap::new();
+
+    engines.insert("empty".to_string(), engine);
+    collections.insert(
+        "empty".to_string(),
+        CollectionConfig {
+            id: "empty".to_string(),
+            title: "Empty".to_string(),
+            description: "All-nodata fixture for #162".to_string(),
+            data_path: None,
+            apis: vec!["wms".to_string()],
+            engine_type: "geotiff".to_string(),
+            geotiff: None,
+            querydata: None,
+            wms: None,
+            grib: None,
+            postgis: None,
+            preview: None,
+        },
+    );
+
+    let cmap = Arc::new(LutColorMap::from_builtin(
+        BuiltinColormap::Viridis,
+        0.0,
+        1.0,
+    ));
+    let mut layer_styles = HashMap::new();
+    layer_styles.insert(
+        "default".to_string(),
+        StyleInfo {
+            name: "default".to_string(),
+            title: "Default".to_string(),
+            colormap: cmap,
+            min: 0.0,
+            max: 1.0,
+            parameter: None,
+        },
+    );
+    styles_map.insert("empty".to_string(), layer_styles);
+
+    let state = Arc::new(ArcSwap::from_pointee(WmsState {
+        engines,
+        collections,
+        styles: styles_map,
+        render_semaphore: Arc::new(tokio::sync::Semaphore::new(4)),
+        rendered_cache: Arc::new(RenderedCache::new(16)),
+        base_url: String::new(),
+    }));
+    api_wms::router(state)
+}
+
+/// Regression for #162: when the engine produces an all-nodata tile,
+/// the WMS GetMap handler short-circuits to a freshly-encoded
+/// transparent PNG without going through the format-aware encoder.
+/// Before the fix the response carried the *requested* Content-Type
+/// (e.g. `image/jpeg`) over PNG bytes, breaking decoders that trust
+/// the header. Both header and body must agree.
+#[tokio::test]
+async fn empty_tile_forces_png_content_type_even_when_jpeg_requested() {
+    let app = build_empty_router();
+    let req = Request::builder()
+        .uri(
+            "/?SERVICE=WMS&REQUEST=GetMap&VERSION=1.3.0&LAYERS=empty\
+             &CRS=CRS:84&BBOX=10,55,30,70&WIDTH=64&HEIGHT=64\
+             &FORMAT=image/jpeg",
+        )
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let headers = resp.headers().clone();
+    assert_eq!(
+        headers.get("content-type").unwrap(),
+        "image/png",
+        "empty-tile response must self-declare PNG, not the requested image/jpeg"
+    );
+    assert_eq!(headers.get("x-cache").unwrap(), "EMPTY");
+    let body = resp.into_body().collect().await.unwrap().to_bytes();
+    assert!(
+        body.starts_with(&[0x89, b'P', b'N', b'G']),
+        "body must be a real PNG, got first bytes {:?}",
+        &body[..4.min(body.len())]
+    );
+}
+
+#[tokio::test]
+async fn empty_tile_forces_png_content_type_even_when_webp_requested() {
+    // Second format for symmetry — WebP takes a distinct `ImageFormat`
+    // branch through the cache key, so this exercises a different code
+    // path than the JPEG case above.
+    let app = build_empty_router();
+    let req = Request::builder()
+        .uri(
+            "/?SERVICE=WMS&REQUEST=GetMap&VERSION=1.3.0&LAYERS=empty\
+             &CRS=CRS:84&BBOX=10,55,30,70&WIDTH=64&HEIGHT=64\
+             &FORMAT=image/webp",
+        )
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let headers = resp.headers().clone();
+    assert_eq!(headers.get("content-type").unwrap(), "image/png");
+    assert_eq!(headers.get("x-cache").unwrap(), "EMPTY");
+}


### PR DESCRIPTION
## Summary

Closes #162.

When a GetMap / map / tile request hit an all-nodata tile, the three render handlers short-circuited and returned a transparent PNG without going through the format-aware encoder — but the \`Content-Type\` header had already been computed from the *requested* \`FORMAT\`/\`f=\`. A client asking for \`image/jpeg\` or \`image/webp\` who landed on an empty tile got PNG bytes with \`Content-Type: image/jpeg\` (or \`.../webp\`), breaking decoders that trust the header.

### Fix shape — same in all three handlers

Track \`Content-Type\` alongside the body in the match arm so the fast paths can emit \`image/png\` truthfully:

\`\`\`rust
let (image_bytes, x_cache, response_content_type) = match ... {
    Ok(Some(bytes)) => (..., \"MISS\",  content_type /* requested */),
    Ok(None)        => (..., \"EMPTY\", \"image/png\"),
    Err(e)          => (..., \"ERROR\", \"image/png\"),  // WMS only
};
\`\`\`

### Why option 2 (issue #162 enumerated three)

This is the issue author's recommended option: smallest change, truthful header, fast path preserved. Option 1 (re-encode into the requested format) would erase the empty-tile fast-path benefit, and JPEG can't carry alpha anyway so its \"empty\" output is degenerate either way.

### Affected files

- \`crates/api-wms/src/handlers.rs\` — covers both the \`Ok(None)\` empty branch and the \`Err(e)\` error-tile branch. \`render_error_tile\` also emits PNG, so it was lying about Content-Type via the same code path.
- \`crates/api-maps/src/handlers.rs\` — \`Ok(None)\` branch only (errors return JSON 500 from \`MapsError::Internal\`).
- \`crates/api-tiles/src/handlers.rs\` — uses the pre-generated \`EMPTY_TILE_PNG\` global. Same fix shape.
- \`README.md\` — amend the Tiles \"Raster Tiles\" step 4 to mention \`Content-Type: image/png\` on EMPTY and explain the rationale.

### Trade-off documented

The README now spells out the consequence: clients with strict JPEG/WebP pipelines should check \`X-Cache: EMPTY\` and refetch only if needed. The alternative (re-encoding a known-uniform RGBA buffer on every empty tile) burns CPU for negligible benefit, and JPEG-with-alpha doesn't exist anyway.

## Test plan

- [x] \`cargo test -p api-wms -p api-maps -p api-tiles\` — all existing tests still pass
- [x] \`cargo clippy -p api-wms -p api-maps -p api-tiles\` clean
- [x] \`cargo fmt --check\` clean
- [ ] Reviewer eyeballs the three match-arm sites for symmetry
- [ ] Manual: \`curl '...REQUEST=GetMap&FORMAT=image/jpeg&BBOX=<empty-area>'\` returns \`Content-Type: image/png\` with \`X-Cache: EMPTY\`