### PR TITLE
feat(engine-odim): S3 object-store source (Phase 2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -790,6 +790,7 @@ name = "ds-storage"
 version = "0.1.0"
 dependencies = [
  "bytes",
+ "chrono",
  "ds-core",
  "futures",
  "object_store",
@@ -885,6 +886,7 @@ dependencies = [
  "arc-swap",
  "chrono",
  "ds-core",
+ "ds-storage",
  "hdf5-reader",
  "ndarray",
  "regex",

--- a/collections.d/radar-opera-composite-s3.toml
+++ b/collections.d/radar-opera-composite-s3.toml
@@ -1,0 +1,37 @@
+# EUMETNET OPERA pan-European radar composite (ODIM_H5 v2.4) — S3 source.
+#
+# Streams `OPERA@YYYYMMDDTHHMM@0@DBZH.h5` composites directly from
+# CloudFerro's public `openradar-24h` bucket — no local mirror, no
+# gdalwarp preprocessing. New timesteps land every 5 minutes; the
+# bucket keeps a rolling 24h window.
+#
+#   https://s3.waw3-1.cloudferro.com/openradar-24h/YYYY/MM/DD/OPERA/COMP/
+#
+# 4400x3800 grid at 2km/px over Europe, Lambert Azimuthal Equal Area
+# (+lat_0=55 +lon_0=10 +ellps=WGS84). DBZH quantity in physical dBZ.
+#
+# The local-fixture twin of this collection is `radar-opera-composite`.
+
+id = "radar-opera-composite-s3"
+title = "OPERA Pan-European Radar Composite (DBZH, S3)"
+description = """\
+EUMETNET OPERA pan-European weather-radar composite via ODIM_H5 v2.4, \
+streamed from CloudFerro S3. Maximum reflectivity (DBZH) on a 2km \
+Lambert Azimuthal Equal Area grid covering Europe.\
+"""
+engine_type = "odim"
+apis = ["edr", "wms", "maps", "tiles"]
+
+[odim]
+endpoint = "https://s3.waw3-1.cloudferro.com"
+bucket = "openradar-24h"
+prefix_pattern = "%Y/%m/%d/OPERA/COMP/"
+filename_template = "OPERA@%Y%m%dT%H%M@0@DBZH.h5"
+parameter = "reflectivity"
+unit = "dBZ"
+# Keep only the last 12h of the 24h bucket in the catalog.
+time_window = "-PT12H"
+poll_interval_secs = 300
+
+[wms]
+colormap = "radar_dbz"

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -361,16 +361,21 @@ pub struct OdimConfig {
     /// directory may hold years of history.
     pub max_files: Option<usize>,
 
-    /// S3-compatible endpoint URL. Phase 1 ignores this — Phase 2 will
-    /// wire S3 catalogs via `ds-storage::ObjectStore`. Engine boots
-    /// with a WARN if set, so a config typo doesn't silently fall
-    /// back to local-directory mode.
+    /// S3-compatible endpoint URL (e.g. `https://s3.waw3-1.cloudferro.com`).
+    /// When `endpoint` + `bucket` are set the engine reads from S3;
+    /// otherwise it scans the collection's local `data_path`.
     pub endpoint: Option<String>,
-    /// S3 bucket name. Phase 2; ignored with WARN in Phase 1.
+    /// S3 bucket name. Required when `endpoint` is set.
     pub bucket: Option<String>,
-    /// Object prefix, optionally with strftime templates. Phase 2;
-    /// ignored with WARN in Phase 1.
+    /// Object key prefix, optionally carrying strftime templates
+    /// (e.g. `%Y/%m/%d/OPERA/COMP/`). Expanded per UTC date on every
+    /// poll so the scan stays current across day boundaries.
     pub prefix_pattern: Option<String>,
+    /// ISO 8601 duration bounding which timesteps to keep, relative to
+    /// now (e.g. `-PT12H` for the last 12 hours). Drives both prefix
+    /// date expansion and timestamp filtering for S3 sources. When
+    /// unset, the scan falls back to a fixed recent-days window.
+    pub time_window: Option<String>,
 }
 
 fn default_grib_poll_interval() -> u64 {

--- a/crates/engine-odim/Cargo.toml
+++ b/crates/engine-odim/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 ds-core = { path = "../core" }
+ds-storage = { path = "../storage" }
 hdf5-reader = "0.4"
 ndarray = "0.17"
 chrono = { version = "0.4", features = ["serde"] }

--- a/crates/engine-odim/src/catalog.rs
+++ b/crates/engine-odim/src/catalog.rs
@@ -10,8 +10,8 @@
 //!
 //! A scan — local-directory ([`scan_local_directory`]) or S3/HTTP
 //! object-store ([`scan_remote`]) — applies the regex to each
-//! filename, parses the timestamp, and returns a sorted list of
-//! `(timestamp, path)` entries.
+//! filename, parses the timestamp, and returns a list of
+//! [`CatalogEntry`] values sorted by timestamp ascending.
 
 use std::path::{Path, PathBuf};
 
@@ -49,10 +49,43 @@ pub enum CatalogError {
 }
 
 /// One file in the catalog, sorted by `time` ascending.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 pub struct CatalogEntry {
     pub time: DateTime<Utc>,
-    pub path: PathBuf,
+    pub location: Location,
+}
+
+/// Where one catalog entry's bytes live.
+///
+/// Local and remote entries are deliberately distinct types, not a
+/// shared `PathBuf`: an S3/HTTP object key is **not** a filesystem
+/// path. Keys always use `/` regardless of host OS, so round-tripping
+/// one through `PathBuf` would corrupt it on a platform with a
+/// different separator. A `Remote` location also carries the
+/// [`ds_storage::DataStore`] handle (a cheap `Arc` clone) so the
+/// entry is self-sufficient — it can be fetched without threading the
+/// engine's source state back through every call site.
+#[derive(Debug, Clone)]
+pub enum Location {
+    /// A local filesystem path.
+    Local(PathBuf),
+    /// An object store plus the full object key within it.
+    Remote {
+        store: ds_storage::DataStore,
+        key: String,
+    },
+}
+
+impl Location {
+    /// Stable identity string — used for cache keying and log /
+    /// error messages. For `Local` this is the path; for `Remote`
+    /// the object key.
+    pub fn id(&self) -> String {
+        match self {
+            Location::Local(path) => path.display().to_string(),
+            Location::Remote { key, .. } => key.clone(),
+        }
+    }
 }
 
 /// Compiled regex + chrono format for matching ODIM filenames and
@@ -178,7 +211,10 @@ pub fn scan_local_directory(
             continue;
         };
         if let Some(time) = matcher.parse_timestamp(name) {
-            entries.push(CatalogEntry { time, path });
+            entries.push(CatalogEntry {
+                time,
+                location: Location::Local(path),
+            });
         }
     }
     entries.sort_by_key(|e| e.time);
@@ -252,7 +288,10 @@ pub fn scan_remote(
             }
             entries.push(CatalogEntry {
                 time,
-                path: PathBuf::from(key),
+                location: Location::Remote {
+                    store: store.clone(),
+                    key,
+                },
             });
         }
     }
@@ -276,7 +315,11 @@ pub fn scan_remote(
     // Sort by timestamp ascending; on a duplicate timestamp order the
     // key descending so the lexicographically-last key survives the
     // `dedup_by` (which keeps the first of each equal-timestamp run).
-    entries.sort_by(|a, b| a.time.cmp(&b.time).then_with(|| b.path.cmp(&a.path)));
+    entries.sort_by(|a, b| {
+        a.time
+            .cmp(&b.time)
+            .then_with(|| b.location.id().cmp(&a.location.id()))
+    });
     entries.dedup_by(|a, b| a.time == b.time);
 
     if let Some(cap) = max_files {
@@ -545,7 +588,7 @@ mod tests {
         assert_eq!(entries.len(), 2);
         let names: Vec<_> = entries
             .iter()
-            .map(|e| e.path.file_name().unwrap().to_str().unwrap().to_string())
+            .map(|e| e.location.id().rsplit('/').next().unwrap().to_string())
             .collect();
         assert_eq!(
             names,
@@ -587,13 +630,50 @@ mod tests {
         // time_filter drops entries outside the [00:05, 00:10] range.
         let start = "2026-05-15T00:05:00Z".parse().unwrap();
         let end = "2026-05-15T00:10:00Z".parse().unwrap();
-        let windowed =
-            scan_remote(&store, &["".to_string()], &matcher, Some((start, end)), None).unwrap();
+        let windowed = scan_remote(
+            &store,
+            &["".to_string()],
+            &matcher,
+            Some((start, end)),
+            None,
+        )
+        .unwrap();
         let times: Vec<_> = windowed.iter().map(|e| e.time.to_rfc3339()).collect();
         assert_eq!(
             times,
             ["2026-05-15T00:05:00+00:00", "2026-05-15T00:10:00+00:00"]
         );
+    }
+
+    /// Two objects under different prefixes share a timestamp. `dedup`
+    /// must collapse them to exactly one entry, deterministically
+    /// keeping the lexicographically-last key. Pins the tie-break so a
+    /// future change to the sort predicate can't silently flip the
+    /// winner.
+    #[test]
+    fn scan_remote_dedups_duplicate_timestamps_keeping_last_key() {
+        let dir = tempfile::tempdir().unwrap();
+        for sub in ["a", "b"] {
+            std::fs::create_dir(dir.path().join(sub)).unwrap();
+            std::fs::write(
+                dir.path().join(sub).join("OPERA@20260515T0000@0@DBZH.h5"),
+                b"x",
+            )
+            .unwrap();
+        }
+        let (store, _) = ds_storage::build_store(dir.path().to_str().unwrap()).unwrap();
+        let matcher = FilenameMatcher::from_template("OPERA@%Y%m%dT%H%M@0@DBZH.h5").unwrap();
+
+        let entries = scan_remote(
+            &store,
+            &["a".to_string(), "b".to_string()],
+            &matcher,
+            None,
+            None,
+        )
+        .unwrap();
+        assert_eq!(entries.len(), 1, "duplicate timestamp must collapse to one");
+        assert_eq!(entries[0].location.id(), "b/OPERA@20260515T0000@0@DBZH.h5");
     }
 
     /// Entries from multiple prefixes are merged; a prefix that yields
@@ -603,11 +683,7 @@ mod tests {
     fn scan_remote_merges_prefixes() {
         let dir = tempfile::tempdir().unwrap();
         std::fs::create_dir(dir.path().join("good")).unwrap();
-        std::fs::write(
-            dir.path().join("good/OPERA@20260515T0000@0@DBZH.h5"),
-            b"x",
-        )
-        .unwrap();
+        std::fs::write(dir.path().join("good/OPERA@20260515T0000@0@DBZH.h5"), b"x").unwrap();
         let (store, _) = ds_storage::build_store(dir.path().to_str().unwrap()).unwrap();
         let matcher = FilenameMatcher::from_template("OPERA@%Y%m%dT%H%M@0@DBZH.h5").unwrap();
 

--- a/crates/engine-odim/src/catalog.rs
+++ b/crates/engine-odim/src/catalog.rs
@@ -230,8 +230,10 @@ pub fn scan_local_directory(
 /// Skip remote objects larger than this — a guard against fetching a
 /// mis-uploaded or non-ODIM blob into memory. ODIM COMP composites run
 /// from ~35 KB (FMI single-radar) to a few MB (OPERA pan-European);
-/// 64 MB is a generous ceiling above any real composite.
-const MAX_REMOTE_FILE_SIZE: u64 = 64 * 1024 * 1024;
+/// 64 MB is a generous ceiling above any real composite. Enforced both
+/// at `list` time ([`scan_remote`]) and at `get` time (the engine's
+/// `fetch_bytes`) so an object that grew after listing is still caught.
+pub(crate) const MAX_REMOTE_FILE_SIZE: u64 = 64 * 1024 * 1024;
 
 /// Scan an S3/HTTP object store for ODIM files under the given set of
 /// (already date-expanded) key prefixes.
@@ -312,9 +314,12 @@ pub fn scan_remote(
         );
     }
 
-    // Sort by timestamp ascending; on a duplicate timestamp order the
-    // key descending so the lexicographically-last key survives the
-    // `dedup_by` (which keeps the first of each equal-timestamp run).
+    // Sort by timestamp ascending. Within an equal-timestamp run,
+    // order the key *descending* so the lexicographically-greatest key
+    // lands first (at the lower array index). `dedup_by` retains the
+    // first element of each run — so that greatest key is the one that
+    // survives. The sort direction (descending) and the dedup
+    // behaviour (keep-first) must stay consistent for this to hold.
     entries.sort_by(|a, b| {
         a.time
             .cmp(&b.time)

--- a/crates/engine-odim/src/catalog.rs
+++ b/crates/engine-odim/src/catalog.rs
@@ -8,17 +8,15 @@
 //! 1. A regex that matches just the timestamp portion of the filename
 //! 2. A chrono strftime format for parsing the matched substring
 //!
-//! Then a local-directory scan walks the directory, applies the regex
-//! to each filename, parses the timestamp, and returns a sorted list
-//! of `(timestamp, path)` entries.
-//!
-//! Phase 1 scope is local directories only. S3-backed catalogs land
-//! in Phase 1.5 once the engine wiring is proven end-to-end (see
-//! [[project_odim_engine_plan]]).
+//! A scan — local-directory ([`scan_local_directory`]) or S3/HTTP
+//! object-store ([`scan_remote`]) — applies the regex to each
+//! filename, parses the timestamp, and returns a sorted list of
+//! `(timestamp, path)` entries.
 
 use std::path::{Path, PathBuf};
 
 use chrono::{DateTime, NaiveDateTime, Utc};
+use ds_core::error::DataServerError;
 use regex::Regex;
 use tracing::warn;
 
@@ -184,6 +182,103 @@ pub fn scan_local_directory(
         }
     }
     entries.sort_by_key(|e| e.time);
+    if let Some(cap) = max_files {
+        if entries.len() > cap {
+            let start = entries.len() - cap;
+            entries.drain(..start);
+        }
+    }
+    Ok(entries)
+}
+
+/// Skip remote objects larger than this — a guard against fetching a
+/// mis-uploaded or non-ODIM blob into memory. ODIM COMP composites run
+/// from ~35 KB (FMI single-radar) to a few MB (OPERA pan-European);
+/// 64 MB is a generous ceiling above any real composite.
+const MAX_REMOTE_FILE_SIZE: u64 = 64 * 1024 * 1024;
+
+/// Scan an S3/HTTP object store for ODIM files under the given set of
+/// (already date-expanded) key prefixes.
+///
+/// Each prefix is `list`ed; object basenames are matched against
+/// `matcher`. Matched entries' `path` holds the full object key — not
+/// a filesystem path — which `OdimEngine` resolves back through the
+/// object store when loading composites.
+///
+/// `time_filter`, when set, drops entries whose timestamp falls
+/// outside the `(start, end)` range. `max_files` caps the result to
+/// the most recent N. Returns entries sorted by timestamp ascending.
+///
+/// A prefix that fails to `list` (e.g. a date partition that doesn't
+/// exist yet) is logged and skipped. If *every* prefix fails the call
+/// errors rather than silently returning an empty catalog.
+pub fn scan_remote(
+    store: &ds_storage::DataStore,
+    prefixes: &[String],
+    matcher: &FilenameMatcher,
+    time_filter: Option<(DateTime<Utc>, DateTime<Utc>)>,
+    max_files: Option<usize>,
+) -> Result<Vec<CatalogEntry>, DataServerError> {
+    use ds_storage::object_store::path::Path as ObjectPath;
+
+    let mut entries: Vec<CatalogEntry> = Vec::new();
+    let mut errors: Vec<String> = Vec::new();
+
+    for prefix in prefixes {
+        let listed = match store.list(&ObjectPath::from(prefix.as_str())) {
+            Ok(objects) => objects,
+            Err(e) => {
+                errors.push(format!("'{prefix}': {e}"));
+                continue;
+            }
+        };
+        for obj in listed {
+            if obj.size as u64 > MAX_REMOTE_FILE_SIZE {
+                warn!(
+                    "[catalog] skipping oversized remote object `{}` ({} bytes)",
+                    obj.location, obj.size
+                );
+                continue;
+            }
+            let key = obj.location.to_string();
+            let name = key.rsplit('/').next().unwrap_or(key.as_str());
+            let Some(time) = matcher.parse_timestamp(name) else {
+                continue;
+            };
+            if let Some((start, end)) = time_filter {
+                if time < start || time > end {
+                    continue;
+                }
+            }
+            entries.push(CatalogEntry {
+                time,
+                path: PathBuf::from(key),
+            });
+        }
+    }
+
+    if entries.is_empty() && !errors.is_empty() {
+        return Err(DataServerError::Engine(format!(
+            "all {} ODIM S3 prefix scan(s) failed: {}",
+            errors.len(),
+            errors.join("; ")
+        )));
+    }
+    if !errors.is_empty() {
+        warn!(
+            "[catalog] {} ODIM S3 prefix scan(s) failed (kept {} entries from the rest): {}",
+            errors.len(),
+            entries.len(),
+            errors.join("; ")
+        );
+    }
+
+    // Sort by timestamp ascending; on a duplicate timestamp order the
+    // key descending so the lexicographically-last key survives the
+    // `dedup_by` (which keeps the first of each equal-timestamp run).
+    entries.sort_by(|a, b| a.time.cmp(&b.time).then_with(|| b.path.cmp(&a.path)));
+    entries.dedup_by(|a, b| a.time == b.time);
+
     if let Some(cap) = max_files {
         if entries.len() > cap {
             let start = entries.len() - cap;
@@ -459,5 +554,72 @@ mod tests {
                 "20250714T0400_radar_fi.h5".to_string(),
             ]
         );
+    }
+
+    /// `scan_remote` against a `DataStore` backed by the local
+    /// filesystem — exercises the list → match → filter → cap pipeline
+    /// without needing a live S3 endpoint. The `LocalFileSystem`
+    /// object store behaves like S3 for `list`, so this covers the
+    /// real remote code path.
+    #[test]
+    fn scan_remote_matches_filters_and_caps() {
+        let dir = tempfile::tempdir().unwrap();
+        for name in [
+            "OPERA@20260515T0000@0@DBZH.h5",
+            "OPERA@20260515T0005@0@DBZH.h5",
+            "OPERA@20260515T0010@0@DBZH.h5",
+            "OPERA@20260515T0015@0@DBZH.h5",
+            "README.md",
+        ] {
+            std::fs::write(dir.path().join(name), b"x").unwrap();
+        }
+        let (store, _) = ds_storage::build_store(dir.path().to_str().unwrap()).unwrap();
+        let matcher = FilenameMatcher::from_template("OPERA@%Y%m%dT%H%M@0@DBZH.h5").unwrap();
+
+        // max_files caps to the most recent 2; README is skipped.
+        let capped = scan_remote(&store, &["".to_string()], &matcher, None, Some(2)).unwrap();
+        let times: Vec<_> = capped.iter().map(|e| e.time.to_rfc3339()).collect();
+        assert_eq!(
+            times,
+            ["2026-05-15T00:10:00+00:00", "2026-05-15T00:15:00+00:00"]
+        );
+
+        // time_filter drops entries outside the [00:05, 00:10] range.
+        let start = "2026-05-15T00:05:00Z".parse().unwrap();
+        let end = "2026-05-15T00:10:00Z".parse().unwrap();
+        let windowed =
+            scan_remote(&store, &["".to_string()], &matcher, Some((start, end)), None).unwrap();
+        let times: Vec<_> = windowed.iter().map(|e| e.time.to_rfc3339()).collect();
+        assert_eq!(
+            times,
+            ["2026-05-15T00:05:00+00:00", "2026-05-15T00:10:00+00:00"]
+        );
+    }
+
+    /// Entries from multiple prefixes are merged; a prefix that yields
+    /// nothing (or fails to `list`) doesn't sink the scan as long as
+    /// another prefix produces entries.
+    #[test]
+    fn scan_remote_merges_prefixes() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir(dir.path().join("good")).unwrap();
+        std::fs::write(
+            dir.path().join("good/OPERA@20260515T0000@0@DBZH.h5"),
+            b"x",
+        )
+        .unwrap();
+        let (store, _) = ds_storage::build_store(dir.path().to_str().unwrap()).unwrap();
+        let matcher = FilenameMatcher::from_template("OPERA@%Y%m%dT%H%M@0@DBZH.h5").unwrap();
+
+        let entries = scan_remote(
+            &store,
+            &["good".to_string(), "missing".to_string()],
+            &matcher,
+            None,
+            None,
+        )
+        .unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].time.to_rfc3339(), "2026-05-15T00:00:00+00:00");
     }
 }

--- a/crates/engine-odim/src/edr.rs
+++ b/crates/engine-odim/src/edr.rs
@@ -243,7 +243,7 @@ impl OdimEngine {
         let mut values = Vec::with_capacity(entries.len());
         for entry in &entries {
             times.push(entry.time);
-            match self.load_composite(&entry.path) {
+            match self.load_composite(&entry.location) {
                 Ok(composite) => {
                     let gain = self.gain_override.unwrap_or(composite.gain);
                     let offset = self.offset_override.unwrap_or(composite.offset);
@@ -264,7 +264,7 @@ impl OdimEngine {
                     tracing::warn!(
                         "[{}] EDR position query: failed to load `{}`: {e}",
                         self.collection_id,
-                        entry.path.display()
+                        entry.location.id()
                     );
                     values.push(None);
                 }
@@ -362,13 +362,13 @@ impl OdimEngine {
 
         for entry in &entries {
             times.push(entry.time);
-            let composite = match self.load_composite(&entry.path) {
+            let composite = match self.load_composite(&entry.location) {
                 Ok(c) => c,
                 Err(e) => {
                     tracing::warn!(
                         "[{}] EDR area query: failed to load `{}`: {e}",
                         self.collection_id,
-                        entry.path.display()
+                        entry.location.id()
                     );
                     all_values.extend(std::iter::repeat_n(None, ny * nx));
                     continue;

--- a/crates/engine-odim/src/engine.rs
+++ b/crates/engine-odim/src/engine.rs
@@ -111,6 +111,12 @@ fn scan_source(
 }
 
 /// Fetch the raw bytes of one ODIM file from its catalog location.
+///
+/// Remote fetches re-check the object size against
+/// [`crate::catalog::MAX_REMOTE_FILE_SIZE`] via `head` before `get`.
+/// `scan_remote` already filters by size at list time, but an object
+/// can grow between listing and fetching — the `head` closes that gap
+/// so a runaway object can't be pulled unbounded into memory.
 fn fetch_bytes(location: &Location) -> Result<Vec<u8>, DataServerError> {
     match location {
         Location::Local(path) => std::fs::read(path).map_err(|e| {
@@ -121,6 +127,14 @@ fn fetch_bytes(location: &Location) -> Result<Vec<u8>, DataServerError> {
         }),
         Location::Remote { store, key } => {
             let object = ds_storage::object_store::path::Path::from(key.as_str());
+            let meta = store.head(&object)?;
+            if meta.size as u64 > crate::catalog::MAX_REMOTE_FILE_SIZE {
+                return Err(DataServerError::Engine(format!(
+                    "ODIM object `{key}` is {} bytes — exceeds the {}-byte limit",
+                    meta.size,
+                    crate::catalog::MAX_REMOTE_FILE_SIZE
+                )));
+            }
             store.get(&object).map(|b| b.to_vec())
         }
     }

--- a/crates/engine-odim/src/engine.rs
+++ b/crates/engine-odim/src/engine.rs
@@ -1,10 +1,11 @@
 //! `MapEngine` impl backed by an ODIM_H5 composite catalog.
 //!
 //! At construction time, [`OdimEngine::new`] scans the configured
-//! local directory for ODIM files matching the `filename_template`
-//! pattern and pre-loads the most recent one so `raster_info()`
-//! can answer with non-empty `spatial_extent` and `times`. After
-//! that, every `get_raster_tile` call:
+//! source — a local directory or an S3/HTTP object-store prefix — for
+//! ODIM files matching the `filename_template` pattern and pre-loads
+//! the most recent one so `raster_info()` can answer with non-empty
+//! `spatial_extent` and `times`. After that, every `get_raster_tile`
+//! call:
 //!
 //! 1. Picks the catalog entry matching the requested time (or the
 //!    most recent if `time` is `None`).
@@ -14,11 +15,12 @@
 //!    or Web-Mercator output coords into the composite's native
 //!    CRS, and samples via nearest-neighbour.
 //!
-//! Phase 1 narrows the scope from the format's full capabilities:
-//! - Local directories only (no S3 / STAC — those land later)
+//! Scope is still narrowed from the format's full capabilities:
+//! - Single-dataset COMP composites (no PVOL polar volumes yet)
 //! - Single-parameter (one composite quantity per collection)
+//! - STAC sources land in a later phase
 //!
-//! A background `poll_loop` re-scans `data_dir` every
+//! A background `poll_loop` re-scans the source every
 //! `poll_interval_secs` and atomically swaps the catalog
 //! (`ArcSwap<Vec<CatalogEntry>>`) when the file set changes, so
 //! new ODIM files appear in the temporal extent without needing
@@ -39,8 +41,88 @@ use std::sync::atomic::{AtomicBool, Ordering};
 
 use tokio::sync::Notify;
 
-use crate::catalog::{scan_local_directory, CatalogEntry, FilenameMatcher};
+use ds_storage::discovery::{expand_prefix_for_dates, expand_prefix_pattern, TimeWindow};
+
+use crate::catalog::{scan_local_directory, scan_remote, CatalogEntry, FilenameMatcher};
 use crate::reader::{read_composite, OdimComposite};
+
+/// Days of date-partitioned prefixes to scan when an S3 source has no
+/// `time_window`. Two days covers the just-after-midnight case where
+/// the recent tail still straddles yesterday's partition.
+const DEFAULT_SCAN_DAYS: u32 = 2;
+
+/// Where an [`OdimEngine`] reads ODIM files from.
+#[derive(Clone)]
+enum Source {
+    /// A local filesystem directory, scanned with `read_dir`.
+    Local { data_dir: PathBuf },
+    /// An S3/HTTP object store. `prefix_pattern` may carry strftime
+    /// codes (e.g. `%Y/%m/%d/OPERA/COMP/`); it is expanded per UTC
+    /// date on every scan so the listing stays current across day
+    /// boundaries. `time_window`, when set, bounds both the dates
+    /// expanded and the timestamps kept.
+    Remote {
+        store: ds_storage::DataStore,
+        prefix_pattern: String,
+        time_window: Option<TimeWindow>,
+    },
+}
+
+/// Scan `source` for ODIM files, returning catalog entries sorted by
+/// timestamp ascending. Blocking — remote scans bridge async object-
+/// store I/O internally (see [`ds_storage::DataStore`]).
+fn scan_source(
+    source: &Source,
+    matcher: &FilenameMatcher,
+    max_files: Option<usize>,
+) -> Result<Vec<CatalogEntry>, EngineError> {
+    match source {
+        Source::Local { data_dir } => Ok(scan_local_directory(data_dir, matcher, max_files)?),
+        Source::Remote {
+            store,
+            prefix_pattern,
+            time_window,
+        } => {
+            let now = Utc::now();
+            let (prefixes, time_filter) = match time_window {
+                Some(tw) => (
+                    expand_prefix_for_dates(prefix_pattern, &tw.scan_dates(now)),
+                    Some(tw.to_range(now)),
+                ),
+                None => (
+                    expand_prefix_pattern(prefix_pattern, DEFAULT_SCAN_DAYS),
+                    None,
+                ),
+            };
+            Ok(scan_remote(
+                store,
+                &prefixes,
+                matcher,
+                time_filter,
+                max_files,
+            )?)
+        }
+    }
+}
+
+/// Fetch the raw bytes of one ODIM file from `source`.
+fn fetch_bytes(source: &Source, path: &Path) -> Result<Vec<u8>, DataServerError> {
+    match source {
+        Source::Local { .. } => std::fs::read(path).map_err(|e| {
+            DataServerError::Engine(format!(
+                "failed to read ODIM file `{}`: {e}",
+                path.display()
+            ))
+        }),
+        Source::Remote { store, .. } => {
+            let key = path.to_str().ok_or_else(|| {
+                DataServerError::Engine(format!("non-UTF8 ODIM object key `{}`", path.display()))
+            })?;
+            let object = ds_storage::object_store::path::Path::from(key);
+            store.get(&object).map(|b| b.to_vec())
+        }
+    }
+}
 
 /// `MapEngine` implementation backed by an ODIM_H5 composite catalog.
 ///
@@ -75,8 +157,8 @@ pub struct OdimEngine {
     /// at high request rates — keeping the last file resident makes
     /// hot-tile loops effectively free of read cost.
     pub(crate) cached: Mutex<Option<(PathBuf, Arc<OdimComposite>)>>,
-    /// Source state for the poll loop.
-    data_dir: PathBuf,
+    /// Local directory or S3/HTTP object store the poll loop re-scans.
+    source: Source,
     matcher: FilenameMatcher,
     max_files: Option<usize>,
     poll_interval: Duration,
@@ -105,16 +187,23 @@ pub enum EngineError {
     #[error("filename pattern build failed: {0}")]
     BadPattern(#[from] crate::catalog::CatalogError),
     #[error(
-        "no ODIM files found in `{dir}` matching the configured filename pattern — \
-         verify the directory exists and the template matches the producer's layout"
+        "ODIM collection has no source — set a local `data_path` or an S3 \
+         `endpoint` + `bucket`"
     )]
-    NoFiles { dir: PathBuf },
-    #[error("failed to read seed composite `{path}`: {source}")]
-    SeedReadFailed {
-        path: PathBuf,
-        #[source]
-        source: std::io::Error,
-    },
+    NoSource,
+    #[error(
+        "ODIM S3 config is incomplete — `endpoint` and `bucket` must both be \
+         set (or both omitted for a local `data_path` source)"
+    )]
+    IncompleteS3Config,
+    #[error(
+        "no ODIM files found at `{location}` matching the configured filename \
+         pattern — verify the source exists and the template matches the \
+         producer's layout"
+    )]
+    NoFiles { location: String },
+    #[error("ODIM source error: {0}")]
+    Storage(#[from] DataServerError),
     #[error("failed to parse seed composite `{path}`: {source}")]
     SeedParseFailed {
         path: PathBuf,
@@ -124,35 +213,23 @@ pub enum EngineError {
 }
 
 impl OdimEngine {
-    /// Build an engine by scanning `data_dir` for files matching the
-    /// configured filename pattern. Loads the most recent file
-    /// synchronously to populate metadata; raises [`EngineError`]
-    /// when the directory is empty.
+    /// Build an engine by scanning its configured source for files
+    /// matching the filename pattern. The source is a local directory
+    /// (`data_path`) or an S3 bucket (`endpoint`/`bucket`/`prefix_pattern`).
+    /// Loads the most recent file synchronously to populate metadata;
+    /// raises [`EngineError`] when the source yields no files.
     pub fn new(
-        data_dir: &Path,
         collection_id: &str,
+        data_path: Option<&str>,
         config: &ds_core::config::OdimConfig,
     ) -> Result<Self, EngineError> {
-        // Phase 1 supports local directories only. S3-style config
-        // fields (`endpoint`, `bucket`, `prefix_pattern`) are present
-        // in `OdimConfig` as Phase 2 stubs — if an operator filled
-        // them in expecting remote behaviour, warn loudly so the
-        // misconfiguration is visible rather than silently producing
-        // a "local data not found" error.
-        if config.endpoint.is_some() || config.bucket.is_some() || config.prefix_pattern.is_some() {
-            tracing::warn!(
-                "[{}] ODIM config carries S3 fields (endpoint/bucket/prefix_pattern) but \
-                 Phase 1 supports local directories only — these fields are ignored. \
-                 Remote source support lands in Phase 2 (STAC) / Phase 3 (PVOL S3).",
-                collection_id
-            );
-        }
-
         let matcher = build_matcher(config)?;
-        let catalog = scan_local_directory(data_dir, &matcher, config.max_files)?;
+        let source = build_source(collection_id, data_path, config)?;
+
+        let catalog = scan_source(&source, &matcher, config.max_files)?;
         if catalog.is_empty() {
             return Err(EngineError::NoFiles {
-                dir: data_dir.to_path_buf(),
+                location: source_label(&source),
             });
         }
 
@@ -161,10 +238,7 @@ impl OdimEngine {
         // misconfigured filename pattern surfaces at engine
         // construction rather than at first request.
         let seed_path = catalog.last().expect("catalog non-empty").path.clone();
-        let bytes = std::fs::read(&seed_path).map_err(|e| EngineError::SeedReadFailed {
-            path: seed_path.clone(),
-            source: e,
-        })?;
+        let bytes = fetch_bytes(&source, &seed_path)?;
         let composite =
             Arc::new(
                 read_composite(&bytes).map_err(|e| EngineError::SeedParseFailed {
@@ -191,7 +265,7 @@ impl OdimEngine {
             seed_xsize,
             seed_ysize,
             cached: Mutex::new(Some((seed_path, composite))),
-            data_dir: data_dir.to_path_buf(),
+            source,
             matcher,
             max_files: config.max_files,
             poll_interval: Duration::from_secs(config.poll_interval_secs.max(1)),
@@ -200,19 +274,19 @@ impl OdimEngine {
         })
     }
 
-    /// Run the directory poll loop. Exits when [`OdimEngine::shutdown`]
-    /// is called. Each tick re-scans `data_dir`, atomically swaps the
+    /// Run the source poll loop. Exits when [`OdimEngine::shutdown`]
+    /// is called. Each tick re-scans the source, atomically swaps the
     /// catalog `ArcSwap` if the file set changed, and logs at INFO
     /// when new files appear so operators can confirm the polling is
     /// alive.
     ///
-    /// The actual `read_dir` runs on `tokio::task::spawn_blocking`
-    /// so a slow filesystem (network mount, large directory) doesn't
-    /// stall the Tokio worker thread for the duration of the scan.
+    /// The scan runs on `tokio::task::spawn_blocking` so neither a
+    /// slow filesystem (network mount, large directory) nor a slow S3
+    /// `list` stalls a Tokio worker thread for its duration.
     ///
-    /// Errors from the scan (e.g. `data_dir` temporarily disappears)
-    /// are logged at WARN and otherwise ignored — the previous
-    /// catalog stays in place so live requests keep working.
+    /// Errors from the scan (source temporarily unavailable, S3
+    /// timeout) are logged at WARN and otherwise ignored — the
+    /// previous catalog stays in place so live requests keep working.
     pub async fn poll_loop(&self) {
         let mut interval = tokio::time::interval(self.poll_interval);
         interval.tick().await; // skip immediate first tick (already loaded at boot)
@@ -258,13 +332,11 @@ impl OdimEngine {
     }
 
     async fn poll_once(&self) {
-        let data_dir = self.data_dir.clone();
+        let source = self.source.clone();
         let matcher = self.matcher.clone();
         let max_files = self.max_files;
-        let scan_result = tokio::task::spawn_blocking(move || {
-            scan_local_directory(&data_dir, &matcher, max_files)
-        })
-        .await;
+        let scan_result =
+            tokio::task::spawn_blocking(move || scan_source(&source, &matcher, max_files)).await;
         let scan = match scan_result {
             Ok(Ok(s)) => s,
             Ok(Err(e)) => {
@@ -359,9 +431,9 @@ impl OdimEngine {
     /// Read + parse the ODIM file at `path` and return a shared
     /// `Arc<OdimComposite>` snapshot. Cached single-entry by path.
     ///
-    /// **Blocking call** — uses `std::fs::read` and HDF5 parsing
-    /// directly. Callers from async contexts must wrap in
-    /// `tokio::task::spawn_blocking`. Two call paths reach here:
+    /// **Blocking call** — reads the file (local `read` or S3 `get`)
+    /// and parses HDF5 directly. Callers from async contexts must wrap
+    /// in `tokio::task::spawn_blocking`. Two call paths reach here:
     ///
     /// - `MapEngine::get_raster_tile` — already runs inside
     ///   `spawn_blocking` (the WMS / Maps / Tiles handlers do this).
@@ -389,7 +461,7 @@ impl OdimEngine {
         // Different-path concurrent misses (e.g. two adjacent
         // timestep requests arriving during a time-slider scrub)
         // are tolerated but not optimised: both callers fall
-        // through to `std::fs::read`, both decode, and whichever
+        // through to a fresh fetch, both decode, and whichever
         // takes the write lock last evicts the other's entry. Both
         // callers still get a valid `Arc` (data is correct,
         // composites are immutable) — the cost is at most one
@@ -417,13 +489,8 @@ impl OdimEngine {
                 }
             }
         }
-        let bytes = std::fs::read(path).map_err(|e| {
-            DataServerError::Engine(format!(
-                "[{}] failed to read ODIM file `{}`: {e}",
-                self.collection_id,
-                path.display()
-            ))
-        })?;
+        let bytes = fetch_bytes(&self.source, path)
+            .map_err(|e| DataServerError::Engine(format!("[{}] {e}", self.collection_id)))?;
         let composite = Arc::new(read_composite(&bytes).map_err(|e| {
             DataServerError::Engine(format!(
                 "[{}] failed to parse ODIM file `{}`: {e}",
@@ -454,6 +521,53 @@ fn build_matcher(config: &ds_core::config::OdimConfig) -> Result<FilenameMatcher
         return Ok(FilenameMatcher::from_pattern(pattern, format)?);
     }
     Err(EngineError::NoFilenamePattern)
+}
+
+/// Resolve the engine's [`Source`] from config. `endpoint` + `bucket`
+/// select an S3 source; their absence falls back to the local
+/// `data_path`. Setting exactly one of `endpoint` / `bucket` is a
+/// configuration error rather than a silent fallback.
+fn build_source(
+    collection_id: &str,
+    data_path: Option<&str>,
+    config: &ds_core::config::OdimConfig,
+) -> Result<Source, EngineError> {
+    match (config.endpoint.as_deref(), config.bucket.as_deref()) {
+        (Some(endpoint), Some(bucket)) => {
+            let store = ds_storage::build_s3_store_from_parts(endpoint, bucket)?;
+            let prefix_pattern = config.prefix_pattern.clone().unwrap_or_default();
+            let time_window = match &config.time_window {
+                Some(s) => Some(TimeWindow::parse(s)?),
+                None => None,
+            };
+            tracing::info!(
+                "[{}] ODIM S3 source: endpoint={endpoint} bucket={bucket} prefix='{prefix_pattern}'",
+                collection_id
+            );
+            Ok(Source::Remote {
+                store,
+                prefix_pattern,
+                time_window,
+            })
+        }
+        (None, None) => {
+            let data_path = data_path.ok_or(EngineError::NoSource)?;
+            Ok(Source::Local {
+                data_dir: PathBuf::from(data_path),
+            })
+        }
+        _ => Err(EngineError::IncompleteS3Config),
+    }
+}
+
+/// Human-readable description of a [`Source`] for error messages.
+fn source_label(source: &Source) -> String {
+    match source {
+        Source::Local { data_dir } => data_dir.display().to_string(),
+        Source::Remote { prefix_pattern, .. } => {
+            format!("s3 prefix `{prefix_pattern}`")
+        }
+    }
 }
 
 /// Convert WGS84 latitude (degrees) to Web Mercator Y (metres).

--- a/crates/engine-odim/src/engine.rs
+++ b/crates/engine-odim/src/engine.rs
@@ -245,6 +245,16 @@ impl OdimEngine {
         data_path: Option<&str>,
         config: &ds_core::config::OdimConfig,
     ) -> Result<Self, EngineError> {
+        // `time_window` only constrains S3 prefix expansion + timestamp
+        // filtering. A local `data_path` source ignores it — warn so a
+        // misplaced setting doesn't silently do nothing.
+        if config.time_window.is_some() && config.endpoint.is_none() {
+            tracing::warn!(
+                "[{collection_id}] `time_window` is set but has no effect on a \
+                 local `data_path` ODIM source — it only applies to S3 sources"
+            );
+        }
+
         let matcher = build_matcher(config)?;
         let source = build_source(collection_id, data_path, config)?;
 

--- a/crates/engine-odim/src/engine.rs
+++ b/crates/engine-odim/src/engine.rs
@@ -28,7 +28,7 @@
 //!
 //! See [[project_odim_engine_plan]] for the full multi-phase plan.
 
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -43,7 +43,7 @@ use tokio::sync::Notify;
 
 use ds_storage::discovery::{expand_prefix_for_dates, expand_prefix_pattern, TimeWindow};
 
-use crate::catalog::{scan_local_directory, scan_remote, CatalogEntry, FilenameMatcher};
+use crate::catalog::{scan_local_directory, scan_remote, CatalogEntry, FilenameMatcher, Location};
 use crate::reader::{read_composite, OdimComposite};
 
 /// Days of date-partitioned prefixes to scan when an S3 source has no
@@ -60,9 +60,13 @@ enum Source {
     /// codes (e.g. `%Y/%m/%d/OPERA/COMP/`); it is expanded per UTC
     /// date on every scan so the listing stays current across day
     /// boundaries. `time_window`, when set, bounds both the dates
-    /// expanded and the timestamps kept.
+    /// expanded and the timestamps kept. `endpoint` / `bucket` are
+    /// retained purely for diagnostics (the `store` already targets
+    /// them) so log and error messages can name the store.
     Remote {
         store: ds_storage::DataStore,
+        endpoint: String,
+        bucket: String,
         prefix_pattern: String,
         time_window: Option<TimeWindow>,
     },
@@ -82,6 +86,7 @@ fn scan_source(
             store,
             prefix_pattern,
             time_window,
+            ..
         } => {
             let now = Utc::now();
             let (prefixes, time_filter) = match time_window {
@@ -105,20 +110,17 @@ fn scan_source(
     }
 }
 
-/// Fetch the raw bytes of one ODIM file from `source`.
-fn fetch_bytes(source: &Source, path: &Path) -> Result<Vec<u8>, DataServerError> {
-    match source {
-        Source::Local { .. } => std::fs::read(path).map_err(|e| {
+/// Fetch the raw bytes of one ODIM file from its catalog location.
+fn fetch_bytes(location: &Location) -> Result<Vec<u8>, DataServerError> {
+    match location {
+        Location::Local(path) => std::fs::read(path).map_err(|e| {
             DataServerError::Engine(format!(
                 "failed to read ODIM file `{}`: {e}",
                 path.display()
             ))
         }),
-        Source::Remote { store, .. } => {
-            let key = path.to_str().ok_or_else(|| {
-                DataServerError::Engine(format!("non-UTF8 ODIM object key `{}`", path.display()))
-            })?;
-            let object = ds_storage::object_store::path::Path::from(key);
+        Location::Remote { store, key } => {
+            let object = ds_storage::object_store::path::Path::from(key.as_str());
             store.get(&object).map(|b| b.to_vec())
         }
     }
@@ -152,11 +154,11 @@ pub struct OdimEngine {
     pub(crate) seed_spatial_extent: [f64; 4],
     pub(crate) seed_xsize: u32,
     pub(crate) seed_ysize: u32,
-    /// Single-entry path-keyed cache. ODIM composites are small (a
-    /// few MB) but HDF5 parsing dominates `get_raster_tile` latency
-    /// at high request rates — keeping the last file resident makes
-    /// hot-tile loops effectively free of read cost.
-    pub(crate) cached: Mutex<Option<(PathBuf, Arc<OdimComposite>)>>,
+    /// Single-entry cache keyed by [`Location::id`]. ODIM composites
+    /// are small (a few MB) but HDF5 parsing dominates `get_raster_tile`
+    /// latency at high request rates — keeping the last file resident
+    /// makes hot-tile loops effectively free of read cost.
+    pub(crate) cached: Mutex<Option<(String, Arc<OdimComposite>)>>,
     /// Local directory or S3/HTTP object store the poll loop re-scans.
     source: Source,
     matcher: FilenameMatcher,
@@ -197,6 +199,12 @@ pub enum EngineError {
     )]
     IncompleteS3Config,
     #[error(
+        "ODIM S3 source is missing `prefix_pattern` — set it to the bucket's \
+         date-partitioned key prefix (e.g. `%Y/%m/%d/OPERA/COMP/`), or to an \
+         empty string to scan the bucket root"
+    )]
+    MissingPrefixPattern,
+    #[error(
         "no ODIM files found at `{location}` matching the configured filename \
          pattern — verify the source exists and the template matches the \
          producer's layout"
@@ -204,9 +212,9 @@ pub enum EngineError {
     NoFiles { location: String },
     #[error("ODIM source error: {0}")]
     Storage(#[from] DataServerError),
-    #[error("failed to parse seed composite `{path}`: {source}")]
+    #[error("failed to parse seed composite `{location}`: {source}")]
     SeedParseFailed {
-        path: PathBuf,
+        location: String,
         #[source]
         source: crate::reader::ReadError,
     },
@@ -237,12 +245,12 @@ impl OdimEngine {
         // populate `spatial_extent` and `times` immediately, and so a
         // misconfigured filename pattern surfaces at engine
         // construction rather than at first request.
-        let seed_path = catalog.last().expect("catalog non-empty").path.clone();
-        let bytes = fetch_bytes(&source, &seed_path)?;
+        let seed_location = catalog.last().expect("catalog non-empty").location.clone();
+        let bytes = fetch_bytes(&seed_location)?;
         let composite =
             Arc::new(
                 read_composite(&bytes).map_err(|e| EngineError::SeedParseFailed {
-                    path: seed_path.clone(),
+                    location: seed_location.id(),
                     source: e,
                 })?,
             );
@@ -264,7 +272,7 @@ impl OdimEngine {
             seed_spatial_extent,
             seed_xsize,
             seed_ysize,
-            cached: Mutex::new(Some((seed_path, composite))),
+            cached: Mutex::new(Some((seed_location.id(), composite))),
             source,
             matcher,
             max_files: config.max_files,
@@ -447,16 +455,16 @@ impl OdimEngine {
     ///   handlers rather than per-engine.
     pub(crate) fn load_composite(
         &self,
-        path: &Path,
+        location: &Location,
     ) -> Result<Arc<OdimComposite>, DataServerError> {
-        // Use a path-keyed single-entry cache. Cache hits return the
+        // Use an id-keyed single-entry cache. Cache hits return the
         // same `Arc` to every caller; on a cold miss two concurrent
         // `spawn_blocking` callers may both read the file and both
         // write the cache slot — the second write overwrites the
         // first with an identical, immutable composite. The cost is
         // at most one redundant read at the moment the slot fills,
-        // never visible to clients. A swap to a different path
-        // happens only when a different file is asked for.
+        // never visible to clients. A swap to a different file
+        // happens only when a different entry is asked for.
         //
         // Different-path concurrent misses (e.g. two adjacent
         // timestep requests arriving during a time-slider scrub)
@@ -471,10 +479,11 @@ impl OdimEngine {
         //
         // Mutex poison is recovered (rather than silently disabling
         // the cache for the lifetime of the engine). The cached
-        // entry is just bytes + path — no invariants to protect —
-        // so the previous panic that poisoned the lock can't have
-        // corrupted what we're reading. An ERROR-level log on
-        // recovery makes the latent panic visible.
+        // entry is just an id string + composite — no invariants to
+        // protect — so the previous panic that poisoned the lock
+        // can't have corrupted what we're reading. An ERROR-level log
+        // on recovery makes the latent panic visible.
+        let cache_key = location.id();
         {
             let guard = self.cached.lock().unwrap_or_else(|e| {
                 tracing::error!(
@@ -483,19 +492,18 @@ impl OdimEngine {
                 );
                 e.into_inner()
             });
-            if let Some((ref cached_path, ref cached_comp)) = *guard {
-                if cached_path == path {
+            if let Some((ref cached_key, ref cached_comp)) = *guard {
+                if *cached_key == cache_key {
                     return Ok(cached_comp.clone());
                 }
             }
         }
-        let bytes = fetch_bytes(&self.source, path)
+        let bytes = fetch_bytes(location)
             .map_err(|e| DataServerError::Engine(format!("[{}] {e}", self.collection_id)))?;
         let composite = Arc::new(read_composite(&bytes).map_err(|e| {
             DataServerError::Engine(format!(
                 "[{}] failed to parse ODIM file `{}`: {e}",
-                self.collection_id,
-                path.display()
+                self.collection_id, cache_key
             ))
         })?);
         let mut guard = self.cached.lock().unwrap_or_else(|e| {
@@ -505,7 +513,7 @@ impl OdimEngine {
             );
             e.into_inner()
         });
-        *guard = Some((path.to_path_buf(), composite.clone()));
+        *guard = Some((cache_key, composite.clone()));
         Ok(composite)
     }
 }
@@ -534,8 +542,15 @@ fn build_source(
 ) -> Result<Source, EngineError> {
     match (config.endpoint.as_deref(), config.bucket.as_deref()) {
         (Some(endpoint), Some(bucket)) => {
+            // A missing `prefix_pattern` is almost always a config
+            // mistake: it would list the whole bucket on every poll.
+            // An explicit empty string is a deliberate flat-bucket
+            // opt-in and is allowed.
+            let prefix_pattern = config
+                .prefix_pattern
+                .clone()
+                .ok_or(EngineError::MissingPrefixPattern)?;
             let store = ds_storage::build_s3_store_from_parts(endpoint, bucket)?;
-            let prefix_pattern = config.prefix_pattern.clone().unwrap_or_default();
             let time_window = match &config.time_window {
                 Some(s) => Some(TimeWindow::parse(s)?),
                 None => None,
@@ -546,6 +561,8 @@ fn build_source(
             );
             Ok(Source::Remote {
                 store,
+                endpoint: endpoint.to_string(),
+                bucket: bucket.to_string(),
                 prefix_pattern,
                 time_window,
             })
@@ -560,13 +577,18 @@ fn build_source(
     }
 }
 
-/// Human-readable description of a [`Source`] for error messages.
+/// Human-readable description of a [`Source`] for error messages —
+/// names the local directory, or the S3 endpoint/bucket/prefix, so an
+/// operator reading a log entry knows exactly which store to check.
 fn source_label(source: &Source) -> String {
     match source {
         Source::Local { data_dir } => data_dir.display().to_string(),
-        Source::Remote { prefix_pattern, .. } => {
-            format!("s3 prefix `{prefix_pattern}`")
-        }
+        Source::Remote {
+            endpoint,
+            bucket,
+            prefix_pattern,
+            ..
+        } => format!("s3 {endpoint}/{bucket}/{prefix_pattern}"),
     }
 }
 
@@ -609,7 +631,7 @@ impl MapEngine for OdimEngine {
                 self.collection_id
             ))
         })?;
-        let composite = self.load_composite(&entry.path)?;
+        let composite = self.load_composite(&entry.location)?;
 
         let [west, south, east, north] = bbox;
         let gain = self.gain_override.unwrap_or(composite.gain);

--- a/crates/engine-odim/tests/integration.rs
+++ b/crates/engine-odim/tests/integration.rs
@@ -42,10 +42,15 @@ fn dmi_engine() -> (engine_odim::OdimEngine, tempfile::TempDir) {
         endpoint: None,
         bucket: None,
         prefix_pattern: None,
+        time_window: None,
     };
 
-    let engine = engine_odim::OdimEngine::new(dir.path(), "dmi-test", &config)
-        .expect("OdimEngine::new succeeds on the DMI fixture");
+    let engine = engine_odim::OdimEngine::new(
+        "dmi-test",
+        Some(dir.path().to_str().expect("utf8 fixture path")),
+        &config,
+    )
+    .expect("OdimEngine::new succeeds on the DMI fixture");
 
     (engine, dir)
 }
@@ -329,9 +334,14 @@ fn edr_query_area_rejects_too_many_timesteps() {
         endpoint: None,
         bucket: None,
         prefix_pattern: None,
+        time_window: None,
     };
-    let engine = engine_odim::OdimEngine::new(dir.path(), "dmi-cap-test", &config)
-        .expect("engine builds over the 65-file catalog");
+    let engine = engine_odim::OdimEngine::new(
+        "dmi-cap-test",
+        Some(dir.path().to_str().expect("utf8 fixture path")),
+        &config,
+    )
+    .expect("engine builds over the 65-file catalog");
 
     // No datetime filter → all 65 entries → over the cap → error.
     let err = engine

--- a/crates/server/src/admin.rs
+++ b/crates/server/src/admin.rs
@@ -960,22 +960,6 @@ pub fn load_collections(
                 });
             }
             "odim" => {
-                let data_path = match collection.data_path.as_deref() {
-                    Some(p) => p,
-                    None => {
-                        tracing::error!(
-                            "Collection '{}': engine_type 'odim' requires data_path, skipping",
-                            collection.id
-                        );
-                        health.push(CollectionHealth {
-                            id: collection.id.clone(),
-                            engine_type: "odim".into(),
-                            status: CollectionStatus::Failed,
-                            error: Some("missing data_path".into()),
-                        });
-                        continue;
-                    }
-                };
                 let odim_cfg = match collection.odim.as_ref() {
                     Some(c) => c,
                     None => {
@@ -993,8 +977,8 @@ pub fn load_collections(
                     }
                 };
                 let engine = match engine_odim::OdimEngine::new(
-                    std::path::Path::new(data_path),
                     &collection.id,
+                    collection.data_path.as_deref(),
                     odim_cfg,
                 ) {
                     Ok(e) => Arc::new(e),

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 ds-core = { path = "../core" }
 object_store = { version = "0.11", features = ["aws", "http"] }
 tokio = { version = "1", features = ["rt", "rt-multi-thread"] }
+chrono = "0.4"
 bytes = "1"
 futures = "0.3"
 url = "2"

--- a/crates/storage/src/discovery.rs
+++ b/crates/storage/src/discovery.rs
@@ -1,0 +1,244 @@
+//! Time-windowed prefix discovery for date-partitioned object stores.
+//!
+//! S3/HTTP buckets that hold time-series data (radar composites, NWP
+//! runs) almost always partition objects under a date-templated key
+//! prefix such as `%Y/%m/%d/OPERA/COMP/`. Two pieces of logic recur
+//! across every engine that polls such a bucket:
+//!
+//! 1. [`TimeWindow`] — parse an ISO 8601 duration (`-PT12H`, `-P2D`)
+//!    and turn "now" into the concrete `(start, end)` range and the
+//!    set of UTC dates that range touches.
+//! 2. [`expand_prefix_for_dates`] / [`expand_prefix_pattern`] —
+//!    substitute those dates into a strftime prefix template, yielding
+//!    one literal prefix per day to `list`.
+//!
+//! This module is the shared home for both. `engine-odim` uses it
+//! today; `engine-geotiff` and `engine-grib` carry their own copies
+//! and are tracked for migration.
+
+use chrono::{DateTime, Duration, NaiveDate, Utc};
+use ds_core::error::DataServerError;
+
+/// A signed ISO 8601 duration describing how far back (or forward)
+/// from "now" a collection's useful data extends.
+#[derive(Debug, Clone)]
+pub struct TimeWindow {
+    /// Duration in seconds. Negative = into the past, positive = future.
+    seconds: i64,
+}
+
+impl TimeWindow {
+    /// Parse an ISO 8601 duration string.
+    ///
+    /// Supports `P[nD]T[nH][nM][nS]` with an optional leading `-` for
+    /// past-facing windows. Examples: `-PT2H`, `PT30M`, `-P1DT6H`.
+    pub fn parse(s: &str) -> Result<Self, DataServerError> {
+        let (negative, rest) = match s.strip_prefix('-') {
+            Some(r) => (true, r),
+            None => (false, s),
+        };
+
+        let rest = rest.strip_prefix('P').ok_or_else(|| {
+            DataServerError::Config(format!(
+                "Invalid time_window '{s}': must start with 'P' or '-P'"
+            ))
+        })?;
+
+        let (date_part, time_part) = match rest.find('T') {
+            Some(t) => (&rest[..t], &rest[t + 1..]),
+            None => (rest, ""),
+        };
+
+        let mut total_seconds: i64 = 0;
+
+        if !date_part.is_empty() {
+            total_seconds += parse_component(date_part, 'D', s)? * 86_400;
+        }
+
+        if !time_part.is_empty() {
+            let mut remaining = time_part;
+            if let Some(pos) = remaining.find('H') {
+                total_seconds += parse_int(&remaining[..pos], "hours", s)? * 3_600;
+                remaining = &remaining[pos + 1..];
+            }
+            if let Some(pos) = remaining.find('M') {
+                total_seconds += parse_int(&remaining[..pos], "minutes", s)? * 60;
+                remaining = &remaining[pos + 1..];
+            }
+            if let Some(pos) = remaining.find('S') {
+                total_seconds += parse_int(&remaining[..pos], "seconds", s)?;
+            }
+        }
+
+        if total_seconds == 0 {
+            return Err(DataServerError::Config(format!(
+                "Invalid time_window '{s}': zero duration"
+            )));
+        }
+
+        if negative {
+            total_seconds = -total_seconds;
+        }
+
+        Ok(TimeWindow {
+            seconds: total_seconds,
+        })
+    }
+
+    /// Compute the `(start, end)` range relative to `now`.
+    ///
+    /// Past windows (`seconds < 0`) return `(now + seconds, now)`;
+    /// future windows return `(now, now + seconds)`.
+    pub fn to_range(&self, now: DateTime<Utc>) -> (DateTime<Utc>, DateTime<Utc>) {
+        let offset = Duration::seconds(self.seconds);
+        if self.seconds < 0 {
+            (now + offset, now)
+        } else {
+            (now, now + offset)
+        }
+    }
+
+    /// The distinct UTC dates the window spans — one per day inclusive
+    /// of both ends. These are the dates that need prefix expansion.
+    pub fn scan_dates(&self, now: DateTime<Utc>) -> Vec<NaiveDate> {
+        let (start, end) = self.to_range(now);
+        let mut dates = Vec::new();
+        let mut d = start.date_naive();
+        let last = end.date_naive();
+        while d <= last {
+            dates.push(d);
+            d += Duration::days(1);
+        }
+        dates
+    }
+
+    /// Upper bound on the number of days the window could touch — used
+    /// as a static fallback when an exact `scan_dates` isn't available.
+    pub fn max_scan_days(&self) -> u32 {
+        let days = (self.seconds.unsigned_abs() / 3_600 / 24) as u32;
+        (days + 2).max(2)
+    }
+}
+
+fn parse_component(s: &str, suffix: char, original: &str) -> Result<i64, DataServerError> {
+    let stripped = s.strip_suffix(suffix).ok_or_else(|| {
+        DataServerError::Config(format!(
+            "Invalid date component in time_window '{original}'"
+        ))
+    })?;
+    parse_int(stripped, "days", original)
+}
+
+fn parse_int(s: &str, field: &str, original: &str) -> Result<i64, DataServerError> {
+    s.parse().map_err(|_| {
+        DataServerError::Config(format!("Invalid {field} in time_window '{original}'"))
+    })
+}
+
+/// Expand a strftime prefix template for a specific set of dates.
+///
+/// E.g. `"%Y/%m/%d/OPERA/COMP/"` with `[2026-05-15, 2026-05-14]`
+/// yields `["2026/05/15/OPERA/COMP", "2026/05/14/OPERA/COMP"]`.
+///
+/// A pattern with no `%` is a fixed prefix — returned as a single
+/// entry regardless of `dates`.
+pub fn expand_prefix_for_dates(pattern: &str, dates: &[NaiveDate]) -> Vec<String> {
+    if !pattern.contains('%') {
+        return vec![pattern.trim_end_matches('/').to_string()];
+    }
+    dates
+        .iter()
+        .map(|date| {
+            date.format(pattern)
+                .to_string()
+                .trim_end_matches('/')
+                .to_string()
+        })
+        .collect()
+}
+
+/// Expand a prefix template over the most recent `scan_days` days,
+/// counting back from today (UTC). Fallback for callers without a
+/// [`TimeWindow`]; `scan_days` is clamped to at least 1.
+pub fn expand_prefix_pattern(pattern: &str, scan_days: u32) -> Vec<String> {
+    let today = Utc::now().date_naive();
+    let dates: Vec<_> = (0..scan_days.max(1))
+        .map(|offset| today - Duration::days(offset as i64))
+        .collect();
+    expand_prefix_for_dates(pattern, &dates)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_past_and_future() {
+        assert_eq!(TimeWindow::parse("-PT2H").unwrap().seconds, -7_200);
+        assert_eq!(TimeWindow::parse("PT6H").unwrap().seconds, 21_600);
+        assert_eq!(TimeWindow::parse("-PT30M").unwrap().seconds, -1_800);
+        assert_eq!(TimeWindow::parse("-P2D").unwrap().seconds, -172_800);
+        assert_eq!(
+            TimeWindow::parse("-P1DT6H").unwrap().seconds,
+            -(86_400 + 21_600)
+        );
+        assert_eq!(
+            TimeWindow::parse("-PT2H30M").unwrap().seconds,
+            -(7_200 + 1_800)
+        );
+    }
+
+    #[test]
+    fn invalid_windows_rejected() {
+        assert!(TimeWindow::parse("PT0H").is_err());
+        assert!(TimeWindow::parse("2H").is_err());
+        assert!(TimeWindow::parse("").is_err());
+        assert!(TimeWindow::parse("P").is_err());
+    }
+
+    #[test]
+    fn scan_dates_spans_window() {
+        let tw = TimeWindow::parse("-PT2H").unwrap();
+        // 15:00 - 2h stays inside one day.
+        let midday = NaiveDate::from_ymd_opt(2026, 5, 15)
+            .unwrap()
+            .and_hms_opt(15, 0, 0)
+            .unwrap()
+            .and_utc();
+        assert_eq!(tw.scan_dates(midday).len(), 1);
+        // 01:00 - 2h crosses midnight into the previous day.
+        let early = NaiveDate::from_ymd_opt(2026, 5, 15)
+            .unwrap()
+            .and_hms_opt(1, 0, 0)
+            .unwrap()
+            .and_utc();
+        let dates = tw.scan_dates(early);
+        assert_eq!(dates.len(), 2);
+        assert_eq!(dates[0], NaiveDate::from_ymd_opt(2026, 5, 14).unwrap());
+        assert_eq!(dates[1], NaiveDate::from_ymd_opt(2026, 5, 15).unwrap());
+    }
+
+    #[test]
+    fn expand_static_prefix_is_single_entry() {
+        assert_eq!(
+            expand_prefix_for_dates("some/fixed/prefix/", &[]),
+            vec!["some/fixed/prefix"]
+        );
+        assert_eq!(
+            expand_prefix_pattern("some/fixed/prefix", 5),
+            vec!["some/fixed/prefix"]
+        );
+    }
+
+    #[test]
+    fn expand_dated_prefix() {
+        let dates = [
+            NaiveDate::from_ymd_opt(2026, 5, 15).unwrap(),
+            NaiveDate::from_ymd_opt(2026, 5, 14).unwrap(),
+        ];
+        assert_eq!(
+            expand_prefix_for_dates("%Y/%m/%d/OPERA/COMP/", &dates),
+            vec!["2026/05/15/OPERA/COMP", "2026/05/14/OPERA/COMP"]
+        );
+    }
+}

--- a/crates/storage/src/discovery.rs
+++ b/crates/storage/src/discovery.rs
@@ -67,6 +67,15 @@ impl TimeWindow {
             }
             if let Some(pos) = remaining.find('S') {
                 total_seconds += parse_int(&remaining[..pos], "seconds", s)?;
+                remaining = &remaining[pos + 1..];
+            }
+            // Reject anything left over — e.g. `PT2H5` (a bare `5`
+            // with no unit) or `PT2H30M5SFOO` — rather than silently
+            // dropping it and returning a partial duration.
+            if !remaining.is_empty() {
+                return Err(DataServerError::Config(format!(
+                    "Invalid time_window '{s}': unexpected trailing characters '{remaining}'"
+                )));
             }
         }
 
@@ -187,6 +196,10 @@ mod tests {
         assert!(TimeWindow::parse("2H").is_err());
         assert!(TimeWindow::parse("").is_err());
         assert!(TimeWindow::parse("P").is_err());
+        // Trailing characters must not be silently dropped.
+        assert!(TimeWindow::parse("PT2H5").is_err());
+        assert!(TimeWindow::parse("PT2H30M5SFOO").is_err());
+        assert!(TimeWindow::parse("PT2HFOO").is_err());
     }
 
     #[test]

--- a/crates/storage/src/discovery.rs
+++ b/crates/storage/src/discovery.rs
@@ -111,13 +111,6 @@ impl TimeWindow {
         }
         dates
     }
-
-    /// Upper bound on the number of days the window could touch — used
-    /// as a static fallback when an exact `scan_dates` isn't available.
-    pub fn max_scan_days(&self) -> u32 {
-        let days = (self.seconds.unsigned_abs() / 3_600 / 24) as u32;
-        (days + 2).max(2)
-    }
 }
 
 fn parse_component(s: &str, suffix: char, original: &str) -> Result<i64, DataServerError> {

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -3,6 +3,7 @@
 //! Provides a synchronous `DataStore` over the `object_store` crate,
 //! supporting local filesystem, S3, and HTTP backends.
 
+pub mod discovery;
 mod error;
 
 use std::ops::Range;


### PR DESCRIPTION
## Summary

Adds an S3 object-store source to `engine-odim`. The S3 config fields (`endpoint` / `bucket` / `prefix_pattern`) existed but were ignored with a WARN — this wires them up so ODIM composites can be streamed straight from an S3-compatible bucket with no local mirror.

- **Shared `ds_storage::discovery` module** (new): `TimeWindow` (ISO 8601 duration parsing, scan-date computation) + `expand_prefix_for_dates`/`expand_prefix_pattern` (strftime prefix expansion). New canonical home — *not* copied into `engine-odim`. `engine-geotiff`/`engine-grib` keep their own copies for now; migration tracked in #181.
- **`engine-odim`**: new `Source` enum — `endpoint`+`bucket` selects S3, else local `data_path`. `catalog::scan_remote` lists date-expanded prefixes, matches basenames, applies the time-window filter + `max_files` cap. Seed load, poll loop, and `load_composite` all branch on the source. `OdimConfig` gains `time_window`. `OdimEngine::new` now takes `data_path: Option<&str>`, mirroring `GeoTiffEngine::new`.
- **Config**: `collections.d/radar-opera-composite-s3.toml` — streams OPERA DBZH composites from CloudFerro's `openradar-24h` bucket with a 12 h `time_window`.

## Test plan

- [x] `cargo test -p ds-storage -p engine-odim` — 47 unit + 11 integration tests pass; new `scan_remote` tests cover match/filter/cap and multi-prefix merge via a local-filesystem object store.
- [x] `cargo clippy --workspace` — clean.
- [x] Live server load against CloudFerro: EDR `bbox` `[-39.5, 31.7, 57.8, 73.9]`, 12 h temporal window, EDR position query → 200 CoverageJSON, WMS GetMap renders a real OPERA composite over Europe.

## Notes

- CloudFerro public GET works unauthenticated — the prior "403 on GET" assumption was stale; `ds-storage` already special-cases `.cloudferro.com` with `skip_signature`.
- An EDR position query with *no* `datetime` returns 400 (datetime-range default) — pre-existing EDR-layer behaviour, identical on the local OPERA collection, not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)