### PR TITLE
ci(release): restore versioned release-PR title

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,6 +5,7 @@
   "include-v-in-tag": true,
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": false,
+  "pull-request-title-pattern": "chore${scope}: release ${version}",
   "plugins": [
     {
       "type": "cargo-workspace",


### PR DESCRIPTION
## Summary

Cosmetic follow-up to #168.

Enabling the \`cargo-workspace\` plugin in #168 switched release-please from per-component mode to merged mode. The default merged-mode title is \`chore: release main\` — the version is dropped, which makes it hard to scan the release queue at a glance.

Set \`pull-request-title-pattern\` to restore the per-component style:

\`\`\`json
\"pull-request-title-pattern\": \"chore\${scope}: release \${version}\"
\`\`\`

Expands to \`chore(main): release 0.3.0\` (same shape the per-component default produced before #168).

## What this affects

| | Before this PR | After this PR |
|---|---|---|
| Tag | \`v0.3.0\` | \`v0.3.0\` (unchanged) |
| CHANGELOG content | unchanged | unchanged |
| Cargo.lock bump | yes (from #168) | yes (unchanged) |
| Release-PR title | \`chore: release main\` | \`chore(main): release 0.3.0\` |

Open release PR #173 will be retitled on the next release-please workflow run after this lands.

## Test plan

- [x] \`python3 -c 'import json; json.load(open(\"release-please-config.json\"))'\` — JSON valid
- [ ] Reviewer eyeballs the placeholder syntax against release-please docs (\`\${scope}\`, \`\${version}\`)
- [ ] Post-merge: confirm #173's title updates from \`chore: release main\` to \`chore(main): release 0.3.0\`