### PR TITLE
fix(server): bind listen port before loading collections

### DIFF
--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -160,6 +160,20 @@ async fn main() {
     let base_url = config.server.base_url();
     info!("Base URL: {base_url}");
 
+    // Bind the listen socket before loading collections: engine
+    // construction runs synchronous S3/disk scans that can take
+    // minutes, so a port conflict must fail fast rather than after
+    // that whole load. The listener is held until `axum::serve`.
+    let addr = format!("{}:{}", config.server.host, config.server.port);
+    let listener = match tokio::net::TcpListener::bind(&addr).await {
+        Ok(listener) => listener,
+        Err(e) => {
+            tracing::error!("Failed to bind {addr}: {e}");
+            std::process::exit(1);
+        }
+    };
+    info!("Listening on {addr}");
+
     let result = admin::load_collections(&config.collections, &config.style_bundles, &base_url);
 
     let loaded = result
@@ -314,12 +328,7 @@ async fn main() {
     // Normalize trailing slashes (e.g., /wms/ → /wms) before routing
     let app = NormalizePathLayer::trim_trailing_slash().layer(app);
 
-    let addr = format!("{}:{}", config.server.host, config.server.port);
-    info!("Starting server on {addr}");
-
-    let listener = tokio::net::TcpListener::bind(&addr)
-        .await
-        .expect("Failed to bind");
+    info!("Server ready, accepting requests");
 
     axum::serve(
         listener,

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -172,7 +172,11 @@ async fn main() {
             std::process::exit(1);
         }
     };
-    info!("Listening on {addr}");
+    // The socket is bound + listening from here, but HTTP is not served
+    // until `axum::serve` below — keep the message explicit so a
+    // log-watching operator isn't misled. (A TCP-only readiness probe
+    // will see the port open early; probe `/health` over HTTP instead.)
+    info!("Socket bound to {addr} — loading collections, not yet serving");
 
     let result = admin::load_collections(&config.collections, &config.style_bundles, &base_url);
 


### PR DESCRIPTION
## Summary

- Binds the listen socket **before** `load_collections()` instead of after. Engine construction runs synchronous S3/disk boot scans that can take minutes; with the bind at the end of startup, a port conflict surfaced only as a late panic — the operator waited through the entire data load to learn the port was in use.
- A bind failure now logs a clean `ERROR` and exits non-zero, rather than panicking via `.expect("Failed to bind")`.

Closes #189.

## Test plan

- [x] `cargo build -p server` + `cargo clippy -p server` clean
- [x] With the port free, the server binds, loads collections, and serves normally
- [x] With the port already held by another instance, the second instance logs `Failed to bind 127.0.0.1:8000: Address already in use` **immediately** (before any `Loaded … collections` log) and exits — verified no panic

🤖 Generated with [Claude Code](https://claude.com/claude-code)