### PR TITLE
feat(engine-odim): PVOL polar-volume reader + Cartesian display

### DIFF
--- a/collections.d/radar-fmi-volume.toml
+++ b/collections.d/radar-fmi-volume.toml
@@ -1,0 +1,27 @@
+# FMI weather-radar polar volumes (ODIM_H5 PVOL).
+#
+# Each radar site is a stack of elevation sweeps, each with multiple
+# dual-pol moments (TH, DBZH, VRADH, ZDR, RHOHV...). The odim-volume
+# engine renders the lowest sweep of a chosen site as a Cartesian
+# raster; the WMS layer tree is one group per radar site, with the
+# moments as quantity sub-layers (parameter = `<site>:<quantity>`).
+#
+# data_path here points at the local test fixture directory; an S3
+# source for the FMI volume bucket lands in a later milestone.
+
+id = "radar-fmi-volume"
+title = "FMI Radar Polar Volumes"
+description = """\
+Finnish weather-radar polar volumes (ODIM_H5 PVOL). One layer group \
+per radar site; reflectivity and dual-polarisation moments as \
+sub-layers, rendered from the lowest elevation sweep.\
+"""
+engine_type = "odim-volume"
+apis = ["wms", "maps", "tiles"]
+data_path = "testdata/radar-fmi-pvol"
+
+[odim]
+poll_interval_secs = 300
+
+[wms]
+colormap = "radar_dbz"

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -334,12 +334,15 @@ pub struct OdimConfig {
     pub timestamp_format: Option<String>,
 
     /// Parameter name advertised to clients (e.g. `"reflectivity"`).
-    /// One parameter per collection in Phase 1 — multi-parameter PVOL
-    /// volumes ship in Phase 3.
-    pub parameter: String,
+    /// Required for single-parameter `engine_type = "odim"` (COMP)
+    /// collections. Unused — and may be omitted — by the multi-parameter
+    /// `engine_type = "odim-volume"` (PVOL) engine, which derives one
+    /// parameter per `<site>:<quantity>` pair from the volume files.
+    pub parameter: Option<String>,
     /// Unit of measurement (e.g. `"dBZ"`). Pure metadata: the engine
-    /// does not convert between units.
-    pub unit: String,
+    /// does not convert between units. Required for `engine_type = "odim"`;
+    /// optional for `engine_type = "odim-volume"`.
+    pub unit: Option<String>,
 
     /// Override nodata sentinel. Takes precedence over the file's
     /// `/dataset1/data1/what/nodata` attribute. Useful when a

--- a/crates/core/src/map_engine.rs
+++ b/crates/core/src/map_engine.rs
@@ -33,7 +33,7 @@ pub struct RasterInfo {
     pub native_crs: String,
     /// Native spatial extent [west, south, east, north] in WGS84.
     pub spatial_extent: Option<[f64; 4]>,
-    /// Available timestamps, most recent first.
+    /// Available timestamps, oldest first (ascending).
     pub times: Vec<DateTime<Utc>>,
     /// Default parameter name (e.g., "reflectivity").
     pub parameter: String,

--- a/crates/engine-odim/src/engine.rs
+++ b/crates/engine-odim/src/engine.rs
@@ -232,6 +232,12 @@ pub enum EngineError {
         #[source]
         source: crate::reader::ReadError,
     },
+    #[error(
+        "ODIM COMP collection is missing `[odim].{field}` — single-parameter \
+         `engine_type = \"odim\"` collections must set both `parameter` and \
+         `unit` (only `engine_type = \"odim-volume\"` may omit them)"
+    )]
+    MissingCompField { field: &'static str },
 }
 
 impl OdimEngine {
@@ -254,6 +260,18 @@ impl OdimEngine {
                  local `data_path` ODIM source — it only applies to S3 sources"
             );
         }
+
+        // COMP is single-parameter — `parameter`/`unit` are mandatory.
+        // (The shared `OdimConfig` makes both `Option` so the
+        // multi-parameter `odim-volume` engine can omit them.)
+        let parameter = config
+            .parameter
+            .clone()
+            .ok_or(EngineError::MissingCompField { field: "parameter" })?;
+        let unit = config
+            .unit
+            .clone()
+            .ok_or(EngineError::MissingCompField { field: "unit" })?;
 
         let matcher = build_matcher(config)?;
         let source = build_source(collection_id, data_path, config)?;
@@ -287,8 +305,8 @@ impl OdimEngine {
         Ok(Self {
             catalog: Arc::new(ArcSwap::from_pointee(catalog)),
             collection_id: collection_id.to_string(),
-            parameter: config.parameter.clone(),
-            unit: config.unit.clone(),
+            parameter,
+            unit,
             gain_override: config.gain,
             offset_override: config.offset,
             nodata_override: config.nodata,

--- a/crates/engine-odim/src/lib.rs
+++ b/crates/engine-odim/src/lib.rs
@@ -22,6 +22,9 @@ pub mod catalog;
 pub mod edr;
 pub mod engine;
 pub mod proj;
+pub mod pvol;
 pub mod reader;
+pub mod volume_engine;
 
 pub use engine::{EngineError, OdimEngine};
+pub use volume_engine::PolarVolumeEngine;

--- a/crates/engine-odim/src/pvol.rs
+++ b/crates/engine-odim/src/pvol.rs
@@ -286,6 +286,8 @@ fn read_sweep(
     let nrays = read_f64_attr(&where_path, "nrays")? as usize;
     let rscale = read_f64_attr(&where_path, "rscale")?;
     // rstart / a1gate are optional with documented defaults.
+    // ODIM_H5 v2.4 Table 4 defines rstart in metres (same unit as
+    // rscale) — no km→m scaling, despite older OPERA conventions.
     let rstart = read_f64_attr(&where_path, "rstart").unwrap_or(0.0);
     let a1gate = read_f64_attr(&where_path, "a1gate").unwrap_or(0.0) as usize;
 

--- a/crates/engine-odim/src/pvol.rs
+++ b/crates/engine-odim/src/pvol.rs
@@ -1,0 +1,546 @@
+//! ODIM_H5 polar-volume (PVOL) reader.
+//!
+//! Where [`crate::reader`] handles 2-D cartesian `COMP` composites,
+//! this module reads **polar volumes**: multi-elevation, multi-moment
+//! radar data in native spherical (range × azimuth) coordinates,
+//! before any cartesian compositing.
+//!
+//! ## PVOL HDF5 layout
+//!
+//! - `/what` — `object` (string; FMI mislabels polar volumes as
+//!   `"SCAN"` — accepted regardless), `date`/`time` (UTC stamp),
+//!   `source` (comma-separated `TYP:VALUE` tokens — `NOD`/`PLC`/`WMO`
+//!   extracted by [`parse_source`]).
+//! - `/where` — `lon`/`lat`/`height` (radar antenna position).
+//! - `/dataset1` .. `/datasetN` — one group per elevation sweep,
+//!   enumerated by probing until `file.group()` errors.
+//!   - `/datasetN/where` — `elangle`, `nbins`, `nrays`, `rscale`,
+//!     `rstart` (default 0.0), `a1gate` (default 0).
+//!   - `/datasetN/data1` .. `/datasetN/dataM` — one group per radar
+//!     moment, enumerated by probing until it errors.
+//!     - `/datasetN/dataM/what` — `quantity`, `gain`, `offset`,
+//!       `nodata`, `undetect`. Missing scaling attributes fall back
+//!       to `/datasetN/what` (producer variation).
+//!     - `/datasetN/dataM/data` — raw array, shape `{nrays, nbins}`.
+//!
+//! Milestone 1 is reader + domain model only — nothing here is wired
+//! into the engine, `MapEngine`, EDR, or the server.
+
+use chrono::{DateTime, NaiveDate, NaiveTime, Utc};
+use hdf5_reader::{Attribute, Hdf5File};
+
+use crate::reader::{RawPixels, ReadError};
+
+/// Radar site metadata parsed from `/where` plus the `/what/source`
+/// identifier string.
+#[derive(Debug, Clone)]
+pub struct RadarSite {
+    /// Antenna longitude (degrees east).
+    pub lon: f64,
+    /// Antenna latitude (degrees north).
+    pub lat: f64,
+    /// Antenna height above sea level (metres).
+    pub height: f64,
+    /// ODIM node identifier (`NOD:` token of `/what/source`, e.g.
+    /// `"fianj"`). `None` if the token is absent.
+    pub nod: Option<String>,
+    /// Place name (`PLC:` token, e.g. `"Anjalankoski"`).
+    pub plc: Option<String>,
+    /// WMO station number (`WMO:` token, e.g. `"02954"`).
+    pub wmo: Option<String>,
+}
+
+/// A single radar moment (quantity) within one elevation sweep.
+#[derive(Debug, Clone)]
+pub struct PolarMoment {
+    /// ODIM quantity name, e.g. `"DBZH"`, `"VRADH"`, `"ZDR"`.
+    pub quantity: String,
+    /// Linear scale factor: `physical = raw * gain + offset`.
+    pub gain: f64,
+    /// Linear offset.
+    pub offset: f64,
+    /// Raw value indicating "no data" / out-of-coverage.
+    pub nodata: f64,
+    /// Raw value indicating "no echo detected".
+    pub undetect: f64,
+    /// Raw data array, indexed `[ray, bin]` — shape `(nrays, nbins)`.
+    pub data: RawPixels,
+}
+
+/// One elevation sweep of a polar volume: all moments measured at a
+/// single antenna elevation angle.
+#[derive(Debug, Clone)]
+pub struct Sweep {
+    /// Antenna elevation angle (degrees above horizontal).
+    pub elangle: f64,
+    /// Number of range bins per ray.
+    pub nbins: usize,
+    /// Number of azimuth rays in the sweep.
+    pub nrays: usize,
+    /// Range-bin spacing (metres per bin).
+    pub rscale: f64,
+    /// Range to the start of the first bin (metres).
+    pub rstart: f64,
+    /// Index of the first radiated azimuth ray.
+    pub a1gate: usize,
+    /// Radar moments measured in this sweep.
+    pub moments: Vec<PolarMoment>,
+}
+
+/// A parsed ODIM polar volume: the radar site plus every elevation
+/// sweep, sorted by elevation angle ascending.
+#[derive(Debug, Clone)]
+pub struct PolarVolume {
+    /// Radar antenna position + identifiers.
+    pub site: RadarSite,
+    /// Nominal acquisition time (UTC), from `/what/date` + `/what/time`.
+    pub time: DateTime<Utc>,
+    /// Raw `/what/object` value (e.g. `"PVOL"` or — for FMI — `"SCAN"`).
+    /// Kept for diagnostics; never used to reject a file.
+    pub object: String,
+    /// Elevation sweeps, sorted by `elangle` ascending.
+    pub sweeps: Vec<Sweep>,
+}
+
+/// Parse an ODIM `/what/source` string into `(NOD, PLC, WMO)`.
+///
+/// The source attribute is a comma-separated list of `TYP:VALUE`
+/// tokens, e.g.
+/// `"WIGOS:0-246-0-101234,WMO:02954,RAD:FI44,PLC:Anjalankoski,NOD:fianj"`.
+/// Tokens whose type is not requested are ignored; a requested type
+/// that is absent yields `None`. Surrounding whitespace and HDF5
+/// NUL-padding are trimmed.
+fn parse_source(source: &str) -> (Option<String>, Option<String>, Option<String>) {
+    let mut nod = None;
+    let mut plc = None;
+    let mut wmo = None;
+    for token in source.split(',') {
+        let token = token.trim_matches(|c: char| c.is_whitespace() || c == '\0');
+        let Some((typ, value)) = token.split_once(':') else {
+            continue;
+        };
+        let value = value.trim();
+        if value.is_empty() {
+            continue;
+        }
+        match typ.trim() {
+            "NOD" => nod = Some(value.to_string()),
+            "PLC" => plc = Some(value.to_string()),
+            "WMO" => wmo = Some(value.to_string()),
+            _ => {}
+        }
+    }
+    (nod, plc, wmo)
+}
+
+/// Read a `RawPixels` array of declared shape `(nrays, nbins)` from a
+/// `/datasetN/dataM/data` dataset, probing u8 → u16 → f64 — the same
+/// dtype-fallback chain [`crate::reader::read_composite`] uses.
+fn read_moment_array(
+    file: &Hdf5File,
+    path: &str,
+    nrays: usize,
+    nbins: usize,
+) -> Result<RawPixels, ReadError> {
+    let ds = file
+        .dataset(path)
+        .map_err(|_| ReadError::MissingGroup(path.to_string()))?;
+    let shape = ds.shape();
+    if shape.len() != 2 {
+        return Err(ReadError::UnsupportedRank(shape.len()));
+    }
+
+    let check = |dim: (usize, usize)| -> Result<(), ReadError> {
+        if dim != (nrays, nbins) {
+            return Err(ReadError::DatasetRead(format!(
+                "{path}: array shape {dim:?} doesn't match sweep metadata {nrays}x{nbins}"
+            )));
+        }
+        Ok(())
+    };
+
+    if let Ok(arr) = ds.read_array::<u8>() {
+        let a2 = arr
+            .into_dimensionality::<ndarray::Ix2>()
+            .map_err(|e| ReadError::DatasetRead(format!("{path}: u8 reshape failed: {e}")))?;
+        check(a2.dim())?;
+        return Ok(RawPixels::U8(a2));
+    }
+    if let Ok(arr) = ds.read_array::<u16>() {
+        let a2 = arr
+            .into_dimensionality::<ndarray::Ix2>()
+            .map_err(|e| ReadError::DatasetRead(format!("{path}: u16 reshape failed: {e}")))?;
+        check(a2.dim())?;
+        return Ok(RawPixels::U16(a2));
+    }
+    if let Ok(arr) = ds.read_array::<f64>() {
+        let a2 = arr
+            .into_dimensionality::<ndarray::Ix2>()
+            .map_err(|e| ReadError::DatasetRead(format!("{path}: f64 reshape failed: {e}")))?;
+        check(a2.dim())?;
+        return Ok(RawPixels::F64(a2));
+    }
+    Err(ReadError::UnsupportedPixelType)
+}
+
+/// Parse an ODIM_H5 polar volume from a byte slice. The whole file
+/// must fit in memory — typical PVOL files are 10–30 MB.
+///
+/// Sweeps are returned sorted by elevation angle ascending. A volume
+/// with zero `/datasetN` groups, or a sweep with zero moments, is an
+/// error ([`ReadError::NoSweeps`] / [`ReadError::NoMoments`]).
+pub fn read_polar_volume(bytes: &[u8]) -> Result<PolarVolume, ReadError> {
+    let file = Hdf5File::from_bytes(bytes).map_err(|e| ReadError::OpenFailed(e.to_string()))?;
+
+    // Closure-based attribute helpers — `Group` isn't pub-exported by
+    // `hdf5-reader`, so each helper resolves the group by path.
+    let fetch_attr = |group_path: &str, name: &str| -> Result<Attribute, ReadError> {
+        let grp = file
+            .group(group_path)
+            .map_err(|_| ReadError::MissingGroup(group_path.to_string()))?;
+        grp.attribute(name)
+            .map_err(|_| ReadError::MissingAttribute {
+                group: group_path.to_string(),
+                name: name.to_string(),
+            })
+    };
+    let read_string_attr = |group_path: &str, name: &str| -> Result<String, ReadError> {
+        let attr = fetch_attr(group_path, name)?;
+        attr.read_string()
+            .map_err(|e| ReadError::AttributeRead(format!("{group_path}/{name}: {e}")))
+    };
+    let read_f64_attr = |group_path: &str, name: &str| -> Result<f64, ReadError> {
+        let attr = fetch_attr(group_path, name)?;
+        attr.read_as_f64()
+            .map_err(|e| ReadError::AttributeRead(format!("{group_path}/{name}: {e}")))
+    };
+
+    // /what — object kind, timestamp, source identifier. The `object`
+    // value is recorded but never used to reject the file: FMI ships
+    // polar volumes labelled `"SCAN"` rather than `"PVOL"`.
+    let object = read_string_attr("/what", "object")?
+        .trim_end_matches('\0')
+        .trim()
+        .to_string();
+    let date = read_string_attr("/what", "date")?;
+    let time_str = read_string_attr("/what", "time")?;
+    let time = parse_odim_timestamp(&date, &time_str)?;
+    let source = read_string_attr("/what", "source").unwrap_or_default();
+    let (nod, plc, wmo) = parse_source(&source);
+
+    // /where — radar antenna position.
+    let site = RadarSite {
+        lon: read_f64_attr("/where", "lon")?,
+        lat: read_f64_attr("/where", "lat")?,
+        height: read_f64_attr("/where", "height")?,
+        nod,
+        plc,
+        wmo,
+    };
+
+    // Enumerate /dataset1, /dataset2, … by probing until a group is
+    // absent. ODIM numbers datasets contiguously from 1.
+    let mut sweeps = Vec::new();
+    let mut n = 1usize;
+    loop {
+        let ds_path = format!("/dataset{n}");
+        if file.group(&ds_path).is_err() {
+            break;
+        }
+        sweeps.push(read_sweep(
+            &file,
+            &ds_path,
+            &read_string_attr,
+            &read_f64_attr,
+        )?);
+        n += 1;
+    }
+    if sweeps.is_empty() {
+        return Err(ReadError::NoSweeps);
+    }
+
+    // Sort by elevation angle ascending. ODIM does not mandate that
+    // /datasetN groups are stored in elevation order, so sort
+    // explicitly. `total_cmp` keeps a stray NaN from poisoning the
+    // ordering.
+    sweeps.sort_by(|a, b| a.elangle.total_cmp(&b.elangle));
+
+    Ok(PolarVolume {
+        site,
+        time,
+        object,
+        sweeps,
+    })
+}
+
+/// Read one `/datasetN` elevation sweep, including every moment group.
+fn read_sweep(
+    file: &Hdf5File,
+    ds_path: &str,
+    read_string_attr: &impl Fn(&str, &str) -> Result<String, ReadError>,
+    read_f64_attr: &impl Fn(&str, &str) -> Result<f64, ReadError>,
+) -> Result<Sweep, ReadError> {
+    let where_path = format!("{ds_path}/where");
+    let elangle = read_f64_attr(&where_path, "elangle")?;
+    let nbins = read_f64_attr(&where_path, "nbins")? as usize;
+    let nrays = read_f64_attr(&where_path, "nrays")? as usize;
+    let rscale = read_f64_attr(&where_path, "rscale")?;
+    // rstart / a1gate are optional with documented defaults.
+    let rstart = read_f64_attr(&where_path, "rstart").unwrap_or(0.0);
+    let a1gate = read_f64_attr(&where_path, "a1gate").unwrap_or(0.0) as usize;
+
+    // Enumerate /datasetN/data1, /data2, … by probing.
+    let mut moments = Vec::new();
+    let mut m = 1usize;
+    loop {
+        let data_path = format!("{ds_path}/data{m}");
+        if file.group(&data_path).is_err() {
+            break;
+        }
+        moments.push(read_moment(
+            file,
+            ds_path,
+            &data_path,
+            nrays,
+            nbins,
+            read_string_attr,
+            read_f64_attr,
+        )?);
+        m += 1;
+    }
+    if moments.is_empty() {
+        return Err(ReadError::NoMoments {
+            dataset: ds_path.to_string(),
+        });
+    }
+
+    Ok(Sweep {
+        elangle,
+        nbins,
+        nrays,
+        rscale,
+        rstart,
+        a1gate,
+        moments,
+    })
+}
+
+/// Read one `/datasetN/dataM` moment group. `nrays`/`nbins` come from
+/// the parent sweep's `/where` and the data array is validated against
+/// them.
+#[allow(clippy::too_many_arguments)]
+fn read_moment(
+    file: &Hdf5File,
+    ds_path: &str,
+    data_path: &str,
+    nrays: usize,
+    nbins: usize,
+    read_string_attr: &impl Fn(&str, &str) -> Result<String, ReadError>,
+    read_f64_attr: &impl Fn(&str, &str) -> Result<f64, ReadError>,
+) -> Result<PolarMoment, ReadError> {
+    let what_path = format!("{data_path}/what");
+    let ds_what = format!("{ds_path}/what");
+
+    let quantity = read_string_attr(&what_path, "quantity")
+        .map(|q| q.trim_end_matches('\0').trim().to_string())
+        .map_err(|_| ReadError::MissingAttribute {
+            group: what_path.clone(),
+            name: "quantity".into(),
+        })?;
+
+    // gain/offset/nodata/undetect: prefer the per-moment what group,
+    // fall back to the sweep-level /datasetN/what (producer variation,
+    // mirroring read_composite's scaling-attribute fallback).
+    let read_scaling = |name: &str, default: Option<f64>| -> Result<f64, ReadError> {
+        if let Ok(v) = read_f64_attr(&what_path, name) {
+            return Ok(v);
+        }
+        if let Ok(v) = read_f64_attr(&ds_what, name) {
+            return Ok(v);
+        }
+        default.ok_or_else(|| ReadError::MissingAttribute {
+            group: format!("{what_path} | {ds_what}"),
+            name: name.to_string(),
+        })
+    };
+    let gain = read_scaling("gain", Some(1.0))?;
+    let offset = read_scaling("offset", Some(0.0))?;
+    let nodata = read_scaling("nodata", None)?;
+    let undetect = read_scaling("undetect", None)?;
+
+    let data = read_moment_array(file, &format!("{data_path}/data"), nrays, nbins)?;
+
+    Ok(PolarMoment {
+        quantity,
+        gain,
+        offset,
+        nodata,
+        undetect,
+        data,
+    })
+}
+
+/// Combine ODIM's split `/what/date` (`YYYYMMDD`) and `/what/time`
+/// (`HHMMSS`) into a UTC timestamp.
+fn parse_odim_timestamp(date: &str, time: &str) -> Result<DateTime<Utc>, ReadError> {
+    let date = date.trim_matches(|c: char| c.is_whitespace() || c == '\0');
+    let time = time.trim_matches(|c: char| c.is_whitespace() || c == '\0');
+    let parsed_date =
+        NaiveDate::parse_from_str(date, "%Y%m%d").map_err(|e| ReadError::InvalidTimestamp {
+            date: date.into(),
+            time: time.into(),
+            reason: format!("date: {e}"),
+        })?;
+    let parsed_time =
+        NaiveTime::parse_from_str(time, "%H%M%S").map_err(|e| ReadError::InvalidTimestamp {
+            date: date.into(),
+            time: time.into(),
+            reason: format!("time: {e}"),
+        })?;
+    Ok(parsed_date.and_time(parsed_time).and_utc())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    /// The canonical FMI `/what/source` string carries all three
+    /// identifiers we care about, plus `WIGOS` and `RAD` tokens we
+    /// deliberately ignore.
+    #[test]
+    fn parse_source_extracts_nod_plc_wmo() {
+        let src = "WIGOS:0-246-0-101234,WMO:02954,RAD:FI44,PLC:Anjalankoski,NOD:fianj";
+        let (nod, plc, wmo) = parse_source(src);
+        assert_eq!(nod.as_deref(), Some("fianj"));
+        assert_eq!(plc.as_deref(), Some("Anjalankoski"));
+        assert_eq!(wmo.as_deref(), Some("02954"));
+    }
+
+    /// Tokens that are absent yield `None` rather than an empty string
+    /// or an error.
+    #[test]
+    fn parse_source_missing_tokens_are_none() {
+        let (nod, plc, wmo) = parse_source("RAD:FI44,PLC:Korpo");
+        assert_eq!(nod, None);
+        assert_eq!(plc.as_deref(), Some("Korpo"));
+        assert_eq!(wmo, None);
+    }
+
+    /// An empty / absent source string yields all `None`.
+    #[test]
+    fn parse_source_empty_is_all_none() {
+        let (nod, plc, wmo) = parse_source("");
+        assert!(nod.is_none() && plc.is_none() && wmo.is_none());
+    }
+
+    /// HDF5 NUL-padding and stray whitespace around tokens and values
+    /// must not leak into the parsed identifiers.
+    #[test]
+    fn parse_source_trims_padding_and_whitespace() {
+        let (nod, plc, wmo) = parse_source(" NOD:fikor , WMO:02949 ,PLC:Korpo\0");
+        assert_eq!(nod.as_deref(), Some("fikor"));
+        assert_eq!(wmo.as_deref(), Some("02949"));
+        assert_eq!(plc.as_deref(), Some("Korpo"));
+    }
+
+    /// A token with no `:` separator, or an empty value, is skipped
+    /// without poisoning the rest of the parse.
+    #[test]
+    fn parse_source_skips_malformed_tokens() {
+        let (nod, plc, wmo) = parse_source("garbage,NOD:,WMO:02954,PLC:Vimpeli");
+        assert_eq!(nod, None, "empty NOD value must yield None");
+        assert_eq!(wmo.as_deref(), Some("02954"));
+        assert_eq!(plc.as_deref(), Some("Vimpeli"));
+    }
+
+    /// End-to-end read of the real FMI Anjalankoski polar volume.
+    ///
+    /// The 15 MB fixture is **not committed to git**, so the test
+    /// skips gracefully when it is absent — CI stays green; a local
+    /// checkout with the fixture exercises the full reader.
+    #[test]
+    fn reads_fmi_anjalankoski_pvol_fixture() {
+        let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../../testdata/radar-fmi-pvol/202605150000_fianj_PVOL.h5");
+        if !path.exists() {
+            eprintln!("skipping reads_fmi_anjalankoski_pvol_fixture: fixture absent at {path:?}");
+            return;
+        }
+
+        let bytes = std::fs::read(&path).expect("read fixture bytes");
+        let vol = read_polar_volume(&bytes).expect("parse FMI PVOL fixture");
+
+        // 13 elevation sweeps, sorted ascending by elevation angle.
+        assert_eq!(vol.sweeps.len(), 13, "expected 13 elevation sweeps");
+        assert!(
+            (vol.sweeps[0].elangle - 0.3).abs() < 0.05,
+            "lowest sweep elangle should be ~0.3°, got {}",
+            vol.sweeps[0].elangle
+        );
+        for w in vol.sweeps.windows(2) {
+            assert!(
+                w[0].elangle <= w[1].elangle,
+                "sweeps must be elangle-ascending: {} then {}",
+                w[0].elangle,
+                w[1].elangle
+            );
+        }
+
+        // Every sweep has 360 azimuth rays. Range-bin counts vary by
+        // elevation (the real FMI volume uses fewer/coarser bins on
+        // higher sweeps), so only the lowest sweep is pinned to 500.
+        for (i, sweep) in vol.sweeps.iter().enumerate() {
+            eprintln!(
+                "sweep {i}: elangle={:.2} nrays={} nbins={} moments={}",
+                sweep.elangle,
+                sweep.nrays,
+                sweep.nbins,
+                sweep.moments.len()
+            );
+            assert_eq!(sweep.nrays, 360, "sweep {i} nrays");
+            assert!(!sweep.moments.is_empty(), "sweep {i} has moments");
+        }
+        assert_eq!(vol.sweeps[0].nbins, 500, "lowest sweep nbins");
+
+        // The lowest sweep carries 16 moments including TH and ZDR.
+        let sweep0 = &vol.sweeps[0];
+        assert_eq!(sweep0.moments.len(), 16, "sweep[0] moment count");
+        let quantities: Vec<&str> = sweep0.moments.iter().map(|m| m.quantity.as_str()).collect();
+        assert!(
+            quantities.contains(&"TH"),
+            "sweep[0] should expose TH, got {quantities:?}"
+        );
+        assert!(
+            quantities.contains(&"ZDR"),
+            "sweep[0] should expose ZDR, got {quantities:?}"
+        );
+
+        // Each moment's array shape matches its own sweep's grid —
+        // read_polar_volume validates this internally, so assert it
+        // holds across every sweep/moment pair.
+        for sweep in &vol.sweeps {
+            for m in &sweep.moments {
+                assert_eq!(
+                    m.data.shape(),
+                    (sweep.nrays, sweep.nbins),
+                    "moment {} array shape vs sweep grid",
+                    m.quantity
+                );
+            }
+        }
+
+        // Radar site identifiers + antenna position.
+        assert_eq!(vol.site.nod.as_deref(), Some("fianj"));
+        assert!(
+            (vol.site.lat - 60.9039).abs() < 0.01,
+            "site lat ~60.9039, got {}",
+            vol.site.lat
+        );
+        assert!(
+            (vol.site.lon - 27.1081).abs() < 0.01,
+            "site lon ~27.1081, got {}",
+            vol.site.lon
+        );
+    }
+}

--- a/crates/engine-odim/src/reader.rs
+++ b/crates/engine-odim/src/reader.rs
@@ -78,6 +78,10 @@ pub enum ReadError {
     DatasetRead(String),
     #[error("attribute read failed: {0}")]
     AttributeRead(String),
+    #[error("polar volume contains no `/datasetN` elevation sweeps")]
+    NoSweeps,
+    #[error("elevation sweep `{dataset}` contains no `/dataM` moment groups")]
+    NoMoments { dataset: String },
 }
 
 /// Raw pixel storage as it appears on disk. ODIM composites ship
@@ -143,11 +147,25 @@ impl RawPixels {
         // letting a near-sentinel through (false negative); stick to
         // exact == until a producer is observed shipping non-integer
         // sentinels.
-        if raw == nodata {
+        //
+        // NaN-aware: some PVOL producers declare `nodata`/`undetect`
+        // as NaN. `raw == nodata` is always false when `nodata` is
+        // NaN (IEEE-754), so it would never mask — and a NaN raw
+        // value would fall through to `raw * gain + offset = NaN`,
+        // which the colorizer renders as a stray pixel. Treat a NaN
+        // sentinel as "mask any NaN raw"; also mask a NaN raw value
+        // unconditionally, since a NaN physical value is never
+        // meaningful radar data.
+        if raw.is_nan() {
+            return None;
+        }
+        if nodata.is_nan() {
+            // sentinel is NaN — only NaN raws (handled above) match it
+        } else if raw == nodata {
             return None;
         }
         if let Some(u) = undetect {
-            if raw == u {
+            if !u.is_nan() && raw == u {
                 return None;
             }
         }

--- a/crates/engine-odim/src/volume_engine.rs
+++ b/crates/engine-odim/src/volume_engine.rs
@@ -123,6 +123,9 @@ fn merc_y_to_lat(y: f64) -> f64 {
 /// snapshot without re-parsing HDF5.
 #[derive(Clone)]
 struct VolumeEntry {
+    /// Source file path — the parse-cache key; used to evict cache
+    /// entries the (`max_files`-capped) catalog no longer references.
+    path: PathBuf,
     /// Parsed volume — `Arc` so repeated requests share one parse.
     volume: Arc<PolarVolume>,
 }
@@ -171,6 +174,7 @@ fn scan_directory(
     collection_id: &str,
     data_dir: &std::path::Path,
     cache: &Mutex<HashMap<PathBuf, Arc<PolarVolume>>>,
+    max_files: Option<usize>,
 ) -> Result<Catalog, EngineError> {
     let read_dir = std::fs::read_dir(data_dir).map_err(|e| {
         EngineError::Storage(DataServerError::Engine(format!(
@@ -180,8 +184,6 @@ fn scan_directory(
     })?;
 
     let mut by_site: HashMap<String, Vec<VolumeEntry>> = HashMap::new();
-    // Files seen this scan — used to evict dropped files from the cache.
-    let mut seen: Vec<PathBuf> = Vec::new();
 
     for entry in read_dir.flatten() {
         let path = entry.path();
@@ -192,7 +194,6 @@ fn scan_directory(
         if !is_h5 || !path.is_file() {
             continue;
         }
-        seen.push(path.clone());
 
         // Cache hit — reuse the parsed volume.
         let cached = {
@@ -240,18 +241,32 @@ fn scan_directory(
             continue;
         };
 
-        by_site.entry(nod).or_default().push(VolumeEntry { volume });
+        by_site
+            .entry(nod)
+            .or_default()
+            .push(VolumeEntry { path, volume });
     }
 
-    // Evict cache entries for files that no longer exist.
-    {
-        let mut guard = cache.lock().unwrap_or_else(|e| e.into_inner());
-        guard.retain(|k, _| seen.contains(k));
-    }
-
-    // Sort each site's volumes by time ascending.
+    // Sort each site's volumes by time ascending, then cap each site
+    // to the most-recent `max_files` — an archive directory holding
+    // years of data must not load and cache every file.
     for list in by_site.values_mut() {
         list.sort_by_key(|e| e.volume.time);
+        if let Some(cap) = max_files {
+            if list.len() > cap {
+                list.drain(..list.len() - cap);
+            }
+        }
+    }
+
+    // Evict parse-cache entries the catalog no longer references —
+    // files deleted from disk, plus volumes aged out of a site's
+    // `max_files` window. `kept` is a set, so this is O(cache).
+    {
+        let kept: std::collections::HashSet<&PathBuf> =
+            by_site.values().flatten().map(|e| &e.path).collect();
+        let mut guard = cache.lock().unwrap_or_else(|e| e.into_inner());
+        guard.retain(|k, _| kept.contains(k));
     }
 
     // Derive parameters from each site's lowest sweep.
@@ -274,6 +289,9 @@ fn scan_directory(
         }
     }
     parameters.sort_by(|a, b| a.0.cmp(&b.0));
+    // A producer shipping a sweep with a duplicate quantity name would
+    // otherwise advertise the same `<nod>:<quantity>` layer twice.
+    parameters.dedup_by(|a, b| a.0 == b.0);
 
     // Distinct, sorted volume times across all sites.
     let mut times: Vec<DateTime<Utc>> = by_site
@@ -320,6 +338,9 @@ pub struct PolarVolumeEngine {
     collection_id: String,
     /// Directory of `.h5` polar-volume files, re-scanned by the poll loop.
     data_dir: PathBuf,
+    /// Per-site cap on retained volumes (`OdimConfig.max_files`) — keeps
+    /// an archive directory from loading every file into the catalog.
+    max_files: Option<usize>,
     /// Lock-free catalog snapshot for `raster_info()` + `get_raster_tile`.
     catalog: Arc<ArcSwap<Catalog>>,
     /// Multi-entry parse cache keyed by file path — a PVOL network of
@@ -361,7 +382,7 @@ impl PolarVolumeEngine {
         let data_dir = PathBuf::from(data_path);
 
         let parse_cache = Mutex::new(HashMap::new());
-        let catalog = scan_directory(collection_id, &data_dir, &parse_cache)?;
+        let catalog = scan_directory(collection_id, &data_dir, &parse_cache, config.max_files)?;
         if catalog.by_site.is_empty() {
             tracing::warn!(
                 "[{collection_id}] no PVOL `.h5` files found in `{}` yet — \
@@ -380,6 +401,7 @@ impl PolarVolumeEngine {
         Ok(Self {
             collection_id: collection_id.to_string(),
             data_dir,
+            max_files: config.max_files,
             catalog: Arc::new(ArcSwap::from_pointee(catalog)),
             parse_cache,
             poll_interval: Duration::from_secs(config.poll_interval_secs.max(1)),
@@ -420,7 +442,12 @@ impl PolarVolumeEngine {
     }
 
     fn poll_once(&self) {
-        match scan_directory(&self.collection_id, &self.data_dir, &self.parse_cache) {
+        match scan_directory(
+            &self.collection_id,
+            &self.data_dir,
+            &self.parse_cache,
+            self.max_files,
+        ) {
             Ok(catalog) => {
                 let prev = self.catalog.load();
                 let changed = prev.by_site.len() != catalog.by_site.len()
@@ -655,10 +682,9 @@ mod tests {
     #[test]
     fn bearing_due_north_is_zero() {
         let (_d, az) = ground_distance_bearing(25.0, 60.0, 25.0, 60.5);
-        assert!(
-            !(0.01..=359.99).contains(&az),
-            "due-north bearing ≈ 0°, got {az}"
-        );
+        // `rem_euclid(360)` keeps `az` in [0, 360), so due-north is a
+        // small positive angle — assert that directly.
+        assert!(az < 0.01, "due-north bearing ≈ 0°, got {az}");
     }
 
     /// A pixel ~10 km due east of the site has bearing ≈ 90° and

--- a/crates/engine-odim/src/volume_engine.rs
+++ b/crates/engine-odim/src/volume_engine.rs
@@ -659,8 +659,7 @@ impl MapEngine for PolarVolumeEngine {
         RasterInfo {
             native_crs: "CRS:84".to_string(),
             spatial_extent: catalog.spatial_extent,
-            // Most-recent-first, matching the `RasterInfo::times` contract.
-            times: catalog.times.iter().rev().copied().collect(),
+            times: catalog.times.clone(),
             parameter,
             // PVOL quantities span multiple physical units (dBZ, m/s,
             // dB, …); the per-layer unit is not a single collection

--- a/crates/engine-odim/src/volume_engine.rs
+++ b/crates/engine-odim/src/volume_engine.rs
@@ -1,0 +1,826 @@
+//! `MapEngine` impl backed by an ODIM_H5 polar-volume (PVOL) catalog.
+//!
+//! Where [`crate::engine::OdimEngine`] serves pre-projected 2-D `COMP`
+//! composites, this engine serves **native polar volumes** — multi-
+//! elevation, multi-moment radar data in spherical (range × azimuth)
+//! coordinates — and resamples them into Cartesian raster tiles on the
+//! fly.
+//!
+//! ## Layer model
+//!
+//! A PVOL collection covers a radar **network**: a local directory of
+//! `.h5` polar-volume files spanning multiple sites and multiple
+//! acquisition times. Each radar **site** is a layer group; each radar
+//! **quantity** (`DBZH`, `TH`, `VRADH`, `ZDR`, …) is a sub-layer —
+//! exactly like a multi-parameter GRIB collection. The advertised
+//! parameter name is `<nod>:<quantity>` (e.g. `fianj:DBZH`).
+//!
+//! The `:` separator is deliberate. WMS layer names are
+//! `collection-id/parameter` and the api-wms handler splits on the
+//! *first* `/`, so the parameter token must not itself contain `/`.
+//! `:` is safe in a WMS `LAYERS=` value and in a Maps/Tiles
+//! `?parameter-name=` query parameter, and reads naturally as a
+//! site-scoped quantity.
+//!
+//! ## Interim scope (Milestone 2)
+//!
+//! - Renders **only the lowest elevation sweep** (`sweeps[0]`) of each
+//!   site. Higher sweeps are parsed but not exposed.
+//! - **No mosaic / compositing** — each site is rendered independently.
+//! - Treats the sweep range axis as **ground range**: a proper slant-
+//!   range / 4⁄3-Earth ground-range correction is deferred. For a
+//!   near-horizon lowest sweep the error is small; see [`polar_sample`].
+//!
+//! A background `poll_loop` re-scans `data_path` every
+//! `poll_interval_secs` and atomically swaps the catalog so new volume
+//! files appear without an admin reload — mirroring `OdimEngine`.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use arc_swap::ArcSwap;
+use chrono::{DateTime, Utc};
+use ds_core::error::DataServerError;
+use ds_core::map_engine::{MapEngine, OutputCrs, RasterInfo, RasterTile};
+use tokio::sync::Notify;
+
+use crate::engine::EngineError;
+use crate::pvol::{read_polar_volume, PolarVolume};
+
+/// Separator between the ODIM node id and the radar quantity in an
+/// advertised parameter name (`fianj:DBZH`). See the module docs for
+/// why `:` and not `/`.
+pub const SITE_QUANTITY_SEP: char = ':';
+
+/// Mean Earth radius (metres) used by the geodesic helper. A sphere is
+/// the right model here: radar ground range is itself a spherical
+/// approximation, and the per-pixel error of WGS84-vs-sphere at radar
+/// ranges (≤ ~250 km) is far below one output pixel.
+const EARTH_RADIUS_M: f64 = 6_371_000.0;
+
+/// Web-Mercator sphere radius (metres) — EPSG:3857 uses 6378137.
+const MERC_RADIUS_M: f64 = 6_378_137.0;
+
+// ---------------------------------------------------------------------------
+// Geodesic helper
+// ---------------------------------------------------------------------------
+
+/// Ground distance (metres) and initial bearing (degrees, 0° = north,
+/// clockwise) from `(lon0, lat0)` to `(lon1, lat1)` on a sphere of
+/// radius [`EARTH_RADIUS_M`].
+///
+/// Distance is the haversine great-circle distance; bearing is the
+/// standard initial-bearing (forward azimuth) formula, normalised to
+/// `[0, 360)`. All inputs are degrees.
+///
+/// Kept as a small standalone function so it can be unit-tested in
+/// isolation — the polar→Cartesian resampler's correctness hinges on
+/// it.
+pub fn ground_distance_bearing(lon0: f64, lat0: f64, lon1: f64, lat1: f64) -> (f64, f64) {
+    let lat0_r = lat0.to_radians();
+    let lat1_r = lat1.to_radians();
+    let dlat = (lat1 - lat0).to_radians();
+    let dlon = (lon1 - lon0).to_radians();
+
+    // Haversine great-circle distance.
+    let a = (dlat / 2.0).sin().powi(2) + lat0_r.cos() * lat1_r.cos() * (dlon / 2.0).sin().powi(2);
+    let c = 2.0 * a.sqrt().clamp(0.0, 1.0).asin();
+    let distance = EARTH_RADIUS_M * c;
+
+    // Initial bearing (forward azimuth): atan2 of the east/north
+    // components of the great-circle tangent at the start point.
+    let y = dlon.sin() * lat1_r.cos();
+    let x = lat0_r.cos() * lat1_r.sin() - lat0_r.sin() * lat1_r.cos() * dlon.cos();
+    let bearing = y.atan2(x).to_degrees().rem_euclid(360.0);
+
+    (distance, bearing)
+}
+
+// ---------------------------------------------------------------------------
+// Web-Mercator row interpolation (mirrors engine.rs)
+// ---------------------------------------------------------------------------
+
+/// WGS84 latitude (degrees) → Web-Mercator Y (metres).
+fn lat_to_merc_y(lat_deg: f64) -> f64 {
+    let lat_rad = lat_deg.to_radians();
+    MERC_RADIUS_M * ((std::f64::consts::FRAC_PI_4 + lat_rad / 2.0).tan()).ln()
+}
+
+/// Inverse of [`lat_to_merc_y`].
+fn merc_y_to_lat(y: f64) -> f64 {
+    (std::f64::consts::FRAC_PI_2 - 2.0 * (-y / MERC_RADIUS_M).exp().atan()).to_degrees()
+}
+
+// ---------------------------------------------------------------------------
+// Catalog
+// ---------------------------------------------------------------------------
+
+/// One parsed polar volume in the catalog. The volume is held behind
+/// `Arc` so the catalog can be cheaply cloned out of the `ArcSwap`
+/// snapshot without re-parsing HDF5.
+#[derive(Clone)]
+struct VolumeEntry {
+    /// Parsed volume — `Arc` so repeated requests share one parse.
+    volume: Arc<PolarVolume>,
+}
+
+/// The engine's catalog: per-site time-sorted volume lists, plus the
+/// derived metadata `raster_info()` answers from.
+struct Catalog {
+    /// Volumes grouped by `site.nod`, each list sorted by `time`
+    /// ascending.
+    by_site: HashMap<String, Vec<VolumeEntry>>,
+    /// `(parameter_name, title)` pairs — one per `<nod>:<quantity>`
+    /// from each site's lowest sweep. Sorted for stable output.
+    parameters: Vec<(String, String)>,
+    /// All distinct volume times across every site, sorted ascending.
+    times: Vec<DateTime<Utc>>,
+    /// Union of per-site coverage bboxes `[w, s, e, n]` in WGS84.
+    spatial_extent: Option<[f64; 4]>,
+}
+
+/// WGS84 bounding box `[w, s, e, n]` of the circular coverage area of
+/// one site: a circle of radius `radius_m` metres centred on
+/// `(lon, lat)`. Computed by projecting the four cardinal extremes on
+/// a sphere — the max-latitude reach is due north/south, the
+/// max-longitude reach is at the latitude-scaled east/west offset.
+fn site_coverage_bbox(lon: f64, lat: f64, radius_m: f64) -> [f64; 4] {
+    let dlat = (radius_m / EARTH_RADIUS_M).to_degrees();
+    // Longitude span widens toward the poles: divide by cos(lat). At
+    // the latitude extremes of the circle the parallel is shortest, so
+    // use the larger of the centre and edge latitudes' cos to bound
+    // the east/west reach conservatively.
+    let lat_for_lon = (lat.abs() + dlat).min(89.9);
+    let cos_lat = lat_for_lon.to_radians().cos().max(1e-6);
+    let dlon = dlat / cos_lat;
+    [
+        lon - dlon,
+        (lat - dlat).max(-90.0),
+        lon + dlon,
+        (lat + dlat).min(90.0),
+    ]
+}
+
+/// Scan `data_dir` for `.h5` polar-volume files, reusing already-parsed
+/// volumes from `cache` (keyed by path) so a poll cycle doesn't
+/// re-parse unchanged files. Returns the freshly built [`Catalog`].
+fn scan_directory(
+    collection_id: &str,
+    data_dir: &std::path::Path,
+    cache: &Mutex<HashMap<PathBuf, Arc<PolarVolume>>>,
+) -> Result<Catalog, EngineError> {
+    let read_dir = std::fs::read_dir(data_dir).map_err(|e| {
+        EngineError::Storage(DataServerError::Engine(format!(
+            "[{collection_id}] failed to read PVOL directory `{}`: {e}",
+            data_dir.display()
+        )))
+    })?;
+
+    let mut by_site: HashMap<String, Vec<VolumeEntry>> = HashMap::new();
+    // Files seen this scan — used to evict dropped files from the cache.
+    let mut seen: Vec<PathBuf> = Vec::new();
+
+    for entry in read_dir.flatten() {
+        let path = entry.path();
+        let is_h5 = path
+            .extension()
+            .map(|e| e.eq_ignore_ascii_case("h5"))
+            .unwrap_or(false);
+        if !is_h5 || !path.is_file() {
+            continue;
+        }
+        seen.push(path.clone());
+
+        // Cache hit — reuse the parsed volume.
+        let cached = {
+            let guard = cache.lock().unwrap_or_else(|e| e.into_inner());
+            guard.get(&path).cloned()
+        };
+        let volume = match cached {
+            Some(v) => v,
+            None => {
+                let bytes = match std::fs::read(&path) {
+                    Ok(b) => b,
+                    Err(e) => {
+                        tracing::warn!(
+                            "[{collection_id}] skipping PVOL file `{}`: read failed: {e}",
+                            path.display()
+                        );
+                        continue;
+                    }
+                };
+                match read_polar_volume(&bytes) {
+                    Ok(v) => {
+                        let v = Arc::new(v);
+                        cache
+                            .lock()
+                            .unwrap_or_else(|e| e.into_inner())
+                            .insert(path.clone(), v.clone());
+                        v
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            "[{collection_id}] skipping PVOL file `{}`: parse failed: {e}",
+                            path.display()
+                        );
+                        continue;
+                    }
+                }
+            }
+        };
+
+        let Some(nod) = volume.site.nod.clone() else {
+            tracing::warn!(
+                "[{collection_id}] skipping PVOL file `{}`: no NOD identifier in /what/source",
+                path.display()
+            );
+            continue;
+        };
+
+        by_site.entry(nod).or_default().push(VolumeEntry { volume });
+    }
+
+    // Evict cache entries for files that no longer exist.
+    {
+        let mut guard = cache.lock().unwrap_or_else(|e| e.into_inner());
+        guard.retain(|k, _| seen.contains(k));
+    }
+
+    // Sort each site's volumes by time ascending.
+    for list in by_site.values_mut() {
+        list.sort_by_key(|e| e.volume.time);
+    }
+
+    // Derive parameters from each site's lowest sweep.
+    let mut parameters: Vec<(String, String)> = Vec::new();
+    for (nod, list) in &by_site {
+        // Use the most recent volume's lowest sweep for the quantity
+        // list — quantity sets are stable across a site's volumes.
+        let Some(latest) = list.last() else { continue };
+        let Some(sweep0) = latest.volume.sweeps.first() else {
+            continue;
+        };
+        let plc = latest.volume.site.plc.as_deref();
+        for moment in &sweep0.moments {
+            let name = format!("{nod}{SITE_QUANTITY_SEP}{}", moment.quantity);
+            let title = match plc {
+                Some(place) => format!("{place} — {}", moment.quantity),
+                None => name.clone(),
+            };
+            parameters.push((name, title));
+        }
+    }
+    parameters.sort_by(|a, b| a.0.cmp(&b.0));
+
+    // Distinct, sorted volume times across all sites.
+    let mut times: Vec<DateTime<Utc>> = by_site
+        .values()
+        .flat_map(|l| l.iter().map(|e| e.volume.time))
+        .collect();
+    times.sort_unstable();
+    times.dedup();
+
+    // Union of per-site coverage bboxes.
+    let mut spatial_extent: Option<[f64; 4]> = None;
+    for list in by_site.values() {
+        let Some(latest) = list.last() else { continue };
+        let Some(sweep0) = latest.volume.sweeps.first() else {
+            continue;
+        };
+        let site = &latest.volume.site;
+        let radius_m = sweep0.nbins as f64 * sweep0.rscale + sweep0.rstart;
+        let bb = site_coverage_bbox(site.lon, site.lat, radius_m);
+        spatial_extent = Some(match spatial_extent {
+            None => bb,
+            Some([w, s, e, n]) => [w.min(bb[0]), s.min(bb[1]), e.max(bb[2]), n.max(bb[3])],
+        });
+    }
+
+    Ok(Catalog {
+        by_site,
+        parameters,
+        times,
+        spatial_extent,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// PolarVolumeEngine
+// ---------------------------------------------------------------------------
+
+/// `MapEngine` implementation backed by an ODIM_H5 polar-volume catalog.
+///
+/// Construct with [`PolarVolumeEngine::new`]; drive metadata freshness
+/// with [`PolarVolumeEngine::poll_loop`] and stop it with
+/// [`PolarVolumeEngine::shutdown`].
+pub struct PolarVolumeEngine {
+    collection_id: String,
+    /// Directory of `.h5` polar-volume files, re-scanned by the poll loop.
+    data_dir: PathBuf,
+    /// Lock-free catalog snapshot for `raster_info()` + `get_raster_tile`.
+    catalog: Arc<ArcSwap<Catalog>>,
+    /// Multi-entry parse cache keyed by file path — a PVOL network of
+    /// ~10 sites at 5-min cadence keeps tens of volumes resident; HDF5
+    /// parsing (not the few-MB read) dominates, so caching every parsed
+    /// volume keeps both the poll loop and hot tile requests cheap.
+    parse_cache: Mutex<HashMap<PathBuf, Arc<PolarVolume>>>,
+    poll_interval: Duration,
+    shutdown: AtomicBool,
+    shutdown_notify: Notify,
+}
+
+impl PolarVolumeEngine {
+    /// Build a polar-volume engine over the local directory `data_path`.
+    /// Performs one synchronous scan so `raster_info()` answers with a
+    /// populated parameter list, temporal extent, and spatial extent
+    /// immediately. An empty / file-less directory is allowed (the poll
+    /// loop will pick files up later) — only an unreadable directory or
+    /// a missing `data_path` is a hard error.
+    ///
+    /// `config` is the shared [`ds_core::config::OdimConfig`]; the
+    /// volume engine ignores its `parameter`/`unit` fields (a PVOL
+    /// collection is inherently multi-parameter) and uses only
+    /// `poll_interval_secs`. S3 fields are not yet supported for PVOL.
+    pub fn new(
+        collection_id: &str,
+        data_path: Option<&str>,
+        config: &ds_core::config::OdimConfig,
+    ) -> Result<Self, EngineError> {
+        if config.endpoint.is_some() || config.bucket.is_some() {
+            tracing::warn!(
+                "[{collection_id}] `endpoint`/`bucket` are set but the PVOL \
+                 (`odim-volume`) engine only supports a local `data_path` \
+                 source — the S3 settings are ignored"
+            );
+        }
+
+        let data_path = data_path.ok_or(EngineError::NoSource)?;
+        let data_dir = PathBuf::from(data_path);
+
+        let parse_cache = Mutex::new(HashMap::new());
+        let catalog = scan_directory(collection_id, &data_dir, &parse_cache)?;
+        if catalog.by_site.is_empty() {
+            tracing::warn!(
+                "[{collection_id}] no PVOL `.h5` files found in `{}` yet — \
+                 the catalog will populate on the next poll",
+                data_dir.display()
+            );
+        } else {
+            tracing::info!(
+                "[{collection_id}] PVOL catalog: {} site(s), {} parameter(s), {} time(s)",
+                catalog.by_site.len(),
+                catalog.parameters.len(),
+                catalog.times.len()
+            );
+        }
+
+        Ok(Self {
+            collection_id: collection_id.to_string(),
+            data_dir,
+            catalog: Arc::new(ArcSwap::from_pointee(catalog)),
+            parse_cache,
+            poll_interval: Duration::from_secs(config.poll_interval_secs.max(1)),
+            shutdown: AtomicBool::new(false),
+            shutdown_notify: Notify::new(),
+        })
+    }
+
+    /// Re-scan the directory and atomically swap the catalog. Exits
+    /// when [`shutdown`](Self::shutdown) is called. Mirrors
+    /// `OdimEngine::poll_loop` — `AtomicBool` flag + `Notify` wake-up.
+    pub async fn poll_loop(&self) {
+        let mut interval = tokio::time::interval(self.poll_interval);
+        interval.tick().await; // skip immediate first tick (scanned at boot)
+
+        loop {
+            if self.shutdown.load(Ordering::Acquire) {
+                tracing::info!("[{}] PVOL poll loop shutting down", self.collection_id);
+                break;
+            }
+            tokio::select! {
+                _ = interval.tick() => {
+                    if !self.shutdown.load(Ordering::Acquire) {
+                        self.poll_once();
+                    }
+                }
+                _ = self.shutdown_notify.notified() => {}
+            }
+        }
+    }
+
+    /// Signal the poll loop to stop. Idempotent; safe to call before
+    /// `poll_loop` starts.
+    pub fn shutdown(&self) {
+        if !self.shutdown.swap(true, Ordering::Release) {
+            self.shutdown_notify.notify_waiters();
+        }
+    }
+
+    fn poll_once(&self) {
+        match scan_directory(&self.collection_id, &self.data_dir, &self.parse_cache) {
+            Ok(catalog) => {
+                let prev = self.catalog.load();
+                let changed = prev.by_site.len() != catalog.by_site.len()
+                    || prev.times.last() != catalog.times.last()
+                    || prev.parameters.len() != catalog.parameters.len();
+                if changed {
+                    tracing::info!(
+                        "[{}] PVOL catalog refreshed: {} → {} site(s), {} → {} time(s)",
+                        self.collection_id,
+                        prev.by_site.len(),
+                        catalog.by_site.len(),
+                        prev.times.len(),
+                        catalog.times.len(),
+                    );
+                }
+                self.catalog.store(Arc::new(catalog));
+            }
+            Err(e) => {
+                tracing::warn!("[{}] PVOL catalog refresh failed: {e}", self.collection_id);
+            }
+        }
+    }
+}
+
+/// Resample one polar moment of a sweep into a Cartesian output grid.
+///
+/// `bbox` is `[west, south, east, north]` in WGS84 degrees. For
+/// [`OutputCrs::WebMercator`], output row latitudes are interpolated in
+/// Mercator-Y so pixels are square in the projection; for
+/// [`OutputCrs::Wgs84`] they are linear in latitude. For each output
+/// pixel centre the algorithm:
+///
+/// 1. computes ground distance + azimuth from the site via
+///    [`ground_distance_bearing`];
+/// 2. maps distance to a range bin (ground range — see below);
+/// 3. maps azimuth to a stored ray index;
+/// 4. samples the raw moment array and applies gain/offset/nodata.
+///
+/// **Ground-range interim.** The sweep range axis is treated as ground
+/// range: `bin = floor((d - rstart) / rscale)`. A proper slant-range /
+/// 4⁄3-Earth ground-range correction is deferred — for the lowest
+/// elevation sweep this M2 interim, the near-horizon geometry keeps the
+/// slant-vs-ground discrepancy small.
+fn polar_sample(
+    volume: &PolarVolume,
+    quantity: &str,
+    bbox: [f64; 4],
+    width: u32,
+    height: u32,
+    output_crs: &OutputCrs,
+) -> Result<RasterTile, DataServerError> {
+    // Lowest elevation sweep — M1 sorts `sweeps` ascending by elangle.
+    let sweep = volume.sweeps.first().ok_or_else(|| {
+        DataServerError::Engine(format!(
+            "PVOL site `{}` has no elevation sweeps",
+            volume.site.nod.as_deref().unwrap_or("?")
+        ))
+    })?;
+
+    let moment = sweep
+        .moments
+        .iter()
+        .find(|m| m.quantity == quantity)
+        .ok_or_else(|| {
+            DataServerError::InvalidParameter(format!(
+                "quantity `{quantity}` is not present in the lowest sweep of \
+                 PVOL site `{}`",
+                volume.site.nod.as_deref().unwrap_or("?")
+            ))
+        })?;
+
+    let [west, south, east, north] = bbox;
+    let (site_lon, site_lat) = (volume.site.lon, volume.site.lat);
+    let nrays = sweep.nrays;
+    let nbins = sweep.nbins;
+    if nrays == 0 || nbins == 0 {
+        return Err(DataServerError::Engine(
+            "PVOL lowest sweep has zero rays or bins".into(),
+        ));
+    }
+    let ray_step_deg = 360.0 / nrays as f64;
+
+    let (merc_y_north, merc_y_south) = if *output_crs == OutputCrs::WebMercator {
+        (lat_to_merc_y(north), lat_to_merc_y(south))
+    } else {
+        (0.0, 0.0)
+    };
+
+    let mut values: Vec<Option<f64>> = Vec::with_capacity((width as usize) * (height as usize));
+    for oy in 0..height {
+        let frac_y = (oy as f64 + 0.5) / height as f64;
+        let lat = if *output_crs == OutputCrs::WebMercator {
+            let merc_y = merc_y_north - frac_y * (merc_y_north - merc_y_south);
+            merc_y_to_lat(merc_y)
+        } else {
+            north - frac_y * (north - south)
+        };
+        for ox in 0..width {
+            let frac_x = (ox as f64 + 0.5) / width as f64;
+            let lon = west + frac_x * (east - west);
+
+            let (dist, az) = ground_distance_bearing(site_lon, site_lat, lon, lat);
+
+            // Range bin. Ground-range interim — see the doc comment;
+            // a slant-range / 4⁄3-Earth correction is deferred.
+            let bin = ((dist - sweep.rstart) / sweep.rscale).floor() as i64;
+            if bin < 0 || bin >= nbins as i64 {
+                values.push(None);
+                continue;
+            }
+
+            // Azimuth ray. ODIM rays are stored north-first, clockwise,
+            // already re-sorted into geographic order — `a1gate`
+            // records *acquisition* order only and must NOT offset the
+            // stored-array index here.
+            let ray = (az / ray_step_deg).floor() as usize % nrays;
+
+            // `RawPixels` is indexed [ray, bin].
+            values.push(moment.data.sample(
+                ray,
+                bin as usize,
+                moment.gain,
+                moment.offset,
+                moment.nodata,
+                Some(moment.undetect),
+            ));
+        }
+    }
+
+    Ok(RasterTile {
+        width,
+        height,
+        values,
+    })
+}
+
+/// Split an advertised `<nod>:<quantity>` parameter name into its
+/// `(site, quantity)` parts. Returns `None` when the separator is
+/// absent or either side is empty.
+fn parse_parameter(parameter: &str) -> Option<(&str, &str)> {
+    let (site, quantity) = parameter.split_once(SITE_QUANTITY_SEP)?;
+    if site.is_empty() || quantity.is_empty() {
+        return None;
+    }
+    Some((site, quantity))
+}
+
+impl MapEngine for PolarVolumeEngine {
+    fn get_raster_tile(
+        &self,
+        bbox: [f64; 4],
+        width: u32,
+        height: u32,
+        time: Option<DateTime<Utc>>,
+        output_crs: &OutputCrs,
+        parameter: Option<&str>,
+    ) -> Result<RasterTile, DataServerError> {
+        // A PVOL collection is inherently multi-parameter — the caller
+        // must name a `<nod>:<quantity>` layer.
+        let parameter = parameter.ok_or_else(|| {
+            DataServerError::InvalidParameter(format!(
+                "[{}] PVOL collection requires a `<site>{SITE_QUANTITY_SEP}<quantity>` \
+                 parameter (e.g. `fianj{SITE_QUANTITY_SEP}DBZH`)",
+                self.collection_id
+            ))
+        })?;
+        let (site, quantity) = parse_parameter(parameter).ok_or_else(|| {
+            DataServerError::InvalidParameter(format!(
+                "[{}] unparseable PVOL parameter `{parameter}` — expected \
+                 `<site>{SITE_QUANTITY_SEP}<quantity>`",
+                self.collection_id
+            ))
+        })?;
+
+        let catalog = self.catalog.load();
+        let site_volumes = catalog.by_site.get(site).ok_or_else(|| {
+            DataServerError::InvalidParameter(format!(
+                "[{}] unknown PVOL site `{site}`",
+                self.collection_id
+            ))
+        })?;
+
+        // Select the volume nearest `time` (latest if `None`) — mirrors
+        // `OdimEngine::select_entry`.
+        let entry = match time {
+            Some(target) => site_volumes
+                .iter()
+                .min_by_key(|e| (e.volume.time - target).num_seconds().abs()),
+            None => site_volumes.last(),
+        }
+        .ok_or_else(|| {
+            DataServerError::Engine(format!(
+                "[{}] PVOL site `{site}` has no volumes",
+                self.collection_id
+            ))
+        })?;
+
+        polar_sample(&entry.volume, quantity, bbox, width, height, output_crs)
+    }
+
+    fn raster_info(&self) -> RasterInfo {
+        let catalog = self.catalog.load();
+        let parameters = catalog.parameters.clone();
+        let parameter = parameters
+            .first()
+            .map(|(name, _)| name.clone())
+            .unwrap_or_default();
+
+        RasterInfo {
+            native_crs: "CRS:84".to_string(),
+            spatial_extent: catalog.spatial_extent,
+            // Most-recent-first, matching the `RasterInfo::times` contract.
+            times: catalog.times.iter().rev().copied().collect(),
+            parameter,
+            // PVOL quantities span multiple physical units (dBZ, m/s,
+            // dB, …); the per-layer unit is not a single collection
+            // constant, so leave it blank.
+            unit: String::new(),
+            parameters,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pvol::{PolarMoment, RadarSite, Sweep};
+    use crate::reader::RawPixels;
+    use ndarray::Array2;
+
+    /// A pixel due north of the site has bearing ≈ 0°.
+    #[test]
+    fn bearing_due_north_is_zero() {
+        let (_d, az) = ground_distance_bearing(25.0, 60.0, 25.0, 60.5);
+        assert!(
+            !(0.01..=359.99).contains(&az),
+            "due-north bearing ≈ 0°, got {az}"
+        );
+    }
+
+    /// A pixel ~10 km due east of the site has bearing ≈ 90° and
+    /// distance ≈ 10 km. 10 km east at 60°N is ~0.1796° of longitude
+    /// (10000 / (EARTH_RADIUS·cos60°·π/180)).
+    #[test]
+    fn bearing_due_east_ten_km() {
+        let lat = 60.0_f64;
+        let dlon =
+            10_000.0 / (EARTH_RADIUS_M * lat.to_radians().cos()) * 180.0 / std::f64::consts::PI;
+        let (d, az) = ground_distance_bearing(25.0, lat, 25.0 + dlon, lat);
+        assert!((d - 10_000.0).abs() < 5.0, "distance ≈ 10 km, got {d}");
+        assert!((az - 90.0).abs() < 0.2, "due-east bearing ≈ 90°, got {az}");
+    }
+
+    /// Distance is symmetric and zero at the site itself.
+    #[test]
+    fn distance_zero_at_site() {
+        let (d, _az) = ground_distance_bearing(25.0, 60.0, 25.0, 60.0);
+        assert!(d < 1e-6, "distance at site ≈ 0, got {d}");
+    }
+
+    /// Build a synthetic single-site, single-sweep, single-moment
+    /// volume whose raw value at `[ray, bin]` encodes the bin index,
+    /// so a rendered pixel's sampled value reveals which bin it hit.
+    fn synthetic_volume(lon: f64, lat: f64) -> PolarVolume {
+        let nrays = 360usize;
+        let nbins = 100usize;
+        // raw[ray][bin] = bin  → physical = bin*1.0 + 0.0 = bin.
+        let mut data = Array2::<u16>::zeros((nrays, nbins));
+        for ray in 0..nrays {
+            for bin in 0..nbins {
+                data[(ray, bin)] = bin as u16;
+            }
+        }
+        let moment = PolarMoment {
+            quantity: "DBZH".to_string(),
+            gain: 1.0,
+            offset: 0.0,
+            // 65535 is an unused raw value — nothing masks.
+            nodata: 65_535.0,
+            undetect: 65_534.0,
+            data: RawPixels::U16(data),
+        };
+        let sweep = Sweep {
+            elangle: 0.5,
+            nbins,
+            nrays,
+            rscale: 1_000.0, // 1 km per bin
+            rstart: 0.0,
+            a1gate: 0,
+            moments: vec![moment],
+        };
+        PolarVolume {
+            site: RadarSite {
+                lon,
+                lat,
+                height: 100.0,
+                nod: Some("test".to_string()),
+                plc: Some("Test Site".to_string()),
+                wmo: None,
+            },
+            time: Utc::now(),
+            object: "PVOL".to_string(),
+            sweeps: vec![sweep],
+        }
+    }
+
+    /// Polar→Cartesian: a pixel at a known bearing/range must sample
+    /// the bin matching its ground distance. The output bbox is a
+    /// small box just east of the site; the rightmost pixels are
+    /// farther out, so they sample higher bin indices.
+    #[test]
+    fn polar_sample_maps_distance_to_bin() {
+        let (site_lon, site_lat) = (25.0, 60.0);
+        let vol = synthetic_volume(site_lon, site_lat);
+
+        // A box from the site eastward ~50 km. With 1 km bins the
+        // sampled value at each pixel equals its ground-distance / 1000.
+        let dlon_50km = 50_000.0 / (EARTH_RADIUS_M * site_lat.to_radians().cos()) * 180.0
+            / std::f64::consts::PI;
+        let bbox = [
+            site_lon,
+            site_lat - 0.001,
+            site_lon + dlon_50km,
+            site_lat + 0.001,
+        ];
+        let tile = polar_sample(&vol, "DBZH", bbox, 50, 1, &OutputCrs::Wgs84).unwrap();
+
+        assert_eq!(tile.values.len(), 50);
+        // Leftmost pixel ≈ at the site → bin 0.
+        let first = tile.values[0].expect("near-site pixel should sample");
+        assert!(first < 2.0, "near-site pixel ≈ bin 0, got {first}");
+        // Rightmost pixel ≈ 50 km out → bin ≈ 49.
+        let last = tile.values[49].expect("far pixel should sample");
+        assert!(
+            (45.0..=50.0).contains(&last),
+            "far pixel ≈ bin 49, got {last}"
+        );
+        // Values increase monotonically with eastward distance.
+        for w in tile.values.iter().flatten().collect::<Vec<_>>().windows(2) {
+            assert!(w[0] <= w[1], "bin index must rise with distance");
+        }
+    }
+
+    /// A pixel beyond the sweep's maximum range samples `None`.
+    #[test]
+    fn polar_sample_beyond_range_is_none() {
+        let (site_lon, site_lat) = (25.0, 60.0);
+        let vol = synthetic_volume(site_lon, site_lat); // 100 bins × 1 km = 100 km
+
+        // 300 km east — well past the 100 km sweep.
+        let dlon = 300_000.0 / (EARTH_RADIUS_M * site_lat.to_radians().cos()) * 180.0
+            / std::f64::consts::PI;
+        let bbox = [
+            site_lon + dlon - 0.01,
+            site_lat - 0.001,
+            site_lon + dlon + 0.01,
+            site_lat + 0.001,
+        ];
+        let tile = polar_sample(&vol, "DBZH", bbox, 4, 1, &OutputCrs::Wgs84).unwrap();
+        assert!(
+            tile.values.iter().all(Option::is_none),
+            "pixels past max range must be None"
+        );
+    }
+
+    /// An absent quantity is an `InvalidParameter` error, not a panic.
+    #[test]
+    fn polar_sample_unknown_quantity_errors() {
+        let vol = synthetic_volume(25.0, 60.0);
+        // `RasterTile` has no `Debug`, so match rather than `unwrap_err`.
+        match polar_sample(
+            &vol,
+            "VRADH",
+            [24.0, 59.0, 26.0, 61.0],
+            4,
+            4,
+            &OutputCrs::Wgs84,
+        ) {
+            Err(DataServerError::InvalidParameter(_)) => {}
+            Err(other) => panic!("expected InvalidParameter, got {other:?}"),
+            Ok(_) => panic!("expected an error for an absent quantity"),
+        }
+    }
+
+    /// `parse_parameter` round-trips a `<nod>:<quantity>` name and
+    /// rejects malformed inputs.
+    #[test]
+    fn parse_parameter_splits_and_rejects() {
+        assert_eq!(parse_parameter("fianj:DBZH"), Some(("fianj", "DBZH")));
+        assert_eq!(parse_parameter("nodbzh"), None);
+        assert_eq!(parse_parameter(":DBZH"), None);
+        assert_eq!(parse_parameter("fianj:"), None);
+    }
+
+    /// `site_coverage_bbox` brackets the centre and widens with radius.
+    #[test]
+    fn site_coverage_bbox_brackets_centre() {
+        let [w, s, e, n] = site_coverage_bbox(25.0, 60.0, 250_000.0);
+        assert!(w < 25.0 && e > 25.0 && s < 60.0 && n > 60.0);
+        // ~250 km ≈ 2.25° of latitude.
+        assert!((n - s - 4.5).abs() < 0.5, "lat span ≈ 4.5°, got {}", n - s);
+    }
+}

--- a/crates/engine-odim/tests/integration.rs
+++ b/crates/engine-odim/tests/integration.rs
@@ -32,8 +32,8 @@ fn dmi_engine() -> (engine_odim::OdimEngine, tempfile::TempDir) {
         filename_template: Some("dk.com.%Y%m%d%H%M.500_max.h5".into()),
         filename_pattern: None,
         timestamp_format: None,
-        parameter: "reflectivity".into(),
-        unit: "dBZ".into(),
+        parameter: Some("reflectivity".into()),
+        unit: Some("dBZ".into()),
         nodata: None,
         gain: None,
         offset: None,
@@ -324,8 +324,8 @@ fn edr_query_area_rejects_too_many_timesteps() {
         filename_template: Some("dk.com.%Y%m%d%H%M.500_max.h5".into()),
         filename_pattern: None,
         timestamp_format: None,
-        parameter: "reflectivity".into(),
-        unit: "dBZ".into(),
+        parameter: Some("reflectivity".into()),
+        unit: Some("dBZ".into()),
         nodata: None,
         gain: None,
         offset: None,
@@ -387,4 +387,149 @@ fn edr_query_area_masks_outside_polygon() {
         masked > 0,
         "a thin triangle must leave some bbox cells outside the polygon"
     );
+}
+
+// ---------------------------------------------------------------------------
+// PolarVolumeEngine — ODIM polar-volume (PVOL) MapEngine
+// ---------------------------------------------------------------------------
+
+/// End-to-end render against the real FMI Anjalankoski polar volume
+/// (`testdata/radar-fmi-pvol/202605150000_fianj_PVOL.h5`).
+///
+/// The 15 MB fixture is **not committed to git**, so this test skips
+/// gracefully when it is absent — CI stays green; a local checkout
+/// with the fixture exercises the full PVOL render pipeline.
+#[test]
+fn pvol_engine_renders_fmi_anjalankoski_volume() {
+    let fixture = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../testdata/radar-fmi-pvol/202605150000_fianj_PVOL.h5");
+    if !fixture.exists() {
+        eprintln!(
+            "skipping pvol_engine_renders_fmi_anjalankoski_volume: fixture absent at {fixture:?}"
+        );
+        return;
+    }
+
+    // The PVOL engine scans a directory; point it at the directory the
+    // fixture lives in.
+    let data_dir = fixture
+        .parent()
+        .expect("fixture has a parent directory")
+        .to_str()
+        .expect("utf8 fixture dir");
+
+    // `odim-volume` ignores `parameter`/`unit`; both may be `None`.
+    let config = OdimConfig {
+        filename_template: None,
+        filename_pattern: None,
+        timestamp_format: None,
+        parameter: None,
+        unit: None,
+        nodata: None,
+        gain: None,
+        offset: None,
+        poll_interval_secs: 30,
+        max_files: None,
+        endpoint: None,
+        bucket: None,
+        prefix_pattern: None,
+        time_window: None,
+    };
+
+    let engine = engine_odim::PolarVolumeEngine::new("fianj-pvol-test", Some(data_dir), &config)
+        .expect("PolarVolumeEngine::new over the PVOL directory");
+
+    let info = engine.raster_info();
+    assert_eq!(info.native_crs, "CRS:84");
+    assert!(!info.times.is_empty(), "PVOL catalog must have a timestep");
+    assert!(
+        info.spatial_extent.is_some(),
+        "PVOL catalog must report a coverage bbox"
+    );
+
+    // The FMI Anjalankoski volume's lowest sweep exposes TH (and DBZH).
+    // At least one `fianj:<quantity>` parameter must surface.
+    let fianj_params: Vec<&str> = info
+        .parameters
+        .iter()
+        .map(|(name, _)| name.as_str())
+        .filter(|n| n.starts_with("fianj:"))
+        .collect();
+    assert!(
+        !fianj_params.is_empty(),
+        "expected fianj:<quantity> parameters, got {:?}",
+        info.parameters
+    );
+    // Prefer TH if present (every FMI lowest sweep carries it), else
+    // any available fianj quantity.
+    let render_param = if fianj_params.contains(&"fianj:TH") {
+        "fianj:TH".to_string()
+    } else if fianj_params.contains(&"fianj:DBZH") {
+        "fianj:DBZH".to_string()
+    } else {
+        fianj_params[0].to_string()
+    };
+
+    // Render a tile over the radar's coverage bbox. Anjalankoski sits
+    // near 27.11°E, 60.90°N; a ~2° box centred there is well inside
+    // the ~250 km sweep, so a real volume must produce some echoes.
+    let bbox = [26.0, 60.0, 28.2, 61.8];
+    let tile = engine
+        .get_raster_tile(bbox, 128, 128, None, &OutputCrs::Wgs84, Some(&render_param))
+        .expect("PVOL get_raster_tile over the coverage bbox");
+
+    assert_eq!(tile.width, 128);
+    assert_eq!(tile.height, 128);
+    assert_eq!(tile.values.len(), 128 * 128);
+    let non_none = tile.values.iter().filter(|v| v.is_some()).count();
+    assert!(
+        non_none > 0,
+        "a render over the radar's own coverage bbox must sample some \
+         non-None values (parameter {render_param})"
+    );
+}
+
+/// A `get_raster_tile` call with no `parameter` (or an unparseable
+/// one) on a PVOL collection is a clean error, not a panic.
+#[test]
+fn pvol_engine_rejects_missing_parameter() {
+    let fixture = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../testdata/radar-fmi-pvol/202605150000_fianj_PVOL.h5");
+    if !fixture.exists() {
+        eprintln!("skipping pvol_engine_rejects_missing_parameter: fixture absent");
+        return;
+    }
+    let data_dir = fixture.parent().unwrap().to_str().unwrap();
+    let config = OdimConfig {
+        filename_template: None,
+        filename_pattern: None,
+        timestamp_format: None,
+        parameter: None,
+        unit: None,
+        nodata: None,
+        gain: None,
+        offset: None,
+        poll_interval_secs: 30,
+        max_files: None,
+        endpoint: None,
+        bucket: None,
+        prefix_pattern: None,
+        time_window: None,
+    };
+    let engine =
+        engine_odim::PolarVolumeEngine::new("fianj-pvol-test", Some(data_dir), &config).unwrap();
+
+    // `RasterTile` has no `Debug`, so match rather than `unwrap_err`.
+    match engine.get_raster_tile(
+        [26.0, 60.0, 28.0, 62.0],
+        8,
+        8,
+        None,
+        &OutputCrs::Wgs84,
+        None,
+    ) {
+        Err(ds_core::error::DataServerError::InvalidParameter(_)) => {}
+        Err(other) => panic!("missing parameter must be InvalidParameter, got {other:?}"),
+        Ok(_) => panic!("missing parameter on a PVOL collection must error"),
+    }
 }

--- a/crates/server/src/admin.rs
+++ b/crates/server/src/admin.rs
@@ -339,6 +339,7 @@ pub struct ServerState {
     pub querydata_engines: RwLock<Vec<Arc<engine_querydata::QueryDataEngine>>>,
     pub grib_engines: RwLock<Vec<Arc<engine_grib::GribEngine>>>,
     pub odim_engines: RwLock<Vec<Arc<engine_odim::OdimEngine>>>,
+    pub odim_volume_engines: RwLock<Vec<Arc<engine_odim::PolarVolumeEngine>>>,
     pub postgis_engines: RwLock<Vec<Arc<engine_postgis::PostgisEngine>>>,
     /// Serializes reload requests to prevent concurrent reloads from racing.
     pub reload_lock: tokio::sync::Mutex<()>,
@@ -364,6 +365,7 @@ pub struct LoadResult {
     pub querydata_engines: Vec<Arc<engine_querydata::QueryDataEngine>>,
     pub grib_engines: Vec<Arc<engine_grib::GribEngine>>,
     pub odim_engines: Vec<Arc<engine_odim::OdimEngine>>,
+    pub odim_volume_engines: Vec<Arc<engine_odim::PolarVolumeEngine>>,
     pub postgis_engines: Vec<Arc<engine_postgis::PostgisEngine>>,
 }
 
@@ -402,6 +404,7 @@ pub fn load_collections(
     let mut querydata_engines: Vec<Arc<engine_querydata::QueryDataEngine>> = Vec::new();
     let mut grib_engines: Vec<Arc<engine_grib::GribEngine>> = Vec::new();
     let mut odim_engines: Vec<Arc<engine_odim::OdimEngine>> = Vec::new();
+    let mut odim_volume_engines: Vec<Arc<engine_odim::PolarVolumeEngine>> = Vec::new();
     let mut postgis_engines: Vec<Arc<engine_postgis::PostgisEngine>> = Vec::new();
     // Pool registry is local to this load: collections sharing a DSN share a
     // pool via Arc<Pool>. Across reloads, pools are rebuilt — documented
@@ -427,6 +430,7 @@ pub fn load_collections(
             "querydata" => &["edr", "wms", "maps", "tiles"],
             "grib" => &["edr", "wms", "maps", "tiles"],
             "odim" => &["edr", "wms", "maps", "tiles"],
+            "odim-volume" => &["wms", "maps", "tiles"],
             "postgis" => &["edr", "features", "tiles"],
             _ => &[],
         };
@@ -1074,6 +1078,113 @@ pub fn load_collections(
                     error: None,
                 });
             }
+            "odim-volume" => {
+                let odim_cfg = match collection.odim.as_ref() {
+                    Some(c) => c,
+                    None => {
+                        tracing::error!(
+                            "Collection '{}': engine_type 'odim-volume' but missing [collections.odim] config, skipping",
+                            collection.id
+                        );
+                        health.push(CollectionHealth {
+                            id: collection.id.clone(),
+                            engine_type: "odim-volume".into(),
+                            status: CollectionStatus::Failed,
+                            error: Some("missing [collections.odim] config".into()),
+                        });
+                        continue;
+                    }
+                };
+                let engine = match engine_odim::PolarVolumeEngine::new(
+                    &collection.id,
+                    collection.data_path.as_deref(),
+                    odim_cfg,
+                ) {
+                    Ok(e) => Arc::new(e),
+                    Err(e) => {
+                        tracing::error!(
+                            "Collection '{}': failed to initialize ODIM polar-volume engine: {}",
+                            collection.id,
+                            e
+                        );
+                        health.push(CollectionHealth {
+                            id: collection.id.clone(),
+                            engine_type: "odim-volume".into(),
+                            status: CollectionStatus::Failed,
+                            error: Some(format!("{e}")),
+                        });
+                        continue;
+                    }
+                };
+
+                odim_volume_engines.push(engine.clone());
+
+                // PVOL is multi-parameter (one layer per <site>:<quantity>).
+                let raster_params =
+                    ds_core::map_engine::MapEngine::raster_info(engine.as_ref()).parameters;
+
+                if collection.apis.contains(&"wms".to_string()) {
+                    map_engines.insert(
+                        collection.id.clone(),
+                        engine.clone() as Arc<dyn ds_core::map_engine::MapEngine>,
+                    );
+                    map_collections.insert(collection.id.clone(), collection.clone());
+                    let styles = build_styles(collection, &bundle_index);
+                    map_styles.insert(collection.id.clone(), styles);
+                    if !raster_params.is_empty() {
+                        register_parameter_layer_styles(
+                            collection,
+                            &raster_params,
+                            &mut map_styles,
+                            &bundle_index,
+                        );
+                    }
+                    info!("Collection '{}': wired to WMS API", collection.id);
+                }
+                if collection.apis.contains(&"maps".to_string()) {
+                    maps_engines.insert(
+                        collection.id.clone(),
+                        engine.clone() as Arc<dyn ds_core::map_engine::MapEngine>,
+                    );
+                    maps_collections.insert(collection.id.clone(), collection.clone());
+                    let styles = build_styles(collection, &bundle_index);
+                    maps_styles.insert(collection.id.clone(), styles);
+                    if !raster_params.is_empty() {
+                        register_parameter_layer_styles(
+                            collection,
+                            &raster_params,
+                            &mut maps_styles,
+                            &bundle_index,
+                        );
+                    }
+                    info!("Collection '{}': wired to Maps API", collection.id);
+                }
+                if collection.apis.contains(&"tiles".to_string()) {
+                    tiles_engines.insert(
+                        collection.id.clone(),
+                        engine.clone() as Arc<dyn ds_core::map_engine::MapEngine>,
+                    );
+                    tiles_collections.insert(collection.id.clone(), collection.clone());
+                    let styles = build_styles(collection, &bundle_index);
+                    tiles_styles.insert(collection.id.clone(), styles);
+                    if !raster_params.is_empty() {
+                        register_parameter_layer_styles(
+                            collection,
+                            &raster_params,
+                            &mut tiles_styles,
+                            &bundle_index,
+                        );
+                    }
+                    info!("Collection '{}': wired to Tiles API", collection.id);
+                }
+
+                health.push(CollectionHealth {
+                    id: collection.id.clone(),
+                    engine_type: "odim-volume".into(),
+                    status: CollectionStatus::Ready,
+                    error: None,
+                });
+            }
             "postgis" => {
                 let postgis_cfg = match collection.postgis.as_ref() {
                     Some(c) => c,
@@ -1303,6 +1414,7 @@ pub fn load_collections(
         querydata_engines,
         grib_engines,
         odim_engines,
+        odim_volume_engines,
         postgis_engines,
     }
 }
@@ -1669,6 +1781,13 @@ pub async fn reload_handler(
         for engine in old_odim.iter() {
             engine.shutdown();
         }
+        let old_odim_volume = state
+            .odim_volume_engines
+            .read()
+            .unwrap_or_else(|e| e.into_inner());
+        for engine in old_odim_volume.iter() {
+            engine.shutdown();
+        }
     }
 
     let result = load_collections(&config.collections, &config.style_bundles, &base_url);
@@ -1721,6 +1840,12 @@ pub async fn reload_handler(
             poller.poll_loop().await;
         });
     }
+    for engine in &result.odim_volume_engines {
+        let poller = engine.clone();
+        tokio::spawn(async move {
+            poller.poll_loop().await;
+        });
+    }
 
     // Atomically swap state
     state.edr.store(Arc::new(result.edr_state));
@@ -1750,6 +1875,10 @@ pub async fn reload_handler(
         .odim_engines
         .write()
         .unwrap_or_else(|e| e.into_inner()) = result.odim_engines;
+    *state
+        .odim_volume_engines
+        .write()
+        .unwrap_or_else(|e| e.into_inner()) = result.odim_volume_engines;
     *state
         .postgis_engines
         .write()

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -206,6 +206,12 @@ async fn main() {
             poller.poll_loop().await;
         });
     }
+    for engine in &result.odim_volume_engines {
+        let poller = engine.clone();
+        tokio::spawn(async move {
+            poller.poll_loop().await;
+        });
+    }
 
     // Set initial health gauges
     admin::update_health_gauges(&result.health);
@@ -239,6 +245,7 @@ async fn main() {
         querydata_engines: RwLock::new(result.querydata_engines),
         grib_engines: RwLock::new(result.grib_engines),
         odim_engines: RwLock::new(result.odim_engines),
+        odim_volume_engines: RwLock::new(result.odim_volume_engines),
         postgis_engines: RwLock::new(result.postgis_engines),
         reload_lock: tokio::sync::Mutex::new(()),
         admin_token,
@@ -349,6 +356,13 @@ async fn main() {
         .read()
         .unwrap_or_else(|e| e.into_inner());
     for engine in odim.iter() {
+        engine.shutdown();
+    }
+    let odim_volume = server_state
+        .odim_volume_engines
+        .read()
+        .unwrap_or_else(|e| e.into_inner());
+    for engine in odim_volume.iter() {
         engine.shutdown();
     }
     info!("Server shut down gracefully");

--- a/crates/server/src/preview.rs
+++ b/crates/server/src/preview.rs
@@ -945,6 +945,7 @@ mod tests {
             querydata_engines: RwLock::new(Vec::new()),
             grib_engines: RwLock::new(Vec::new()),
             odim_engines: RwLock::new(Vec::new()),
+            odim_volume_engines: RwLock::new(Vec::new()),
             postgis_engines: RwLock::new(Vec::new()),
             reload_lock: tokio::sync::Mutex::new(()),
             admin_token: None,


### PR DESCRIPTION
## Summary

First two milestones of ODIM polar-volume (PVOL) support — *read* polar volumes and *display* them in Cartesian coordinates. Polar volumes are multi-elevation, multi-moment radar data in spherical coordinates, distinct from the 2-D `COMP` composites the engine handled before.

- **`pvol.rs`** — `read_polar_volume()` parses multi-dataset / multi-moment ODIM polar volumes into `PolarVolume { site, sweeps }`. Does **not** gate on `/what/object` (FMI mislabels polar volumes as `"SCAN"`); range-bin counts vary per elevation sweep.
- **`volume_engine.rs`** — `PolarVolumeEngine` implements `MapEngine`. One collection per radar network; each radar **site** is a layer group and each ODIM **quantity** a sub-layer (`parameter = "<site>:<quantity>"`, modelled on multi-parameter GRIB). `get_raster_tile` renders the **lowest elevation sweep**, polar→Cartesian via haversine distance + bearing.
- **`OdimConfig.parameter`/`unit`** are now `Option` (a volume collection is multi-parameter); the COMP engine requires them via a `MissingCompField` error.
- **`RawPixels::sample()`** is now NaN-aware (NaN `nodata` sentinels).
- **`engine_type = "odim-volume"`** wired into the server (WMS/Maps/Tiles), with poll loop + graceful shutdown.

### Interim scope (deliberate)

- Lowest elevation sweep only; nearest-neighbour sampling; ground-range ≈ slant-range.
- A vertical (elevation) `MapEngine` dimension is deferred to #185.
- Spoke-artifact / 4⁄3-Earth ground-range refinements tracked in #186.
- **Local-directory source only** — FMI S3 / DMI STAC sources are the next milestone (in progress).

## Test plan

- [x] `cargo test` — 6 PVOL reader tests + 17 volume-engine tests (geodesic, polar→Cartesian, parameter parsing, fixture render); full `engine-odim` + `ds-core` suites green.
- [x] `cargo fmt --all --check` + `cargo clippy` warning-clean across `engine-odim` / `ds-core` / `server`.
- [x] Reader verified against a real 15 MB FMI Anjalankoski polar volume (13 sweeps, 16 moments).
- [x] Live end-to-end: server loads a `radar-fmi-volume` collection, WMS `GetMap` for `radar-fmi-volume/fianj:DBZH` returns a valid PNG with the radar echoes rendered in Cartesian.

🤖 Generated with [Claude Code](https://claude.com/claude-code)