### PR TITLE
feat(engine-odim): EDR support for the odim-volume engine (M3a)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,7 +130,8 @@ Currently implemented: `PointSeries`, `Grid`.
 | GeoJSON | `FeatureEngine` | Features |
 | GeoTIFF | `EdrEngine` + `MapEngine` | EDR (position, area), WMS, Maps, Tiles |
 | GRIB | `EdrEngine` + `MapEngine` | EDR, WMS, Maps, Tiles |
-| ODIM | `EdrEngine` + `MapEngine` | EDR (position, area), WMS, Maps, Tiles |
+| ODIM COMP | `EdrEngine` + `MapEngine` | EDR (position, area), WMS, Maps, Tiles |
+| ODIM PVOL | `EdrEngine` + `MapEngine` | EDR (position, locations, area), WMS, Maps, Tiles |
 | QueryData | `EdrEngine` + `MapEngine` | EDR (position only), WMS, Maps, Tiles |
 | PostGIS | `EdrEngine` + `FeatureEngine` | EDR (position, locations, area), Features |
 

--- a/collections.d/radar-fi-volume-local-h5.toml
+++ b/collections.d/radar-fi-volume-local-h5.toml
@@ -13,7 +13,7 @@ id = "radar-fi-volume-local-h5"
 title = "FMI — radar polar volumes (local, ODIM_H5)"
 description = "Finnish radar polar volumes (ODIM_H5 PVOL) from local sample files — every elevation sweep and dual-polarisation moment."
 engine_type = "odim-volume"
-apis = ["wms", "maps", "tiles"]
+apis = ["edr", "wms", "maps", "tiles"]
 data_path = "testdata/radar-fmi-pvol"
 
 [odim]

--- a/collections.d/radar-fi-volume-s3-h5.toml
+++ b/collections.d/radar-fi-volume-s3-h5.toml
@@ -10,26 +10,26 @@
 # site as a Cartesian raster; the WMS layer tree is one group per radar
 # site with the dual-pol moments as quantity sub-layers (TH, DBZH,
 # VRADH, ZDR, RHOHV...). Parameter names are `<site>:<quantity>`, e.g.
-# `fivih:DBZH`.
+# `fivih:DBZH`. On the EDR API each radar site is a location (id = ODIM
+# NOD code) and each quantity is a parameter.
 #
-# `prefix_pattern` currently targets the Vihti site (`fivih`); widening
-# this collection to the full FMI radar network — with sites exposed as
-# EDR locations — is milestone M3 of the odim-volume roadmap.
-#
-# `time_window = "-PT3H"` bounds both the date-partitioned prefixes
-# listed and the volume timestamps kept to the most recent 3 hours.
+# `prefix_pattern` covers the whole date partition (`%Y/%m/%d/`), so the
+# scan picks up every FMI radar site, not just one. `time_window`
+# bounds both the date-partitioned prefixes listed and the volume
+# timestamps kept — with ~12 sites at 5-min cadence a wide window pulls
+# a lot of multi-MB volumes, so it is deliberately short.
 
 id = "radar-fi-volume-s3-h5"
 title = "FMI — radar polar volumes (S3, ODIM_H5)"
-description = "Finnish radar polar volumes (ODIM_H5 PVOL) streamed from FMI's open-data S3 bucket — every elevation sweep and dual-polarisation moment. Currently the Vihti site; the full FMI network is planned (M3)."
+description = "Finnish radar polar volumes (ODIM_H5 PVOL) streamed from FMI's open-data S3 bucket — every FMI radar site, all elevation sweeps and dual-polarisation moments."
 engine_type = "odim-volume"
-apis = ["wms", "maps", "tiles"]
+apis = ["edr", "wms", "maps", "tiles"]
 
 [odim]
 endpoint = "https://s3-eu-west-1.amazonaws.com"
 bucket = "fmi-opendata-radar-volume-hdf5"
-prefix_pattern = "%Y/%m/%d/fivih/"
-time_window = "-PT3H"
+prefix_pattern = "%Y/%m/%d/"
+time_window = "-PT1H"
 poll_interval_secs = 300
 
 [wms]

--- a/crates/api-edr/tests/covjson_validation.rs
+++ b/crates/api-edr/tests/covjson_validation.rs
@@ -125,6 +125,25 @@ fn coverage_with_multiple_params_validates() {
     validate(&json, &schema);
 }
 
+/// The ODIM polar-volume engine emits multi-quantity `PointSeries`
+/// coverages with **blank units** (ODIM moment groups carry no unit
+/// attribute). Confirm that shape — distinct from the populated-unit
+/// case above — still validates.
+#[test]
+fn coverage_with_blank_units_validates() {
+    let schema = load_schema();
+    let times: Vec<DateTime<Utc>> = (0..3).map(make_time).collect();
+    let result = make_query_result(
+        times,
+        vec![
+            ("DBZH", "", vec![Some(12.5), None, Some(18.0)]),
+            ("VRADH", "", vec![Some(-4.2), Some(-3.8), None]),
+        ],
+    );
+    let json = query_result_to_coverage_json(&result);
+    validate(&json, &schema);
+}
+
 #[test]
 fn coverage_with_single_param_validates() {
     let schema = load_schema();

--- a/crates/core/src/feature.rs
+++ b/crates/core/src/feature.rs
@@ -313,7 +313,13 @@ pub fn parse_area_coords(coords: &str) -> Result<QueryPolygon, DataServerError> 
     ))
 }
 
-/// Parse an EDR position-query `coords` value into `(lat, lon)`.
+/// Parse an EDR position-query `coords` value.
+///
+/// **Returns `(lat, lon)` — latitude first**, matching the
+/// position-query callers in `engine-odim` and `engine-geotiff`. Note
+/// that `engine-grib`'s local `parse_coords` returns `(lon, lat)`; a
+/// future migration of that engine onto this shared parser must
+/// account for the swapped order.
 ///
 /// Accepts WKT `POINT(lon lat)` (a leading space before `(` is
 /// tolerated for PROJ-style input) and the bare `lon,lat` shorthand.

--- a/crates/core/src/feature.rs
+++ b/crates/core/src/feature.rs
@@ -313,6 +313,50 @@ pub fn parse_area_coords(coords: &str) -> Result<QueryPolygon, DataServerError> 
     ))
 }
 
+/// Parse an EDR position-query `coords` value into `(lat, lon)`.
+///
+/// Accepts WKT `POINT(lon lat)` (a leading space before `(` is
+/// tolerated for PROJ-style input) and the bare `lon,lat` shorthand.
+/// Longitude/latitude must be finite and within `±180` / `±90`, so a
+/// transposed `lat,lon` pair fails loudly rather than querying a
+/// nonsense location.
+pub fn parse_point_coords(coords: &str) -> Result<(f64, f64), DataServerError> {
+    let trimmed = coords.trim();
+
+    let pair = if let Some(inner) = trimmed
+        .strip_prefix("POINT(")
+        .or_else(|| trimmed.strip_prefix("POINT ("))
+        .and_then(|s| s.strip_suffix(')'))
+    {
+        inner.split_whitespace().collect::<Vec<_>>()
+    } else {
+        trimmed.split(',').map(str::trim).collect::<Vec<_>>()
+    };
+
+    if pair.len() != 2 {
+        return Err(DataServerError::InvalidParameter(
+            "Expected POINT(lon lat) or lon,lat format".into(),
+        ));
+    }
+    let lon: f64 = pair[0].parse().map_err(|_| {
+        DataServerError::InvalidParameter(format!("Invalid longitude: {}", pair[0]))
+    })?;
+    let lat: f64 = pair[1]
+        .parse()
+        .map_err(|_| DataServerError::InvalidParameter(format!("Invalid latitude: {}", pair[1])))?;
+    if !lon.is_finite() || !lat.is_finite() {
+        return Err(DataServerError::InvalidParameter(
+            "Coordinates must be finite numbers".into(),
+        ));
+    }
+    if !(-180.0..=180.0).contains(&lon) || !(-90.0..=90.0).contains(&lat) {
+        return Err(DataServerError::InvalidParameter(format!(
+            "Coordinates out of range: lon={lon}, lat={lat}"
+        )));
+    }
+    Ok((lat, lon))
+}
+
 /// A typed property value. Keeps ds-core free of serde_json.
 #[derive(Debug, Clone, PartialEq)]
 pub enum PropertyValue {
@@ -604,5 +648,35 @@ mod tests {
     #[test]
     fn parse_rejects_out_of_range_coords() {
         assert!(parse_area_coords("POLYGON((0 0, 200 0, 200 10, 0 10, 0 0))").is_err());
+    }
+
+    #[test]
+    fn parse_point_coords_accepts_wkt_and_bare_pair() {
+        // WKT, with and without the PROJ-style space before `(`.
+        assert_eq!(
+            parse_point_coords("POINT(10.5 56.0)").unwrap(),
+            (56.0, 10.5)
+        );
+        assert_eq!(
+            parse_point_coords("POINT (10.5 56.0)").unwrap(),
+            (56.0, 10.5)
+        );
+        // Bare `lon,lat` shorthand, surrounding whitespace tolerated.
+        assert_eq!(parse_point_coords("10.5, 56.0").unwrap(), (56.0, 10.5));
+        assert_eq!(parse_point_coords("  -3.2,48.7 ").unwrap(), (48.7, -3.2));
+    }
+
+    #[test]
+    fn parse_point_coords_rejects_malformed_and_out_of_range() {
+        assert!(parse_point_coords("POINT(10.5)").is_err());
+        assert!(parse_point_coords("10.5").is_err());
+        assert!(parse_point_coords("a,b").is_err());
+        assert!(parse_point_coords("10.5,56.0,3").is_err());
+        // Out-of-range so a transposed lat,lon pair fails loudly.
+        assert!(parse_point_coords("200.0, 10.0").is_err());
+        assert!(parse_point_coords("POINT(10 91)").is_err());
+        // Non-finite.
+        assert!(parse_point_coords("NaN, 10.0").is_err());
+        assert!(parse_point_coords("inf, 10.0").is_err());
     }
 }

--- a/crates/engine-odim/src/volume_engine.rs
+++ b/crates/engine-odim/src/volume_engine.rs
@@ -53,15 +53,20 @@ use std::time::Duration;
 
 use arc_swap::ArcSwap;
 use chrono::{DateTime, Utc};
+use ds_core::edr_engine::EdrEngine;
 use ds_core::error::DataServerError;
+use ds_core::feature::{parse_area_coords, parse_point_coords};
 use ds_core::map_engine::{MapEngine, OutputCrs, RasterInfo, RasterTile};
+use ds_core::model::{
+    AreaQueryResult, DomainDescription, Location, NdArray, ParameterDescription, QueryResult,
+};
 use tokio::sync::Notify;
 
 use ds_storage::discovery::{expand_prefix_for_dates, expand_prefix_pattern, TimeWindow};
 
 use crate::catalog::MAX_REMOTE_FILE_SIZE;
 use crate::engine::EngineError;
-use crate::pvol::{read_polar_volume, PolarVolume};
+use crate::pvol::{read_polar_volume, PolarMoment, PolarVolume, Sweep};
 
 /// Days of date-partitioned prefixes to scan when an S3 source has no
 /// `time_window`. Two days covers the just-after-midnight case where
@@ -259,8 +264,14 @@ struct Catalog {
     /// ascending.
     by_site: HashMap<String, Vec<VolumeEntry>>,
     /// `(parameter_name, title)` pairs — one per `<nod>:<quantity>`
-    /// from each site's lowest sweep. Sorted for stable output.
+    /// from each site's lowest sweep. Sorted for stable output. This is
+    /// the Map/WMS layer list (site-scoped).
     parameters: Vec<(String, String)>,
+    /// Distinct ODIM quantity names across every site's lowest sweep,
+    /// sorted — the EDR parameter list. Unlike `parameters` these carry
+    /// no `<site>:` prefix: in EDR the site is the *location* and the
+    /// quantity is the *parameter*.
+    quantities: Vec<String>,
     /// All distinct volume times across every site, sorted ascending.
     times: Vec<DateTime<Utc>>,
     /// Union of per-site coverage bboxes `[w, s, e, n]` in WGS84.
@@ -617,8 +628,10 @@ fn derive_catalog(
         guard.retain(|k, _| kept.contains(k));
     }
 
-    // Derive parameters from each site's lowest sweep.
+    // Derive parameters (Map layers) and quantities (EDR parameters)
+    // from each site's lowest sweep.
     let mut parameters: Vec<(String, String)> = Vec::new();
+    let mut quantities: Vec<String> = Vec::new();
     for (nod, list) in &by_site {
         // Use the most recent volume's lowest sweep for the quantity
         // list — quantity sets are stable across a site's volumes.
@@ -634,12 +647,16 @@ fn derive_catalog(
                 None => name.clone(),
             };
             parameters.push((name, title));
+            quantities.push(moment.quantity.clone());
         }
     }
     parameters.sort_by(|a, b| a.0.cmp(&b.0));
     // A producer shipping a sweep with a duplicate quantity name would
     // otherwise advertise the same `<nod>:<quantity>` layer twice.
     parameters.dedup_by(|a, b| a.0 == b.0);
+    // Quantities recur across sites — collapse to the distinct set.
+    quantities.sort();
+    quantities.dedup();
 
     // Distinct, sorted volume times across all sites.
     let mut times: Vec<DateTime<Utc>> = by_site
@@ -668,6 +685,7 @@ fn derive_catalog(
     Catalog {
         by_site,
         parameters,
+        quantities,
         times,
         spatial_extent,
     }
@@ -881,6 +899,48 @@ impl PolarVolumeEngine {
     }
 }
 
+/// Sample one moment of a sweep at a WGS84 `(lon, lat)`.
+///
+/// Computes ground distance + azimuth from the site, maps them to a
+/// range bin and stored ray, and reads the raw array with gain/offset/
+/// nodata applied. `None` when the point is out of range or the bin is
+/// `nodata`/`undetect`. **Ground-range interim** — see [`polar_sample`].
+fn sample_sweep_moment(
+    sweep: &Sweep,
+    moment: &PolarMoment,
+    site_lon: f64,
+    site_lat: f64,
+    lon: f64,
+    lat: f64,
+) -> Option<f64> {
+    if sweep.nrays == 0 || sweep.nbins == 0 {
+        return None;
+    }
+    let (dist, az) = ground_distance_bearing(site_lon, site_lat, lon, lat);
+
+    // Range bin. Ground-range interim — a slant-range / 4⁄3-Earth
+    // correction is deferred.
+    let bin = ((dist - sweep.rstart) / sweep.rscale).floor() as i64;
+    if bin < 0 || bin >= sweep.nbins as i64 {
+        return None;
+    }
+
+    // Azimuth ray. ODIM rays are stored north-first, clockwise, already
+    // re-sorted into geographic order — `a1gate` records *acquisition*
+    // order only and must NOT offset the stored-array index here.
+    let ray = (az / (360.0 / sweep.nrays as f64)).floor() as usize % sweep.nrays;
+
+    // `RawPixels` is indexed [ray, bin].
+    moment.data.sample(
+        ray,
+        bin as usize,
+        moment.gain,
+        moment.offset,
+        moment.nodata,
+        Some(moment.undetect),
+    )
+}
+
 /// Resample one polar moment of a sweep into a Cartesian output grid.
 ///
 /// `bbox` is `[west, south, east, north]` in WGS84 degrees. For
@@ -930,14 +990,11 @@ fn polar_sample(
 
     let [west, south, east, north] = bbox;
     let (site_lon, site_lat) = (volume.site.lon, volume.site.lat);
-    let nrays = sweep.nrays;
-    let nbins = sweep.nbins;
-    if nrays == 0 || nbins == 0 {
+    if sweep.nrays == 0 || sweep.nbins == 0 {
         return Err(DataServerError::Engine(
             "PVOL lowest sweep has zero rays or bins".into(),
         ));
     }
-    let ray_step_deg = 360.0 / nrays as f64;
 
     let (merc_y_north, merc_y_south) = if *output_crs == OutputCrs::WebMercator {
         (lat_to_merc_y(north), lat_to_merc_y(south))
@@ -958,30 +1015,8 @@ fn polar_sample(
             let frac_x = (ox as f64 + 0.5) / width as f64;
             let lon = west + frac_x * (east - west);
 
-            let (dist, az) = ground_distance_bearing(site_lon, site_lat, lon, lat);
-
-            // Range bin. Ground-range interim — see the doc comment;
-            // a slant-range / 4⁄3-Earth correction is deferred.
-            let bin = ((dist - sweep.rstart) / sweep.rscale).floor() as i64;
-            if bin < 0 || bin >= nbins as i64 {
-                values.push(None);
-                continue;
-            }
-
-            // Azimuth ray. ODIM rays are stored north-first, clockwise,
-            // already re-sorted into geographic order — `a1gate`
-            // records *acquisition* order only and must NOT offset the
-            // stored-array index here.
-            let ray = (az / ray_step_deg).floor() as usize % nrays;
-
-            // `RawPixels` is indexed [ray, bin].
-            values.push(moment.data.sample(
-                ray,
-                bin as usize,
-                moment.gain,
-                moment.offset,
-                moment.nodata,
-                Some(moment.undetect),
+            values.push(sample_sweep_moment(
+                sweep, moment, site_lon, site_lat, lon, lat,
             ));
         }
     }
@@ -1079,10 +1114,272 @@ impl MapEngine for PolarVolumeEngine {
     }
 }
 
+// ---------------------------------------------------------------------------
+// EdrEngine
+// ---------------------------------------------------------------------------
+
+/// `ParameterDescription` for an ODIM quantity. ODIM moment groups
+/// carry no unit attribute and quantities span several physical units,
+/// so the unit is left blank (matching `raster_info`); the label
+/// mirrors the `EdrEngine` default-description convention.
+fn quantity_description(quantity: &str) -> ParameterDescription {
+    ParameterDescription {
+        label: quantity.replace('_', " "),
+        unit: String::new(),
+        observed_property: quantity.to_string(),
+    }
+}
+
+/// NOD code of the radar site nearest to `(lon, lat)` by ground
+/// distance. `None` only when the catalog holds no sites.
+fn nearest_site(catalog: &Catalog, lon: f64, lat: f64) -> Option<&str> {
+    catalog
+        .by_site
+        .iter()
+        .filter_map(|(nod, list)| {
+            let site = &list.last()?.volume.site;
+            let (dist, _) = ground_distance_bearing(site.lon, site.lat, lon, lat);
+            Some((nod.as_str(), dist))
+        })
+        .min_by(|a, b| a.1.total_cmp(&b.1))
+        .map(|(nod, _)| nod)
+}
+
+/// Build a `PointSeries` coverage for one radar site: sample the lowest
+/// sweep of every volume in `volumes` (time-sorted) at WGS84
+/// `(lon, lat)` — one value per quantity per timestep.
+///
+/// `(lon, lat)` is both the coverage's domain point and the sample
+/// point: for a location query it is the radar site itself; for a
+/// position query it is the requested point against the nearest site.
+///
+/// **M3a interim** — only the lowest elevation sweep is sampled. The
+/// vertical (`z`) dimension that turns a no-`z` query into a profile
+/// across all sweeps arrives with M3b (#185).
+fn build_site_point_series(
+    volumes: &[VolumeEntry],
+    lon: f64,
+    lat: f64,
+    datetime: Option<(DateTime<Utc>, DateTime<Utc>)>,
+    parameters: Option<&[String]>,
+) -> Result<QueryResult, DataServerError> {
+    let selected: Vec<&VolumeEntry> = match datetime {
+        Some((start, end)) => volumes
+            .iter()
+            .filter(|e| e.volume.time >= start && e.volume.time <= end)
+            .collect(),
+        None => volumes.iter().collect(),
+    };
+    if selected.is_empty() {
+        return Err(DataServerError::LocationNotFound(
+            "No PVOL data available for the requested time range".into(),
+        ));
+    }
+
+    // The lowest sweep of the most recent volume defines the available
+    // quantity set (stable across a site's volumes); intersect it with
+    // the optional `parameters` filter.
+    let available: Vec<String> = selected
+        .last()
+        .and_then(|e| e.volume.sweeps.first())
+        .map(|s| s.moments.iter().map(|m| m.quantity.clone()).collect())
+        .unwrap_or_default();
+    let quantities: Vec<String> = match parameters {
+        Some(req) => available
+            .into_iter()
+            .filter(|q| req.iter().any(|p| p == q))
+            .collect(),
+        None => available,
+    };
+    if quantities.is_empty() {
+        return Err(DataServerError::InvalidParameter(
+            "No requested parameter is available at this PVOL site".into(),
+        ));
+    }
+
+    let times: Vec<DateTime<Utc>> = selected.iter().map(|e| e.volume.time).collect();
+
+    let mut ranges = HashMap::new();
+    let mut param_descs = HashMap::new();
+    for quantity in &quantities {
+        let values: Vec<Option<f64>> = selected
+            .iter()
+            .map(|e| {
+                let sweep = e.volume.sweeps.first()?;
+                let moment = sweep.moments.iter().find(|m| &m.quantity == quantity)?;
+                sample_sweep_moment(
+                    sweep,
+                    moment,
+                    e.volume.site.lon,
+                    e.volume.site.lat,
+                    lon,
+                    lat,
+                )
+            })
+            .collect();
+        ranges.insert(
+            quantity.clone(),
+            NdArray {
+                shape: vec![times.len()],
+                axis_names: vec!["t".to_string()],
+                values,
+            },
+        );
+        param_descs.insert(quantity.clone(), quantity_description(quantity));
+    }
+
+    Ok(QueryResult {
+        domain: DomainDescription::PointSeries {
+            x: lon,
+            y: lat,
+            t: times,
+        },
+        parameters: param_descs,
+        ranges,
+    })
+}
+
+impl EdrEngine for PolarVolumeEngine {
+    /// One EDR location per radar site — `id` is the ODIM NOD code and
+    /// the point geometry is the antenna position.
+    fn get_locations(&self) -> Result<Vec<Location>, DataServerError> {
+        let catalog = self.catalog.load();
+        let mut locations: Vec<Location> = catalog
+            .by_site
+            .iter()
+            .filter_map(|(nod, list)| {
+                let site = &list.last()?.volume.site;
+                Some(Location {
+                    id: nod.clone(),
+                    label: site.plc.clone().unwrap_or_else(|| nod.clone()),
+                    latitude: site.lat,
+                    longitude: site.lon,
+                })
+            })
+            .collect();
+        locations.sort_by(|a, b| a.id.cmp(&b.id));
+        Ok(locations)
+    }
+
+    /// Query one radar site by NOD code — a `PointSeries` of every
+    /// quantity at the site, sampled from the lowest sweep.
+    fn query_location(
+        &self,
+        location_id: &str,
+        datetime: Option<(DateTime<Utc>, DateTime<Utc>)>,
+        parameters: Option<&[String]>,
+    ) -> Result<QueryResult, DataServerError> {
+        let catalog = self.catalog.load();
+        let volumes = catalog
+            .by_site
+            .get(location_id)
+            .ok_or_else(|| DataServerError::LocationNotFound(location_id.to_string()))?;
+        // The location *is* the radar site, so the coverage point is
+        // the antenna itself.
+        let site = &volumes
+            .last()
+            .ok_or_else(|| DataServerError::LocationNotFound(location_id.to_string()))?
+            .volume
+            .site;
+        build_site_point_series(volumes, site.lon, site.lat, datetime, parameters)
+    }
+
+    fn get_parameters(&self) -> Vec<String> {
+        self.catalog.load().quantities.clone()
+    }
+
+    fn get_temporal_extent(&self) -> Option<(DateTime<Utc>, DateTime<Utc>)> {
+        let catalog = self.catalog.load();
+        Some((*catalog.times.first()?, *catalog.times.last()?))
+    }
+
+    /// PVOL volumes arrive at discrete (typically 5-min) steps, so
+    /// advertise the exact timestamps rather than just the interval —
+    /// same rationale as the COMP engine.
+    fn get_available_times(&self) -> Option<Vec<DateTime<Utc>>> {
+        let times = self.catalog.load().times.clone();
+        (!times.is_empty()).then_some(times)
+    }
+
+    fn get_spatial_extent(&self) -> Option<[f64; 4]> {
+        self.catalog.load().spatial_extent
+    }
+
+    fn supported_query_types(&self) -> Vec<String> {
+        vec![
+            "locations".to_string(),
+            "position".to_string(),
+            "area".to_string(),
+        ]
+    }
+
+    /// Position query — a `PointSeries` sampled from the radar site
+    /// nearest the requested point.
+    fn query_position(
+        &self,
+        coords: &str,
+        datetime: Option<(DateTime<Utc>, DateTime<Utc>)>,
+        parameters: Option<&[String]>,
+    ) -> Result<QueryResult, DataServerError> {
+        let (lat, lon) = parse_point_coords(coords)?;
+        let catalog = self.catalog.load();
+        let nod = nearest_site(&catalog, lon, lat).ok_or_else(|| {
+            DataServerError::LocationNotFound("PVOL catalog has no radar sites".into())
+        })?;
+        let volumes = catalog
+            .by_site
+            .get(nod)
+            .expect("nearest_site returns an existing by_site key");
+        build_site_point_series(volumes, lon, lat, datetime, parameters)
+    }
+
+    /// Area query — a `CoverageCollection` of one `PointSeries` per
+    /// radar site whose antenna falls inside the polygon.
+    fn query_area(
+        &self,
+        coords: &str,
+        datetime: Option<(DateTime<Utc>, DateTime<Utc>)>,
+        parameters: Option<&[String]>,
+    ) -> Result<AreaQueryResult, DataServerError> {
+        let polygon = parse_area_coords(coords)?;
+        let catalog = self.catalog.load();
+
+        // Stable, sorted iteration so the collection order is
+        // deterministic across requests.
+        let mut nods: Vec<&String> = catalog.by_site.keys().collect();
+        nods.sort();
+
+        let mut coverages = Vec::new();
+        for nod in nods {
+            let volumes = &catalog.by_site[nod];
+            let Some(site) = volumes.last().map(|e| &e.volume.site) else {
+                continue;
+            };
+            if !polygon.contains(site.lon, site.lat) {
+                continue;
+            }
+            match build_site_point_series(volumes, site.lon, site.lat, datetime, parameters) {
+                Ok(qr) => coverages.push(qr),
+                // A site inside the polygon but with no data in the
+                // requested window is skipped, not fatal.
+                Err(DataServerError::LocationNotFound(_)) => continue,
+                Err(e) => return Err(e),
+            }
+        }
+
+        if coverages.is_empty() {
+            return Err(DataServerError::LocationNotFound(
+                "No radar sites with data found within the requested area".into(),
+            ));
+        }
+        Ok(AreaQueryResult::Collection(coverages))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::pvol::{PolarMoment, RadarSite, Sweep};
+    use crate::pvol::RadarSite;
     use crate::reader::RawPixels;
     use ndarray::Array2;
 
@@ -1377,5 +1674,104 @@ mod tests {
         // then falls through to the post-parse window filter).
         assert!(parse_key_timestamp("radar_volume.h5").is_none());
         assert!(parse_key_timestamp("999999999999_x.h5").is_none());
+    }
+
+    // --- EdrEngine helpers -------------------------------------------------
+
+    /// Wrap a synthetic volume in a `VolumeEntry` for catalog tests.
+    fn entry(volume: PolarVolume, id: &str) -> VolumeEntry {
+        VolumeEntry {
+            id: id.to_string(),
+            volume: Arc::new(volume),
+        }
+    }
+
+    /// `build_site_point_series` yields a `PointSeries` at the queried
+    /// point, with one time-aligned range per quantity.
+    #[test]
+    fn build_site_point_series_yields_point_series() {
+        let (site_lon, site_lat) = (25.0, 60.0);
+        let volumes = vec![entry(synthetic_volume(site_lon, site_lat), "v0")];
+        // 10.5 km due east — safely mid-bin 10 of the 1 km-spaced sweep,
+        // so the sampled bin index is robust against rounding.
+        let dlon = 10_500.0 / (EARTH_RADIUS_M * site_lat.to_radians().cos()) * 180.0
+            / std::f64::consts::PI;
+        let result =
+            build_site_point_series(&volumes, site_lon + dlon, site_lat, None, None).unwrap();
+        match result.domain {
+            DomainDescription::PointSeries { x, y, t } => {
+                assert!((x - (site_lon + dlon)).abs() < 1e-9);
+                assert!((y - site_lat).abs() < 1e-9);
+                assert_eq!(t.len(), 1);
+            }
+            _ => panic!("expected PointSeries"),
+        }
+        let dbzh = result.ranges.get("DBZH").expect("DBZH range");
+        assert_eq!(dbzh.shape, vec![1]);
+        assert_eq!(dbzh.axis_names, vec!["t".to_string()]);
+        // raw[ray][bin] = bin, gain 1 → the sampled value is the bin
+        // index, i.e. ground distance / 1 km.
+        assert_eq!(dbzh.values[0], Some(10.0));
+        assert!(result.parameters.contains_key("DBZH"));
+    }
+
+    /// An out-of-window `datetime` range yields `LocationNotFound`.
+    #[test]
+    fn build_site_point_series_empty_window_errors() {
+        let volumes = vec![entry(synthetic_volume(25.0, 60.0), "v0")];
+        let past = DateTime::parse_from_rfc3339("2000-01-01T00:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        match build_site_point_series(&volumes, 25.0, 60.0, Some((past, past)), None) {
+            Err(DataServerError::LocationNotFound(_)) => {}
+            other => panic!("expected LocationNotFound, got {other:?}"),
+        }
+    }
+
+    /// A `parameters` filter naming no real quantity is rejected.
+    #[test]
+    fn build_site_point_series_unknown_parameter_errors() {
+        let volumes = vec![entry(synthetic_volume(25.0, 60.0), "v0")];
+        let filter = ["NONESUCH".to_string()];
+        match build_site_point_series(&volumes, 25.0, 60.0, None, Some(&filter)) {
+            Err(DataServerError::InvalidParameter(_)) => {}
+            other => panic!("expected InvalidParameter, got {other:?}"),
+        }
+    }
+
+    /// `nearest_site` picks the site with the smallest ground distance.
+    #[test]
+    fn nearest_site_picks_closest() {
+        let mut by_site: HashMap<String, Vec<VolumeEntry>> = HashMap::new();
+        by_site.insert(
+            "west".to_string(),
+            vec![entry(synthetic_volume(20.0, 60.0), "w")],
+        );
+        by_site.insert(
+            "east".to_string(),
+            vec![entry(synthetic_volume(30.0, 60.0), "e")],
+        );
+        let catalog = Catalog {
+            by_site,
+            parameters: vec![],
+            quantities: vec![],
+            times: vec![],
+            spatial_extent: None,
+        };
+        assert_eq!(nearest_site(&catalog, 29.0, 60.0), Some("east"));
+        assert_eq!(nearest_site(&catalog, 21.0, 60.0), Some("west"));
+    }
+
+    /// An empty catalog has no nearest site.
+    #[test]
+    fn nearest_site_empty_catalog_is_none() {
+        let catalog = Catalog {
+            by_site: HashMap::new(),
+            parameters: vec![],
+            quantities: vec![],
+            times: vec![],
+            spatial_extent: None,
+        };
+        assert_eq!(nearest_site(&catalog, 25.0, 60.0), None);
     }
 }

--- a/crates/engine-odim/src/volume_engine.rs
+++ b/crates/engine-odim/src/volume_engine.rs
@@ -1326,10 +1326,12 @@ impl EdrEngine for PolarVolumeEngine {
         let nod = nearest_site(&catalog, lon, lat).ok_or_else(|| {
             DataServerError::LocationNotFound("PVOL catalog has no radar sites".into())
         })?;
-        let volumes = catalog
-            .by_site
-            .get(nod)
-            .expect("nearest_site returns an existing by_site key");
+        // `nearest_site` returns a key it read from `by_site`, so the
+        // lookup cannot miss — but a graceful error beats a panicking
+        // request thread should a refactor ever break that invariant.
+        let volumes = catalog.by_site.get(nod).ok_or_else(|| {
+            DataServerError::Engine("internal: nearest_site returned a missing by_site key".into())
+        })?;
         build_site_point_series(volumes, lon, lat, datetime, parameters)
     }
 
@@ -1360,9 +1362,16 @@ impl EdrEngine for PolarVolumeEngine {
             }
             match build_site_point_series(volumes, site.lon, site.lat, datetime, parameters) {
                 Ok(qr) => coverages.push(qr),
-                // A site inside the polygon but with no data in the
-                // requested window is skipped, not fatal.
-                Err(DataServerError::LocationNotFound(_)) => continue,
+                // A site inside the polygon is skipped — not fatal to
+                // the whole area query — when it has no data in the
+                // requested window (`LocationNotFound`) or none of the
+                // requested quantities (`InvalidParameter`): a
+                // heterogeneous network mixes single- and dual-pol
+                // radars, so a `ZDR` filter legitimately misses some
+                // sites while matching others.
+                Err(
+                    DataServerError::LocationNotFound(_) | DataServerError::InvalidParameter(_),
+                ) => continue,
                 Err(e) => return Err(e),
             }
         }

--- a/crates/engine-odim/tests/integration.rs
+++ b/crates/engine-odim/tests/integration.rs
@@ -631,3 +631,152 @@ fn pvol_engine_rejects_missing_parameter() {
         Ok(_) => panic!("missing parameter on a PVOL collection must error"),
     }
 }
+
+// ---------------------------------------------------------------------------
+// PolarVolumeEngine — EdrEngine (M3a: sites as locations + position queries)
+// ---------------------------------------------------------------------------
+
+/// Build a PVOL engine over the local `radar-fmi-pvol` fixture
+/// directory, or `None` when the (uncommitted, 15 MB) fixture is
+/// absent — so these tests skip gracefully in CI.
+fn pvol_fixture_engine() -> Option<engine_odim::PolarVolumeEngine> {
+    let fixture_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../testdata/radar-fmi-pvol");
+    if !fixture_dir.join("202605150000_fianj_PVOL.h5").exists() {
+        return None;
+    }
+    let config = OdimConfig {
+        filename_template: None,
+        filename_pattern: None,
+        timestamp_format: None,
+        parameter: None,
+        unit: None,
+        nodata: None,
+        gain: None,
+        offset: None,
+        poll_interval_secs: 30,
+        max_files: None,
+        endpoint: None,
+        bucket: None,
+        prefix_pattern: None,
+        time_window: None,
+    };
+    Some(
+        engine_odim::PolarVolumeEngine::new(
+            "fianj-edr-test",
+            Some(fixture_dir.to_str().expect("utf8 fixture dir")),
+            &config,
+        )
+        .expect("PolarVolumeEngine::new over the PVOL fixture directory"),
+    )
+}
+
+/// `get_locations` exposes each radar site as an EDR location keyed by
+/// its ODIM NOD code, with the antenna position as the point geometry.
+#[test]
+fn pvol_edr_get_locations_lists_sites() {
+    let Some(engine) = pvol_fixture_engine() else {
+        eprintln!("skipping pvol_edr_get_locations_lists_sites: fixture absent");
+        return;
+    };
+    let locations = EdrEngine::get_locations(&engine).expect("get_locations");
+    assert!(
+        !locations.is_empty(),
+        "the PVOL fixture must surface at least one radar site"
+    );
+    let fianj = locations
+        .iter()
+        .find(|l| l.id == "fianj")
+        .expect("Anjalankoski site keyed by NOD code `fianj`");
+    // Anjalankoski sits near 27.1°E, 60.9°N.
+    assert!(
+        (26.0..28.5).contains(&fianj.longitude) && (60.0..61.8).contains(&fianj.latitude),
+        "fianj antenna near 27.1E/60.9N, got {},{}",
+        fianj.longitude,
+        fianj.latitude
+    );
+    assert!(!fianj.label.is_empty(), "a location carries a label");
+}
+
+/// A position query near a radar samples its lowest sweep and returns
+/// a `PointSeries` whose ranges are aligned with the time axis.
+#[test]
+fn pvol_edr_query_position_returns_point_series() {
+    let Some(engine) = pvol_fixture_engine() else {
+        eprintln!("skipping pvol_edr_query_position_returns_point_series: fixture absent");
+        return;
+    };
+    // ~30 km north of Anjalankoski — inside the lowest sweep.
+    let result = EdrEngine::query_position(&engine, "POINT(27.1 61.2)", None, None)
+        .expect("position query inside radar coverage");
+    match &result.domain {
+        DomainDescription::PointSeries { x, y, t } => {
+            assert!((*x - 27.1).abs() < 1e-9 && (*y - 61.2).abs() < 1e-9);
+            assert!(!t.is_empty(), "PointSeries must carry a time axis");
+            for arr in result.ranges.values() {
+                assert_eq!(arr.shape, vec![t.len()]);
+                assert_eq!(arr.axis_names, vec!["t".to_string()]);
+                assert_eq!(arr.values.len(), t.len());
+            }
+        }
+        other => panic!("position query must yield a PointSeries, got {other:?}"),
+    }
+    assert!(
+        !result.ranges.is_empty(),
+        "the volume's lowest sweep exposes at least one quantity"
+    );
+}
+
+/// `query_location` by NOD code returns the site's `PointSeries`; an
+/// unknown id is `LocationNotFound` (HTTP 404), not a panic.
+#[test]
+fn pvol_edr_query_location_by_nod() {
+    let Some(engine) = pvol_fixture_engine() else {
+        eprintln!("skipping pvol_edr_query_location_by_nod: fixture absent");
+        return;
+    };
+    let result = EdrEngine::query_location(&engine, "fianj", None, None)
+        .expect("query_location for the fianj site");
+    assert!(matches!(
+        result.domain,
+        DomainDescription::PointSeries { .. }
+    ));
+    assert!(!result.ranges.is_empty());
+
+    match EdrEngine::query_location(&engine, "nosuchsite", None, None) {
+        Err(ds_core::error::DataServerError::LocationNotFound(_)) => {}
+        other => panic!("unknown location id must be LocationNotFound, got {other:?}"),
+    }
+}
+
+/// An area query collects one `PointSeries` per radar site inside the
+/// polygon; a polygon far from any radar is `LocationNotFound`.
+#[test]
+fn pvol_edr_query_area_collects_sites() {
+    let Some(engine) = pvol_fixture_engine() else {
+        eprintln!("skipping pvol_edr_query_area_collects_sites: fixture absent");
+        return;
+    };
+    // A bbox enclosing Anjalankoski (27.1E, 60.9N).
+    let result = EdrEngine::query_area(&engine, "25.0,59.0,29.0,62.5", None, None)
+        .expect("area query enclosing the fianj site");
+    match result {
+        AreaQueryResult::Collection(coverages) => {
+            assert!(
+                !coverages.is_empty(),
+                "the polygon encloses fianj, so the collection is non-empty"
+            );
+            for qr in &coverages {
+                assert!(matches!(qr.domain, DomainDescription::PointSeries { .. }));
+            }
+        }
+        AreaQueryResult::Single(_) => {
+            panic!("a point/observation area query must return a Collection")
+        }
+    }
+
+    // A polygon far from any FMI radar matches nothing.
+    match EdrEngine::query_area(&engine, "0.0,0.0,1.0,1.0", None, None) {
+        Err(ds_core::error::DataServerError::LocationNotFound(_)) => {}
+        other => panic!("an empty area must be LocationNotFound, got {other:?}"),
+    }
+}

--- a/crates/server/src/admin.rs
+++ b/crates/server/src/admin.rs
@@ -430,7 +430,7 @@ pub fn load_collections(
             "querydata" => &["edr", "wms", "maps", "tiles"],
             "grib" => &["edr", "wms", "maps", "tiles"],
             "odim" => &["edr", "wms", "maps", "tiles"],
-            "odim-volume" => &["wms", "maps", "tiles"],
+            "odim-volume" => &["edr", "wms", "maps", "tiles"],
             "postgis" => &["edr", "features", "tiles"],
             _ => &[],
         };
@@ -1118,6 +1118,15 @@ pub fn load_collections(
                 };
 
                 odim_volume_engines.push(engine.clone());
+
+                if collection.apis.contains(&"edr".to_string()) {
+                    edr_engines.insert(
+                        collection.id.clone(),
+                        engine.clone() as Arc<dyn ds_core::edr_engine::EdrEngine>,
+                    );
+                    edr_collections.insert(collection.id.clone(), collection.clone());
+                    info!("Collection '{}': wired to EDR API", collection.id);
+                }
 
                 // PVOL is multi-parameter (one layer per <site>:<quantity>).
                 let raster_params =


### PR DESCRIPTION
Implements **#196** — the non-vertical slice (M3a) of EDR support for the PVOL `odim-volume` engine, which until now was `MapEngine`-only.

## Summary

`impl EdrEngine for PolarVolumeEngine`:

| Query | Behaviour | CoverageJSON |
|---|---|---|
| `locations` (list) | one location per radar site, id = ODIM NOD code, point geometry at the antenna | Locations `FeatureCollection` |
| `position` | samples the lowest sweep of the radar site **nearest** the requested point | `PointSeries` |
| `locations/{nod}` | same, for a site addressed by its NOD code | `PointSeries` |
| `area` | one coverage per radar site whose antenna falls inside the polygon | `CoverageCollection` of `PointSeries` |

`get_parameters` exposes the ODIM quantities (DBZH, TH, VRADH, ZDR…) **without** the `<site>:` prefix the Map layer naming uses — in EDR the site is the *location* and the quantity is the *parameter*.

Only the lowest elevation sweep is sampled. The vertical (`z`) dimension — turning a no-`z` query into a profile across all sweeps — is **M3b (#197)**, gated on **#185**.

## Supporting changes

- `ds_core::feature::parse_point_coords` — a shared WKT `POINT(lon lat)` / bare `lon,lat` parser, sibling to `parse_area_coords`.
- `sample_sweep_moment` factored out of `polar_sample` so the EDR point query and the Map raster path share one sampling routine (no duplicated polar math).
- `odim-volume` wired into the EDR registry in `server/admin.rs`; both FMI volume collections gain `edr` in `apis`.
- The FMI S3 collection (`radar-fi-volume-s3-h5`) prefix widened from `.../fivih/` to the whole date partition so every FMI radar site is discovered and exposed as a location.

## Test plan

- [x] `cargo test --workspace` — green; new unit tests (`build_site_point_series`, `nearest_site`, `parse_point_coords`) + integration tests exercising `get_locations` / `query_position` / `query_location` / `query_area` against the real FMI Anjalankoski volume (skip gracefully when the fixture is absent)
- [x] CoverageJSON schema validation — new `covjson_validation.rs` case for the blank-unit multi-quantity `PointSeries` the engine emits
- [x] End-to-end: server `/edr/collections/radar-fi-volume-local-h5/{locations,position,area}` return schema-shaped Coverage / CoverageCollection with real radar moments

🤖 Generated with [Claude Code](https://claude.com/claude-code)