### PR TITLE
feat(engine-odim): EdrEngine — position + area queries (Phase 1.5)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,7 +130,7 @@ Currently implemented: `PointSeries`, `Grid`.
 | GeoJSON | `FeatureEngine` | Features |
 | GeoTIFF | `EdrEngine` + `MapEngine` | EDR (position, area), WMS, Maps, Tiles |
 | GRIB | `EdrEngine` + `MapEngine` | EDR, WMS, Maps, Tiles |
-| ODIM | `MapEngine` (EDR follow-up) | WMS, Maps, Tiles |
+| ODIM | `EdrEngine` + `MapEngine` | EDR (position, area), WMS, Maps, Tiles |
 | QueryData | `EdrEngine` + `MapEngine` | EDR (position only), WMS, Maps, Tiles |
 | PostGIS | `EdrEngine` + `FeatureEngine` | EDR (position, locations, area), Features |
 

--- a/collections.d/radar-dmi-composite.toml
+++ b/collections.d/radar-dmi-composite.toml
@@ -18,7 +18,7 @@ Files are 500m maximum-reflectivity composite (`dk.com.*.500_max.h5`) \
 in stereographic projection centered on Denmark.\
 """
 engine_type = "odim"
-apis = ["wms", "maps", "tiles"]
+apis = ["edr", "wms", "maps", "tiles"]
 data_path = "testdata/radar-dmi"
 
 [odim]

--- a/collections.d/radar-dwd-composite.toml
+++ b/collections.d/radar-dwd-composite.toml
@@ -20,7 +20,7 @@ ODIM_H5 v2.3. 250m polar stereographic grid covering Germany and \
 neighbouring countries.\
 """
 engine_type = "odim"
-apis = ["wms", "maps", "tiles"]
+apis = ["edr", "wms", "maps", "tiles"]
 data_path = "testdata/radar-dwd"
 
 [odim]

--- a/collections.d/radar-opera-composite.toml
+++ b/collections.d/radar-opera-composite.toml
@@ -18,7 +18,7 @@ Maximum reflectivity (DBZH) on a 2km Lambert Azimuthal Equal Area grid \
 covering Europe.\
 """
 engine_type = "odim"
-apis = ["wms", "maps", "tiles"]
+apis = ["edr", "wms", "maps", "tiles"]
 data_path = "testdata/radar-opera"
 
 [odim]

--- a/crates/engine-odim/src/edr.rs
+++ b/crates/engine-odim/src/edr.rs
@@ -22,6 +22,12 @@
 //! directories hold at most `max_files` entries (typically ≤288 at
 //! 5-min cadence), so this is acceptable for v1; a multi-entry
 //! composite cache is a follow-up.
+//!
+//! Those reads are blocking (HDF5 parse). The api-edr handlers call
+//! `EdrEngine` methods directly from `async fn`s without
+//! `spawn_blocking`, so the work currently lands on a Tokio worker —
+//! a pre-existing api-edr gap that affects every EDR engine, tracked
+//! in issue #178 and to be fixed in the api-edr handlers.
 
 use std::collections::HashMap;
 

--- a/crates/engine-odim/src/edr.rs
+++ b/crates/engine-odim/src/edr.rs
@@ -1,0 +1,536 @@
+//! `EdrEngine` impl for engine-odim — position and area queries
+//! against the same ODIM_H5 composite grid the `MapEngine` impl
+//! serves.
+//!
+//! Both query types resample the native (projected) radar grid to
+//! WGS84 query geometry:
+//!
+//! - **position** — bilinear interpolation at a single `(lon, lat)`,
+//!   one value per catalog timestep, returned as a `PointSeries`
+//!   coverage.
+//! - **area** — a regular WGS84 lon/lat grid covering the requested
+//!   polygon's bounding box, each cell bilinearly sampled and then
+//!   masked to the polygon, returned as a `Grid` coverage.
+//!
+//! ODIM composites carry no station list, so `get_locations` is
+//! empty and `query_location` is unsupported — clients use the
+//! position endpoint instead.
+//!
+//! Phase 1.5 scope: the position query loads one composite per
+//! timestep through `OdimEngine`'s single-entry cache, so a query
+//! spanning N timesteps performs N sequential file reads. ODIM
+//! directories hold at most `max_files` entries (typically ≤288 at
+//! 5-min cadence), so this is acceptable for v1; a multi-entry
+//! composite cache is a follow-up.
+
+use std::collections::HashMap;
+
+use chrono::{DateTime, Utc};
+use ds_core::edr_engine::EdrEngine;
+use ds_core::error::DataServerError;
+use ds_core::feature::{parse_area_coords, QueryPolygon};
+use ds_core::model::{
+    AreaQueryResult, DomainDescription, Location, NdArray, ParameterDescription, QueryResult,
+};
+
+use crate::catalog::CatalogEntry;
+use crate::engine::OdimEngine;
+use crate::reader::OdimComposite;
+
+/// Per-dimension cap on the area-query output grid. An ODIM
+/// composite can be ~4400 px across; without a cap an area query
+/// over the whole grid would emit a multi-megabyte coverage per
+/// timestep. 256 keeps a single-timestep area response well under
+/// 1 MB while still being finer than most display use cases need.
+const MAX_AREA_DIM: usize = 256;
+
+/// Parse an EDR `coords` value for a position query into
+/// `(lat, lon)`. Accepts WKT `POINT(lon lat)` and the bare
+/// `lon,lat` shorthand — the same two forms the other engines
+/// accept (each engine carries its own copy; there is no shared
+/// parser in `ds-core`).
+fn parse_point_coords(coords: &str) -> Result<(f64, f64), DataServerError> {
+    let trimmed = coords.trim();
+
+    let pair = if let Some(inner) = trimmed
+        .strip_prefix("POINT(")
+        .or_else(|| trimmed.strip_prefix("POINT ("))
+        .and_then(|s| s.strip_suffix(')'))
+    {
+        inner.split_whitespace().collect::<Vec<_>>()
+    } else {
+        trimmed.split(',').map(str::trim).collect::<Vec<_>>()
+    };
+
+    if pair.len() != 2 {
+        return Err(DataServerError::InvalidParameter(
+            "Expected POINT(lon lat) or lon,lat format".into(),
+        ));
+    }
+    let lon: f64 = pair[0].parse().map_err(|_| {
+        DataServerError::InvalidParameter(format!("Invalid longitude: {}", pair[0]))
+    })?;
+    let lat: f64 = pair[1]
+        .parse()
+        .map_err(|_| DataServerError::InvalidParameter(format!("Invalid latitude: {}", pair[1])))?;
+    if !lon.is_finite() || !lat.is_finite() {
+        return Err(DataServerError::InvalidParameter(
+            "Coordinates must be finite numbers".into(),
+        ));
+    }
+    if !(-180.0..=180.0).contains(&lon) || !(-90.0..=90.0).contains(&lat) {
+        return Err(DataServerError::InvalidParameter(format!(
+            "Coordinates out of range: lon={lon}, lat={lat}"
+        )));
+    }
+    Ok((lat, lon))
+}
+
+/// Bilinearly interpolate the composite's physical value at a WGS84
+/// `(lon, lat)`. Returns `None` when the point falls outside the
+/// grid, projects to a non-finite coordinate, or any of the four
+/// surrounding pixels is `nodata`/`undetect` — in the last case it
+/// degrades to a nearest-neighbour sample (matching what
+/// `MapEngine::get_raster_tile` would return) rather than dropping
+/// the point entirely.
+fn sample_bilinear(
+    composite: &OdimComposite,
+    lon: f64,
+    lat: f64,
+    gain: f64,
+    offset: f64,
+    nodata: f64,
+    undetect: Option<f64>,
+) -> Option<f64> {
+    let (x, y) = composite.crs.forward(lon, lat);
+    if !x.is_finite() || !y.is_finite() {
+        return None;
+    }
+
+    let [src_w, src_s, src_e, src_n] = composite.bbox;
+    let src_dx = (src_e - src_w) / composite.xsize as f64;
+    let src_dy = (src_n - src_s) / composite.ysize as f64;
+    let (rows, cols) = composite.pixels.shape();
+
+    // Fractional position relative to pixel *centres*. A pixel `c`
+    // spans native-x `[src_w + c·dx, src_w + (c+1)·dx)`, so its
+    // centre sits at `src_w + (c+0.5)·dx` — hence the `-0.5`.
+    let col_f = (x - src_w) / src_dx - 0.5;
+    let row_f = (src_n - y) / src_dy - 0.5;
+    let col0 = col_f.floor();
+    let row0 = row_f.floor();
+    let fx = col_f - col0;
+    let fy = row_f - row0;
+    let c0 = col0 as i64;
+    let r0 = row0 as i64;
+
+    let in_bounds = |r: i64, c: i64| r >= 0 && c >= 0 && (r as usize) < rows && (c as usize) < cols;
+    let s = |r: i64, c: i64| {
+        composite
+            .pixels
+            .sample(r as usize, c as usize, gain, offset, nodata, undetect)
+    };
+
+    if in_bounds(r0, c0)
+        && in_bounds(r0, c0 + 1)
+        && in_bounds(r0 + 1, c0)
+        && in_bounds(r0 + 1, c0 + 1)
+    {
+        if let (Some(tl), Some(tr), Some(bl), Some(br)) =
+            (s(r0, c0), s(r0, c0 + 1), s(r0 + 1, c0), s(r0 + 1, c0 + 1))
+        {
+            let top = tl + (tr - tl) * fx;
+            let bot = bl + (br - bl) * fx;
+            return Some(top + (bot - top) * fy);
+        }
+    }
+
+    // Fallback: nearest-neighbour, identical to the indexing
+    // `get_raster_tile` uses.
+    let col = ((x - src_w) / src_dx).floor() as i64;
+    let row = ((src_n - y) / src_dy).floor() as i64;
+    if col < 0 || col >= cols as i64 || row < 0 || row >= rows as i64 {
+        return None;
+    }
+    composite
+        .pixels
+        .sample(row as usize, col as usize, gain, offset, nodata, undetect)
+}
+
+impl OdimEngine {
+    /// Snapshot the catalog entries whose timestamps fall in the
+    /// inclusive `datetime` range (or all entries when `None`).
+    /// Returns owned clones so the `ArcSwap` guard drops immediately.
+    fn catalog_entries_in_range(
+        &self,
+        datetime: Option<(DateTime<Utc>, DateTime<Utc>)>,
+    ) -> Vec<CatalogEntry> {
+        let snapshot = self.catalog.load();
+        match datetime {
+            Some((start, end)) => snapshot
+                .iter()
+                .filter(|e| e.time >= start && e.time <= end)
+                .cloned()
+                .collect(),
+            None => snapshot.iter().cloned().collect(),
+        }
+    }
+
+    /// Reject a `parameters` filter that doesn't name this engine's
+    /// single quantity. A `None` filter (all parameters) is fine.
+    fn check_parameter_filter(&self, parameters: Option<&[String]>) -> Result<(), DataServerError> {
+        if let Some(params) = parameters {
+            if !params.iter().any(|p| p == &self.parameter) {
+                return Err(DataServerError::InvalidParameter(format!(
+                    "Unknown parameter. Available: {}",
+                    self.parameter
+                )));
+            }
+        }
+        Ok(())
+    }
+
+    /// Build the single-entry parameter-description map this engine
+    /// advertises (one quantity per collection).
+    fn parameter_map(&self) -> HashMap<String, ParameterDescription> {
+        let mut map = HashMap::new();
+        map.insert(
+            self.parameter.clone(),
+            ParameterDescription {
+                label: self.parameter.replace('_', " "),
+                unit: self.unit.clone(),
+                observed_property: self.parameter.clone(),
+            },
+        );
+        map
+    }
+
+    /// Position query: a `PointSeries` coverage with one bilinearly
+    /// interpolated value per catalog timestep in range.
+    fn query_point(
+        &self,
+        lat: f64,
+        lon: f64,
+        datetime: Option<(DateTime<Utc>, DateTime<Utc>)>,
+        parameters: Option<&[String]>,
+    ) -> Result<QueryResult, DataServerError> {
+        self.check_parameter_filter(parameters)?;
+
+        let entries = self.catalog_entries_in_range(datetime);
+        if entries.is_empty() {
+            return Err(DataServerError::LocationNotFound(
+                "No ODIM data available for the requested time range".into(),
+            ));
+        }
+
+        let mut times = Vec::with_capacity(entries.len());
+        let mut values = Vec::with_capacity(entries.len());
+        for entry in &entries {
+            times.push(entry.time);
+            match self.load_composite(&entry.path) {
+                Ok(composite) => {
+                    let gain = self.gain_override.unwrap_or(composite.gain);
+                    let offset = self.offset_override.unwrap_or(composite.offset);
+                    let nodata = self.nodata_override.unwrap_or(composite.nodata);
+                    values.push(sample_bilinear(
+                        &composite,
+                        lon,
+                        lat,
+                        gain,
+                        offset,
+                        nodata,
+                        composite.undetect,
+                    ));
+                }
+                Err(e) => {
+                    // A single unreadable file shouldn't fail the
+                    // whole series — emit a gap and carry on.
+                    tracing::warn!(
+                        "[{}] EDR position query: failed to load `{}`: {e}",
+                        self.collection_id,
+                        entry.path.display()
+                    );
+                    values.push(None);
+                }
+            }
+        }
+
+        let mut ranges = HashMap::new();
+        ranges.insert(
+            self.parameter.clone(),
+            NdArray {
+                shape: vec![values.len()],
+                axis_names: vec!["t".to_string()],
+                values,
+            },
+        );
+
+        Ok(QueryResult {
+            domain: DomainDescription::PointSeries {
+                x: lon,
+                y: lat,
+                t: times,
+            },
+            parameters: self.parameter_map(),
+            ranges,
+        })
+    }
+
+    /// Area query: a `Grid` coverage over the polygon's bounding
+    /// box. The output grid is a regular WGS84 lon/lat lattice;
+    /// cells whose centre falls outside the polygon are masked to
+    /// `None`.
+    fn query_polygon(
+        &self,
+        polygon: &QueryPolygon,
+        datetime: Option<(DateTime<Utc>, DateTime<Utc>)>,
+        parameters: Option<&[String]>,
+    ) -> Result<QueryResult, DataServerError> {
+        self.check_parameter_filter(parameters)?;
+
+        let entries = self.catalog_entries_in_range(datetime);
+        if entries.is_empty() {
+            return Err(DataServerError::LocationNotFound(
+                "No ODIM data available for the requested time range".into(),
+            ));
+        }
+
+        // Load the first composite to size the output grid against
+        // the source's native resolution.
+        let first = self.load_composite(&entries[0].path)?;
+        let [ll_lon, ll_lat, ur_lon, ur_lat] = first.wgs84_corners;
+        let deg_per_px_lon = ((ur_lon - ll_lon).abs() / first.xsize as f64).max(f64::MIN_POSITIVE);
+        let deg_per_px_lat = ((ur_lat - ll_lat).abs() / first.ysize as f64).max(f64::MIN_POSITIVE);
+
+        let west = polygon.bbox.west;
+        let south = polygon.bbox.south;
+        let east = polygon.bbox.east;
+        let north = polygon.bbox.north;
+
+        // Match the source resolution, clamped to [1, MAX_AREA_DIM].
+        let nx = (((east - west) / deg_per_px_lon).ceil() as usize).clamp(1, MAX_AREA_DIM);
+        let ny = (((north - south) / deg_per_px_lat).ceil() as usize).clamp(1, MAX_AREA_DIM);
+
+        // Cell centres. `x` ascends west→east, `y` descends
+        // north→south (index 0 = north), matching the row order the
+        // raster sampler and `NdArray` layout use.
+        let cell_w = (east - west) / nx as f64;
+        let cell_h = (north - south) / ny as f64;
+        let x_values: Vec<f64> = (0..nx)
+            .map(|ix| west + (ix as f64 + 0.5) * cell_w)
+            .collect();
+        let y_values: Vec<f64> = (0..ny)
+            .map(|iy| north - (iy as f64 + 0.5) * cell_h)
+            .collect();
+
+        let has_time = entries.len() > 1;
+        let mut times = Vec::with_capacity(entries.len());
+        let mut all_values: Vec<Option<f64>> = Vec::with_capacity(entries.len() * ny * nx);
+
+        for entry in &entries {
+            times.push(entry.time);
+            let composite = match self.load_composite(&entry.path) {
+                Ok(c) => c,
+                Err(e) => {
+                    tracing::warn!(
+                        "[{}] EDR area query: failed to load `{}`: {e}",
+                        self.collection_id,
+                        entry.path.display()
+                    );
+                    all_values.extend(std::iter::repeat_n(None, ny * nx));
+                    continue;
+                }
+            };
+            let gain = self.gain_override.unwrap_or(composite.gain);
+            let offset = self.offset_override.unwrap_or(composite.offset);
+            let nodata = self.nodata_override.unwrap_or(composite.nodata);
+            for &y in &y_values {
+                for &x in &x_values {
+                    if polygon.contains(x, y) {
+                        all_values.push(sample_bilinear(
+                            &composite,
+                            x,
+                            y,
+                            gain,
+                            offset,
+                            nodata,
+                            composite.undetect,
+                        ));
+                    } else {
+                        all_values.push(None);
+                    }
+                }
+            }
+        }
+
+        let (domain, shape, axis_names) = if has_time {
+            (
+                DomainDescription::Grid {
+                    x: x_values,
+                    y: y_values,
+                    t: Some(times),
+                },
+                vec![entries.len(), ny, nx],
+                vec!["t".to_string(), "y".to_string(), "x".to_string()],
+            )
+        } else {
+            (
+                DomainDescription::Grid {
+                    x: x_values,
+                    y: y_values,
+                    t: None,
+                },
+                vec![ny, nx],
+                vec!["y".to_string(), "x".to_string()],
+            )
+        };
+
+        let mut ranges = HashMap::new();
+        ranges.insert(
+            self.parameter.clone(),
+            NdArray {
+                shape,
+                axis_names,
+                values: all_values,
+            },
+        );
+
+        Ok(QueryResult {
+            domain,
+            parameters: self.parameter_map(),
+            ranges,
+        })
+    }
+}
+
+impl EdrEngine for OdimEngine {
+    fn get_locations(&self) -> Result<Vec<Location>, DataServerError> {
+        // ODIM composites are gridded fields, not station networks.
+        Ok(vec![])
+    }
+
+    fn query_location(
+        &self,
+        _location_id: &str,
+        _datetime: Option<(DateTime<Utc>, DateTime<Utc>)>,
+        _parameters: Option<&[String]>,
+    ) -> Result<QueryResult, DataServerError> {
+        Err(DataServerError::InvalidParameter(
+            "ODIM engine does not support named location queries. \
+             Use the position query endpoint instead (e.g. /position?coords=POINT(lon lat))."
+                .into(),
+        ))
+    }
+
+    fn get_parameters(&self) -> Vec<String> {
+        vec![self.parameter.clone()]
+    }
+
+    fn get_parameter_descriptions(&self) -> HashMap<String, ParameterDescription> {
+        self.parameter_map()
+    }
+
+    fn get_temporal_extent(&self) -> Option<(DateTime<Utc>, DateTime<Utc>)> {
+        let snapshot = self.catalog.load();
+        let first = snapshot.first()?.time;
+        let last = snapshot.last()?.time;
+        Some((first, last))
+    }
+
+    fn get_available_times(&self) -> Option<Vec<DateTime<Utc>>> {
+        // Radar composites arrive at discrete (typically 5-min)
+        // steps, so advertise the exact timestamps rather than just
+        // the interval — same rationale as the GRIB engine.
+        let times: Vec<DateTime<Utc>> = self.catalog.load().iter().map(|e| e.time).collect();
+        if times.is_empty() {
+            None
+        } else {
+            Some(times)
+        }
+    }
+
+    fn get_spatial_extent(&self) -> Option<[f64; 4]> {
+        // The seed composite loaded at construction carries the
+        // WGS84 corner envelope; read it under the same recovered
+        // mutex `raster_info` uses.
+        let guard = self.cached.lock().unwrap_or_else(|e| {
+            tracing::error!(
+                "[{}] ODIM cache mutex was poisoned in get_spatial_extent; recovering",
+                self.collection_id
+            );
+            e.into_inner()
+        });
+        guard.as_ref().map(|(_, c)| c.wgs84_corners)
+    }
+
+    fn supported_query_types(&self) -> Vec<String> {
+        vec!["position".to_string(), "area".to_string()]
+    }
+
+    fn query_position(
+        &self,
+        coords: &str,
+        datetime: Option<(DateTime<Utc>, DateTime<Utc>)>,
+        parameters: Option<&[String]>,
+    ) -> Result<QueryResult, DataServerError> {
+        let (lat, lon) = parse_point_coords(coords)?;
+        self.query_point(lat, lon, datetime, parameters)
+    }
+
+    fn query_area(
+        &self,
+        coords: &str,
+        datetime: Option<(DateTime<Utc>, DateTime<Utc>)>,
+        parameters: Option<&[String]>,
+    ) -> Result<AreaQueryResult, DataServerError> {
+        let polygon = parse_area_coords(coords)?;
+        let result = self.query_polygon(&polygon, datetime, parameters)?;
+        Ok(AreaQueryResult::Single(result))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_point_coords_accepts_wkt() {
+        let (lat, lon) = parse_point_coords("POINT(10.5 56.0)").unwrap();
+        assert_eq!((lat, lon), (56.0, 10.5));
+        // PROJ-style space before the paren is tolerated.
+        let (lat, lon) = parse_point_coords("POINT (10.5 56.0)").unwrap();
+        assert_eq!((lat, lon), (56.0, 10.5));
+    }
+
+    #[test]
+    fn parse_point_coords_accepts_bare_pair() {
+        let (lat, lon) = parse_point_coords("10.5, 56.0").unwrap();
+        assert_eq!((lat, lon), (56.0, 10.5));
+        let (lat, lon) = parse_point_coords("  -3.2,48.7 ").unwrap();
+        assert_eq!((lat, lon), (48.7, -3.2));
+    }
+
+    #[test]
+    fn parse_point_coords_rejects_malformed() {
+        assert!(parse_point_coords("POINT(10.5)").is_err());
+        assert!(parse_point_coords("10.5").is_err());
+        assert!(parse_point_coords("a,b").is_err());
+        assert!(parse_point_coords("10.5,56.0,3").is_err());
+    }
+
+    #[test]
+    fn parse_point_coords_rejects_out_of_range() {
+        // Longitude past ±180 / latitude past ±90 are rejected so a
+        // transposed `lat,lon` pair fails loudly instead of querying
+        // a nonsense location.
+        assert!(parse_point_coords("200.0, 10.0").is_err());
+        assert!(parse_point_coords("10.0, 95.0").is_err());
+        assert!(parse_point_coords("POINT(10 91)").is_err());
+    }
+
+    #[test]
+    fn parse_point_coords_rejects_non_finite() {
+        assert!(parse_point_coords("NaN, 10.0").is_err());
+        assert!(parse_point_coords("inf, 10.0").is_err());
+    }
+}

--- a/crates/engine-odim/src/edr.rs
+++ b/crates/engine-odim/src/edr.rs
@@ -50,6 +50,16 @@ use crate::reader::OdimComposite;
 /// 1 MB while still being finer than most display use cases need.
 const MAX_AREA_DIM: usize = 256;
 
+/// Cap on the number of timesteps an area query may span. The area
+/// coverage is an `ny × nx` grid (each ≤ `MAX_AREA_DIM`) *per*
+/// timestep, so an unbounded count would let one request allocate
+/// hundreds of MB. 64 × 256 × 256 `Option<f64>` ≈ 67 MB worst case,
+/// which bounds a deliberate area-over-time query while still
+/// rejecting a "give me everything" request against a full
+/// 5-min-cadence catalog (~288 entries). A position query has no
+/// such cap because it yields only `N` scalars, not `N · ny · nx`.
+const MAX_AREA_TIMESTEPS: usize = 64;
+
 /// Parse an EDR `coords` value for a position query into
 /// `(lat, lon)`. Accepts WKT `POINT(lon lat)` and the bare
 /// `lon,lat` shorthand — the same two forms the other engines
@@ -301,12 +311,29 @@ impl OdimEngine {
             ));
         }
 
-        // Load the first composite to size the output grid against
-        // the source's native resolution.
-        let first = self.load_composite(&entries[0].path)?;
-        let [ll_lon, ll_lat, ur_lon, ur_lat] = first.wgs84_corners;
-        let deg_per_px_lon = ((ur_lon - ll_lon).abs() / first.xsize as f64).max(f64::MIN_POSITIVE);
-        let deg_per_px_lat = ((ur_lat - ll_lat).abs() / first.ysize as f64).max(f64::MIN_POSITIVE);
+        // Bound the response size. An area query produces an
+        // `ny × nx` grid per timestep (`ny`, `nx` ≤ `MAX_AREA_DIM`),
+        // so an unfiltered query over a full 5-min-cadence catalog
+        // (`max_files` up to ~288) would allocate hundreds of MB.
+        // Cap the timestep count and tell the client to narrow
+        // `datetime` rather than silently truncating their request.
+        if entries.len() > MAX_AREA_TIMESTEPS {
+            return Err(DataServerError::InvalidParameter(format!(
+                "Area query spans {} timesteps; the maximum is {MAX_AREA_TIMESTEPS}. \
+                 Narrow the `datetime` range.",
+                entries.len()
+            )));
+        }
+
+        // Grid resolution comes from the seed composite's dimensions
+        // (every timestep shares the same grid) — no probe load, so
+        // a single unreadable first file no longer hard-fails the
+        // whole query the way an earlier `load_composite(...)?` did.
+        let [ll_lon, ll_lat, ur_lon, ur_lat] = self.seed_spatial_extent;
+        let deg_per_px_lon =
+            ((ur_lon - ll_lon).abs() / self.seed_xsize as f64).max(f64::MIN_POSITIVE);
+        let deg_per_px_lat =
+            ((ur_lat - ll_lat).abs() / self.seed_ysize as f64).max(f64::MIN_POSITIVE);
 
         let west = polygon.bbox.west;
         let south = polygon.bbox.south;

--- a/crates/engine-odim/src/edr.rs
+++ b/crates/engine-odim/src/edr.rs
@@ -415,8 +415,13 @@ impl EdrEngine for OdimEngine {
         _datetime: Option<(DateTime<Utc>, DateTime<Utc>)>,
         _parameters: Option<&[String]>,
     ) -> Result<QueryResult, DataServerError> {
-        Err(DataServerError::InvalidParameter(
-            "ODIM engine does not support named location queries. \
+        // An ODIM composite is a gridded field with no named
+        // locations, so any location id is genuinely "not found" →
+        // HTTP 404 (`LocationNotFound`), not "bad request" (400).
+        // Same variant `CsvEngine`/`PostgisEngine` use for an
+        // unknown location id.
+        Err(DataServerError::LocationNotFound(
+            "ODIM engine has no named locations. \
              Use the position query endpoint instead (e.g. /position?coords=POINT(lon lat))."
                 .into(),
         ))
@@ -450,17 +455,11 @@ impl EdrEngine for OdimEngine {
     }
 
     fn get_spatial_extent(&self) -> Option<[f64; 4]> {
-        // The seed composite loaded at construction carries the
-        // WGS84 corner envelope; read it under the same recovered
-        // mutex `raster_info` uses.
-        let guard = self.cached.lock().unwrap_or_else(|e| {
-            tracing::error!(
-                "[{}] ODIM cache mutex was poisoned in get_spatial_extent; recovering",
-                self.collection_id
-            );
-            e.into_inner()
-        });
-        guard.as_ref().map(|(_, c)| c.wgs84_corners)
+        // Seed field captured at construction — stable for the
+        // engine's lifetime and independent of whether the render
+        // cache has been warmed, so an `apis = ["edr"]`-only
+        // collection still reports a real extent.
+        Some(self.seed_spatial_extent)
     }
 
     fn supported_query_types(&self) -> Vec<String> {

--- a/crates/engine-odim/src/engine.rs
+++ b/crates/engine-odim/src/engine.rs
@@ -57,6 +57,17 @@ pub struct OdimEngine {
     pub(crate) gain_override: Option<f64>,
     pub(crate) offset_override: Option<f64>,
     pub(crate) nodata_override: Option<f64>,
+    /// Native-CRS label and WGS84 corner envelope captured from the
+    /// seed composite at construction. Every timestep of a given
+    /// ODIM collection shares the same grid, so these are stable
+    /// for the engine's lifetime. Holding them as plain fields lets
+    /// `raster_info()` (MapEngine) and `get_spatial_extent()` (EDR)
+    /// answer collection metadata without touching the render
+    /// cache `Mutex` — and, crucially, without depending on whether
+    /// a `get_raster_tile` call has warmed that cache yet (an
+    /// `apis = ["edr"]`-only collection never issues one).
+    pub(crate) seed_native_crs: String,
+    pub(crate) seed_spatial_extent: [f64; 4],
     /// Single-entry path-keyed cache. ODIM composites are small (a
     /// few MB) but HDF5 parsing dominates `get_raster_tile` latency
     /// at high request rates — keeping the last file resident makes
@@ -160,6 +171,9 @@ impl OdimEngine {
                 })?,
             );
 
+        let seed_native_crs = crs_label(&composite.crs);
+        let seed_spatial_extent = composite.wgs84_corners;
+
         Ok(Self {
             catalog: Arc::new(ArcSwap::from_pointee(catalog)),
             collection_id: collection_id.to_string(),
@@ -168,6 +182,8 @@ impl OdimEngine {
             gain_override: config.gain,
             offset_override: config.offset,
             nodata_override: config.nodata,
+            seed_native_crs,
+            seed_spatial_extent,
             cached: Mutex::new(Some((seed_path, composite))),
             data_dir: data_dir.to_path_buf(),
             matcher,
@@ -532,28 +548,16 @@ impl MapEngine for OdimEngine {
     }
 
     fn raster_info(&self) -> RasterInfo {
-        // Read native_crs and spatial_extent from the seed-loaded
-        // composite under a single lock acquisition. Times come from
-        // the catalog (separate lock-free ArcSwap snapshot). Recover
-        // from a poisoned mutex (same rationale as `load_composite`).
-        let cached_guard = self.cached.lock().unwrap_or_else(|e| {
-            tracing::error!(
-                "[{}] ODIM cache mutex was poisoned in raster_info; recovering",
-                self.collection_id
-            );
-            e.into_inner()
-        });
-        let (native_crs, spatial_extent) = cached_guard
-            .as_ref()
-            .map(|(_, c)| (crs_label(&c.crs), Some(c.wgs84_corners)))
-            .unwrap_or_else(|| ("unknown".into(), None));
-        drop(cached_guard);
-
+        // `native_crs` / `spatial_extent` come from the seed fields
+        // captured at construction — every timestep shares the same
+        // grid, so this needs neither the render-cache `Mutex` nor a
+        // warmed cache. Times come from the lock-free `ArcSwap`
+        // catalog snapshot.
         let times: Vec<DateTime<Utc>> = self.catalog.load().iter().map(|e| e.time).collect();
 
         RasterInfo {
-            native_crs,
-            spatial_extent,
+            native_crs: self.seed_native_crs.clone(),
+            spatial_extent: Some(self.seed_spatial_extent),
             times,
             parameter: self.parameter.clone(),
             unit: self.unit.clone(),

--- a/crates/engine-odim/src/engine.rs
+++ b/crates/engine-odim/src/engine.rs
@@ -355,11 +355,18 @@ impl OdimEngine {
     ///
     /// **Blocking call** — uses `std::fs::read` and HDF5 parsing
     /// directly. Callers from async contexts must wrap in
-    /// `tokio::task::spawn_blocking`. The `MapEngine::get_raster_tile`
-    /// call chain already runs inside `spawn_blocking` (the WMS /
-    /// Maps / Tiles handlers do this); a future `EdrEngine` impl
-    /// or a health-check pre-warmer would need its own
-    /// `spawn_blocking` to avoid stalling Tokio workers.
+    /// `tokio::task::spawn_blocking`. Two call paths reach here:
+    ///
+    /// - `MapEngine::get_raster_tile` — already runs inside
+    ///   `spawn_blocking` (the WMS / Maps / Tiles handlers do this).
+    /// - `EdrEngine::query_position` / `query_area` (see `edr.rs`) —
+    ///   the api-edr handlers currently call these directly from an
+    ///   `async fn` *without* `spawn_blocking`, so this blocking
+    ///   work lands on a Tokio worker. That is a pre-existing
+    ///   api-edr-level gap affecting every EDR engine (GeoTIFF,
+    ///   QueryData, GRIB all do blocking I/O in `query_position`
+    ///   too) — tracked in issue #178, to be fixed in the api-edr
+    ///   handlers rather than per-engine.
     pub(crate) fn load_composite(
         &self,
         path: &Path,

--- a/crates/engine-odim/src/engine.rs
+++ b/crates/engine-odim/src/engine.rs
@@ -57,17 +57,19 @@ pub struct OdimEngine {
     pub(crate) gain_override: Option<f64>,
     pub(crate) offset_override: Option<f64>,
     pub(crate) nodata_override: Option<f64>,
-    /// Native-CRS label and WGS84 corner envelope captured from the
-    /// seed composite at construction. Every timestep of a given
-    /// ODIM collection shares the same grid, so these are stable
-    /// for the engine's lifetime. Holding them as plain fields lets
-    /// `raster_info()` (MapEngine) and `get_spatial_extent()` (EDR)
-    /// answer collection metadata without touching the render
-    /// cache `Mutex` — and, crucially, without depending on whether
-    /// a `get_raster_tile` call has warmed that cache yet (an
-    /// `apis = ["edr"]`-only collection never issues one).
+    /// Native-CRS label, WGS84 corner envelope, and grid dimensions
+    /// captured from the seed composite at construction. Every
+    /// timestep of a given ODIM collection shares the same grid, so
+    /// these are stable for the engine's lifetime. Holding them as
+    /// plain fields lets `raster_info()` (MapEngine) and the EDR
+    /// metadata / area-grid-sizing paths answer without touching the
+    /// render cache `Mutex` — and, crucially, without depending on
+    /// whether a `get_raster_tile` call has warmed that cache yet
+    /// (an `apis = ["edr"]`-only collection never issues one).
     pub(crate) seed_native_crs: String,
     pub(crate) seed_spatial_extent: [f64; 4],
+    pub(crate) seed_xsize: u32,
+    pub(crate) seed_ysize: u32,
     /// Single-entry path-keyed cache. ODIM composites are small (a
     /// few MB) but HDF5 parsing dominates `get_raster_tile` latency
     /// at high request rates — keeping the last file resident makes
@@ -173,6 +175,8 @@ impl OdimEngine {
 
         let seed_native_crs = crs_label(&composite.crs);
         let seed_spatial_extent = composite.wgs84_corners;
+        let seed_xsize = composite.xsize;
+        let seed_ysize = composite.ysize;
 
         Ok(Self {
             catalog: Arc::new(ArcSwap::from_pointee(catalog)),
@@ -184,6 +188,8 @@ impl OdimEngine {
             nodata_override: config.nodata,
             seed_native_crs,
             seed_spatial_extent,
+            seed_xsize,
+            seed_ysize,
             cached: Mutex::new(Some((seed_path, composite))),
             data_dir: data_dir.to_path_buf(),
             matcher,

--- a/crates/engine-odim/src/engine.rs
+++ b/crates/engine-odim/src/engine.rs
@@ -48,18 +48,20 @@ use crate::reader::{read_composite, OdimComposite};
 /// publish refreshed entries (new files, removed files) without
 /// disturbing in-flight reads.
 pub struct OdimEngine {
-    catalog: Arc<ArcSwap<Vec<CatalogEntry>>>,
-    collection_id: String,
-    parameter: String,
-    unit: String,
-    gain_override: Option<f64>,
-    offset_override: Option<f64>,
-    nodata_override: Option<f64>,
+    // Fields used by both the `MapEngine` impl (this file) and the
+    // `EdrEngine` impl (`edr.rs`) are `pub(crate)`.
+    pub(crate) catalog: Arc<ArcSwap<Vec<CatalogEntry>>>,
+    pub(crate) collection_id: String,
+    pub(crate) parameter: String,
+    pub(crate) unit: String,
+    pub(crate) gain_override: Option<f64>,
+    pub(crate) offset_override: Option<f64>,
+    pub(crate) nodata_override: Option<f64>,
     /// Single-entry path-keyed cache. ODIM composites are small (a
     /// few MB) but HDF5 parsing dominates `get_raster_tile` latency
     /// at high request rates — keeping the last file resident makes
     /// hot-tile loops effectively free of read cost.
-    cached: Mutex<Option<(PathBuf, Arc<OdimComposite>)>>,
+    pub(crate) cached: Mutex<Option<(PathBuf, Arc<OdimComposite>)>>,
     /// Source state for the poll loop.
     data_dir: PathBuf,
     matcher: FilenameMatcher,
@@ -342,7 +344,10 @@ impl OdimEngine {
     /// Maps / Tiles handlers do this); a future `EdrEngine` impl
     /// or a health-check pre-warmer would need its own
     /// `spawn_blocking` to avoid stalling Tokio workers.
-    fn load_composite(&self, path: &Path) -> Result<Arc<OdimComposite>, DataServerError> {
+    pub(crate) fn load_composite(
+        &self,
+        path: &Path,
+    ) -> Result<Arc<OdimComposite>, DataServerError> {
         // Use a path-keyed single-entry cache. Cache hits return the
         // same `Arc` to every caller; on a cold miss two concurrent
         // `spawn_blocking` callers may both read the file and both

--- a/crates/engine-odim/src/lib.rs
+++ b/crates/engine-odim/src/lib.rs
@@ -19,6 +19,7 @@
 //! integration map that Phase 2 will draw on.
 
 pub mod catalog;
+pub mod edr;
 pub mod engine;
 pub mod proj;
 pub mod reader;

--- a/crates/engine-odim/tests/integration.rs
+++ b/crates/engine-odim/tests/integration.rs
@@ -278,6 +278,67 @@ fn edr_query_area_returns_grid() {
     );
 }
 
+/// An unbounded area query (`datetime = None`) over a catalog with
+/// more than `MAX_AREA_TIMESTEPS` (64) entries is rejected with a
+/// `400`-class error rather than allocating a hundreds-of-MB
+/// coverage cube. Builds a 65-file catalog by copying the DMI
+/// fixture to distinct 5-minute-spaced timestamps.
+#[test]
+fn edr_query_area_rejects_too_many_timesteps() {
+    let dir = tempfile::tempdir().expect("create tempdir");
+    let src = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../testdata/odim-dmi-fixture.h5")
+        .canonicalize()
+        .expect("fixture path canonicalises");
+    // 65 files at 5-min spacing from 2026-05-14 00:00 — one past the
+    // 64-timestep cap.
+    for i in 0..65 {
+        let total_min = i * 5;
+        let hh = total_min / 60;
+        let mm = total_min % 60;
+        let name = format!("dk.com.20260514{hh:02}{mm:02}.500_max.h5");
+        std::fs::copy(&src, dir.path().join(name)).expect("copy fixture");
+    }
+
+    let config = OdimConfig {
+        filename_template: Some("dk.com.%Y%m%d%H%M.500_max.h5".into()),
+        filename_pattern: None,
+        timestamp_format: None,
+        parameter: "reflectivity".into(),
+        unit: "dBZ".into(),
+        nodata: None,
+        gain: None,
+        offset: None,
+        poll_interval_secs: 30,
+        max_files: None,
+        endpoint: None,
+        bucket: None,
+        prefix_pattern: None,
+    };
+    let engine = engine_odim::OdimEngine::new(dir.path(), "dmi-cap-test", &config)
+        .expect("engine builds over the 65-file catalog");
+
+    // No datetime filter → all 65 entries → over the cap → error.
+    let err = engine
+        .query_area("9.0,55.0,12.0,57.5", None, None)
+        .unwrap_err();
+    assert!(
+        format!("{err}").contains("maximum is 64"),
+        "expected a timestep-cap error, got: {err}"
+    );
+
+    // A narrow datetime range keeps it under the cap → succeeds.
+    use chrono::{TimeZone, Utc};
+    let start = Utc.with_ymd_and_hms(2026, 5, 14, 0, 0, 0).unwrap();
+    let end = Utc.with_ymd_and_hms(2026, 5, 14, 0, 30, 0).unwrap();
+    assert!(
+        engine
+            .query_area("9.0,55.0,12.0,57.5", Some((start, end)), None)
+            .is_ok(),
+        "a 7-timestep window must stay under the cap"
+    );
+}
+
 /// A `POLYGON(...)` area query masks cells outside the ring to
 /// `None`. A degenerate thin triangle leaves most of its bbox grid
 /// masked, so the masked-cell count is strictly positive.

--- a/crates/engine-odim/tests/integration.rs
+++ b/crates/engine-odim/tests/integration.rs
@@ -12,7 +12,9 @@
 use std::path::Path;
 
 use ds_core::config::OdimConfig;
+use ds_core::edr_engine::EdrEngine;
 use ds_core::map_engine::{MapEngine, OutputCrs};
+use ds_core::model::{AreaQueryResult, DomainDescription};
 
 /// Construct an `OdimEngine` over `testdata/odim-dmi-fixture.h5`
 /// (a real DMI v2.0 ODIM_H5 composite shipped in this repo). Returns
@@ -145,4 +147,158 @@ fn get_raster_tile_full_extent_does_not_panic() {
         .expect("full-extent render succeeds");
 
     assert_eq!(tile.values.len(), 32 * 32);
+}
+
+// ---------------------------------------------------------------------------
+// EdrEngine (Phase 1.5)
+// ---------------------------------------------------------------------------
+
+/// EDR collection-metadata accessors report sane values for the DMI
+/// fixture: one parameter, position+area query types, a single-step
+/// temporal extent, and a Denmark-ish spatial extent.
+#[test]
+fn edr_metadata_is_consistent() {
+    let (engine, _guard) = dmi_engine();
+
+    assert_eq!(engine.get_parameters(), vec!["reflectivity".to_string()]);
+
+    let mut qt = engine.supported_query_types();
+    qt.sort();
+    assert_eq!(qt, vec!["area".to_string(), "position".to_string()]);
+
+    let (start, end) = engine
+        .get_temporal_extent()
+        .expect("fixture has a temporal extent");
+    assert_eq!(start, end, "single-file fixture → degenerate interval");
+
+    let times = engine
+        .get_available_times()
+        .expect("fixture advertises discrete times");
+    assert_eq!(times.len(), 1);
+
+    let bbox = engine
+        .get_spatial_extent()
+        .expect("fixture has a spatial extent");
+    assert!(
+        bbox[0] > 0.0 && bbox[2] < 25.0 && bbox[1] > 50.0 && bbox[3] < 60.0,
+        "spatial extent should cover Denmark-ish range, got {bbox:?}"
+    );
+
+    // ODIM has no station list — locations is empty, query_location
+    // is unsupported.
+    assert!(engine.get_locations().unwrap().is_empty());
+    assert!(engine.query_location("anything", None, None).is_err());
+}
+
+/// `query_position` over central Denmark returns a `PointSeries`
+/// coverage: x/y pinned to the requested point, one timestep, an
+/// `NdArray` shaped `[1]` over the `t` axis. Pixel content isn't
+/// asserted — the checked-in fixture is a clear-air snapshot.
+#[test]
+fn edr_query_position_returns_point_series() {
+    let (engine, _guard) = dmi_engine();
+    let result = engine
+        .query_position("POINT(10.5 56.0)", None, None)
+        .expect("position query succeeds");
+
+    match result.domain {
+        DomainDescription::PointSeries { x, y, ref t } => {
+            assert_eq!((x, y), (10.5, 56.0));
+            assert_eq!(t.len(), 1);
+        }
+        other => panic!("expected PointSeries, got {other:?}"),
+    }
+    let range = result
+        .ranges
+        .get("reflectivity")
+        .expect("range keyed by parameter name");
+    assert_eq!(range.shape, vec![1]);
+    assert_eq!(range.axis_names, vec!["t".to_string()]);
+    assert_eq!(range.values.len(), 1);
+}
+
+/// A position query for a point far outside the composite still
+/// returns a well-formed coverage — the single value is simply
+/// `None` (off-grid), not an error.
+#[test]
+fn edr_query_position_off_grid_is_none() {
+    let (engine, _guard) = dmi_engine();
+    let result = engine
+        .query_position("POINT(-140.0 12.0)", None, None)
+        .expect("off-grid position query still succeeds");
+    let range = &result.ranges["reflectivity"];
+    assert_eq!(range.values, vec![None]);
+}
+
+/// An unknown `parameters` filter is rejected.
+#[test]
+fn edr_query_position_rejects_unknown_parameter() {
+    let (engine, _guard) = dmi_engine();
+    let err = engine
+        .query_position("POINT(10.5 56.0)", None, Some(&["temperature".to_string()]))
+        .unwrap_err();
+    assert!(format!("{err}").contains("Unknown parameter"));
+}
+
+/// `query_area` over a Denmark bbox returns a `Single` `Grid`
+/// coverage whose `NdArray` length equals the product of its shape
+/// dimensions (the CoverageJSON NdArray invariant).
+#[test]
+fn edr_query_area_returns_grid() {
+    let (engine, _guard) = dmi_engine();
+    let result = engine
+        .query_area("9.0,55.0,12.0,57.5", None, None)
+        .expect("area query succeeds");
+
+    let coverage = match result {
+        AreaQueryResult::Single(qr) => qr,
+        AreaQueryResult::Collection(_) => panic!("ODIM area query must return Single"),
+    };
+
+    let (nx, ny) = match coverage.domain {
+        DomainDescription::Grid {
+            ref x,
+            ref y,
+            ref t,
+        } => {
+            assert!(t.is_none(), "single-file fixture → no time axis");
+            (x.len(), y.len())
+        }
+        other => panic!("expected Grid, got {other:?}"),
+    };
+    assert!(nx > 0 && ny > 0);
+
+    let range = &coverage.ranges["reflectivity"];
+    assert_eq!(range.shape, vec![ny, nx]);
+    assert_eq!(range.axis_names, vec!["y".to_string(), "x".to_string()]);
+    assert_eq!(
+        range.values.len(),
+        ny * nx,
+        "NdArray length must equal the product of shape dims"
+    );
+}
+
+/// A `POLYGON(...)` area query masks cells outside the ring to
+/// `None`. A degenerate thin triangle leaves most of its bbox grid
+/// masked, so the masked-cell count is strictly positive.
+#[test]
+fn edr_query_area_masks_outside_polygon() {
+    let (engine, _guard) = dmi_engine();
+    let result = engine
+        .query_area(
+            "POLYGON((9.0 55.0, 12.0 55.0, 9.0 57.0, 9.0 55.0))",
+            None,
+            None,
+        )
+        .expect("polygon area query succeeds");
+    let coverage = match result {
+        AreaQueryResult::Single(qr) => qr,
+        AreaQueryResult::Collection(_) => panic!("expected Single"),
+    };
+    let range = &coverage.ranges["reflectivity"];
+    let masked = range.values.iter().filter(|v| v.is_none()).count();
+    assert!(
+        masked > 0,
+        "a thin triangle must leave some bbox cells outside the polygon"
+    );
 }

--- a/crates/server/src/admin.rs
+++ b/crates/server/src/admin.rs
@@ -426,11 +426,7 @@ pub fn load_collections(
             "geotiff" => &["edr", "wms", "maps", "tiles"],
             "querydata" => &["edr", "wms", "maps", "tiles"],
             "grib" => &["edr", "wms", "maps", "tiles"],
-            // ODIM Phase 1 ships MapEngine only — EDR is being added in a
-            // follow-up commit. Listing it here as unsupported makes a
-            // config typo `apis = ["edr"]` fail loudly at load rather
-            // than silently serving 404s.
-            "odim" => &["wms", "maps", "tiles"],
+            "odim" => &["edr", "wms", "maps", "tiles"],
             "postgis" => &["edr", "features", "tiles"],
             _ => &[],
         };
@@ -1020,9 +1016,15 @@ pub fn load_collections(
 
                 odim_engines.push(engine.clone());
 
-                // EDR will be wired here in a follow-up commit once
-                // `OdimEngine` implements `EdrEngine`. For now ODIM
-                // serves WMS/Maps/Tiles only.
+                if collection.apis.contains(&"edr".to_string()) {
+                    edr_engines.insert(
+                        collection.id.clone(),
+                        engine.clone() as Arc<dyn ds_core::edr_engine::EdrEngine>,
+                    );
+                    edr_collections.insert(collection.id.clone(), collection.clone());
+                    info!("Collection '{}': wired to EDR API", collection.id);
+                }
+
                 let raster_params =
                     ds_core::map_engine::MapEngine::raster_info(engine.as_ref()).parameters;
 


### PR DESCRIPTION
## Summary

ODIM Phase 1 (#176) shipped `MapEngine` only — WMS/Maps/Tiles raster output. Phase 1.5 adds the `EdrEngine` impl so the same ODIM_H5 radar composites answer OGC API - EDR **position** and **area** queries, reaching capability parity with the GeoTIFF raster engine.

- **position** — `POINT(lon lat)` / bare `lon,lat` → bilinear interpolation at that point for every catalog timestep in range → `PointSeries` coverage. Bilinear reprojects into the composite's native CRS, samples the four surrounding pixel centres, and degrades to nearest-neighbour when a neighbour is nodata/undetect.
- **area** — WKT polygon or `w,s,e,n` bbox → a regular WGS84 lon/lat output grid sized to the source's native resolution (capped 256/dim to bound response size), each cell bilinearly sampled, cells outside the polygon masked to `None` → `Single(Grid)` coverage.
- metadata: parameters (with configured unit), temporal extent + discrete `available_times` from the catalog, spatial extent from the seed composite, `supported_query_types = ["position","area"]`.
- no station list on a gridded radar field → `get_locations` empty, `query_location` unsupported (matches GeoTIFF).

## Implementation notes

- New `crates/engine-odim/src/edr.rs`. `OdimEngine`'s catalog/parameter/cache fields and `load_composite` became `pub(crate)` so the sibling module reuses the Phase 1 catalog + composite-cache machinery — no duplication.
- `server/src/admin.rs`: `odim` supported-APIs set gains `"edr"`; the odim load arm registers into `edr_engines` when the collection lists `edr`.
- The three ODIM collection configs (`radar-dmi`, `radar-dwd`, `radar-opera`) add `"edr"` to `apis`.
- No `api-edr` changes — the position/area endpoints + CoverageJSON serializers are engine-agnostic and already exist.

## Test plan

- [x] `cargo test -p engine-odim` — 43 lib + 10 integration tests pass (6 new EDR integration tests against the checked-in DMI fixture: position PointSeries shape, off-grid → `None`, unknown-parameter rejection, area Grid shape + NdArray-length invariant, polygon masking, metadata consistency)
- [x] `cargo test -p server` — 45 + 10 pass (admin wiring)
- [x] `cargo test -p api-edr` — CoverageJSON schema-validation suite passes
- [x] `cargo clippy -p engine-odim -p server --all-targets -D warnings` — clean
- [x] End-to-end against a live server: `/edr/collections/radar-dmi-composite/position` returns a 5-timestep `PointSeries`; `/area` returns a `[256,182]` `Grid` with 151 non-null interpolated pixels from a real DMI file; malformed `coords` → HTTP 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)