### PR TITLE
fix(engine-odim): report the true WGS84 envelope of projected grids

### DIFF
--- a/crates/engine-odim/src/engine.rs
+++ b/crates/engine-odim/src/engine.rs
@@ -174,7 +174,7 @@ impl OdimEngine {
             );
 
         let seed_native_crs = crs_label(&composite.crs);
-        let seed_spatial_extent = composite.wgs84_corners;
+        let seed_spatial_extent = composite.wgs84_bbox;
         let seed_xsize = composite.xsize;
         let seed_ysize = composite.ysize;
 

--- a/crates/engine-odim/src/reader.rs
+++ b/crates/engine-odim/src/reader.rs
@@ -170,11 +170,18 @@ pub struct OdimComposite {
     /// outer pixel boundaries (not pixel centres). For projected
     /// CRSes this is in metres; for `Wgs84` it's in degrees.
     pub bbox: [f64; 4],
-    /// WGS84-corner bbox `[ll_lon, ll_lat, ur_lon, ur_lat]` straight
-    /// from the file's `/where` group. Kept alongside `bbox` so
-    /// callers can pick whichever frame is cheaper for their query
-    /// without re-running the projection forward.
-    pub wgs84_corners: [f64; 4],
+    /// WGS84 bounding box `[west, south, east, north]` — the
+    /// envelope of the grid in lon/lat, computed by sampling points
+    /// along every edge of `bbox` and inverse-projecting them.
+    ///
+    /// **Not** the file's raw `LL`/`UR` corner attributes: for a
+    /// projected grid (LAEA, stereographic, …) the grid is a
+    /// quadrilateral that bows in lon/lat, so its true lon/lat
+    /// extent is wider than the LL→UR diagonal. OPERA's LAEA grid,
+    /// for instance, reaches ~29° further west at its `UL` corner
+    /// than at `LL`. Edge sampling captures that (the same approach
+    /// `ds_core::geo::GeoTransform::bbox` uses for GeoTIFF).
+    pub wgs84_bbox: [f64; 4],
     /// Nominal acquisition time (UTC), parsed from
     /// `/what/date` + `/what/time`.
     pub time: DateTime<Utc>,
@@ -197,6 +204,57 @@ pub struct OdimComposite {
     /// because flipping a 2000×2000 u16 array is wasteful when
     /// callers can flip indices for free.
     pub pixels: RawPixels,
+}
+
+/// Compute the WGS84 envelope `[west, south, east, north]` of a
+/// native-CRS `bbox` `[west, south, east, north]` by sampling
+/// `EDGE_SAMPLES` points along every edge and inverse-projecting
+/// each. Points that fail to reproject are skipped.
+///
+/// Sampling the edges (not just the four corners) is what captures
+/// the bow of a projected grid in lon/lat — the same technique
+/// `ds_core::geo::GeoTransform::bbox` uses for GeoTIFF, so the two
+/// raster engines report consistent extents for the same data.
+fn wgs84_envelope(crs: &Crs, bbox: [f64; 4]) -> [f64; 4] {
+    /// Samples per edge. 20 matches `GeoTransform::bbox`; enough to
+    /// pin the bow of a continental LAEA grid to well under a pixel.
+    const EDGE_SAMPLES: usize = 20;
+
+    let [w, s, e, n] = bbox;
+    let mut min_lon = f64::MAX;
+    let mut max_lon = f64::MIN;
+    let mut min_lat = f64::MAX;
+    let mut max_lat = f64::MIN;
+    let mut accumulate = |lon: f64, lat: f64| {
+        min_lon = min_lon.min(lon);
+        max_lon = max_lon.max(lon);
+        min_lat = min_lat.min(lat);
+        max_lat = max_lat.max(lat);
+    };
+    for i in 0..=EDGE_SAMPLES {
+        let frac = i as f64 / EDGE_SAMPLES as f64;
+        // Top + bottom edges (x varies, y pinned).
+        let x = w + frac * (e - w);
+        for &y in &[s, n] {
+            if let Some((lon, lat)) = crs.inverse(x, y) {
+                accumulate(lon, lat);
+            }
+        }
+        // Left + right edges (y varies, x pinned).
+        let y = s + frac * (n - s);
+        for &x in &[w, e] {
+            if let Some((lon, lat)) = crs.inverse(x, y) {
+                accumulate(lon, lat);
+            }
+        }
+    }
+
+    // If every reprojection failed (a pathological CRS), fall back
+    // to the native bbox unchanged rather than emit `[MAX,…,MIN]`.
+    if min_lon > max_lon {
+        return bbox;
+    }
+    [min_lon, min_lat, max_lon, max_lat]
 }
 
 /// Parse an ODIM_H5 composite from a byte slice. The whole file must
@@ -248,28 +306,20 @@ pub fn read_composite(bytes: &[u8]) -> Result<OdimComposite, ReadError> {
     let time_str = read_string_attr("/what", "time")?;
     let time = parse_odim_timestamp(&date, &time_str)?;
 
-    // /where — projection + grid extents. ODIM_H5 v2.4 §6.1.2 makes
-    // all four corner pairs mandatory (LL, LR, UL, UR); some older
-    // producers ship only LL+UR (the canonical "axis-aligned in
-    // lat/lon" case). Read all four when present and fall back to
-    // synthesising LR/UL from LL/UR when they're missing.
+    // /where — projection + grid extents. We need the UL corner as
+    // the anchor for the native `bbox` (built further down). ODIM
+    // v2.4 §6.1.2 makes all four corner pairs mandatory, but some
+    // older producers ship only LL+UR for the axis-aligned
+    // lon/lat case; for those (`Crs::Wgs84` only) synthesise UL as
+    // `(LL_lon, UR_lat)`. On a projected grid that synthesis is
+    // wrong — the UL corner's lon/lat differs materially from LL's
+    // because the projection bows the parallels — so refuse it and
+    // fail loudly rather than anchor the bbox at a corrupt point.
     let projdef = read_string_attr("/where", "projdef")?;
     let crs = proj::parse(&projdef)?;
-    let ll_lon = read_f64_attr("/where", "LL_lon")?;
-    let ll_lat = read_f64_attr("/where", "LL_lat")?;
-    let ur_lon = read_f64_attr("/where", "UR_lon")?;
-    let ur_lat = read_f64_attr("/where", "UR_lat")?;
-    // The `ul_lon = ll_lon, ul_lat = ur_lat` synthesis below is only
-    // correct for axis-aligned lon/lat grids. On a projected grid
-    // (stereographic, LAEA, TM, LCC) the UL corner's WGS84
-    // longitude differs materially from LL's because the projection
-    // bends the parallels — a 1984×1728 grid at 500 m/px can show
-    // several degrees of offset. Refuse the synthesis there so a
-    // future producer that omits UL on a projected composite fails
-    // loudly rather than producing a corrupted bbox anchor.
     let ul_lon = match read_f64_attr("/where", "UL_lon") {
         Ok(v) => v,
-        Err(_) if matches!(crs, Crs::Wgs84) => ll_lon,
+        Err(_) if matches!(crs, Crs::Wgs84) => read_f64_attr("/where", "LL_lon")?,
         Err(_) => {
             return Err(ReadError::MissingAttribute {
                 group: "/where".into(),
@@ -279,7 +329,7 @@ pub fn read_composite(bytes: &[u8]) -> Result<OdimComposite, ReadError> {
     };
     let ul_lat = match read_f64_attr("/where", "UL_lat") {
         Ok(v) => v,
-        Err(_) if matches!(crs, Crs::Wgs84) => ur_lat,
+        Err(_) if matches!(crs, Crs::Wgs84) => read_f64_attr("/where", "UR_lat")?,
         Err(_) => {
             return Err(ReadError::MissingAttribute {
                 group: "/where".into(),
@@ -287,7 +337,6 @@ pub fn read_composite(bytes: &[u8]) -> Result<OdimComposite, ReadError> {
             });
         }
     };
-    let wgs84_corners = [ll_lon, ll_lat, ur_lon, ur_lat];
 
     // /dataset1/data1/data — read shape early so xsize/ysize can fall
     // back to the data array dimensions for producers (e.g. DMI) that
@@ -392,6 +441,12 @@ pub fn read_composite(bytes: &[u8]) -> Result<OdimComposite, ReadError> {
         xscale,
         yscale
     );
+
+    // WGS84 envelope: sample every edge of the native `bbox` and
+    // inverse-project. The LL→UR diagonal alone under-reports a
+    // projected grid's lon/lat extent (see `wgs84_bbox` docs).
+    let wgs84_bbox = wgs84_envelope(&crs, bbox);
+    tracing::debug!("ODIM WGS84 envelope: {:?}", wgs84_bbox);
 
     // gain/offset/nodata/quantity location varies by producer:
     // - Earlier producers:           /dataset1/what/{...}          (some EUMETNET v2.x files)
@@ -512,7 +567,7 @@ pub fn read_composite(bytes: &[u8]) -> Result<OdimComposite, ReadError> {
         xsize,
         ysize,
         bbox,
-        wgs84_corners,
+        wgs84_bbox,
         time,
         quantity,
         gain,
@@ -551,6 +606,75 @@ fn parse_odim_timestamp(date: &str, time: &str) -> Result<DateTime<Utc>, ReadErr
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// `wgs84_envelope` must capture the lon/lat bow of a projected
+    /// grid, not the LL→UR corner diagonal — and not even just the
+    /// four-corner envelope. Regression for the OPERA LAEA case:
+    ///
+    /// - the grid's `UL` corner reaches ~39.5° W while `LL` is only
+    ///   at ~10.4° W, so an LL→UR diagonal under-reports the west
+    ///   edge by ~29°;
+    /// - the grid's *top edge* bows to ~73.9° N — ~6° past both the
+    ///   `UL` (67.0°) and `UR` (67.6°) corners — so even a
+    ///   four-corner envelope under-reports the north edge.
+    ///   Per-edge sampling is what catches this.
+    ///
+    /// Inputs reproduce the real OPERA composite:
+    ///   projdef `+proj=laea +lat_0=55 +lon_0=10 +x_0=1950000
+    ///            +y_0=-2100000 +ellps=WGS84`
+    ///   grid    3800×4400 at 1000 m, UL anchored at the projected
+    ///           origin → native bbox `[0, -4.4e6, 3.8e6, 0]` m.
+    /// Verified against a live server: envelope ≈
+    ///   `[-39.536, 31.746, 57.812, 73.922]`.
+    #[test]
+    fn wgs84_envelope_captures_laea_trapezoid() {
+        let crs = Crs::LambertAzimuthalEqualArea {
+            lat0: 55.0_f64.to_radians(),
+            lon0: 10.0_f64.to_radians(),
+            false_e: 1_950_000.0,
+            false_n: -2_100_000.0,
+        };
+        let native_bbox = [0.0, -4_400_000.0, 3_800_000.0, 0.0];
+        let [w, s, e, n] = wgs84_envelope(&crs, native_bbox);
+
+        assert!(
+            w < e && s < n,
+            "envelope must be well-formed: {w},{s},{e},{n}"
+        );
+        // The LL→UR shortcut would report west ≈ -10.4 (LL_lon); the
+        // true western reach is the UL corner near -39.5° W.
+        assert!(
+            (-41.0..-38.0).contains(&w),
+            "west should reach the UL corner (~-39.5°), got {w}"
+        );
+        assert!(
+            (56.0..60.0).contains(&e),
+            "east should reach the UR corner (~57.8°), got {e}"
+        );
+        assert!(
+            (30.0..33.0).contains(&s),
+            "south should sit near the LL/LR edge (~31.7°), got {s}"
+        );
+        // The corner shortcut (or a four-corner envelope) would
+        // report north ≈ 67.6° (UR_lat); edge sampling finds the
+        // top edge's ~73.9° bow.
+        assert!(
+            n > 72.0,
+            "north should capture the top-edge bow (~73.9°), got {n}"
+        );
+    }
+
+    /// For a `Wgs84` (axis-aligned lon/lat) grid the envelope is just
+    /// the native bbox — `Crs::Wgs84::inverse` is the identity, so no
+    /// distortion is introduced.
+    #[test]
+    fn wgs84_envelope_is_identity_for_wgs84_grid() {
+        let bbox = [10.0, 50.0, 25.0, 60.0];
+        let env = wgs84_envelope(&Crs::Wgs84, bbox);
+        for (got, want) in env.iter().zip(bbox.iter()) {
+            assert!((got - want).abs() < 1e-9, "got {env:?}, want {bbox:?}");
+        }
+    }
 
     /// Date+time parsing accepts the canonical ODIM format.
     #[test]

--- a/crates/engine-odim/src/reader.rs
+++ b/crates/engine-odim/src/reader.rs
@@ -250,9 +250,14 @@ fn wgs84_envelope(crs: &Crs, bbox: [f64; 4]) -> [f64; 4] {
     }
 
     // If every reprojection failed (a pathological CRS), fall back
-    // to the native bbox unchanged rather than emit `[MAX,…,MIN]`.
+    // to a conservative global extent. Returning the native `bbox`
+    // here would be a unit-confusion bug: for a projected CRS it is
+    // in metres, and the caller expects WGS84 degrees. `[-180, -90,
+    // 180, 90]` is over-broad but at least dimensionally valid.
+    // (Unreachable for any real grid — `Crs::Wgs84::inverse` is the
+    // identity and projected inverses succeed near the grid.)
     if min_lon > max_lon {
-        return bbox;
+        return [-180.0, -90.0, 180.0, 90.0];
     }
     [min_lon, min_lat, max_lon, max_lat]
 }

--- a/crates/engine-odim/tests/integration.rs
+++ b/crates/engine-odim/tests/integration.rs
@@ -51,9 +51,15 @@ fn dmi_engine() -> (engine_odim::OdimEngine, tempfile::TempDir) {
 }
 
 /// `MapEngine::raster_info()` advertises the native CRS as
-/// stereographic and the WGS84 corner envelope as Denmark-ish — a
-/// sanity check that the projection-string parser, projection math,
-/// and metadata bookkeeping are connected.
+/// stereographic and the WGS84 envelope as Denmark-and-surrounds —
+/// a sanity check that the projection-string parser, projection
+/// math, and metadata bookkeeping are connected.
+///
+/// The envelope is the edge-sampled lon/lat extent of the
+/// stereographic grid (`reader::wgs84_envelope`), not the raw
+/// LL→UR corner diagonal — a DMI 500 m composite covers Denmark
+/// plus the surrounding seas and neighbouring coastlines, and the
+/// grid edges bow slightly past the corner latitudes/longitudes.
 #[test]
 fn raster_info_reports_dmi_extents() {
     let (engine, _guard) = dmi_engine();
@@ -67,15 +73,27 @@ fn raster_info_reports_dmi_extents() {
     let bbox = info
         .spatial_extent
         .expect("DMI fixture has a spatial extent");
-    assert!(
-        bbox[0] > 0.0 && bbox[2] < 25.0,
-        "longitude bbox should cover Denmark-ish range, got {bbox:?}"
-    );
-    assert!(
-        bbox[1] > 50.0 && bbox[3] < 60.0,
-        "latitude bbox should cover Denmark-ish range, got {bbox:?}"
-    );
+    assert_dmi_envelope(bbox);
     assert_eq!(info.times.len(), 1, "fixture has a single timestep");
+}
+
+/// Sanity-check a DMI-fixture WGS84 envelope `[w, s, e, n]`. The
+/// fixture's grid is fixed, so the edge-sampled envelope is
+/// deterministic (~`[3.0, 52.15, 20.74, 60.21]`); these bands are
+/// wide enough not to be brittle to projection-math tweaks but
+/// tight enough to catch a gross regression (e.g. the old
+/// LL→UR-corner shortcut, or a degenerate `[MAX,…,MIN]`).
+fn assert_dmi_envelope(bbox: [f64; 4]) {
+    let [w, s, e, n] = bbox;
+    assert!(w < e && s < n, "envelope must be well-formed, got {bbox:?}");
+    assert!(
+        (0.0..6.0).contains(&w) && (16.0..24.0).contains(&e),
+        "longitude envelope should cover Denmark-and-surrounds, got {bbox:?}"
+    );
+    assert!(
+        (48.0..56.0).contains(&s) && (57.0..63.0).contains(&n),
+        "latitude envelope should cover Denmark-and-surrounds, got {bbox:?}"
+    );
 }
 
 /// `MapEngine::get_raster_tile()` produces a 64×64 tile over
@@ -179,10 +197,7 @@ fn edr_metadata_is_consistent() {
     let bbox = engine
         .get_spatial_extent()
         .expect("fixture has a spatial extent");
-    assert!(
-        bbox[0] > 0.0 && bbox[2] < 25.0 && bbox[1] > 50.0 && bbox[3] < 60.0,
-        "spatial extent should cover Denmark-ish range, got {bbox:?}"
-    );
+    assert_dmi_envelope(bbox);
 
     // ODIM has no station list — locations is empty, query_location
     // is unsupported.


### PR DESCRIPTION
## Summary

The ODIM reader derived a composite's reported WGS84 extent as `[LL_lon, LL_lat, UR_lon, UR_lat]` — the lower-left and upper-right corner attributes treated as `[west, south, east, north]`. That holds only for an axis-aligned lon/lat grid. A **projected** grid (LAEA, stereographic, …) is a quadrilateral that bows in lon/lat, so the LL→UR diagonal under-reports the real extent.

Surfaced as an EDR `/collections` `extent.spatial.bbox` mismatch against the **GeoTIFF** version of the same OPERA data — GeoTIFF edge-samples (`ds_core::geo::GeoTransform::bbox`), ODIM used the corner shortcut.

### OPERA (LAEA) — the worst case

| Edge | Corner shortcut | True envelope | Miss |
|---|---|---|---|
| west | −10.43° (`LL_lon`) | **−39.54°** (`UL` corner) | ~29° |
| north | 67.62° (`UR_lat`) | **73.92°** (top-edge bow) | ~6° |

The north miss is the interesting one: the LAEA grid's *top edge* bows ~6° past **both** top corners (`UL` 67.0°, `UR` 67.6°), so even a four-corner envelope would still be wrong. Per-edge sampling is what catches it.

## Fix

Compute the extent the way GeoTIFF already does. New `wgs84_envelope(crs, native_bbox)` samples 20 points along every edge of the native projected `bbox`, inverse-projects each through the CRS, and takes the min/max envelope. The `OdimComposite` field is renamed `wgs84_corners` → `wgs84_bbox` to stop implying it holds raw corner values.

Corner attributes `LL_lat`/`UR_lon` are no longer read (only used by the dropped shortcut); `LL_lon`/`UR_lat` are still read lazily as the `UL`-synthesis fallback for axis-aligned `Wgs84` grids that ship only LL+UR.

This affects every **reported** extent (EDR `/collections`, WMS/Maps/Tiles `GetCapabilities`). Tile/coverage **rendering** was already correct — it forward-projects per pixel and never consulted `wgs84_corners`.

## Test plan

- [x] New `wgs84_envelope_captures_laea_trapezoid` — reproduces OPERA's LAEA grid, asserts west ≈ −39.5° and north > 72° (the top-edge bow), not the corner values
- [x] New `wgs84_envelope_is_identity_for_wgs84_grid` — axis-aligned grids are unaffected
- [x] DMI integration extent assertions updated to the (correct, edge-sampled) values via a shared `assert_dmi_envelope` helper
- [x] `cargo test -p engine-odim` — 45 lib + 11 integration pass; clippy clean; server builds
- [x] Verified against a live server: OPERA EDR `extent.spatial.bbox` `[-10.43, 31.75, 57.81, 67.62]` → `[-39.54, 31.75, 57.81, 73.92]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)