### PR TITLE
fix(wms,maps,tiles): content-derived ETag for raster responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -902,7 +902,7 @@ PNG/WebP responses are always RGBA (transparent for empty tiles). JPEG is RGB. E
 - `Content-Crs:` OGC URI of the output CRS
 - `ETag:` derived from the cache key (quantized bbox + layer + style + format + CRS + width + height + time + parameter)
 - `Cache-Control: public, max-age=86400, immutable` when `datetime` is set; `public, max-age=60, must-revalidate` otherwise
-- `X-Cache: HIT | MISS | EMPTY` for observability
+- `X-Cache: HIT | MISS | EMPTY` for observability (also set on `304 Not Modified` from the cache-HIT branch so clients can distinguish it from a post-render-revalidation 304)
 
 `If-None-Match` short-circuits to `304 Not Modified` before any cache lookup or rendering. An overloaded render semaphore returns `503 Service Unavailable` with the fixed body `{"code":"ServerBusy","description":"Server busy, try again later"}`. Internal errors return 500 with a redacted body; the original detail is captured via `tracing::warn!` for operators.
 

--- a/README.md
+++ b/README.md
@@ -794,7 +794,7 @@ Errors are returned as `ServiceExceptionReport` XML with WMS 1.3.0 error codes: 
 5. On miss: acquire a render semaphore permit (timed out → 503). Run `MapEngine::get_raster_tile()` on a blocking thread — the engine projects the bbox into the source CRS, picks the best overview, reads source tiles, and resamples (nearest-neighbor).
 6. Empty (all-nodata) tile: encode a transparent PNG with `Content-Type: image/png`. Error: render the red error tile (WMS only). Neither is inserted into the cache.
 7. Populated tile: colorize (LUT for discrete data, linear gradient for continuous), encode to PNG/JPEG/WebP, wrap in `CachedRendered` (which derives the ETag via FNV-1a over the bytes), and insert into the cache.
-8. Compare the freshly-computed ETag against `If-None-Match` — match → `304`, otherwise return the body with `X-Cache: MISS | EMPTY | ERROR`.
+8. Compare the freshly-computed ETag against `If-None-Match` — match → `304` carrying the same `X-Cache` label the 200 would have (`MISS`, `EMPTY`, or `ERROR`), otherwise return the body with `X-Cache: MISS | EMPTY | ERROR`. Revalidations stay categorised the same as initial fetches on dashboards.
 
 ### Styling (shared with Maps and Tiles)
 
@@ -902,7 +902,7 @@ PNG/WebP responses are always RGBA (transparent for empty tiles). JPEG is RGB. E
 - `Content-Crs:` OGC URI of the output CRS
 - `ETag:` FNV-1a hash of the encoded response body — changes whenever the rendered pixels change, regardless of whether the cache key changed. This is what makes a server-side fix (e.g. colormap correction) invalidate stale browser caches instead of letting them serve infinite `304`s.
 - `Cache-Control: public, max-age=86400, immutable` when `datetime` is set; `public, max-age=60, must-revalidate` otherwise
-- `X-Cache: HIT | MISS | EMPTY` for observability. Set on every 200 and 304 response: `HIT` for cache-hit revalidations, `MISS` for post-render revalidations, `EMPTY` for transparent-tile fast-paths. Operators can grep dashboards by the value rather than reasoning about header absence.
+- `X-Cache: HIT | MISS | EMPTY | ERROR` for observability. Set on every 200 and 304 response: `HIT` for cache-hit revalidations, `MISS` for post-render revalidations, `EMPTY` for transparent-tile fast-paths, `ERROR` for the WMS error-tile fallback. The 304 carries the same label the 200 would, so revalidations stay in their original dashboard category. Operators can grep by value rather than reasoning about header absence.
 
 `If-None-Match` is evaluated against the content-derived ETag from the cache hit or the freshly-rendered bytes — not before the cache lookup. An overloaded render semaphore returns `503 Service Unavailable` with the fixed body `{"code":"ServerBusy","description":"Server busy, try again later"}`. Internal errors return 500 with a redacted body; the original detail is captured via `tracing::warn!` for operators.
 

--- a/README.md
+++ b/README.md
@@ -789,12 +789,12 @@ Errors are returned as `ServiceExceptionReport` XML with WMS 1.3.0 error codes: 
 
 1. Parse and validate WMS parameters; normalize BBOX to WGS84 `[west, south, east, north]`.
 2. Resolve `MapEngine` by collection ID. For `{id}/{param}` layers, validate `{param}` against `RasterInfo::parameters`.
-3. Build a cache key from quantized bbox, layer, style, format, CRS, width, height, time, and parameter, and compute its ETag.
-4. If the request carries `If-None-Match` and the ETag matches, return `304 Not Modified` immediately.
-5. Check the rendered-image cache (shared LRU). On hit: serve with `X-Cache: HIT`.
-6. On miss: acquire a render semaphore permit (timed out → 503). Run `MapEngine::get_raster_tile()` on a blocking thread — the engine projects the bbox into the source CRS, picks the best overview, reads source tiles, and resamples (nearest-neighbor).
-7. If the tile is all nodata, return a transparent PNG and do not cache.
-8. Otherwise colorize (LUT for discrete data, linear gradient for continuous), encode to PNG/JPEG/WebP, cache, and serve with `X-Cache: MISS`.
+3. Build a cache key from quantized bbox, layer, style, format, CRS, width, height, time, and parameter.
+4. Check the rendered-image cache (shared LRU). On hit: compare the cached entry's content-derived ETag against `If-None-Match` — match → `304` with `X-Cache: HIT`, otherwise return the cached bytes with `X-Cache: HIT`.
+5. On miss: acquire a render semaphore permit (timed out → 503). Run `MapEngine::get_raster_tile()` on a blocking thread — the engine projects the bbox into the source CRS, picks the best overview, reads source tiles, and resamples (nearest-neighbor).
+6. Empty (all-nodata) tile: encode a transparent PNG with `Content-Type: image/png`. Error: render the red error tile (WMS only). Neither is inserted into the cache.
+7. Populated tile: colorize (LUT for discrete data, linear gradient for continuous), encode to PNG/JPEG/WebP, wrap in `CachedRendered` (which derives the ETag via FNV-1a over the bytes), and insert into the cache.
+8. Compare the freshly-computed ETag against `If-None-Match` — match → `304`, otherwise return the body with `X-Cache: MISS | EMPTY | ERROR`.
 
 ### Styling (shared with Maps and Tiles)
 
@@ -900,11 +900,11 @@ PNG/WebP responses are always RGBA (transparent for empty tiles). JPEG is RGB. E
 
 - `Content-Type: image/png|image/jpeg|image/webp`
 - `Content-Crs:` OGC URI of the output CRS
-- `ETag:` derived from the cache key (quantized bbox + layer + style + format + CRS + width + height + time + parameter)
+- `ETag:` FNV-1a hash of the encoded response body — changes whenever the rendered pixels change, regardless of whether the cache key changed. This is what makes a server-side fix (e.g. colormap correction) invalidate stale browser caches instead of letting them serve infinite `304`s.
 - `Cache-Control: public, max-age=86400, immutable` when `datetime` is set; `public, max-age=60, must-revalidate` otherwise
 - `X-Cache: HIT | MISS | EMPTY` for observability (also set on `304 Not Modified` from the cache-HIT branch so clients can distinguish it from a post-render-revalidation 304)
 
-`If-None-Match` short-circuits to `304 Not Modified` before any cache lookup or rendering. An overloaded render semaphore returns `503 Service Unavailable` with the fixed body `{"code":"ServerBusy","description":"Server busy, try again later"}`. Internal errors return 500 with a redacted body; the original detail is captured via `tracing::warn!` for operators.
+`If-None-Match` is evaluated against the content-derived ETag from the cache hit or the freshly-rendered bytes — not before the cache lookup. An overloaded render semaphore returns `503 Service Unavailable` with the fixed body `{"code":"ServerBusy","description":"Server busy, try again later"}`. Internal errors return 500 with a redacted body; the original detail is captured via `tracing::warn!` for operators.
 
 ### Differences from WMS
 

--- a/README.md
+++ b/README.md
@@ -902,7 +902,7 @@ PNG/WebP responses are always RGBA (transparent for empty tiles). JPEG is RGB. E
 - `Content-Crs:` OGC URI of the output CRS
 - `ETag:` FNV-1a hash of the encoded response body — changes whenever the rendered pixels change, regardless of whether the cache key changed. This is what makes a server-side fix (e.g. colormap correction) invalidate stale browser caches instead of letting them serve infinite `304`s.
 - `Cache-Control: public, max-age=86400, immutable` when `datetime` is set; `public, max-age=60, must-revalidate` otherwise
-- `X-Cache: HIT | MISS | EMPTY` for observability (also set on `304 Not Modified` from the cache-HIT branch so clients can distinguish it from a post-render-revalidation 304)
+- `X-Cache: HIT | MISS | EMPTY` for observability. Set on every 200 and 304 response: `HIT` for cache-hit revalidations, `MISS` for post-render revalidations, `EMPTY` for transparent-tile fast-paths. Operators can grep dashboards by the value rather than reasoning about header absence.
 
 `If-None-Match` is evaluated against the content-derived ETag from the cache hit or the freshly-rendered bytes — not before the cache lookup. An overloaded render semaphore returns `503 Service Unavailable` with the fixed body `{"code":"ServerBusy","description":"Server busy, try again later"}`. Internal errors return 500 with a redacted body; the original detail is captured via `tracing::warn!` for operators.
 

--- a/crates/api-maps/src/handlers.rs
+++ b/crates/api-maps/src/handlers.rs
@@ -767,10 +767,15 @@ async fn render_map(
     if let Some(cached) = state.rendered_cache.get(&cache_key) {
         if let Some(ref inm) = if_none_match {
             if ds_render::etag_matches(inm, cached.etag()) {
+                // 304 from the cache-HIT branch. The `x-cache: HIT` header
+                // lets the regression test (and curious clients) distinguish
+                // this from a post-render MISS→304, which the handler also
+                // serves.
                 return Ok(axum::response::Response::builder()
                     .status(StatusCode::NOT_MODIFIED)
                     .header(header::ETAG, cached.etag())
                     .header(header::CACHE_CONTROL, cache_control)
+                    .header(header::HeaderName::from_static("x-cache"), "HIT")
                     .body(axum::body::Body::empty())
                     .unwrap()
                     .into_response());

--- a/crates/api-maps/src/handlers.rs
+++ b/crates/api-maps/src/handlers.rs
@@ -837,10 +837,16 @@ async fn render_map(
     // `CachedRendered` so the response ETag is FNV-1a over the actual
     // bytes — different pixels, different ETag — regardless of which
     // exit we take (#145).
-    let (cached, x_cache, response_content_type, insert_into_cache) = match render_result {
+    // Each arm produces a `CachedRendered` ready to serve. Only the
+    // populated `Ok(Some(_))` path inserts into the rendered cache; the
+    // EMPTY fast-path intentionally doesn't (its bytes are deterministic
+    // for fixed dimensions). Engine errors bail with 500 before this
+    // match.
+    let (cached, x_cache, response_content_type) = match render_result {
         Ok(Some(bytes)) => {
             let cached = ds_render::CachedRendered::new(bytes::Bytes::from(bytes));
-            (cached, "MISS", content_type, true)
+            rendered_cache.insert(cache_key, cached.clone());
+            (cached, "MISS", content_type)
         }
         Ok(None) => {
             // Empty tile: transparent PNG, never cached.
@@ -848,7 +854,7 @@ async fn render_map(
             let png = ds_render::encode_png(&rgba, width, height)
                 .map_err(|e| MapsError::Internal(format!("Failed to encode empty tile: {e}")))?;
             let cached = ds_render::CachedRendered::new(bytes::Bytes::from(png));
-            (cached, "EMPTY", "image/png", false)
+            (cached, "EMPTY", "image/png")
         }
         Err(e) => {
             tracing::warn!("Maps render error for collection '{}': {e}", collection_id);
@@ -856,22 +862,19 @@ async fn render_map(
         }
     };
 
-    if insert_into_cache {
-        rendered_cache.insert(cache_key, cached.clone());
-    }
-
     // Content-derived ETag now available — do the `If-None-Match`
     // comparison here, after rendering. Same flow as `render_vector_tile`
-    // in api-tiles. `x-cache` is *intentionally* absent on this 304: the
-    // cache-HIT 304 above emits `x-cache: HIT`, and the absence here is
-    // what lets clients (and the regression test) tell the two branches
-    // apart. Adding `x-cache: MISS` here would silently break that.
+    // in api-tiles. Emit `x-cache: MISS` so operators can tell
+    // post-render revalidations apart from cache-hit revalidations in
+    // logs/metrics, and tests can pin either branch by the *value* of
+    // the header rather than by its absence.
     if let Some(ref inm) = if_none_match {
         if ds_render::etag_matches(inm, cached.etag()) {
             return Ok(axum::response::Response::builder()
                 .status(StatusCode::NOT_MODIFIED)
                 .header(header::ETAG, cached.etag())
                 .header(header::CACHE_CONTROL, cache_control)
+                .header(header::HeaderName::from_static("x-cache"), "MISS")
                 .body(axum::body::Body::empty())
                 .unwrap()
                 .into_response());

--- a/crates/api-maps/src/handlers.rs
+++ b/crates/api-maps/src/handlers.rs
@@ -864,17 +864,18 @@ async fn render_map(
 
     // Content-derived ETag now available — do the `If-None-Match`
     // comparison here, after rendering. Same flow as `render_vector_tile`
-    // in api-tiles. Emit `x-cache: MISS` so operators can tell
-    // post-render revalidations apart from cache-hit revalidations in
-    // logs/metrics, and tests can pin either branch by the *value* of
-    // the header rather than by its absence.
+    // in api-tiles. Forward the same `x_cache` label the 200 response
+    // would carry (`"MISS"` or `"EMPTY"`) so revalidations look the
+    // same on dashboards as initial fetches — a client revalidating a
+    // cached transparent-tile response sees `304 x-cache: EMPTY`, not
+    // a misleading `MISS`.
     if let Some(ref inm) = if_none_match {
         if ds_render::etag_matches(inm, cached.etag()) {
             return Ok(axum::response::Response::builder()
                 .status(StatusCode::NOT_MODIFIED)
                 .header(header::ETAG, cached.etag())
                 .header(header::CACHE_CONTROL, cache_control)
-                .header(header::HeaderName::from_static("x-cache"), "MISS")
+                .header(header::HeaderName::from_static("x-cache"), x_cache)
                 .body(axum::body::Body::empty())
                 .unwrap()
                 .into_response());

--- a/crates/api-maps/src/handlers.rs
+++ b/crates/api-maps/src/handlers.rs
@@ -786,7 +786,7 @@ async fn render_map(
                 "nosniff",
             )
             .header(header::HeaderName::from_static("x-cache"), "HIT")
-            .body(axum::body::Body::from(cached.bytes))
+            .body(axum::body::Body::from(cached.into_bytes()))
             .unwrap()
             .into_response());
     }
@@ -880,7 +880,7 @@ async fn render_map(
             "nosniff",
         )
         .header(header::HeaderName::from_static("x-cache"), x_cache)
-        .body(axum::body::Body::from(cached.bytes))
+        .body(axum::body::Body::from(cached.into_bytes()))
         .unwrap()
         .into_response())
 }

--- a/crates/api-maps/src/handlers.rs
+++ b/crates/api-maps/src/handlers.rs
@@ -752,29 +752,33 @@ async fn render_map(
         parameter: effective_parameter.clone(),
     };
 
-    let etag = cache_key.etag();
     let cache_control = cache_control_value(has_explicit_time);
+    let if_none_match = headers
+        .get(header::IF_NONE_MATCH)
+        .and_then(|h| h.to_str().ok())
+        .map(str::to_string);
 
-    // Check If-None-Match — return 304 before any cache lookup or rendering
-    if let Some(inm) = headers.get(header::IF_NONE_MATCH) {
-        if let Ok(inm_str) = inm.to_str() {
-            if ds_render::etag_matches(inm_str, &etag) {
+    // Cache lookup runs BEFORE the If-None-Match check. The ETag is
+    // content-derived (see `CachedRendered::new`), so a key-derived 304
+    // short-circuit would be wrong: it would let a browser holding the
+    // pre-fix entry keep getting 304 after the server starts producing
+    // different pixels. Mirror the MVT path in `render_vector_tile`
+    // (the bug #145 fixed for raster tiles).
+    if let Some(cached) = state.rendered_cache.get(&cache_key) {
+        if let Some(ref inm) = if_none_match {
+            if ds_render::etag_matches(inm, cached.etag()) {
                 return Ok(axum::response::Response::builder()
                     .status(StatusCode::NOT_MODIFIED)
-                    .header(header::ETAG, &etag)
+                    .header(header::ETAG, cached.etag())
                     .header(header::CACHE_CONTROL, cache_control)
                     .body(axum::body::Body::empty())
                     .unwrap()
                     .into_response());
             }
         }
-    }
-
-    // Check rendered cache
-    if let Some(cached) = state.rendered_cache.get(&cache_key) {
         return Ok(axum::response::Response::builder()
             .header(header::CONTENT_TYPE, content_type)
-            .header(header::ETAG, &etag)
+            .header(header::ETAG, cached.etag())
             .header(header::CACHE_CONTROL, cache_control)
             .header(header::HeaderName::from_static("content-crs"), content_crs)
             .header(
@@ -782,7 +786,7 @@ async fn render_map(
                 "nosniff",
             )
             .header(header::HeaderName::from_static("x-cache"), "HIT")
-            .body(axum::body::Body::from(cached))
+            .body(axum::body::Body::from(cached.bytes))
             .unwrap()
             .into_response());
     }
@@ -824,21 +828,22 @@ async fn render_map(
 
     // The EMPTY fast path skips the format-aware encoder and emits PNG
     // bytes directly. Track the actual Content-Type per branch so the
-    // header never lies about the payload — previously an `f=image/jpeg`
-    // request that hit an empty tile got PNG bytes with
-    // `Content-Type: image/jpeg`, breaking decoders that trust the type.
-    let (image_bytes, x_cache, response_content_type) = match render_result {
+    // header never lies about the payload (#162). Wrap every branch in
+    // `CachedRendered` so the response ETag is FNV-1a over the actual
+    // bytes — different pixels, different ETag — regardless of which
+    // exit we take (#145).
+    let (cached, x_cache, response_content_type, insert_into_cache) = match render_result {
         Ok(Some(bytes)) => {
-            let image_bytes = bytes::Bytes::from(bytes);
-            rendered_cache.insert(cache_key, image_bytes.clone());
-            (image_bytes, "MISS", content_type)
+            let cached = ds_render::CachedRendered::new(bytes::Bytes::from(bytes));
+            (cached, "MISS", content_type, true)
         }
         Ok(None) => {
-            // Empty tile: return transparent PNG without caching.
+            // Empty tile: transparent PNG, never cached.
             let rgba = vec![0u8; (width * height * 4) as usize];
             let png = ds_render::encode_png(&rgba, width, height)
                 .map_err(|e| MapsError::Internal(format!("Failed to encode empty tile: {e}")))?;
-            (bytes::Bytes::from(png), "EMPTY", "image/png")
+            let cached = ds_render::CachedRendered::new(bytes::Bytes::from(png));
+            (cached, "EMPTY", "image/png", false)
         }
         Err(e) => {
             tracing::warn!("Maps render error for collection '{}': {e}", collection_id);
@@ -846,9 +851,28 @@ async fn render_map(
         }
     };
 
+    if insert_into_cache {
+        rendered_cache.insert(cache_key, cached.clone());
+    }
+
+    // Content-derived ETag now available — do the `If-None-Match`
+    // comparison here, after rendering. Same flow as `render_vector_tile`
+    // in api-tiles.
+    if let Some(ref inm) = if_none_match {
+        if ds_render::etag_matches(inm, cached.etag()) {
+            return Ok(axum::response::Response::builder()
+                .status(StatusCode::NOT_MODIFIED)
+                .header(header::ETAG, cached.etag())
+                .header(header::CACHE_CONTROL, cache_control)
+                .body(axum::body::Body::empty())
+                .unwrap()
+                .into_response());
+        }
+    }
+
     Ok(axum::response::Response::builder()
         .header(header::CONTENT_TYPE, response_content_type)
-        .header(header::ETAG, &etag)
+        .header(header::ETAG, cached.etag())
         .header(header::CACHE_CONTROL, cache_control)
         .header(header::HeaderName::from_static("content-crs"), content_crs)
         .header(
@@ -856,7 +880,7 @@ async fn render_map(
             "nosniff",
         )
         .header(header::HeaderName::from_static("x-cache"), x_cache)
-        .body(axum::body::Body::from(image_bytes))
+        .body(axum::body::Body::from(cached.bytes))
         .unwrap()
         .into_response())
 }

--- a/crates/api-maps/src/handlers.rs
+++ b/crates/api-maps/src/handlers.rs
@@ -862,7 +862,10 @@ async fn render_map(
 
     // Content-derived ETag now available — do the `If-None-Match`
     // comparison here, after rendering. Same flow as `render_vector_tile`
-    // in api-tiles.
+    // in api-tiles. `x-cache` is *intentionally* absent on this 304: the
+    // cache-HIT 304 above emits `x-cache: HIT`, and the absence here is
+    // what lets clients (and the regression test) tell the two branches
+    // apart. Adding `x-cache: MISS` here would silently break that.
     if let Some(ref inm) = if_none_match {
         if ds_render::etag_matches(inm, cached.etag()) {
             return Ok(axum::response::Response::builder()

--- a/crates/api-maps/tests/integration.rs
+++ b/crates/api-maps/tests/integration.rs
@@ -556,6 +556,51 @@ mod get_map {
         );
     }
 
+    /// Pin the post-render MISS → 304 branch. Use a fresh router (no
+    /// cache-warm) so the first `If-None-Match`-bearing request must
+    /// go through the full render path; assert the 304 carries
+    /// `x-cache: MISS` rather than the cache-HIT branch's `HIT`.
+    #[tokio::test]
+    async fn if_none_match_against_fresh_router_returns_304_via_miss_branch() {
+        // Step 1: render once on a separate fresh router to learn the ETag.
+        let etag = {
+            let warm = build_router();
+            let resp = warm
+                .oneshot(
+                    Request::builder()
+                        .uri("/collections/radar/map?bbox=10,55,30,70")
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            resp.headers()
+                .get("etag")
+                .unwrap()
+                .to_str()
+                .unwrap()
+                .to_string()
+        };
+
+        // Step 2: brand-new router with an empty cache. Handler must
+        // render, compute the same content-derived ETag, match the
+        // header, and 304 via the post-render branch.
+        let app = build_router();
+        let req = Request::builder()
+            .uri("/collections/radar/map?bbox=10,55,30,70")
+            .header("If-None-Match", &etag)
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_MODIFIED);
+        assert_eq!(resp.headers().get("etag").unwrap().to_str().unwrap(), etag);
+        assert_eq!(
+            resp.headers().get("x-cache").map(|v| v.to_str().unwrap()),
+            Some("MISS"),
+            "304 must come from the post-render MISS branch, not the cache-HIT branch"
+        );
+    }
+
     /// Cross-parameter staleness protection: different `parameter-name`
     /// values must produce different rendered bytes (because the
     /// `MultiParamMockEngine` varies its output by parameter), which under

--- a/crates/api-maps/tests/integration.rs
+++ b/crates/api-maps/tests/integration.rs
@@ -509,18 +509,37 @@ mod get_map {
         );
     }
 
-    /// Round-trip: a client revalidating with the body's content-derived
-    /// ETag must get a 304. Pins the full If-None-Match handshake.
+    /// Round-trip after a cache warm: a client revalidating with the
+    /// body's content-derived ETag must get a 304 via the **cache-HIT**
+    /// branch (the cache lookup happens before the If-None-Match check
+    /// — see `cached.etag()` comparison in the handler). Sharing one
+    /// router across both calls is load-bearing; building two routers
+    /// would leave the second call's `RenderedCache` empty and the 304
+    /// would fire on the post-render MISS branch instead.
     #[tokio::test]
-    async fn if_none_match_with_content_derived_etag_returns_304() {
-        let (_, headers_a, body) = get_raw("/collections/radar/map?bbox=10,55,30,70").await;
-        let etag = headers_a.get("etag").unwrap().to_str().unwrap().to_string();
-        let derived = ds_render::CachedRendered::new(bytes::Bytes::from(body))
-            .etag()
-            .to_string();
-        assert_eq!(etag, derived);
-
+    async fn if_none_match_after_cache_warm_returns_304_via_cache_hit() {
         let app = build_router();
+        // First request populates the rendered cache.
+        let resp_a = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/collections/radar/map?bbox=10,55,30,70")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let etag = resp_a
+            .headers()
+            .get("etag")
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .to_string();
+
+        // Cache is warm. Same key + matching If-None-Match → cache HIT →
+        // ETag compare against `cached.etag()` → 304.
         let req = Request::builder()
             .uri("/collections/radar/map?bbox=10,55,30,70")
             .header("If-None-Match", &etag)
@@ -531,27 +550,42 @@ mod get_map {
         assert_eq!(resp.headers().get("etag").unwrap().to_str().unwrap(), etag);
     }
 
+    /// Cross-parameter staleness protection: different `parameter-name`
+    /// values must produce different rendered bytes (because the
+    /// `MultiParamMockEngine` varies its output by parameter), which under
+    /// content-derived ETags (#145) means different ETags. Combined with
+    /// `parameter` being part of the cache key, a client switching
+    /// parameters can't get a 304 against the previous parameter's entry.
     #[tokio::test]
-    async fn parameter_name_produces_separate_cache_entries() {
-        // Different `parameter-name` values produce separate rendered-cache
-        // entries (the cache key still includes `parameter`), so a client
-        // switching parameters can't get a stale tile from a different
-        // parameter's slot. ETags are content-derived (#145), so two
-        // requests that happen to produce the same bytes (the mock engine
-        // ignores `parameter-name` for single-band engines) intentionally
-        // share an ETag — that's correct: identical bytes deserve identical
-        // ETags. The cross-parameter behaviour that actually matters is
-        // exercised against the multi-param engine, where the engine
-        // produces distinct pixels per parameter — see the test below.
-        let (_, headers_a, _) =
-            get_raw("/collections/radar/map?bbox=10,55,30,70&parameter-name=2t").await;
-        let (_, headers_b, _) =
-            get_raw("/collections/radar/map?bbox=10,55,30,70&parameter-name=10u").await;
-        // Both succeeded and both populated the rendered cache under
-        // different keys — the ETag value is whatever FNV-1a says about
-        // the bytes, so equality is the *expected* outcome here.
-        assert!(headers_a.contains_key("etag"));
-        assert!(headers_b.contains_key("etag"));
+    async fn parameter_name_changes_content_etag_on_multi_param_engine() {
+        let app = build_multi_param_router();
+        let resp_2t = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/collections/wx/map?bbox=10,55,30,70&parameter-name=2t")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let resp_10u = app
+            .oneshot(
+                Request::builder()
+                    .uri("/collections/wx/map?bbox=10,55,30,70&parameter-name=10u")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let etag_2t = resp_2t.headers().get("etag").unwrap().to_str().unwrap();
+        let etag_10u = resp_10u.headers().get("etag").unwrap().to_str().unwrap();
+        assert_ne!(
+            etag_2t, etag_10u,
+            "parameter-name varies the rendered pixels, so the content-derived \
+             ETag must differ — otherwise a client switching from 2t to 10u \
+             would get a stale 304"
+        );
     }
 
     #[tokio::test]
@@ -725,10 +759,25 @@ impl MapEngine for MultiParamMockEngine {
         height: u32,
         _time: Option<chrono::DateTime<chrono::Utc>>,
         _output_crs: &ds_core::map_engine::OutputCrs,
-        _parameter: Option<&str>,
+        parameter: Option<&str>,
     ) -> Result<ds_core::map_engine::RasterTile, ds_core::error::DataServerError> {
+        // Vary the pixel values by parameter so the `parameter` field on the
+        // cache key actually changes the rendered bytes — the cross-parameter
+        // ETag test depends on this. Fold the parameter name into a value
+        // in [0, 1] (within the style's min/max range) so the colormap
+        // produces a different uniform fill per parameter.
+        let fill: f64 = parameter
+            .map(|p| {
+                let mut h: u64 = 0xcbf29ce484222325;
+                for &b in p.as_bytes() {
+                    h ^= b as u64;
+                    h = h.wrapping_mul(0x100000001b3);
+                }
+                ((h & 0xff) as f64) / 255.0
+            })
+            .unwrap_or(0.0);
         let pixel_count = (width * height) as usize;
-        let values: Vec<Option<f64>> = (0..pixel_count).map(|i| Some(i as f64)).collect();
+        let values: Vec<Option<f64>> = vec![Some(fill); pixel_count];
         Ok(ds_core::map_engine::RasterTile {
             width,
             height,

--- a/crates/api-maps/tests/integration.rs
+++ b/crates/api-maps/tests/integration.rs
@@ -509,13 +509,14 @@ mod get_map {
         );
     }
 
-    /// Round-trip after a cache warm: a client revalidating with the
-    /// body's content-derived ETag must get a 304 via the **cache-HIT**
-    /// branch (the cache lookup happens before the If-None-Match check
-    /// — see `cached.etag()` comparison in the handler). Sharing one
-    /// router across both calls is load-bearing; building two routers
-    /// would leave the second call's `RenderedCache` empty and the 304
-    /// would fire on the post-render MISS branch instead.
+    /// Pin the cache-HIT→304 branch specifically. The handler returns 304
+    /// from two places: the cache-HIT branch (this test, asserted via
+    /// `x-cache: HIT`) and the post-render MISS branch (which also
+    /// compares `If-None-Match` against the freshly-computed ETag and
+    /// returns 304 when matched). A fresh router would still 304 — just
+    /// via the MISS path — so the `x-cache` assertion is what makes
+    /// "we exercised the HIT branch" testable. Sharing one router across
+    /// both calls is how we warm the cache for that branch.
     #[tokio::test]
     async fn if_none_match_after_cache_warm_returns_304_via_cache_hit() {
         let app = build_router();
@@ -539,7 +540,7 @@ mod get_map {
             .to_string();
 
         // Cache is warm. Same key + matching If-None-Match → cache HIT →
-        // ETag compare against `cached.etag()` → 304.
+        // ETag compare against `cached.etag()` → 304 with `x-cache: HIT`.
         let req = Request::builder()
             .uri("/collections/radar/map?bbox=10,55,30,70")
             .header("If-None-Match", &etag)
@@ -548,6 +549,11 @@ mod get_map {
         let resp = app.oneshot(req).await.unwrap();
         assert_eq!(resp.status(), StatusCode::NOT_MODIFIED);
         assert_eq!(resp.headers().get("etag").unwrap().to_str().unwrap(), etag);
+        assert_eq!(
+            resp.headers().get("x-cache").map(|v| v.to_str().unwrap()),
+            Some("HIT"),
+            "304 must come from the cache-HIT branch, not post-render MISS"
+        );
     }
 
     /// Cross-parameter staleness protection: different `parameter-name`

--- a/crates/api-maps/tests/integration.rs
+++ b/crates/api-maps/tests/integration.rs
@@ -714,6 +714,51 @@ mod get_map {
         assert_eq!(headers.get("content-type").unwrap(), "image/png");
         assert_eq!(headers.get("x-cache").unwrap(), "EMPTY");
     }
+
+    /// Revalidating a cached empty-tile response must round-trip the
+    /// `EMPTY` label. Empty tiles bypass `rendered_cache`, so an
+    /// `If-None-Match` request always falls through to the post-render
+    /// branch — exactly the branch the round-7 fix targets.
+    #[tokio::test]
+    async fn if_none_match_on_empty_tile_returns_304_with_x_cache_empty() {
+        let app = build_empty_router();
+        let uri = "/collections/empty/map?bbox=10,55,30,70&f=image/png";
+
+        let etag = {
+            let resp = app
+                .clone()
+                .oneshot(Request::builder().uri(uri).body(Body::empty()).unwrap())
+                .await
+                .unwrap();
+            assert_eq!(resp.headers().get("x-cache").unwrap(), "EMPTY");
+            resp.headers()
+                .get("etag")
+                .unwrap()
+                .to_str()
+                .unwrap()
+                .to_string()
+        };
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri(uri)
+                    .header("If-None-Match", &etag)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_MODIFIED);
+        assert_eq!(resp.headers().get("etag").unwrap().to_str().unwrap(), etag);
+        assert_eq!(
+            resp.headers().get("x-cache").map(|v| v.to_str().unwrap()),
+            Some("EMPTY"),
+            "post-render 304 must forward the `x_cache` label from the \
+             match arm, not hard-code `MISS` — otherwise revalidating an \
+             empty tile silently changes its dashboard category"
+        );
+    }
 }
 
 /// Mock engine that returns an all-`None` (all-nodata) `RasterTile`.

--- a/crates/api-maps/tests/integration.rs
+++ b/crates/api-maps/tests/integration.rs
@@ -488,20 +488,70 @@ mod get_map {
         assert!(body.starts_with(&[0x89, b'P', b'N', b'G']));
     }
 
+    /// Regression for #145: the response `ETag` must be FNV-1a over the
+    /// rendered bytes — not over the cache key — so a server-side fix that
+    /// produces different pixels under the same key surfaces a fresh ETag
+    /// and clients holding the stale entry refetch instead of receiving an
+    /// infinite 304. Direct check: build the same `CachedRendered` the
+    /// handler does and verify the header matches.
     #[tokio::test]
-    async fn parameter_name_changes_etag() {
-        // Different parameter-name values must produce different rendered-cache
-        // entries (and thus different ETags) — otherwise a client switching
-        // parameters would get a stale 304.
+    async fn etag_is_content_derived_over_response_body() {
+        let (status, headers, body) = get_raw("/collections/radar/map?bbox=10,55,30,70").await;
+        assert_eq!(status, StatusCode::OK);
+        let actual_etag = headers.get("etag").unwrap().to_str().unwrap();
+        let expected_etag = ds_render::CachedRendered::new(bytes::Bytes::from(body))
+            .etag()
+            .to_string();
+        assert_eq!(
+            actual_etag, expected_etag,
+            "ETag header must be FNV-1a over the response body (content-derived), \
+             not derived from the CacheKey — see #145"
+        );
+    }
+
+    /// Round-trip: a client revalidating with the body's content-derived
+    /// ETag must get a 304. Pins the full If-None-Match handshake.
+    #[tokio::test]
+    async fn if_none_match_with_content_derived_etag_returns_304() {
+        let (_, headers_a, body) = get_raw("/collections/radar/map?bbox=10,55,30,70").await;
+        let etag = headers_a.get("etag").unwrap().to_str().unwrap().to_string();
+        let derived = ds_render::CachedRendered::new(bytes::Bytes::from(body))
+            .etag()
+            .to_string();
+        assert_eq!(etag, derived);
+
+        let app = build_router();
+        let req = Request::builder()
+            .uri("/collections/radar/map?bbox=10,55,30,70")
+            .header("If-None-Match", &etag)
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_MODIFIED);
+        assert_eq!(resp.headers().get("etag").unwrap().to_str().unwrap(), etag);
+    }
+
+    #[tokio::test]
+    async fn parameter_name_produces_separate_cache_entries() {
+        // Different `parameter-name` values produce separate rendered-cache
+        // entries (the cache key still includes `parameter`), so a client
+        // switching parameters can't get a stale tile from a different
+        // parameter's slot. ETags are content-derived (#145), so two
+        // requests that happen to produce the same bytes (the mock engine
+        // ignores `parameter-name` for single-band engines) intentionally
+        // share an ETag — that's correct: identical bytes deserve identical
+        // ETags. The cross-parameter behaviour that actually matters is
+        // exercised against the multi-param engine, where the engine
+        // produces distinct pixels per parameter — see the test below.
         let (_, headers_a, _) =
             get_raw("/collections/radar/map?bbox=10,55,30,70&parameter-name=2t").await;
         let (_, headers_b, _) =
             get_raw("/collections/radar/map?bbox=10,55,30,70&parameter-name=10u").await;
-        assert_ne!(
-            headers_a.get("etag").unwrap(),
-            headers_b.get("etag").unwrap(),
-            "ETags must differ across parameter-name values"
-        );
+        // Both succeeded and both populated the rendered cache under
+        // different keys — the ETag value is whatever FNV-1a says about
+        // the bytes, so equality is the *expected* outcome here.
+        assert!(headers_a.contains_key("etag"));
+        assert!(headers_b.contains_key("etag"));
     }
 
     #[tokio::test]

--- a/crates/api-tiles/src/handlers.rs
+++ b/crates/api-tiles/src/handlers.rs
@@ -1107,10 +1107,15 @@ async fn render_tile(
     if let Some(cached) = state.rendered_cache.get(&cache_key) {
         if let Some(ref inm) = if_none_match {
             if ds_render::etag_matches(inm, cached.etag()) {
+                // 304 from the cache-HIT branch. The `x-cache: HIT` header
+                // lets the regression test (and curious clients) distinguish
+                // this from a post-render MISS→304, which the handler also
+                // serves.
                 return Ok(axum::response::Response::builder()
                     .status(StatusCode::NOT_MODIFIED)
                     .header(header::ETAG, cached.etag())
                     .header(header::CACHE_CONTROL, cache_control)
+                    .header(header::HeaderName::from_static("x-cache"), "HIT")
                     .body(axum::body::Body::empty())
                     .unwrap()
                     .into_response());

--- a/crates/api-tiles/src/handlers.rs
+++ b/crates/api-tiles/src/handlers.rs
@@ -1210,17 +1210,19 @@ async fn render_tile(
 
     // Content-derived ETag now available — do the `If-None-Match`
     // comparison here, after the (cheap) empty-tile clone or fresh
-    // encode. Emit `x-cache: MISS` so operators can tell post-render
-    // revalidations apart from cache-hit revalidations in logs/metrics,
-    // and tests can pin either branch by the *value* of the header
-    // rather than by its absence.
+    // encode. Forward the same `x_cache` label the 200 response would
+    // carry (`"MISS"` or `"EMPTY"`) so revalidations look the same
+    // on dashboards as initial fetches — a client revalidating a
+    // cached transparent-tile response sees `304 x-cache: EMPTY`,
+    // not a misleading `MISS`. This matters for any tile viewer
+    // panning over out-of-coverage areas.
     if let Some(ref inm) = if_none_match {
         if ds_render::etag_matches(inm, cached.etag()) {
             return Ok(axum::response::Response::builder()
                 .status(StatusCode::NOT_MODIFIED)
                 .header(header::ETAG, cached.etag())
                 .header(header::CACHE_CONTROL, cache_control)
-                .header(header::HeaderName::from_static("x-cache"), "MISS")
+                .header(header::HeaderName::from_static("x-cache"), x_cache)
                 .body(axum::body::Body::empty())
                 .unwrap()
                 .into_response());

--- a/crates/api-tiles/src/handlers.rs
+++ b/crates/api-tiles/src/handlers.rs
@@ -1092,29 +1092,33 @@ async fn render_tile(
         parameter: effective_parameter.clone(),
     };
 
-    let etag = cache_key.etag();
     let cache_control = cache_control_value(has_explicit_time);
+    let if_none_match = headers
+        .get(header::IF_NONE_MATCH)
+        .and_then(|h| h.to_str().ok())
+        .map(str::to_string);
 
-    // Check If-None-Match — return 304 before any cache lookup or rendering
-    if let Some(inm) = headers.get(header::IF_NONE_MATCH) {
-        if let Ok(inm_str) = inm.to_str() {
-            if ds_render::etag_matches(inm_str, &etag) {
+    // Cache lookup runs BEFORE the If-None-Match check. The ETag is
+    // content-derived (see `CachedRendered::new`), so a key-derived 304
+    // short-circuit would be wrong: it would let a browser holding the
+    // pre-fix entry keep getting 304 after the server starts producing
+    // different pixels. Mirror the MVT path in `render_vector_tile` (the
+    // bug #145 fixed for raster tiles).
+    if let Some(cached) = state.rendered_cache.get(&cache_key) {
+        if let Some(ref inm) = if_none_match {
+            if ds_render::etag_matches(inm, cached.etag()) {
                 return Ok(axum::response::Response::builder()
                     .status(StatusCode::NOT_MODIFIED)
-                    .header(header::ETAG, &etag)
+                    .header(header::ETAG, cached.etag())
                     .header(header::CACHE_CONTROL, cache_control)
                     .body(axum::body::Body::empty())
                     .unwrap()
                     .into_response());
             }
         }
-    }
-
-    // Check rendered cache
-    if let Some(cached) = state.rendered_cache.get(&cache_key) {
         return Ok(axum::response::Response::builder()
             .header(header::CONTENT_TYPE, content_type)
-            .header(header::ETAG, &etag)
+            .header(header::ETAG, cached.etag())
             .header(header::CACHE_CONTROL, cache_control)
             .header(header::HeaderName::from_static("content-crs"), content_crs)
             .header(
@@ -1122,7 +1126,7 @@ async fn render_tile(
                 "nosniff",
             )
             .header(header::HeaderName::from_static("x-cache"), "HIT")
-            .body(axum::body::Body::from(cached))
+            .body(axum::body::Body::from(cached.bytes))
             .unwrap()
             .into_response());
     }
@@ -1167,23 +1171,43 @@ async fn render_tile(
         TilesError::Internal(format!("Render failed: {e}"))
     })?;
 
-    // Empty tiles return the pre-generated transparent PNG without caching.
-    // Track the actual Content-Type per branch so the header never lies
-    // about the payload — previously a `?f=image/jpeg` request that hit an
-    // empty tile got PNG bytes with `Content-Type: image/jpeg`, breaking
-    // decoders that trust the type.
-    let (image_bytes, x_cache, response_content_type) = match maybe_bytes {
-        None => (EMPTY_TILE_PNG.clone(), "EMPTY", "image/png"),
+    // Empty tiles return the pre-generated transparent PNG without caching;
+    // populated tiles get cached. Wrap both in `CachedRendered` so the
+    // response ETag is FNV-1a over the actual bytes — different pixels
+    // produce different ETags (#145). Track the actual Content-Type per
+    // branch so the header never lies about the payload (#162).
+    let (cached, x_cache, response_content_type, insert_into_cache) = match maybe_bytes {
+        None => {
+            let cached = ds_render::CachedRendered::new(EMPTY_TILE_PNG.clone());
+            (cached, "EMPTY", "image/png", false)
+        }
         Some(bytes) => {
-            let image_bytes = bytes::Bytes::from(bytes);
-            rendered_cache.insert(cache_key, image_bytes.clone());
-            (image_bytes, "MISS", content_type)
+            let cached = ds_render::CachedRendered::new(bytes::Bytes::from(bytes));
+            (cached, "MISS", content_type, true)
         }
     };
 
+    if insert_into_cache {
+        rendered_cache.insert(cache_key, cached.clone());
+    }
+
+    // Content-derived ETag now available — do the `If-None-Match`
+    // comparison here, after the (cheap) empty-tile clone or fresh encode.
+    if let Some(ref inm) = if_none_match {
+        if ds_render::etag_matches(inm, cached.etag()) {
+            return Ok(axum::response::Response::builder()
+                .status(StatusCode::NOT_MODIFIED)
+                .header(header::ETAG, cached.etag())
+                .header(header::CACHE_CONTROL, cache_control)
+                .body(axum::body::Body::empty())
+                .unwrap()
+                .into_response());
+        }
+    }
+
     Ok(axum::response::Response::builder()
         .header(header::CONTENT_TYPE, response_content_type)
-        .header(header::ETAG, &etag)
+        .header(header::ETAG, cached.etag())
         .header(header::CACHE_CONTROL, cache_control)
         .header(header::HeaderName::from_static("content-crs"), content_crs)
         .header(
@@ -1191,7 +1215,7 @@ async fn render_tile(
             "nosniff",
         )
         .header(header::HeaderName::from_static("x-cache"), x_cache)
-        .body(axum::body::Body::from(image_bytes))
+        .body(axum::body::Body::from(cached.bytes))
         .unwrap()
         .into_response())
 }

--- a/crates/api-tiles/src/handlers.rs
+++ b/crates/api-tiles/src/handlers.rs
@@ -32,6 +32,17 @@ static EMPTY_TILE_PNG: LazyLock<bytes::Bytes> = LazyLock::new(|| {
     )
 });
 
+/// Companion to [`EMPTY_TILE_PNG`]: the same bytes wrapped in
+/// `CachedRendered`, so the FNV-1a hash that produces the empty-tile
+/// ETag is computed **once per process** instead of on every empty-tile
+/// response. Both fields are `Clone`-cheap (`Bytes` is `Arc`-backed,
+/// `String` is a 20-byte allocation done once), so cloning per request
+/// is essentially free. `api-maps` and `api-wms` cannot use this trick
+/// — they allocate fresh empty bytes per request to match the requested
+/// dimensions — but Tiles is always 256×256.
+static EMPTY_TILE_CACHED: LazyLock<ds_render::CachedRendered> =
+    LazyLock::new(|| ds_render::CachedRendered::new(EMPTY_TILE_PNG.clone()));
+
 /// Shared state for the OGC API Tiles service.
 #[derive(Clone)]
 pub struct TilesState {
@@ -1180,12 +1191,11 @@ async fn render_tile(
     // populated tiles get cached. Wrap both in `CachedRendered` so the
     // response ETag is FNV-1a over the actual bytes — different pixels
     // produce different ETags (#145). Track the actual Content-Type per
-    // branch so the header never lies about the payload (#162).
+    // branch so the header never lies about the payload (#162). Empty
+    // tiles reuse the global `EMPTY_TILE_CACHED` so the FNV-1a hash is
+    // computed once per process instead of per request.
     let (cached, x_cache, response_content_type, insert_into_cache) = match maybe_bytes {
-        None => {
-            let cached = ds_render::CachedRendered::new(EMPTY_TILE_PNG.clone());
-            (cached, "EMPTY", "image/png", false)
-        }
+        None => (EMPTY_TILE_CACHED.clone(), "EMPTY", "image/png", false),
         Some(bytes) => {
             let cached = ds_render::CachedRendered::new(bytes::Bytes::from(bytes));
             (cached, "MISS", content_type, true)

--- a/crates/api-tiles/src/handlers.rs
+++ b/crates/api-tiles/src/handlers.rs
@@ -1208,6 +1208,10 @@ async fn render_tile(
 
     // Content-derived ETag now available — do the `If-None-Match`
     // comparison here, after the (cheap) empty-tile clone or fresh encode.
+    // `x-cache` is *intentionally* absent on this 304: the cache-HIT 304
+    // above emits `x-cache: HIT`, and the absence here is what lets
+    // clients (and the regression test) tell the two branches apart.
+    // Adding `x-cache: MISS` here would silently break that.
     if let Some(ref inm) = if_none_match {
         if ds_render::etag_matches(inm, cached.etag()) {
             return Ok(axum::response::Response::builder()

--- a/crates/api-tiles/src/handlers.rs
+++ b/crates/api-tiles/src/handlers.rs
@@ -1194,30 +1194,33 @@ async fn render_tile(
     // branch so the header never lies about the payload (#162). Empty
     // tiles reuse the global `EMPTY_TILE_CACHED` so the FNV-1a hash is
     // computed once per process instead of per request.
-    let (cached, x_cache, response_content_type, insert_into_cache) = match maybe_bytes {
-        None => (EMPTY_TILE_CACHED.clone(), "EMPTY", "image/png", false),
+    // Each arm produces a `CachedRendered` ready to serve. Only the
+    // populated `Some(_)` path inserts into the rendered cache; the
+    // EMPTY fast-path intentionally doesn't (the global
+    // `EMPTY_TILE_CACHED` already serves as the deterministic empty
+    // response).
+    let (cached, x_cache, response_content_type) = match maybe_bytes {
+        None => (EMPTY_TILE_CACHED.clone(), "EMPTY", "image/png"),
         Some(bytes) => {
             let cached = ds_render::CachedRendered::new(bytes::Bytes::from(bytes));
-            (cached, "MISS", content_type, true)
+            rendered_cache.insert(cache_key, cached.clone());
+            (cached, "MISS", content_type)
         }
     };
 
-    if insert_into_cache {
-        rendered_cache.insert(cache_key, cached.clone());
-    }
-
     // Content-derived ETag now available — do the `If-None-Match`
-    // comparison here, after the (cheap) empty-tile clone or fresh encode.
-    // `x-cache` is *intentionally* absent on this 304: the cache-HIT 304
-    // above emits `x-cache: HIT`, and the absence here is what lets
-    // clients (and the regression test) tell the two branches apart.
-    // Adding `x-cache: MISS` here would silently break that.
+    // comparison here, after the (cheap) empty-tile clone or fresh
+    // encode. Emit `x-cache: MISS` so operators can tell post-render
+    // revalidations apart from cache-hit revalidations in logs/metrics,
+    // and tests can pin either branch by the *value* of the header
+    // rather than by its absence.
     if let Some(ref inm) = if_none_match {
         if ds_render::etag_matches(inm, cached.etag()) {
             return Ok(axum::response::Response::builder()
                 .status(StatusCode::NOT_MODIFIED)
                 .header(header::ETAG, cached.etag())
                 .header(header::CACHE_CONTROL, cache_control)
+                .header(header::HeaderName::from_static("x-cache"), "MISS")
                 .body(axum::body::Body::empty())
                 .unwrap()
                 .into_response());

--- a/crates/api-tiles/src/handlers.rs
+++ b/crates/api-tiles/src/handlers.rs
@@ -1126,7 +1126,7 @@ async fn render_tile(
                 "nosniff",
             )
             .header(header::HeaderName::from_static("x-cache"), "HIT")
-            .body(axum::body::Body::from(cached.bytes))
+            .body(axum::body::Body::from(cached.into_bytes()))
             .unwrap()
             .into_response());
     }
@@ -1215,7 +1215,7 @@ async fn render_tile(
             "nosniff",
         )
         .header(header::HeaderName::from_static("x-cache"), x_cache)
-        .body(axum::body::Body::from(cached.bytes))
+        .body(axum::body::Body::from(cached.into_bytes()))
         .unwrap()
         .into_response())
 }

--- a/crates/api-tiles/tests/integration.rs
+++ b/crates/api-tiles/tests/integration.rs
@@ -520,13 +520,11 @@ mod get_tile {
         );
     }
 
-    /// Round-trip after a cache warm: a client revalidating with the
-    /// body's content-derived ETag must get a 304 via the **cache-HIT**
-    /// branch (the cache lookup happens before the If-None-Match check
-    /// — see `cached.etag()` comparison in the handler). Sharing one
-    /// router across both calls is load-bearing; building two routers
-    /// would leave the second call's `RenderedCache` empty and the 304
-    /// would fire on the post-render MISS branch instead.
+    /// Pin the cache-HIT→304 branch specifically. The handler returns 304
+    /// from two places: the cache-HIT branch (this test, asserted via
+    /// `x-cache: HIT`) and the post-render MISS branch. A fresh router
+    /// would still 304 — just via the MISS path — so the `x-cache`
+    /// assertion is what makes "we exercised the HIT branch" testable.
     #[tokio::test]
     async fn if_none_match_after_cache_warm_returns_304_via_cache_hit() {
         let app = build_router();
@@ -559,6 +557,11 @@ mod get_tile {
             resp.headers().get("etag").unwrap().to_str().unwrap(),
             etag,
             "304 response must echo the same content-derived ETag"
+        );
+        assert_eq!(
+            resp.headers().get("x-cache").map(|v| v.to_str().unwrap()),
+            Some("HIT"),
+            "304 must come from the cache-HIT branch, not post-render MISS"
         );
     }
 

--- a/crates/api-tiles/tests/integration.rs
+++ b/crates/api-tiles/tests/integration.rs
@@ -725,6 +725,63 @@ mod get_tile {
         assert_eq!(headers.get("content-type").unwrap(), "image/png");
         assert_eq!(headers.get("x-cache").unwrap(), "EMPTY");
     }
+
+    /// Revalidating a cached empty-tile response must round-trip the
+    /// `EMPTY` label, not be silently re-tagged as `MISS`. Empty tiles
+    /// share the global `EMPTY_TILE_CACHED` (never inserted into
+    /// `rendered_cache`), so an `If-None-Match` request always falls
+    /// through to the post-render branch — which is exactly the branch
+    /// the round-7 fix targets. A viewer panning over out-of-coverage
+    /// areas would otherwise see `304 x-cache: MISS` for every empty
+    /// tile, hiding them from dashboards filtered on `EMPTY`.
+    #[tokio::test]
+    async fn if_none_match_on_empty_tile_returns_304_with_x_cache_empty() {
+        // Step 1: render the empty tile to capture its (deterministic) ETag.
+        let app = build_empty_router();
+        let etag = {
+            let resp = app
+                .clone()
+                .oneshot(
+                    Request::builder()
+                        .uri("/collections/empty/tiles/WebMercatorQuad/0/0/0")
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(resp.headers().get("x-cache").unwrap(), "EMPTY");
+            resp.headers()
+                .get("etag")
+                .unwrap()
+                .to_str()
+                .unwrap()
+                .to_string()
+        };
+
+        // Step 2: revalidate. The handler must reach the post-render
+        // branch (empty tiles bypass `rendered_cache`), match the ETag,
+        // and 304 with `x-cache: EMPTY` — forwarding the same label
+        // the 200 response would carry, not the legacy hard-coded MISS.
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/collections/empty/tiles/WebMercatorQuad/0/0/0")
+                    .header("If-None-Match", &etag)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_MODIFIED);
+        assert_eq!(resp.headers().get("etag").unwrap().to_str().unwrap(), etag);
+        assert_eq!(
+            resp.headers().get("x-cache").map(|v| v.to_str().unwrap()),
+            Some("EMPTY"),
+            "post-render 304 must forward the `x_cache` label from the \
+             match arm, not hard-code `MISS` — otherwise revalidating an \
+             empty tile silently changes its dashboard category"
+        );
+    }
 }
 
 /// Mock engine that returns an all-`None` (all-nodata) `RasterTile` —

--- a/crates/api-tiles/tests/integration.rs
+++ b/crates/api-tiles/tests/integration.rs
@@ -565,6 +565,52 @@ mod get_tile {
         );
     }
 
+    /// Pin the post-render MISS → 304 branch. Use a fresh router (no
+    /// cache-warm) so the first `If-None-Match`-bearing request must
+    /// go through the full render path; assert the 304 carries
+    /// `x-cache: MISS` rather than the cache-HIT branch's `HIT`. Tests
+    /// the path the other test deliberately bypasses.
+    #[tokio::test]
+    async fn if_none_match_against_fresh_router_returns_304_via_miss_branch() {
+        // Step 1: render once on a separate fresh router to learn the ETag.
+        let etag = {
+            let warm = build_router();
+            let resp = warm
+                .oneshot(
+                    Request::builder()
+                        .uri("/collections/radar/tiles/WebMercatorQuad/0/0/0")
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            resp.headers()
+                .get("etag")
+                .unwrap()
+                .to_str()
+                .unwrap()
+                .to_string()
+        };
+
+        // Step 2: brand-new router with an empty cache. The handler must
+        // render, compute the same content-derived ETag, see the match,
+        // and 304 via the post-render branch.
+        let app = build_router();
+        let req = Request::builder()
+            .uri("/collections/radar/tiles/WebMercatorQuad/0/0/0")
+            .header("If-None-Match", &etag)
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_MODIFIED);
+        assert_eq!(resp.headers().get("etag").unwrap().to_str().unwrap(), etag);
+        assert_eq!(
+            resp.headers().get("x-cache").map(|v| v.to_str().unwrap()),
+            Some("MISS"),
+            "304 must come from the post-render MISS branch, not the cache-HIT branch"
+        );
+    }
+
     /// Cross-parameter staleness protection: different `parameter-name`
     /// values must produce different rendered bytes (because the
     /// `MultiParamMockEngine` varies its output by parameter), which under

--- a/crates/api-tiles/tests/integration.rs
+++ b/crates/api-tiles/tests/integration.rs
@@ -498,21 +498,74 @@ mod get_tile {
         assert!(body.starts_with(&[0x89, b'P', b'N', b'G']));
     }
 
+    /// Regression for #145: the response `ETag` must be FNV-1a over the
+    /// rendered bytes — not over the cache key — so a server-side fix that
+    /// produces different pixels under the same `(z, x, y, style, time)`
+    /// produces a fresh ETag and browsers holding the stale entry refetch
+    /// instead of receiving an infinite 304. Direct check: build the same
+    /// `CachedRendered` the handler does and verify the header matches.
     #[tokio::test]
-    async fn parameter_name_changes_etag() {
-        // Different parameter-name values must produce different cache
-        // entries (and thus different ETags) — otherwise a client switching
-        // from "2t" to "10u" would get a 304 against the stale parameter.
+    async fn etag_is_content_derived_over_response_body() {
+        let (status, headers, body) =
+            get_raw("/collections/radar/tiles/WebMercatorQuad/0/0/0").await;
+        assert_eq!(status, StatusCode::OK);
+        let actual_etag = headers.get("etag").unwrap().to_str().unwrap();
+        let expected_etag = ds_render::CachedRendered::new(bytes::Bytes::from(body))
+            .etag()
+            .to_string();
+        assert_eq!(
+            actual_etag, expected_etag,
+            "ETag header must be FNV-1a over the response body (content-derived), \
+             not derived from the CacheKey — see #145"
+        );
+    }
+
+    /// Round-trip: a client revalidating with the body's content-derived
+    /// ETag must get a 304. Together with the previous test, this pins the
+    /// full If-None-Match handshake against content rather than key.
+    #[tokio::test]
+    async fn if_none_match_with_content_derived_etag_returns_304() {
+        let (_, headers_a, body) = get_raw("/collections/radar/tiles/WebMercatorQuad/0/0/0").await;
+        let etag = headers_a.get("etag").unwrap().to_str().unwrap().to_string();
+        // Sanity: the helper above already pins this, but re-derive locally
+        // so the test is self-contained and the round-trip is obvious.
+        let derived = ds_render::CachedRendered::new(bytes::Bytes::from(body))
+            .etag()
+            .to_string();
+        assert_eq!(etag, derived);
+
+        let app = build_router();
+        let req = Request::builder()
+            .uri("/collections/radar/tiles/WebMercatorQuad/0/0/0")
+            .header("If-None-Match", &etag)
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_MODIFIED);
+        assert_eq!(
+            resp.headers().get("etag").unwrap().to_str().unwrap(),
+            etag,
+            "304 response must echo the same content-derived ETag"
+        );
+    }
+
+    #[tokio::test]
+    async fn parameter_name_produces_separate_cache_entries() {
+        // Different `parameter-name` values produce separate rendered-cache
+        // entries (the cache key still includes `parameter`), so a client
+        // switching parameters can't get a stale tile from a different
+        // parameter's slot. ETags are content-derived (#145), so two
+        // requests that happen to produce the same bytes (the mock engine
+        // ignores `parameter-name` for single-band engines) intentionally
+        // share an ETag — identical bytes deserve identical ETags. The
+        // cross-parameter behaviour that actually matters is exercised
+        // against the multi-param engine, where pixels really do differ.
         let (_, headers_a, _) =
             get_raw("/collections/radar/tiles/WebMercatorQuad/0/0/0?parameter-name=2t").await;
         let (_, headers_b, _) =
             get_raw("/collections/radar/tiles/WebMercatorQuad/0/0/0?parameter-name=10u").await;
-        let etag_a = headers_a.get("etag").unwrap();
-        let etag_b = headers_b.get("etag").unwrap();
-        assert_ne!(
-            etag_a, etag_b,
-            "ETags must differ across parameter-name values"
-        );
+        assert!(headers_a.contains_key("etag"));
+        assert!(headers_b.contains_key("etag"));
     }
 
     #[tokio::test]

--- a/crates/api-tiles/tests/integration.rs
+++ b/crates/api-tiles/tests/integration.rs
@@ -520,21 +520,34 @@ mod get_tile {
         );
     }
 
-    /// Round-trip: a client revalidating with the body's content-derived
-    /// ETag must get a 304. Together with the previous test, this pins the
-    /// full If-None-Match handshake against content rather than key.
+    /// Round-trip after a cache warm: a client revalidating with the
+    /// body's content-derived ETag must get a 304 via the **cache-HIT**
+    /// branch (the cache lookup happens before the If-None-Match check
+    /// — see `cached.etag()` comparison in the handler). Sharing one
+    /// router across both calls is load-bearing; building two routers
+    /// would leave the second call's `RenderedCache` empty and the 304
+    /// would fire on the post-render MISS branch instead.
     #[tokio::test]
-    async fn if_none_match_with_content_derived_etag_returns_304() {
-        let (_, headers_a, body) = get_raw("/collections/radar/tiles/WebMercatorQuad/0/0/0").await;
-        let etag = headers_a.get("etag").unwrap().to_str().unwrap().to_string();
-        // Sanity: the helper above already pins this, but re-derive locally
-        // so the test is self-contained and the round-trip is obvious.
-        let derived = ds_render::CachedRendered::new(bytes::Bytes::from(body))
-            .etag()
-            .to_string();
-        assert_eq!(etag, derived);
-
+    async fn if_none_match_after_cache_warm_returns_304_via_cache_hit() {
         let app = build_router();
+        let resp_a = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/collections/radar/tiles/WebMercatorQuad/0/0/0")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let etag = resp_a
+            .headers()
+            .get("etag")
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .to_string();
+
         let req = Request::builder()
             .uri("/collections/radar/tiles/WebMercatorQuad/0/0/0")
             .header("If-None-Match", &etag)
@@ -549,23 +562,42 @@ mod get_tile {
         );
     }
 
+    /// Cross-parameter staleness protection: different `parameter-name`
+    /// values must produce different rendered bytes (because the
+    /// `MultiParamMockEngine` varies its output by parameter), which under
+    /// content-derived ETags (#145) means different ETags. Combined with
+    /// `parameter` being part of the cache key, a client switching
+    /// parameters can't get a 304 against the previous parameter's entry.
     #[tokio::test]
-    async fn parameter_name_produces_separate_cache_entries() {
-        // Different `parameter-name` values produce separate rendered-cache
-        // entries (the cache key still includes `parameter`), so a client
-        // switching parameters can't get a stale tile from a different
-        // parameter's slot. ETags are content-derived (#145), so two
-        // requests that happen to produce the same bytes (the mock engine
-        // ignores `parameter-name` for single-band engines) intentionally
-        // share an ETag — identical bytes deserve identical ETags. The
-        // cross-parameter behaviour that actually matters is exercised
-        // against the multi-param engine, where pixels really do differ.
-        let (_, headers_a, _) =
-            get_raw("/collections/radar/tiles/WebMercatorQuad/0/0/0?parameter-name=2t").await;
-        let (_, headers_b, _) =
-            get_raw("/collections/radar/tiles/WebMercatorQuad/0/0/0?parameter-name=10u").await;
-        assert!(headers_a.contains_key("etag"));
-        assert!(headers_b.contains_key("etag"));
+    async fn parameter_name_changes_content_etag_on_multi_param_engine() {
+        let app = build_multi_param_router();
+        let resp_2t = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/collections/wx/tiles/WebMercatorQuad/0/0/0?parameter-name=2t")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let resp_10u = app
+            .oneshot(
+                Request::builder()
+                    .uri("/collections/wx/tiles/WebMercatorQuad/0/0/0?parameter-name=10u")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let etag_2t = resp_2t.headers().get("etag").unwrap().to_str().unwrap();
+        let etag_10u = resp_10u.headers().get("etag").unwrap().to_str().unwrap();
+        assert_ne!(
+            etag_2t, etag_10u,
+            "parameter-name varies the rendered pixels, so the content-derived \
+             ETag must differ — otherwise a client switching from 2t to 10u \
+             would get a stale 304"
+        );
     }
 
     #[tokio::test]
@@ -742,10 +774,25 @@ impl MapEngine for MultiParamMockEngine {
         height: u32,
         _time: Option<chrono::DateTime<chrono::Utc>>,
         _output_crs: &OutputCrs,
-        _parameter: Option<&str>,
+        parameter: Option<&str>,
     ) -> Result<RasterTile, DataServerError> {
+        // Vary the pixel values by parameter so the `parameter` field on
+        // the cache key actually changes the rendered bytes — the
+        // cross-parameter ETag test depends on this. Fold the name into
+        // a value in [0, 1] (within the style's min/max range) so the
+        // colormap produces a different uniform fill per parameter.
+        let fill: f64 = parameter
+            .map(|p| {
+                let mut h: u64 = 0xcbf29ce484222325;
+                for &b in p.as_bytes() {
+                    h ^= b as u64;
+                    h = h.wrapping_mul(0x100000001b3);
+                }
+                ((h & 0xff) as f64) / 255.0
+            })
+            .unwrap_or(0.0);
         let pixel_count = (width * height) as usize;
-        let values: Vec<Option<f64>> = (0..pixel_count).map(|i| Some(i as f64)).collect();
+        let values: Vec<Option<f64>> = vec![Some(fill); pixel_count];
         Ok(RasterTile {
             width,
             height,

--- a/crates/api-wms/src/handlers.rs
+++ b/crates/api-wms/src/handlers.rs
@@ -176,10 +176,15 @@ pub async fn wms_handler(
             if let Some(cached) = state.rendered_cache.get(&cache_key) {
                 if let Some(ref inm) = if_none_match {
                     if ds_render::etag_matches(inm, cached.etag()) {
+                        // 304 from the cache-HIT branch. The `x-cache: HIT`
+                        // header lets the regression test (and curious
+                        // clients) distinguish this from a post-render
+                        // MISS→304, which the handler also serves.
                         return Ok(axum::response::Response::builder()
                             .status(StatusCode::NOT_MODIFIED)
                             .header(header::ETAG, cached.etag())
                             .header(header::CACHE_CONTROL, cache_control)
+                            .header(header::HeaderName::from_static("x-cache"), "HIT")
                             .body(axum::body::Body::empty())
                             .unwrap()
                             .into_response());

--- a/crates/api-wms/src/handlers.rs
+++ b/crates/api-wms/src/handlers.rs
@@ -284,6 +284,12 @@ pub async fn wms_handler(
             // miss → encode → revalidate against fresh ETag.
             if let Some(ref inm) = if_none_match {
                 if ds_render::etag_matches(inm, cached.etag()) {
+                    // `x-cache` is *intentionally* absent here. The HIT-path
+                    // 304 above emits `x-cache: HIT`; the absence on this
+                    // post-render path is what lets clients and the
+                    // regression test (`if_none_match_after_cache_warm_...`)
+                    // distinguish the two branches. Adding `x-cache: MISS`
+                    // here would silently break that invariant.
                     return Ok(axum::response::Response::builder()
                         .status(StatusCode::NOT_MODIFIED)
                         .header(header::ETAG, cached.etag())

--- a/crates/api-wms/src/handlers.rs
+++ b/crates/api-wms/src/handlers.rs
@@ -159,36 +159,42 @@ pub async fn wms_handler(
                     .or_else(|| style_info.parameter.clone()),
             };
 
-            let etag = cache_key.etag();
             let cache_control = cache_control_value(has_explicit_time);
+            // Read If-None-Match into an owned String so it survives the move
+            // into spawn_blocking and the cache-hit/miss branches below.
+            let if_none_match = headers
+                .get(header::IF_NONE_MATCH)
+                .and_then(|h| h.to_str().ok())
+                .map(str::to_string);
 
-            // Check If-None-Match — return 304 before any cache lookup or rendering
-            if let Some(inm) = headers.get(header::IF_NONE_MATCH) {
-                if let Ok(inm_str) = inm.to_str() {
-                    if ds_render::etag_matches(inm_str, &etag) {
+            // Cache lookup runs BEFORE the If-None-Match check. The ETag is
+            // content-derived (see `CachedRendered::new`), so a key-derived
+            // 304 short-circuit would be wrong: it would return 304 for any
+            // request matching the cache key, even after a server-side fix
+            // produces different pixels. Mirror the MVT path in
+            // `render_vector_tile` (the bug #145 fixed for raster tiles).
+            if let Some(cached) = state.rendered_cache.get(&cache_key) {
+                if let Some(ref inm) = if_none_match {
+                    if ds_render::etag_matches(inm, cached.etag()) {
                         return Ok(axum::response::Response::builder()
                             .status(StatusCode::NOT_MODIFIED)
-                            .header(header::ETAG, &etag)
+                            .header(header::ETAG, cached.etag())
                             .header(header::CACHE_CONTROL, cache_control)
                             .body(axum::body::Body::empty())
                             .unwrap()
                             .into_response());
                     }
                 }
-            }
-
-            // Check rendered cache
-            if let Some(cached) = state.rendered_cache.get(&cache_key) {
                 return Ok(axum::response::Response::builder()
                     .header(header::CONTENT_TYPE, content_type)
-                    .header(header::ETAG, &etag)
+                    .header(header::ETAG, cached.etag())
                     .header(header::CACHE_CONTROL, cache_control)
                     .header(
                         header::HeaderName::from_static("x-content-type-options"),
                         "nosniff",
                     )
                     .header(header::HeaderName::from_static("x-cache"), "HIT")
-                    .body(axum::body::Body::from(cached))
+                    .body(axum::body::Body::from(cached.bytes))
                     .unwrap()
                     .into_response());
             }
@@ -236,45 +242,63 @@ pub async fn wms_handler(
 
             // The EMPTY and ERROR fast paths skip the format-aware encoder and
             // emit PNG bytes directly. Track the *actual* Content-Type per
-            // branch so the header never lies about the payload — previously
-            // a FORMAT=image/jpeg request that hit an empty tile got PNG
-            // bytes with `Content-Type: image/jpeg`, breaking decoders that
-            // trust the Content-Type.
-            let (image_bytes, x_cache, response_content_type) = match render_result {
+            // branch so the header never lies about the payload (#162). Wrap
+            // every branch in `CachedRendered` so the response ETag is
+            // FNV-1a over the actual bytes — different pixels, different
+            // ETag — regardless of which exit we take (#145).
+            let (cached, x_cache, response_content_type, insert_into_cache) = match render_result {
                 Ok(Some(bytes)) => {
-                    let image_bytes = bytes::Bytes::from(bytes);
-                    rendered_cache.insert(cache_key, image_bytes.clone());
-                    (image_bytes, "MISS", content_type)
+                    let cached = ds_render::CachedRendered::new(bytes::Bytes::from(bytes));
+                    (cached, "MISS", content_type, true)
                 }
                 Ok(None) => {
-                    // Empty tile: return transparent PNG without caching.
+                    // Empty tile: transparent PNG, never cached.
                     let rgba = vec![0u8; (params.width * params.height * 4) as usize];
                     let png =
                         ds_render::encode_png(&rgba, params.width, params.height).map_err(|e| {
                             WmsError::Internal(format!("Failed to encode empty tile: {e}"))
                         })?;
-                    (bytes::Bytes::from(png), "EMPTY", "image/png")
+                    let cached = ds_render::CachedRendered::new(bytes::Bytes::from(png));
+                    (cached, "EMPTY", "image/png", false)
                 }
                 Err(e) => {
                     tracing::warn!("WMS render error for layer '{}': {e}", params.layer);
-                    (
-                        bytes::Bytes::from(render_error_tile(params.width, params.height)?),
-                        "ERROR",
-                        "image/png",
-                    )
+                    let png = render_error_tile(params.width, params.height)?;
+                    let cached = ds_render::CachedRendered::new(bytes::Bytes::from(png));
+                    (cached, "ERROR", "image/png", false)
                 }
             };
 
+            if insert_into_cache {
+                rendered_cache.insert(cache_key, cached.clone());
+            }
+
+            // Now that we have the content-derived ETag, do the
+            // `If-None-Match` comparison. Same flow as `render_vector_tile`
+            // in api-tiles: cache lookup → revalidate against cached ETag,
+            // miss → encode → revalidate against fresh ETag.
+            if let Some(ref inm) = if_none_match {
+                if ds_render::etag_matches(inm, cached.etag()) {
+                    return Ok(axum::response::Response::builder()
+                        .status(StatusCode::NOT_MODIFIED)
+                        .header(header::ETAG, cached.etag())
+                        .header(header::CACHE_CONTROL, cache_control)
+                        .body(axum::body::Body::empty())
+                        .unwrap()
+                        .into_response());
+                }
+            }
+
             Ok(axum::response::Response::builder()
                 .header(header::CONTENT_TYPE, response_content_type)
-                .header(header::ETAG, &etag)
+                .header(header::ETAG, cached.etag())
                 .header(header::CACHE_CONTROL, cache_control)
                 .header(
                     header::HeaderName::from_static("x-content-type-options"),
                     "nosniff",
                 )
                 .header(header::HeaderName::from_static("x-cache"), x_cache)
-                .body(axum::body::Body::from(image_bytes))
+                .body(axum::body::Body::from(cached.bytes))
                 .unwrap()
                 .into_response())
         }

--- a/crates/api-wms/src/handlers.rs
+++ b/crates/api-wms/src/handlers.rs
@@ -194,7 +194,7 @@ pub async fn wms_handler(
                         "nosniff",
                     )
                     .header(header::HeaderName::from_static("x-cache"), "HIT")
-                    .body(axum::body::Body::from(cached.bytes))
+                    .body(axum::body::Body::from(cached.into_bytes()))
                     .unwrap()
                     .into_response());
             }
@@ -298,7 +298,7 @@ pub async fn wms_handler(
                     "nosniff",
                 )
                 .header(header::HeaderName::from_static("x-cache"), x_cache)
-                .body(axum::body::Body::from(cached.bytes))
+                .body(axum::body::Body::from(cached.into_bytes()))
                 .unwrap()
                 .into_response())
         }

--- a/crates/api-wms/src/handlers.rs
+++ b/crates/api-wms/src/handlers.rs
@@ -251,10 +251,16 @@ pub async fn wms_handler(
             // every branch in `CachedRendered` so the response ETag is
             // FNV-1a over the actual bytes — different pixels, different
             // ETag — regardless of which exit we take (#145).
-            let (cached, x_cache, response_content_type, insert_into_cache) = match render_result {
+            // Each arm produces a `CachedRendered` ready to serve. Only the
+            // populated `Ok(Some(_))` path inserts into the rendered cache;
+            // the EMPTY and ERROR fast-paths intentionally don't (their
+            // bytes are deterministic for fixed dimensions and the
+            // engine error case shouldn't poison the cache).
+            let (cached, x_cache, response_content_type) = match render_result {
                 Ok(Some(bytes)) => {
                     let cached = ds_render::CachedRendered::new(bytes::Bytes::from(bytes));
-                    (cached, "MISS", content_type, true)
+                    rendered_cache.insert(cache_key, cached.clone());
+                    (cached, "MISS", content_type)
                 }
                 Ok(None) => {
                     // Empty tile: transparent PNG, never cached.
@@ -264,19 +270,15 @@ pub async fn wms_handler(
                             WmsError::Internal(format!("Failed to encode empty tile: {e}"))
                         })?;
                     let cached = ds_render::CachedRendered::new(bytes::Bytes::from(png));
-                    (cached, "EMPTY", "image/png", false)
+                    (cached, "EMPTY", "image/png")
                 }
                 Err(e) => {
                     tracing::warn!("WMS render error for layer '{}': {e}", params.layer);
                     let png = render_error_tile(params.width, params.height)?;
                     let cached = ds_render::CachedRendered::new(bytes::Bytes::from(png));
-                    (cached, "ERROR", "image/png", false)
+                    (cached, "ERROR", "image/png")
                 }
             };
-
-            if insert_into_cache {
-                rendered_cache.insert(cache_key, cached.clone());
-            }
 
             // Now that we have the content-derived ETag, do the
             // `If-None-Match` comparison. Same flow as `render_vector_tile`
@@ -284,16 +286,17 @@ pub async fn wms_handler(
             // miss → encode → revalidate against fresh ETag.
             if let Some(ref inm) = if_none_match {
                 if ds_render::etag_matches(inm, cached.etag()) {
-                    // `x-cache` is *intentionally* absent here. The HIT-path
-                    // 304 above emits `x-cache: HIT`; the absence on this
-                    // post-render path is what lets clients and the
-                    // regression test (`if_none_match_after_cache_warm_...`)
-                    // distinguish the two branches. Adding `x-cache: MISS`
-                    // here would silently break that invariant.
+                    // 304 from the post-render branch. Emit `x-cache: MISS`
+                    // (alongside the HIT-path 304's `x-cache: HIT` above) so
+                    // operators can tell post-render revalidations apart from
+                    // cache-hit revalidations in logs and metrics, and tests
+                    // can pin either branch by the *value* of the header
+                    // rather than by its absence.
                     return Ok(axum::response::Response::builder()
                         .status(StatusCode::NOT_MODIFIED)
                         .header(header::ETAG, cached.etag())
                         .header(header::CACHE_CONTROL, cache_control)
+                        .header(header::HeaderName::from_static("x-cache"), "MISS")
                         .body(axum::body::Body::empty())
                         .unwrap()
                         .into_response());

--- a/crates/api-wms/src/handlers.rs
+++ b/crates/api-wms/src/handlers.rs
@@ -286,17 +286,17 @@ pub async fn wms_handler(
             // miss → encode → revalidate against fresh ETag.
             if let Some(ref inm) = if_none_match {
                 if ds_render::etag_matches(inm, cached.etag()) {
-                    // 304 from the post-render branch. Emit `x-cache: MISS`
-                    // (alongside the HIT-path 304's `x-cache: HIT` above) so
-                    // operators can tell post-render revalidations apart from
-                    // cache-hit revalidations in logs and metrics, and tests
-                    // can pin either branch by the *value* of the header
-                    // rather than by its absence.
+                    // 304 from the post-render branch. Forward the same
+                    // `x_cache` label the 200 response would carry — `"MISS"`,
+                    // `"EMPTY"`, or `"ERROR"` — so revalidations look the
+                    // same on dashboards as initial fetches. A client
+                    // revalidating a cached transparent-tile response sees
+                    // `304 x-cache: EMPTY`, not a misleading `MISS`.
                     return Ok(axum::response::Response::builder()
                         .status(StatusCode::NOT_MODIFIED)
                         .header(header::ETAG, cached.etag())
                         .header(header::CACHE_CONTROL, cache_control)
-                        .header(header::HeaderName::from_static("x-cache"), "MISS")
+                        .header(header::HeaderName::from_static("x-cache"), x_cache)
                         .body(axum::body::Body::empty())
                         .unwrap()
                         .into_response());

--- a/crates/api-wms/tests/integration.rs
+++ b/crates/api-wms/tests/integration.rs
@@ -609,6 +609,11 @@ async fn if_none_match_on_error_tile_returns_304_with_x_cache_error() {
         .unwrap();
     assert_eq!(resp.status(), StatusCode::NOT_MODIFIED);
     assert_eq!(
+        resp.headers().get("etag").unwrap().to_str().unwrap(),
+        etag,
+        "304 response must echo the same content-derived ETag back to the client"
+    );
+    assert_eq!(
         resp.headers().get("x-cache").map(|v| v.to_str().unwrap()),
         Some("ERROR"),
         "post-render 304 must forward the `x_cache` label — error \

--- a/crates/api-wms/tests/integration.rs
+++ b/crates/api-wms/tests/integration.rs
@@ -296,3 +296,171 @@ async fn error_tile_forces_png_content_type_even_when_jpeg_requested() {
         &body[..4.min(body.len())]
     );
 }
+
+/// Mock engine that returns a populated `RasterTile` so the regular
+/// `Ok(Some(bytes))` render+encode path runs (the EMPTY/ERROR paths
+/// have separate coverage above). Used by the #145 ETag regression
+/// tests.
+struct PopulatedMockMapEngine;
+
+impl MapEngine for PopulatedMockMapEngine {
+    fn get_raster_tile(
+        &self,
+        _bbox: [f64; 4],
+        width: u32,
+        height: u32,
+        _time: Option<chrono::DateTime<chrono::Utc>>,
+        _output_crs: &OutputCrs,
+        _parameter: Option<&str>,
+    ) -> Result<RasterTile, DataServerError> {
+        let pixel_count = (width * height) as usize;
+        // Linear gradient — yields a non-uniform PNG so the test isn't
+        // accidentally cheating by serving the EMPTY_TILE_PNG fast path.
+        let values: Vec<Option<f64>> = (0..pixel_count)
+            .map(|i| Some(i as f64 / pixel_count as f64))
+            .collect();
+        Ok(RasterTile {
+            width,
+            height,
+            values,
+        })
+    }
+
+    fn raster_info(&self) -> RasterInfo {
+        RasterInfo {
+            native_crs: "EPSG:4326".into(),
+            spatial_extent: Some([10.0, 55.0, 30.0, 70.0]),
+            times: vec![chrono::DateTime::parse_from_rfc3339("2024-01-01T00:00:00Z")
+                .unwrap()
+                .with_timezone(&chrono::Utc)],
+            parameter: "reflectivity".into(),
+            unit: "dBZ".into(),
+            parameters: vec![],
+        }
+    }
+}
+
+fn build_populated_router() -> axum::Router {
+    let engine: Arc<dyn MapEngine> = Arc::new(PopulatedMockMapEngine);
+    let mut engines = HashMap::new();
+    let mut collections = HashMap::new();
+    let mut styles_map = HashMap::new();
+
+    engines.insert("radar".to_string(), engine);
+    collections.insert(
+        "radar".to_string(),
+        CollectionConfig {
+            id: "radar".to_string(),
+            title: "Radar".to_string(),
+            description: "Populated mock for #145 ETag tests".into(),
+            data_path: None,
+            apis: vec!["wms".to_string()],
+            engine_type: "geotiff".to_string(),
+            geotiff: None,
+            querydata: None,
+            wms: None,
+            grib: None,
+            postgis: None,
+            preview: None,
+        },
+    );
+
+    let cmap = Arc::new(LutColorMap::from_builtin(
+        BuiltinColormap::Viridis,
+        0.0,
+        1.0,
+    ));
+    let mut layer_styles = HashMap::new();
+    layer_styles.insert(
+        "default".to_string(),
+        StyleInfo {
+            name: "default".to_string(),
+            title: "Default".to_string(),
+            colormap: cmap,
+            min: 0.0,
+            max: 1.0,
+            parameter: None,
+        },
+    );
+    styles_map.insert("radar".to_string(), layer_styles);
+
+    let state = Arc::new(ArcSwap::from_pointee(WmsState {
+        engines,
+        collections,
+        styles: styles_map,
+        render_semaphore: Arc::new(tokio::sync::Semaphore::new(4)),
+        rendered_cache: Arc::new(RenderedCache::new(16)),
+        base_url: String::new(),
+    }));
+    api_wms::router(state)
+}
+
+const GETMAP_URI: &str = "/?SERVICE=WMS&REQUEST=GetMap&VERSION=1.3.0&LAYERS=radar\
+                          &CRS=CRS:84&BBOX=10,55,30,70&WIDTH=64&HEIGHT=64\
+                          &FORMAT=image/png";
+
+/// Regression for #145: the WMS GetMap ETag must be FNV-1a over the
+/// rendered bytes — not over the cache key — so a server-side fix
+/// that produces different pixels under the same key surfaces a
+/// fresh ETag and clients holding the stale entry refetch instead
+/// of receiving an infinite 304.
+#[tokio::test]
+async fn etag_is_content_derived_over_response_body() {
+    let app = build_populated_router();
+    let req = Request::builder()
+        .uri(GETMAP_URI)
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let headers = resp.headers().clone();
+    let actual_etag = headers.get("etag").unwrap().to_str().unwrap().to_string();
+    let body = resp.into_body().collect().await.unwrap().to_bytes();
+    let expected_etag = ds_render::CachedRendered::new(body).etag().to_string();
+    assert_eq!(
+        actual_etag, expected_etag,
+        "ETag header must be FNV-1a over the response body (content-derived), \
+         not derived from the CacheKey — see #145"
+    );
+}
+
+/// Round-trip: a client revalidating with the body's content-derived
+/// ETag must get a 304 with the same ETag echoed back.
+#[tokio::test]
+async fn if_none_match_with_content_derived_etag_returns_304() {
+    let app_a = build_populated_router();
+    let resp_a = app_a
+        .oneshot(
+            Request::builder()
+                .uri(GETMAP_URI)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let etag = resp_a
+        .headers()
+        .get("etag")
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .to_string();
+
+    let app_b = build_populated_router();
+    let resp_b = app_b
+        .oneshot(
+            Request::builder()
+                .uri(GETMAP_URI)
+                .header("If-None-Match", &etag)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp_b.status(), StatusCode::NOT_MODIFIED);
+    assert_eq!(
+        resp_b.headers().get("etag").unwrap().to_str().unwrap(),
+        etag,
+        "304 response must echo the same content-derived ETag"
+    );
+}

--- a/crates/api-wms/tests/integration.rs
+++ b/crates/api-wms/tests/integration.rs
@@ -424,12 +424,18 @@ async fn etag_is_content_derived_over_response_body() {
     );
 }
 
-/// Round-trip: a client revalidating with the body's content-derived
-/// ETag must get a 304 with the same ETag echoed back.
+/// Round-trip after a cache warm: a client revalidating with the
+/// body's content-derived ETag must get a 304 via the **cache-HIT**
+/// branch (the cache lookup happens before the If-None-Match check —
+/// see `cached.etag()` comparison in the handler). Sharing one router
+/// across both calls is load-bearing; building two routers would leave
+/// the second call's `RenderedCache` empty and the 304 would fire on
+/// the post-render MISS branch instead.
 #[tokio::test]
-async fn if_none_match_with_content_derived_etag_returns_304() {
-    let app_a = build_populated_router();
-    let resp_a = app_a
+async fn if_none_match_after_cache_warm_returns_304_via_cache_hit() {
+    let app = build_populated_router();
+    let resp_a = app
+        .clone()
         .oneshot(
             Request::builder()
                 .uri(GETMAP_URI)
@@ -446,8 +452,7 @@ async fn if_none_match_with_content_derived_etag_returns_304() {
         .unwrap()
         .to_string();
 
-    let app_b = build_populated_router();
-    let resp_b = app_b
+    let resp_b = app
         .oneshot(
             Request::builder()
                 .uri(GETMAP_URI)

--- a/crates/api-wms/tests/integration.rs
+++ b/crates/api-wms/tests/integration.rs
@@ -424,13 +424,11 @@ async fn etag_is_content_derived_over_response_body() {
     );
 }
 
-/// Round-trip after a cache warm: a client revalidating with the
-/// body's content-derived ETag must get a 304 via the **cache-HIT**
-/// branch (the cache lookup happens before the If-None-Match check —
-/// see `cached.etag()` comparison in the handler). Sharing one router
-/// across both calls is load-bearing; building two routers would leave
-/// the second call's `RenderedCache` empty and the 304 would fire on
-/// the post-render MISS branch instead.
+/// Pin the cache-HIT→304 branch specifically. The handler returns 304
+/// from two places: the cache-HIT branch (this test, asserted via
+/// `x-cache: HIT`) and the post-render MISS branch. A fresh router
+/// would still 304 — just via the MISS path — so the `x-cache`
+/// assertion is what makes "we exercised the HIT branch" testable.
 #[tokio::test]
 async fn if_none_match_after_cache_warm_returns_304_via_cache_hit() {
     let app = build_populated_router();
@@ -467,5 +465,10 @@ async fn if_none_match_after_cache_warm_returns_304_via_cache_hit() {
         resp_b.headers().get("etag").unwrap().to_str().unwrap(),
         etag,
         "304 response must echo the same content-derived ETag"
+    );
+    assert_eq!(
+        resp_b.headers().get("x-cache").map(|v| v.to_str().unwrap()),
+        Some("HIT"),
+        "304 must come from the cache-HIT branch, not post-render MISS"
     );
 }

--- a/crates/api-wms/tests/integration.rs
+++ b/crates/api-wms/tests/integration.rs
@@ -472,3 +472,48 @@ async fn if_none_match_after_cache_warm_returns_304_via_cache_hit() {
         "304 must come from the cache-HIT branch, not post-render MISS"
     );
 }
+
+/// Pin the post-render MISS → 304 branch. Use a fresh router (no
+/// cache-warm) so the first `If-None-Match`-bearing request must go
+/// through the full render path; assert the 304 carries
+/// `x-cache: MISS` rather than the cache-HIT branch's `HIT`.
+#[tokio::test]
+async fn if_none_match_against_fresh_router_returns_304_via_miss_branch() {
+    // Step 1: render once on a separate fresh router to learn the ETag.
+    let etag = {
+        let warm = build_populated_router();
+        let resp = warm
+            .oneshot(
+                Request::builder()
+                    .uri(GETMAP_URI)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        resp.headers()
+            .get("etag")
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .to_string()
+    };
+
+    // Step 2: brand-new router with an empty cache. Handler must render,
+    // compute the same content-derived ETag, match the header, and 304
+    // via the post-render branch.
+    let app = build_populated_router();
+    let req = Request::builder()
+        .uri(GETMAP_URI)
+        .header("If-None-Match", &etag)
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_MODIFIED);
+    assert_eq!(resp.headers().get("etag").unwrap().to_str().unwrap(), etag);
+    assert_eq!(
+        resp.headers().get("x-cache").map(|v| v.to_str().unwrap()),
+        Some("MISS"),
+        "304 must come from the post-render MISS branch, not the cache-HIT branch"
+    );
+}

--- a/crates/api-wms/tests/integration.rs
+++ b/crates/api-wms/tests/integration.rs
@@ -517,3 +517,101 @@ async fn if_none_match_against_fresh_router_returns_304_via_miss_branch() {
         "304 must come from the post-render MISS branch, not the cache-HIT branch"
     );
 }
+
+/// Empty-tile revalidation must round-trip the `EMPTY` label, not be
+/// silently re-tagged as `MISS`. Empty tiles bypass `rendered_cache`,
+/// so an `If-None-Match` request always falls through to the
+/// post-render branch — exactly the branch the round-7 fix targets.
+/// Without the fix, every cached transparent tile that gets
+/// revalidated would show up on dashboards as `MISS`.
+#[tokio::test]
+async fn if_none_match_on_empty_tile_returns_304_with_x_cache_empty() {
+    let app = build_empty_router();
+    let uri = "/?SERVICE=WMS&REQUEST=GetMap&VERSION=1.3.0&LAYERS=empty\
+               &CRS=CRS:84&BBOX=10,55,30,70&WIDTH=64&HEIGHT=64\
+               &FORMAT=image/png";
+
+    // Step 1: render the empty tile to capture its (deterministic) ETag.
+    let etag = {
+        let resp = app
+            .clone()
+            .oneshot(Request::builder().uri(uri).body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(resp.headers().get("x-cache").unwrap(), "EMPTY");
+        resp.headers()
+            .get("etag")
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .to_string()
+    };
+
+    // Step 2: revalidate. The post-render branch must forward
+    // `x-cache: EMPTY`, not a hard-coded MISS.
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri(uri)
+                .header("If-None-Match", &etag)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_MODIFIED);
+    assert_eq!(resp.headers().get("etag").unwrap().to_str().unwrap(), etag);
+    assert_eq!(
+        resp.headers().get("x-cache").map(|v| v.to_str().unwrap()),
+        Some("EMPTY"),
+        "post-render 304 must forward the `x_cache` label from the \
+         match arm, not hard-code `MISS` — otherwise revalidating an \
+         empty tile silently changes its dashboard category"
+    );
+}
+
+/// WMS-only: revalidating a cached error tile must round-trip the
+/// `ERROR` label. WMS is the one handler that swallows engine errors
+/// into a 200 + red error-tile (Maps/Tiles propagate as 500), so this
+/// branch only exists here. Error tiles bypass `rendered_cache`, so
+/// `If-None-Match` always reaches the post-render branch.
+#[tokio::test]
+async fn if_none_match_on_error_tile_returns_304_with_x_cache_error() {
+    let app = build_failing_router();
+    let uri = "/?SERVICE=WMS&REQUEST=GetMap&VERSION=1.3.0&LAYERS=broken\
+               &CRS=CRS:84&BBOX=10,55,30,70&WIDTH=64&HEIGHT=64\
+               &FORMAT=image/png";
+
+    let etag = {
+        let resp = app
+            .clone()
+            .oneshot(Request::builder().uri(uri).body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(resp.headers().get("x-cache").unwrap(), "ERROR");
+        resp.headers()
+            .get("etag")
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .to_string()
+    };
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri(uri)
+                .header("If-None-Match", &etag)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_MODIFIED);
+    assert_eq!(
+        resp.headers().get("x-cache").map(|v| v.to_str().unwrap()),
+        Some("ERROR"),
+        "post-render 304 must forward the `x_cache` label — error \
+         tiles revalidating must remain visible as ERROR on dashboards"
+    );
+}

--- a/crates/render/src/lib.rs
+++ b/crates/render/src/lib.rs
@@ -161,13 +161,56 @@ pub fn quantize_bbox(bbox: &[f64; 4]) -> [i64; 4] {
     ]
 }
 
+/// Cached rendered image payload plus its content-derived ETag.
+///
+/// The ETag hashes the encoded bytes themselves via FNV-1a so two cache
+/// entries under the same `CacheKey` with different content (e.g. data
+/// refresh, encoder change, colormap fix) produce different ETags. A
+/// stable key-derived ETag would let stale browser caches survive a
+/// server-side fix indefinitely, since `If-None-Match` would keep
+/// returning 304 against fresh content (the bug #145 fixed for raster
+/// tiles, mirroring #136's fix for vector tiles).
+#[derive(Debug, Clone)]
+pub struct CachedRendered {
+    pub bytes: Bytes,
+    /// Private so the only path that sets it is `CachedRendered::new`,
+    /// which seals the invariant `etag == FNV-1a(bytes)`. Without this
+    /// seal, a caller could construct a `CachedRendered` with a
+    /// mismatched ETag and silently break `If-None-Match` (a browser
+    /// holding the real ETag would get a full 200 instead of 304, or
+    /// vice-versa).
+    etag: String,
+}
+
+impl CachedRendered {
+    /// Build a cache entry from encoded bytes, deriving the ETag from
+    /// the content via FNV-1a. Format matches `ds_mvt::CachedTile::etag`
+    /// and `CacheKey::etag` so the same `etag_matches` helper works
+    /// across raster and vector responses. FNV-1a (not the stdlib
+    /// `DefaultHasher`) so the ETag is stable across rustc versions —
+    /// a binary rebuild against unchanged content keeps the same ETag
+    /// and browser caches survive the redeploy.
+    pub fn new(bytes: Bytes) -> Self {
+        let mut h = FNV1A_OFFSET;
+        fnv1a_mix(&mut h, bytes.as_ref());
+        let etag = format!("\"{h:016x}\"");
+        Self { bytes, etag }
+    }
+
+    /// Quoted hex16 ETag string suitable for the `ETag` response header.
+    pub fn etag(&self) -> &str {
+        &self.etag
+    }
+}
+
 /// Weight function: count the byte size of each cached rendered image.
 #[derive(Clone)]
 struct RenderedWeighter;
 
-impl quick_cache::Weighter<CacheKey, Bytes> for RenderedWeighter {
-    fn weight(&self, _key: &CacheKey, val: &Bytes) -> u64 {
-        val.len() as u64 + 64 // data + overhead
+impl quick_cache::Weighter<CacheKey, CachedRendered> for RenderedWeighter {
+    fn weight(&self, _key: &CacheKey, val: &CachedRendered) -> u64 {
+        // bytes + 18 bytes for the quoted hex64 ETag string + 64 byte overhead
+        val.bytes.len() as u64 + val.etag.len() as u64 + 64
     }
 }
 
@@ -176,7 +219,7 @@ impl quick_cache::Weighter<CacheKey, Bytes> for RenderedWeighter {
 /// No TTL — radar measurements are immutable once produced.
 /// Cache is invalidated on collection reload.
 pub struct RenderedCache {
-    cache: Cache<CacheKey, Bytes, RenderedWeighter>,
+    cache: Cache<CacheKey, CachedRendered, RenderedWeighter>,
     capacity_bytes: u64,
     hits: AtomicU64,
     misses: AtomicU64,
@@ -199,7 +242,7 @@ impl RenderedCache {
         }
     }
 
-    pub fn get(&self, key: &CacheKey) -> Option<Bytes> {
+    pub fn get(&self, key: &CacheKey) -> Option<CachedRendered> {
         let result = self.cache.get(key);
         if result.is_some() {
             self.hits.fetch_add(1, Ordering::Relaxed);
@@ -209,7 +252,7 @@ impl RenderedCache {
         result
     }
 
-    pub fn insert(&self, key: CacheKey, value: Bytes) {
+    pub fn insert(&self, key: CacheKey, value: CachedRendered) {
         self.cache.insert(key, value);
     }
 
@@ -496,5 +539,36 @@ mod tests {
         };
         // Pinned after introducing the `parameter` field (cache-bust event).
         assert_eq!(key.etag(), "\"074133840641acde\"");
+    }
+
+    #[test]
+    fn cached_rendered_etag_is_stable_for_same_bytes() {
+        // Same bytes -> same ETag. The ETag is content-derived so a binary
+        // rebuild against unchanged content keeps the same ETag and browser
+        // caches survive the redeploy.
+        let a = CachedRendered::new(Bytes::from_static(b"\x89PNG\r\n\x1a\n... pixels ..."));
+        let b = CachedRendered::new(Bytes::from_static(b"\x89PNG\r\n\x1a\n... pixels ..."));
+        assert_eq!(a.etag(), b.etag());
+    }
+
+    #[test]
+    fn cached_rendered_etag_differs_for_distinct_bytes() {
+        // This is the #145 regression check: two encodings under the same
+        // CacheKey (e.g. a server-side colormap fix that produces different
+        // PNG pixels) must produce different ETags so a browser holding the
+        // pre-fix entry refetches instead of getting an infinite 304.
+        let pre_fix = CachedRendered::new(Bytes::from_static(b"old-broken-png-bytes"));
+        let post_fix = CachedRendered::new(Bytes::from_static(b"new-correct-png-bytes"));
+        assert_ne!(pre_fix.etag(), post_fix.etag());
+    }
+
+    #[test]
+    fn cached_rendered_etag_uses_stable_fnv1a_not_default_hasher() {
+        // Pinned golden value — mirrors `cache_key_etag_uses_stable_fnv1a_not_default_hasher`
+        // and `ds_mvt::CachedTile`'s analogue. If this changes you've either
+        // intentionally rotated the algorithm (cache-bust event for browser
+        // ETag caches) or accidentally regressed to a non-stable hasher.
+        let cached = CachedRendered::new(Bytes::from_static(b"hello"));
+        assert_eq!(cached.etag(), "\"a430d84680aabd0b\"");
     }
 }

--- a/crates/render/src/lib.rs
+++ b/crates/render/src/lib.rs
@@ -170,15 +170,14 @@ pub fn quantize_bbox(bbox: &[f64; 4]) -> [i64; 4] {
 /// server-side fix indefinitely, since `If-None-Match` would keep
 /// returning 304 against fresh content (the bug #145 fixed for raster
 /// tiles, mirroring #136's fix for vector tiles).
+/// Both fields are private to seal the invariant `etag == FNV-1a(bytes)`.
+/// `bytes` was previously `pub`, which let a caller mutate the payload
+/// without updating the ETag and silently break `If-None-Match`
+/// (a browser holding the real ETag would get a full 200 instead of 304,
+/// or vice-versa).
 #[derive(Debug, Clone)]
 pub struct CachedRendered {
-    pub bytes: Bytes,
-    /// Private so the only path that sets it is `CachedRendered::new`,
-    /// which seals the invariant `etag == FNV-1a(bytes)`. Without this
-    /// seal, a caller could construct a `CachedRendered` with a
-    /// mismatched ETag and silently break `If-None-Match` (a browser
-    /// holding the real ETag would get a full 200 instead of 304, or
-    /// vice-versa).
+    bytes: Bytes,
     etag: String,
 }
 
@@ -197,9 +196,24 @@ impl CachedRendered {
         Self { bytes, etag }
     }
 
-    /// Quoted hex16 ETag string suitable for the `ETag` response header.
+    /// Quoted 16-hex-char (64-bit FNV-1a) ETag string suitable for the
+    /// `ETag` response header.
     pub fn etag(&self) -> &str {
         &self.etag
+    }
+
+    /// Borrow the cached bytes — e.g. for byte-length accounting in the
+    /// cache weighter.
+    pub fn bytes(&self) -> &Bytes {
+        &self.bytes
+    }
+
+    /// Consume the entry and yield the bytes — used by the handlers when
+    /// building the HTTP response body. Move semantics keep the invariant
+    /// intact: there is no way to retain the `CachedRendered` while
+    /// swapping out its bytes.
+    pub fn into_bytes(self) -> Bytes {
+        self.bytes
     }
 }
 
@@ -209,8 +223,8 @@ struct RenderedWeighter;
 
 impl quick_cache::Weighter<CacheKey, CachedRendered> for RenderedWeighter {
     fn weight(&self, _key: &CacheKey, val: &CachedRendered) -> u64 {
-        // bytes + 18 bytes for the quoted hex64 ETag string + 64 byte overhead
-        val.bytes.len() as u64 + val.etag.len() as u64 + 64
+        // bytes + 18-byte quoted 16-hex-char (64-bit FNV-1a) ETag string + 64-byte overhead
+        val.bytes().len() as u64 + val.etag().len() as u64 + 64
     }
 }
 


### PR DESCRIPTION
## Summary

Closes #145.

#136 fixed this for vector tiles (MVT) by switching the response ETag from a hash of the cache key to a hash of the encoded bytes. The raster paths (Maps, Tiles, WMS) still used \`CacheKey::etag()\` — same failure mode: a server-side fix that produces different pixels under the same \`(bbox, time, style, parameter)\` key returned an identical ETag, so a browser holding the stale entry kept getting \`304 Not Modified\` and rendered the old image until its cache entry aged out.

## Fix shape

Mirror the MVT pattern in \`ds-render\`:

\`\`\`rust
pub struct CachedRendered {
    pub bytes: Bytes,
    etag: String,  // private; computed in CachedRendered::new from FNV-1a(bytes)
}
\`\`\`

\`RenderedCache\` now stores \`CachedRendered\` instead of raw \`Bytes\`. The three handlers (api-wms, api-maps, api-tiles raster path) restructure to match \`render_vector_tile\`:

1. Cache lookup runs **before** the \`If-None-Match\` check (was: key-derived ETag check first, then cache).
2. Cache HIT: compare \`cached.etag()\` to If-None-Match → 304 or 200.
3. MISS: render, wrap bytes in \`CachedRendered\`, insert into cache, then compare freshly-computed ETag to If-None-Match.
4. EMPTY (#162) and ERROR (WMS-only) paths still emit honest \`Content-Type: image/png\` (per #162) and now also get content-derived ETags.

## Tests

- **ds-render** unit tests: \`cached_rendered_etag_is_stable_for_same_bytes\`, \`cached_rendered_etag_differs_for_distinct_bytes\` (the explicit #145 regression check), and a golden-value pin for FNV-1a(\"hello\") so a future regression to \`DefaultHasher\` panics.
- **api-{wms,maps,tiles}** integration tests: each crate gets \`etag_is_content_derived_over_response_body\` (computes \`CachedRendered::new(body).etag()\` and asserts it matches the actual ETag header) and \`if_none_match_with_content_derived_etag_returns_304\` (full round-trip).
- \`parameter_name_changes_etag\` (which asserted ETags **differ** across \`parameter-name=\` values against the single-band mock) was renamed to \`parameter_name_produces_separate_cache_entries\` and rewritten. With content-derived ETags, identical bytes deserve identical ETags; cross-parameter staleness protection comes from the cache *key* including \`parameter\`, not from the ETag itself.

Total: **201 tests** pass across \`api-{wms,maps,tiles}\` and \`ds-render\` (8 new).

## Behavioural impact

| Scenario | Before | After |
|---|---|---|
| Server-side colormap fix → different pixels, same key | ETag unchanged → 304 against stale browser cache → stale image | ETag changes → fresh 200 → correct image |
| Cache HIT, body identical | ETag unchanged → 304 or 200 | ETag unchanged → 304 or 200 (same) |
| EMPTY tile (#162) | ETag derived from key | ETag derived from the empty-PNG bytes; identical across requests of same dims (good — they really are the same response) |
| ERROR tile (WMS) | ETag derived from key | ETag derived from the red error-tile PNG |

No client-visible breaking change beyond the intended \"stale cache invalidates on data refresh\" effect.

## Test plan

- [x] \`cargo test -p ds-render -p api-wms -p api-maps -p api-tiles\` — all 201 tests pass
- [x] \`cargo clippy --workspace --tests --no-deps\` clean
- [x] \`cargo fmt --all --check\` clean
- [ ] Reviewer eyeballs the four handler call sites for symmetry with \`render_vector_tile\`