### PR TITLE
feat: vertical (elevation/level) dimension for MapEngine + EdrEngine

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,7 +107,7 @@ All CoverageJSON output **must** validate against the OGC CoverageJSON 1.0 schem
 - **Coverage**: requires `type` ("Coverage"), `domain`, `parameters`, `ranges`
 - **Domain**: requires `type` ("Domain"), `axes`, `referencing`. `domainType` triggers axis constraints.
 - **PointSeries**: x/y are single-value axes, t is string-values axis, z is an optional single-value axis.
-- **Grid**: x/y are numeric-values axes, t and z optional. NdArray shape: `[t, y, x]` or `[y, x]`.
+- **Grid**: x/y are numeric-values axes, t and z optional. NdArray shape: `[t, y, x]`, `[y, x]`, `[z, y, x]`, or `[t, z, y, x]`.
 - **VerticalProfile**: x/y single-value, z numeric-values axis, t optional single-value. NdArray shape: `[z]`.
 - **Parameter**: requires `observedProperty` with `label` as i18n object `{"en": "..."}`.
 - **NdArray**: requires `shape` and `axisNames` when values has >1 item. `values.length` must equal product of `shape`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,8 +106,9 @@ All CoverageJSON output **must** validate against the OGC CoverageJSON 1.0 schem
 
 - **Coverage**: requires `type` ("Coverage"), `domain`, `parameters`, `ranges`
 - **Domain**: requires `type` ("Domain"), `axes`, `referencing`. `domainType` triggers axis constraints.
-- **PointSeries**: x/y are single-value axes, t is string-values axis. No additional axes allowed.
-- **Grid**: x/y are numeric-values axes, t is optional. NdArray shape: `[t, y, x]` or `[y, x]`.
+- **PointSeries**: x/y are single-value axes, t is string-values axis, z is an optional single-value axis.
+- **Grid**: x/y are numeric-values axes, t and z optional. NdArray shape: `[t, y, x]` or `[y, x]`.
+- **VerticalProfile**: x/y single-value, z numeric-values axis, t optional single-value. NdArray shape: `[z]`.
 - **Parameter**: requires `observedProperty` with `label` as i18n object `{"en": "..."}`.
 - **NdArray**: requires `shape` and `axisNames` when values has >1 item. `values.length` must equal product of `shape`.
 - **i18n objects**: Keys must be BCP 47 language tags (e.g. `"en"`).
@@ -120,7 +121,17 @@ All CoverageJSON output **must** validate against the OGC CoverageJSON 1.0 schem
 3. Check schema's `domainBase.dependencies.domainType` for axis requirements
 4. Add a validation test in `covjson_validation.rs`
 
-Currently implemented: `PointSeries`, `Grid`.
+Currently implemented: `PointSeries`, `Grid`, `VerticalProfile`.
+
+### Vertical dimension
+
+Collections may expose a single vertical axis (`ds_core::vertical::VerticalDimension`,
+surfaced on `RasterInfo.vertical` and `EdrEngine::get_vertical_extent`). `MapEngine::get_raster_tile`
+takes `z: Option<f64>` (one rendered layer); the `EdrEngine` query methods take
+`z: Option<&[f64]>` (one or more levels). The ODIM `odim-volume` engine uses it for
+radar elevation angle. WMS exposes it as the `ELEVATION` dimension; Maps/Tiles as an
+`elevation` query parameter; EDR as the `z` query parameter. The API layer rejects a
+`z`/`elevation` against a collection with no vertical extent (HTTP 400).
 
 ## Engine Capabilities
 

--- a/crates/api-edr/src/handlers.rs
+++ b/crates/api-edr/src/handlers.rs
@@ -698,17 +698,15 @@ fn build_collection_metadata(
     }
 
     // Vertical extent — advertise the available levels so a client knows
-    // what `z` values it may request.
+    // what `z` values it may request. `vrs` is intentionally omitted:
+    // vertical coordinate kinds like radar elevation angle have no
+    // standard OGC vertical-CRS URI, and `vrs` is optional in OGC EDR.
     if let Some(vertical) = engine.get_vertical_extent() {
         let mut vertical_obj = serde_json::Map::new();
         if let Some((lo, hi)) = vertical.extent() {
             vertical_obj.insert("interval".to_string(), json!([[lo, hi]]));
         }
         vertical_obj.insert("values".to_string(), json!(vertical.levels));
-        vertical_obj.insert(
-            "vrs".to_string(),
-            json!(format!("{} ({})", vertical.label, vertical.unit)),
-        );
         extent.insert("vertical".to_string(), json!(vertical_obj));
     }
 

--- a/crates/api-edr/src/handlers.rs
+++ b/crates/api-edr/src/handlers.rs
@@ -314,7 +314,7 @@ pub async fn api_definition(State(state): State<AppState>) -> impl IntoResponse 
                     "in": "query",
                     "required": true,
                     "schema": {"type": "string"},
-                    "description": "WKT POINT or MULTIPOINT geometry. Examples: POINT(24.94 60.17), MULTIPOINT((24.94 60.17),(23.76 61.5))"
+                    "description": "WKT POINT or MULTIPOINT geometry. Examples: POINT(24.94 60.17), MULTIPOINT((24.94 60.17),(23.76 61.5)). Note: for a MULTIPOINT against a collection with a vertical extent, every point's coverages are flattened into one CoverageCollection — per-point grouping is not preserved."
                 },
                 "coords-polygon": {
                     "name": "coords",

--- a/crates/api-edr/src/handlers.rs
+++ b/crates/api-edr/src/handlers.rs
@@ -12,15 +12,12 @@ use ds_core::config::CollectionConfig;
 use ds_core::datetime::parse_datetime_interval;
 use ds_core::edr_engine::EdrEngine;
 
-use ds_core::model::AreaQueryResult;
+use ds_core::model::CoverageResponse;
 
 use crate::params::{
-    split_position_coords, AreaQueryParams, LocationQueryParams, PositionQueryParams,
+    parse_z, split_position_coords, AreaQueryParams, LocationQueryParams, PositionQueryParams,
 };
-use crate::response::{
-    area_query_result_to_json, locations_to_geojson, query_result_to_coverage_json,
-    LocationsContext,
-};
+use crate::response::{coverage_response_to_json, locations_to_geojson, LocationsContext};
 
 /// Shared state for the EDR API: a registry of collection engines + metadata.
 #[derive(Clone)]
@@ -46,6 +43,26 @@ fn lookup_collection<'a>(
     })?;
     let config = state.collections.get(id).unwrap();
     Ok((engine, config))
+}
+
+/// Reject a `z` selector against a collection with no vertical dimension.
+/// Collections that have one let the engine resolve `z`; collections that
+/// don't return HTTP 400 rather than silently ignoring the parameter.
+fn reject_z_without_vertical(
+    engine: &Arc<dyn EdrEngine>,
+    z: &Option<Vec<f64>>,
+) -> Result<(), (StatusCode, Json<serde_json::Value>)> {
+    if z.is_some() && engine.get_vertical_extent().is_none() {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(json!({
+                "code": "BadRequest",
+                "description": "This collection has no vertical dimension; \
+                                the `z` query parameter is not supported"
+            })),
+        ));
+    }
+    Ok(())
 }
 
 pub async fn landing_page(State(state): State<AppState>) -> impl IntoResponse {
@@ -145,7 +162,8 @@ pub async fn api_definition(State(state): State<AppState>) -> impl IntoResponse 
                         "schema": {"type": "string"}
                     },
                     {"$ref": "#/components/parameters/datetime"},
-                    {"$ref": "#/components/parameters/parameter-name"}
+                    {"$ref": "#/components/parameters/parameter-name"},
+                    {"$ref": "#/components/parameters/z"}
                 ],
                 "responses": {
                     "200": {
@@ -173,7 +191,8 @@ pub async fn api_definition(State(state): State<AppState>) -> impl IntoResponse 
                 "parameters": [
                     {"$ref": "#/components/parameters/coords-point"},
                     {"$ref": "#/components/parameters/datetime"},
-                    {"$ref": "#/components/parameters/parameter-name"}
+                    {"$ref": "#/components/parameters/parameter-name"},
+                    {"$ref": "#/components/parameters/z"}
                 ],
                 "responses": {
                     "200": {
@@ -201,7 +220,8 @@ pub async fn api_definition(State(state): State<AppState>) -> impl IntoResponse 
                 "parameters": [
                     {"$ref": "#/components/parameters/coords-polygon"},
                     {"$ref": "#/components/parameters/datetime"},
-                    {"$ref": "#/components/parameters/parameter-name"}
+                    {"$ref": "#/components/parameters/parameter-name"},
+                    {"$ref": "#/components/parameters/z"}
                 ],
                 "responses": {
                     "200": {
@@ -281,6 +301,13 @@ pub async fn api_definition(State(state): State<AppState>) -> impl IntoResponse 
                     "required": false,
                     "schema": {"type": "string"},
                     "description": "Comma-separated list of parameter names to include"
+                },
+                "z": {
+                    "name": "z",
+                    "in": "query",
+                    "required": false,
+                    "schema": {"type": "string"},
+                    "description": "Vertical level selector — a single value or a comma-separated list (e.g. z=0.5 or z=850,700,500). Only valid for collections that advertise a vertical extent."
                 },
                 "coords-point": {
                     "name": "coords",
@@ -432,8 +459,16 @@ pub async fn location_query(
         .as_deref()
         .map(|s| s.split(',').map(|p| p.trim().to_string()).collect());
 
+    let z = parse_z(params.z.as_deref()).map_err(|e| {
+        (
+            StatusCode::BAD_REQUEST,
+            Json(json!({ "code": "BadRequest", "description": e.to_string() })),
+        )
+    })?;
+    reject_z_without_vertical(engine, &z)?;
+
     let result = engine
-        .query_location(&loc_id, datetime, param_names.as_deref())
+        .query_location(&loc_id, datetime, param_names.as_deref(), z.as_deref())
         .map_err(|e| match &e {
             ds_core::error::DataServerError::LocationNotFound(_) => (
                 StatusCode::NOT_FOUND,
@@ -452,7 +487,7 @@ pub async fn location_query(
             }
         })?;
 
-    let body = serde_json::to_string(&query_result_to_coverage_json(&result)).unwrap();
+    let body = serde_json::to_string(&coverage_response_to_json(&result)).unwrap();
     Ok((
         [(header::CONTENT_TYPE, "application/prs.coverage+json")],
         body,
@@ -483,6 +518,14 @@ pub async fn position_query(
         .parameter_name
         .as_deref()
         .map(|s| s.split(',').map(|p| p.trim().to_string()).collect());
+
+    let z = parse_z(params.z.as_deref()).map_err(|e| {
+        (
+            StatusCode::BAD_REQUEST,
+            Json(json!({ "code": "BadRequest", "description": e.to_string() })),
+        )
+    })?;
+    reject_z_without_vertical(engine, &z)?;
 
     // Split coords into one or more POINT(lon lat) strings. A single POINT is
     // passed through to the engine as-is; MULTIPOINT is fanned out into one
@@ -518,24 +561,29 @@ pub async fn position_query(
 
     if points.len() == 1 {
         let result = engine
-            .query_position(&points[0], datetime, param_names.as_deref())
+            .query_position(&points[0], datetime, param_names.as_deref(), z.as_deref())
             .map_err(|e| map_engine_error(&e))?;
-        let body = serde_json::to_string(&query_result_to_coverage_json(&result)).unwrap();
+        let body = serde_json::to_string(&coverage_response_to_json(&result)).unwrap();
         return Ok((
             [(header::CONTENT_TYPE, "application/prs.coverage+json")],
             body,
         ));
     }
 
+    // MULTIPOINT — fan out one query per point and flatten every point's
+    // coverages into a single CoverageCollection.
     let mut coverages = Vec::with_capacity(points.len());
     for point in &points {
         let qr = engine
-            .query_position(point, datetime, param_names.as_deref())
+            .query_position(point, datetime, param_names.as_deref(), z.as_deref())
             .map_err(|e| map_engine_error(&e))?;
-        coverages.push(qr);
+        match qr {
+            CoverageResponse::Single(q) => coverages.push(q),
+            CoverageResponse::Collection(v) => coverages.extend(v),
+        }
     }
 
-    let body = serde_json::to_string(&area_query_result_to_json(&AreaQueryResult::Collection(
+    let body = serde_json::to_string(&coverage_response_to_json(&CoverageResponse::Collection(
         coverages,
     )))
     .unwrap();
@@ -570,8 +618,21 @@ pub async fn area_query(
         .as_deref()
         .map(|s| s.split(',').map(|p| p.trim().to_string()).collect());
 
+    let z = parse_z(params.z.as_deref()).map_err(|e| {
+        (
+            StatusCode::BAD_REQUEST,
+            Json(json!({ "code": "BadRequest", "description": e.to_string() })),
+        )
+    })?;
+    reject_z_without_vertical(engine, &z)?;
+
     let result = engine
-        .query_area(&params.coords, datetime, param_names.as_deref())
+        .query_area(
+            &params.coords,
+            datetime,
+            param_names.as_deref(),
+            z.as_deref(),
+        )
         .map_err(|e| match &e {
             ds_core::error::DataServerError::InvalidParameter(_)
             | ds_core::error::DataServerError::InvalidBbox(_)
@@ -593,7 +654,7 @@ pub async fn area_query(
             }
         })?;
 
-    let body = serde_json::to_string(&area_query_result_to_json(&result)).unwrap();
+    let body = serde_json::to_string(&coverage_response_to_json(&result)).unwrap();
     Ok((
         [(header::CONTENT_TYPE, "application/prs.coverage+json")],
         body,
@@ -634,6 +695,21 @@ fn build_collection_metadata(
         }
 
         extent.insert("temporal".to_string(), json!(temporal_obj));
+    }
+
+    // Vertical extent — advertise the available levels so a client knows
+    // what `z` values it may request.
+    if let Some(vertical) = engine.get_vertical_extent() {
+        let mut vertical_obj = serde_json::Map::new();
+        if let Some((lo, hi)) = vertical.extent() {
+            vertical_obj.insert("interval".to_string(), json!([[lo, hi]]));
+        }
+        vertical_obj.insert("values".to_string(), json!(vertical.levels));
+        vertical_obj.insert(
+            "vrs".to_string(),
+            json!(format!("{} ({})", vertical.label, vertical.unit)),
+        );
+        extent.insert("vertical".to_string(), json!(vertical_obj));
     }
 
     let parameter_names: serde_json::Map<String, serde_json::Value> = param_descs

--- a/crates/api-edr/src/handlers.rs
+++ b/crates/api-edr/src/handlers.rs
@@ -307,7 +307,7 @@ pub async fn api_definition(State(state): State<AppState>) -> impl IntoResponse 
                     "in": "query",
                     "required": false,
                     "schema": {"type": "string"},
-                    "description": "Vertical level selector — a single value or a comma-separated list (e.g. z=0.5 or z=850,700,500). Only valid for collections that advertise a vertical extent."
+                    "description": "Vertical level selector — a single value or a comma-separated list (e.g. z=0.5 or z=850,700,500). Only valid for collections that advertise a vertical extent. Each requested value is snapped to the nearest level in the collection's advertised vertical extent; the response domain reports the snapped level."
                 },
                 "coords-point": {
                     "name": "coords",

--- a/crates/api-edr/src/params.rs
+++ b/crates/api-edr/src/params.rs
@@ -37,12 +37,19 @@ pub fn parse_z(z: Option<&str>) -> Result<Option<Vec<f64>>, DataServerError> {
     let levels: Vec<f64> = raw
         .split(',')
         .map(|part| {
-            part.trim().parse::<f64>().map_err(|_| {
-                DataServerError::InvalidParameter(format!(
-                    "Invalid `z` value '{}' — expected a number",
-                    part.trim()
-                ))
-            })
+            // `parse::<f64>()` also accepts "inf"/"nan"; reject those so a
+            // non-finite level can't reach `quantize_z` (→ `i64::MAX`
+            // cache aliasing) or `nearest_sweep` (NaN distance comparisons).
+            part.trim()
+                .parse::<f64>()
+                .ok()
+                .filter(|v| v.is_finite())
+                .ok_or_else(|| {
+                    DataServerError::InvalidParameter(format!(
+                        "Invalid `z` value '{}' — expected a finite number",
+                        part.trim()
+                    ))
+                })
         })
         .collect::<Result<_, _>>()?;
     Ok((!levels.is_empty()).then_some(levels))

--- a/crates/api-edr/src/params.rs
+++ b/crates/api-edr/src/params.rs
@@ -6,6 +6,7 @@ pub struct LocationQueryParams {
     pub datetime: Option<String>,
     #[serde(rename = "parameter-name")]
     pub parameter_name: Option<String>,
+    pub z: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -14,6 +15,7 @@ pub struct PositionQueryParams {
     pub datetime: Option<String>,
     #[serde(rename = "parameter-name")]
     pub parameter_name: Option<String>,
+    pub z: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -22,6 +24,28 @@ pub struct AreaQueryParams {
     pub datetime: Option<String>,
     #[serde(rename = "parameter-name")]
     pub parameter_name: Option<String>,
+    pub z: Option<String>,
+}
+
+/// Parse the EDR `z` query parameter — a comma-separated list of numeric
+/// vertical levels (e.g. `z=850,700,500` or a single `z=0.5`). An absent
+/// or blank value yields `None` (the whole vertical extent / a profile).
+pub fn parse_z(z: Option<&str>) -> Result<Option<Vec<f64>>, DataServerError> {
+    let Some(raw) = z.map(str::trim).filter(|s| !s.is_empty()) else {
+        return Ok(None);
+    };
+    let levels: Vec<f64> = raw
+        .split(',')
+        .map(|part| {
+            part.trim().parse::<f64>().map_err(|_| {
+                DataServerError::InvalidParameter(format!(
+                    "Invalid `z` value '{}' — expected a number",
+                    part.trim()
+                ))
+            })
+        })
+        .collect::<Result<_, _>>()?;
+    Ok((!levels.is_empty()).then_some(levels))
 }
 
 /// Split a position-query `coords` value into one or more `POINT(lon lat)` WKT

--- a/crates/api-edr/src/params.rs
+++ b/crates/api-edr/src/params.rs
@@ -30,6 +30,10 @@ pub struct AreaQueryParams {
 /// Parse the EDR `z` query parameter — a comma-separated list of numeric
 /// vertical levels (e.g. `z=850,700,500` or a single `z=0.5`). An absent
 /// or blank value yields `None` (the whole vertical extent / a profile).
+///
+/// The EDR `min/max` interval form is not supported — pass the discrete
+/// levels explicitly (the available set is advertised in the collection's
+/// vertical extent).
 pub fn parse_z(z: Option<&str>) -> Result<Option<Vec<f64>>, DataServerError> {
     let Some(raw) = z.map(str::trim).filter(|s| !s.is_empty()) else {
         return Ok(None);
@@ -37,17 +41,21 @@ pub fn parse_z(z: Option<&str>) -> Result<Option<Vec<f64>>, DataServerError> {
     let levels: Vec<f64> = raw
         .split(',')
         .map(|part| {
+            let part = part.trim();
+            if part.is_empty() {
+                return Err(DataServerError::InvalidParameter(
+                    "`z` has an empty element — check for a stray comma".into(),
+                ));
+            }
             // `parse::<f64>()` also accepts "inf"/"nan"; reject those so a
             // non-finite level can't reach `quantize_z` (→ `i64::MAX`
             // cache aliasing) or `nearest_sweep` (NaN distance comparisons).
-            part.trim()
-                .parse::<f64>()
+            part.parse::<f64>()
                 .ok()
                 .filter(|v| v.is_finite())
                 .ok_or_else(|| {
                     DataServerError::InvalidParameter(format!(
-                        "Invalid `z` value '{}' — expected a finite number",
-                        part.trim()
+                        "Invalid `z` value '{part}' — expected a finite number"
                     ))
                 })
         })

--- a/crates/api-edr/src/response.rs
+++ b/crates/api-edr/src/response.rs
@@ -173,18 +173,15 @@ pub fn coverage_response_to_json(result: &CoverageResponse) -> Value {
             // collection may mix domain shapes safely.
             let parameters = build_parameters(&coverages[0]);
 
-            // The collection-level `domainType` below is taken from the
-            // first coverage; today every engine emits a homogeneous
-            // collection. Assert that invariant so a future engine that
-            // mixes domain types fails loudly in tests rather than
-            // emitting a `domainType` that mismatches some coverages.
+            // A collection-level `domainType` is only emitted when every
+            // coverage agrees (it is an optional hint). A heterogeneous
+            // collection omits it rather than emitting a type that
+            // mismatches some coverages — each coverage's domain still
+            // carries its own `domainType`.
             let first_type = domain_type_name(&coverages[0].domain);
-            debug_assert!(
-                coverages
-                    .iter()
-                    .all(|c| domain_type_name(&c.domain) == first_type),
-                "CoverageCollection coverages must share one domain type"
-            );
+            let homogeneous = coverages
+                .iter()
+                .all(|c| domain_type_name(&c.domain) == first_type);
 
             let coverage_items: Vec<Value> = coverages
                 .iter()
@@ -197,12 +194,14 @@ pub fn coverage_response_to_json(result: &CoverageResponse) -> Value {
                 })
                 .collect();
 
-            json!({
-                "type": "CoverageCollection",
-                "domainType": first_type,
-                "parameters": parameters,
-                "coverages": coverage_items
-            })
+            let mut collection = Map::with_capacity(4);
+            collection.insert("type".into(), Value::String("CoverageCollection".into()));
+            if homogeneous {
+                collection.insert("domainType".into(), Value::String(first_type.into()));
+            }
+            collection.insert("parameters".into(), Value::Object(parameters));
+            collection.insert("coverages".into(), Value::Array(coverage_items));
+            Value::Object(collection)
         }
     }
 }

--- a/crates/api-edr/src/response.rs
+++ b/crates/api-edr/src/response.rs
@@ -1,4 +1,4 @@
-use ds_core::model::{AreaQueryResult, DomainDescription, Location, QueryResult};
+use ds_core::model::{CoverageResponse, DomainDescription, Location, QueryResult, VerticalCoord};
 use serde_json::{json, Map, Number, Value};
 
 /// Pre-built reference system objects (shared across all responses).
@@ -18,6 +18,26 @@ fn temporal_ref() -> Value {
         "system": {
             "type": "TemporalRS",
             "calendar": "Gregorian"
+        }
+    })
+}
+
+/// CoverageJSON `referencing` entry for a vertical (`z`) coordinate. The
+/// vertical CRS is described by its coordinate-system axis (name,
+/// direction, unit) rather than an identifier — vertical coordinate
+/// kinds like radar elevation angle have no standard CRS URI.
+fn vertical_ref(z: &VerticalCoord) -> Value {
+    json!({
+        "coordinates": ["z"],
+        "system": {
+            "type": "VerticalCRS",
+            "cs": {
+                "csAxes": [{
+                    "name": { "en": z.kind.default_label() },
+                    "direction": z.kind.direction(),
+                    "unit": { "symbol": z.kind.default_unit() }
+                }]
+            }
         }
     })
 }
@@ -98,7 +118,7 @@ fn build_ndarray(ndarray: &ds_core::model::NdArray) -> Value {
     Value::Object(obj)
 }
 
-pub fn query_result_to_coverage_json(result: &QueryResult) -> Value {
+fn build_parameters(result: &QueryResult) -> Map<String, Value> {
     let mut parameters = Map::with_capacity(result.parameters.len());
     for (name, desc) in &result.parameters {
         parameters.insert(
@@ -106,26 +126,41 @@ pub fn query_result_to_coverage_json(result: &QueryResult) -> Value {
             build_parameter(&desc.label, &desc.unit, &desc.observed_property),
         );
     }
+    parameters
+}
 
+fn build_ranges(result: &QueryResult) -> Map<String, Value> {
     let mut ranges = Map::with_capacity(result.ranges.len());
     for (name, ndarray) in &result.ranges {
         ranges.insert(name.clone(), build_ndarray(ndarray));
     }
+    ranges
+}
 
-    let domain = build_domain(&result.domain);
-
+pub fn query_result_to_coverage_json(result: &QueryResult) -> Value {
     let mut coverage = Map::with_capacity(4);
     coverage.insert("type".into(), Value::String("Coverage".into()));
-    coverage.insert("domain".into(), domain);
-    coverage.insert("parameters".into(), Value::Object(parameters));
-    coverage.insert("ranges".into(), Value::Object(ranges));
+    coverage.insert("domain".into(), build_domain(&result.domain));
+    coverage.insert("parameters".into(), Value::Object(build_parameters(result)));
+    coverage.insert("ranges".into(), Value::Object(build_ranges(result)));
     Value::Object(coverage)
 }
 
-pub fn area_query_result_to_json(result: &AreaQueryResult) -> Value {
+/// CoverageJSON `domainType` string for a domain description.
+fn domain_type_name(domain: &DomainDescription) -> &'static str {
+    match domain {
+        DomainDescription::PointSeries { .. } => "PointSeries",
+        DomainDescription::Grid { .. } => "Grid",
+        DomainDescription::VerticalProfile { .. } => "VerticalProfile",
+    }
+}
+
+/// Serialise an EDR query result — a single `Coverage` or, for multiple
+/// coverages, a `CoverageCollection`.
+pub fn coverage_response_to_json(result: &CoverageResponse) -> Value {
     match result {
-        AreaQueryResult::Single(qr) => query_result_to_coverage_json(qr),
-        AreaQueryResult::Collection(coverages) => {
+        CoverageResponse::Single(qr) => query_result_to_coverage_json(qr),
+        CoverageResponse::Collection(coverages) => {
             if coverages.is_empty() {
                 return json!({
                     "type": "CoverageCollection",
@@ -133,39 +168,26 @@ pub fn area_query_result_to_json(result: &AreaQueryResult) -> Value {
                 });
             }
 
-            // Hoist shared parameters and referencing to collection level
-            let first = &coverages[0];
-            let mut parameters = Map::with_capacity(first.parameters.len());
-            for (name, desc) in &first.parameters {
-                parameters.insert(
-                    name.clone(),
-                    build_parameter(&desc.label, &desc.unit, &desc.observed_property),
-                );
-            }
+            // Hoist the shared parameters to collection level; each
+            // coverage's domain keeps its own `referencing` so a
+            // collection may mix domain shapes safely.
+            let parameters = build_parameters(&coverages[0]);
 
             let coverage_items: Vec<Value> = coverages
                 .iter()
                 .map(|qr| {
-                    let domain = build_domain(&qr.domain);
-
-                    let mut ranges = Map::with_capacity(qr.ranges.len());
-                    for (name, ndarray) in &qr.ranges {
-                        ranges.insert(name.clone(), build_ndarray(ndarray));
-                    }
-
                     let mut cov = Map::with_capacity(3);
                     cov.insert("type".into(), Value::String("Coverage".into()));
-                    cov.insert("domain".into(), domain);
-                    cov.insert("ranges".into(), Value::Object(ranges));
+                    cov.insert("domain".into(), build_domain(&qr.domain));
+                    cov.insert("ranges".into(), Value::Object(build_ranges(qr)));
                     Value::Object(cov)
                 })
                 .collect();
 
             json!({
                 "type": "CoverageCollection",
-                "domainType": "PointSeries",
+                "domainType": domain_type_name(&coverages[0].domain),
                 "parameters": parameters,
-                "referencing": [spatial_ref(), temporal_ref()],
                 "coverages": coverage_items
             })
         }
@@ -174,20 +196,25 @@ pub fn area_query_result_to_json(result: &AreaQueryResult) -> Value {
 
 fn build_domain(desc: &DomainDescription) -> Value {
     match desc {
-        DomainDescription::PointSeries { x, y, t } => {
+        DomainDescription::PointSeries { x, y, t, z } => {
             let times: Vec<String> = t.iter().map(|t| t.to_rfc3339()).collect();
+            let mut axes = Map::new();
+            axes.insert("x".into(), json!({ "values": [x] }));
+            axes.insert("y".into(), json!({ "values": [y] }));
+            axes.insert("t".into(), json!({ "values": times }));
+            let mut referencing = vec![spatial_ref(), temporal_ref()];
+            if let Some(zc) = z {
+                axes.insert("z".into(), json!({ "values": zc.values }));
+                referencing.push(vertical_ref(zc));
+            }
             json!({
                 "type": "Domain",
                 "domainType": "PointSeries",
-                "axes": {
-                    "x": { "values": [x] },
-                    "y": { "values": [y] },
-                    "t": { "values": times }
-                },
-                "referencing": [spatial_ref(), temporal_ref()]
+                "axes": axes,
+                "referencing": referencing
             })
         }
-        DomainDescription::Grid { x, y, t } => {
+        DomainDescription::Grid { x, y, t, z } => {
             let mut axes = Map::new();
             axes.insert("x".into(), json!({ "values": x }));
             axes.insert("y".into(), json!({ "values": y }));
@@ -199,10 +226,31 @@ fn build_domain(desc: &DomainDescription) -> Value {
                 axes.insert("t".into(), json!({ "values": time_strings }));
                 referencing.push(temporal_ref());
             }
+            if let Some(zc) = z {
+                axes.insert("z".into(), json!({ "values": zc.values }));
+                referencing.push(vertical_ref(zc));
+            }
 
             json!({
                 "type": "Domain",
                 "domainType": "Grid",
+                "axes": axes,
+                "referencing": referencing
+            })
+        }
+        DomainDescription::VerticalProfile { x, y, t, z } => {
+            let mut axes = Map::new();
+            axes.insert("x".into(), json!({ "values": [x] }));
+            axes.insert("y".into(), json!({ "values": [y] }));
+            axes.insert("z".into(), json!({ "values": z.values }));
+            let mut referencing = vec![spatial_ref(), vertical_ref(z)];
+            if let Some(time) = t {
+                axes.insert("t".into(), json!({ "values": [time.to_rfc3339()] }));
+                referencing.push(temporal_ref());
+            }
+            json!({
+                "type": "Domain",
+                "domainType": "VerticalProfile",
                 "axes": axes,
                 "referencing": referencing
             })

--- a/crates/api-edr/src/response.rs
+++ b/crates/api-edr/src/response.rs
@@ -173,6 +173,19 @@ pub fn coverage_response_to_json(result: &CoverageResponse) -> Value {
             // collection may mix domain shapes safely.
             let parameters = build_parameters(&coverages[0]);
 
+            // The collection-level `domainType` below is taken from the
+            // first coverage; today every engine emits a homogeneous
+            // collection. Assert that invariant so a future engine that
+            // mixes domain types fails loudly in tests rather than
+            // emitting a `domainType` that mismatches some coverages.
+            let first_type = domain_type_name(&coverages[0].domain);
+            debug_assert!(
+                coverages
+                    .iter()
+                    .all(|c| domain_type_name(&c.domain) == first_type),
+                "CoverageCollection coverages must share one domain type"
+            );
+
             let coverage_items: Vec<Value> = coverages
                 .iter()
                 .map(|qr| {
@@ -186,7 +199,7 @@ pub fn coverage_response_to_json(result: &CoverageResponse) -> Value {
 
             json!({
                 "type": "CoverageCollection",
-                "domainType": domain_type_name(&coverages[0].domain),
+                "domainType": first_type,
                 "parameters": parameters,
                 "coverages": coverage_items
             })

--- a/crates/api-edr/src/response.rs
+++ b/crates/api-edr/src/response.rs
@@ -168,10 +168,15 @@ pub fn coverage_response_to_json(result: &CoverageResponse) -> Value {
                 });
             }
 
-            // Hoist the shared parameters to collection level; each
-            // coverage's domain keeps its own `referencing` so a
-            // collection may mix domain shapes safely.
-            let parameters = build_parameters(&coverages[0]);
+            // Hoist parameters to collection level — the union across
+            // every coverage, so a (hypothetical) mixed-parameter
+            // collection still advertises them all rather than only the
+            // first coverage's. Each coverage's domain keeps its own
+            // `referencing`, so a collection may mix domain shapes safely.
+            let mut parameters = Map::new();
+            for qr in coverages {
+                parameters.append(&mut build_parameters(qr));
+            }
 
             // A collection-level `domainType` is only emitted when every
             // coverage agrees (it is an optional hint). A heterogeneous

--- a/crates/api-edr/tests/covjson_validation.rs
+++ b/crates/api-edr/tests/covjson_validation.rs
@@ -4,8 +4,9 @@ use chrono::{DateTime, Utc};
 use jsonschema::Validator;
 use serde_json::Value;
 
-use api_edr::response::{area_query_result_to_json, query_result_to_coverage_json};
+use api_edr::response::{coverage_response_to_json, query_result_to_coverage_json};
 use ds_core::model::*;
+use ds_core::vertical::VerticalKind;
 
 fn load_schema() -> Value {
     let schema_str = std::fs::read_to_string(concat!(
@@ -67,6 +68,7 @@ fn make_query_result(
             x: 24.9384,
             y: 60.1699,
             t: times,
+            z: None,
         },
         parameters,
         ranges,
@@ -338,7 +340,7 @@ fn make_grid_query_result(
     }
 
     QueryResult {
-        domain: DomainDescription::Grid { x, y, t },
+        domain: DomainDescription::Grid { x, y, t, z: None },
         parameters,
         ranges,
     }
@@ -483,13 +485,12 @@ fn coverage_collection_validates() {
         ),
     ];
 
-    let result = AreaQueryResult::Collection(coverages);
-    let json = area_query_result_to_json(&result);
+    let result = CoverageResponse::Collection(coverages);
+    let json = coverage_response_to_json(&result);
 
     assert_eq!(json["type"], "CoverageCollection");
     assert_eq!(json["domainType"], "PointSeries");
     assert!(json["parameters"].is_object());
-    assert!(json["referencing"].is_array());
     let items = json["coverages"].as_array().unwrap();
     assert_eq!(items.len(), 2);
     for item in items {
@@ -514,16 +515,16 @@ fn coverage_collection_single_station_validates() {
         ],
     )];
 
-    let result = AreaQueryResult::Collection(coverages);
-    let json = area_query_result_to_json(&result);
+    let result = CoverageResponse::Collection(coverages);
+    let json = coverage_response_to_json(&result);
     validate(&json, &schema);
 }
 
 #[test]
 fn coverage_collection_empty_validates() {
     let schema = load_schema();
-    let result = AreaQueryResult::Collection(vec![]);
-    let json = area_query_result_to_json(&result);
+    let result = CoverageResponse::Collection(vec![]);
+    let json = coverage_response_to_json(&result);
     assert_eq!(json["type"], "CoverageCollection");
     assert!(json["coverages"].as_array().unwrap().is_empty());
     validate(&json, &schema);
@@ -537,8 +538,158 @@ fn area_query_single_result_validates() {
     let values: Vec<Option<f64>> =
         vec![Some(1.0), Some(2.0), Some(3.0), Some(4.0), None, Some(6.0)];
     let qr = make_grid_query_result(x, y, None, vec![("reflectivity", "dBZ", values)]);
-    let result = AreaQueryResult::Single(qr);
-    let json = area_query_result_to_json(&result);
+    let result = CoverageResponse::Single(qr);
+    let json = coverage_response_to_json(&result);
     assert_eq!(json["type"], "Coverage");
+    validate(&json, &schema);
+}
+
+// --- VerticalProfile + z-axis tests (#185) ---
+
+/// A `PointSeries` pinned to a single vertical level validates — the `z`
+/// axis is a single-value numeric axis with a `VerticalCRS` reference.
+#[test]
+fn point_series_with_z_validates() {
+    let schema = load_schema();
+    let times = vec![make_time(0), make_time(1)];
+    let mut result = make_query_result(times, vec![("DBZH", "dBZ", vec![Some(12.0), Some(15.0)])]);
+    if let DomainDescription::PointSeries { z, .. } = &mut result.domain {
+        *z = Some(VerticalCoord {
+            kind: VerticalKind::ElevationAngle,
+            values: vec![0.5],
+        });
+    }
+    let json = query_result_to_coverage_json(&result);
+    assert_eq!(json["domain"]["axes"]["z"]["values"][0], 0.5);
+    validate(&json, &schema);
+}
+
+/// A `VerticalProfile` coverage (radar reflectivity vs. elevation angle)
+/// validates against the schema's `VerticalProfile` domain constraints.
+#[test]
+fn vertical_profile_validates() {
+    let schema = load_schema();
+    let levels = vec![0.5, 1.5, 3.0, 5.0];
+    let mut parameters = HashMap::new();
+    parameters.insert(
+        "DBZH".to_string(),
+        ParameterDescription {
+            label: "DBZH".to_string(),
+            unit: String::new(),
+            observed_property: "DBZH".to_string(),
+        },
+    );
+    let mut ranges = HashMap::new();
+    ranges.insert(
+        "DBZH".to_string(),
+        NdArray {
+            shape: vec![levels.len()],
+            axis_names: vec!["z".to_string()],
+            values: vec![Some(20.0), Some(18.0), None, Some(5.0)],
+        },
+    );
+    let result = QueryResult {
+        domain: DomainDescription::VerticalProfile {
+            x: 24.9,
+            y: 60.1,
+            t: Some(make_time(0)),
+            z: VerticalCoord {
+                kind: VerticalKind::ElevationAngle,
+                values: levels,
+            },
+        },
+        parameters,
+        ranges,
+    };
+    let json = query_result_to_coverage_json(&result);
+    assert_eq!(json["domain"]["domainType"], "VerticalProfile");
+    validate(&json, &schema);
+}
+
+/// A `CoverageCollection` of `VerticalProfile`s — the shape a no-`z`
+/// radar position query returns — validates.
+#[test]
+fn vertical_profile_collection_validates() {
+    let schema = load_schema();
+    let make_profile = |hour: u32| {
+        let mut parameters = HashMap::new();
+        parameters.insert(
+            "DBZH".to_string(),
+            ParameterDescription {
+                label: "DBZH".to_string(),
+                unit: String::new(),
+                observed_property: "DBZH".to_string(),
+            },
+        );
+        let mut ranges = HashMap::new();
+        ranges.insert(
+            "DBZH".to_string(),
+            NdArray {
+                shape: vec![2],
+                axis_names: vec!["z".to_string()],
+                values: vec![Some(10.0), Some(8.0)],
+            },
+        );
+        QueryResult {
+            domain: DomainDescription::VerticalProfile {
+                x: 24.9,
+                y: 60.1,
+                t: Some(make_time(hour)),
+                z: VerticalCoord {
+                    kind: VerticalKind::ElevationAngle,
+                    values: vec![0.5, 1.5],
+                },
+            },
+            parameters,
+            ranges,
+        }
+    };
+    let result = CoverageResponse::Collection(vec![make_profile(0), make_profile(1)]);
+    let json = coverage_response_to_json(&result);
+    assert_eq!(json["type"], "CoverageCollection");
+    assert_eq!(json["domainType"], "VerticalProfile");
+    validate(&json, &schema);
+}
+
+/// A `Grid` carrying a vertical (`z`) axis validates — the shape an area
+/// query against a 3-D raster collection produces.
+#[test]
+fn grid_with_z_validates() {
+    let schema = load_schema();
+    let mut parameters = HashMap::new();
+    parameters.insert(
+        "temperature".to_string(),
+        ParameterDescription {
+            label: "temperature".to_string(),
+            unit: "K".to_string(),
+            observed_property: "temperature".to_string(),
+        },
+    );
+    let mut ranges = HashMap::new();
+    // shape [z, y, x] = [2, 2, 2] = 8 values.
+    ranges.insert(
+        "temperature".to_string(),
+        NdArray {
+            shape: vec![2, 2, 2],
+            axis_names: vec!["z".to_string(), "y".to_string(), "x".to_string()],
+            values: (0..8).map(|i| Some(i as f64)).collect(),
+        },
+    );
+    let result = QueryResult {
+        domain: DomainDescription::Grid {
+            x: vec![10.0, 10.5],
+            y: vec![60.0, 60.5],
+            t: None,
+            z: Some(VerticalCoord {
+                kind: VerticalKind::Pressure,
+                values: vec![850.0, 500.0],
+            }),
+        },
+        parameters,
+        ranges,
+    };
+    let json = query_result_to_coverage_json(&result);
+    assert_eq!(json["domain"]["domainType"], "Grid");
+    assert!(json["domain"]["axes"]["z"]["values"].is_array());
     validate(&json, &schema);
 }

--- a/crates/api-edr/tests/covjson_validation.rs
+++ b/crates/api-edr/tests/covjson_validation.rs
@@ -491,6 +491,10 @@ fn coverage_collection_validates() {
     assert_eq!(json["type"], "CoverageCollection");
     assert_eq!(json["domainType"], "PointSeries");
     assert!(json["parameters"].is_object());
+    // No collection-level `referencing`: each coverage's domain carries
+    // its own, so a collection may mix domain shapes (e.g. VerticalProfile
+    // needs a VerticalCRS that PointSeries does not). The schema permits
+    // this — see the `coverageCollection` conditional.
     let items = json["coverages"].as_array().unwrap();
     assert_eq!(items.len(), 2);
     for item in items {

--- a/crates/api-edr/tests/ogc_edr_api_tests.rs
+++ b/crates/api-edr/tests/ogc_edr_api_tests.rs
@@ -930,6 +930,18 @@ mod error_responses {
         assert!(json.get("description").is_some());
     }
 
+    /// A `z` selector against a collection with no vertical extent
+    /// (`MockEngine` does not override `get_vertical_extent`) is a 400 —
+    /// guards the `reject_z_without_vertical` check from a silent
+    /// refactor regression.
+    #[tokio::test]
+    async fn z_against_non_vertical_collection_returns_400() {
+        let (status, json) = get("/collections/weather/locations/helsinki?z=0.5").await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert!(json.get("code").is_some(), "400 error must have 'code'");
+        assert!(json.get("description").is_some());
+    }
+
     #[tokio::test]
     async fn error_code_is_string() {
         let (_, json) = get("/collections/nonexistent").await;

--- a/crates/api-edr/tests/ogc_edr_api_tests.rs
+++ b/crates/api-edr/tests/ogc_edr_api_tests.rs
@@ -73,6 +73,7 @@ impl MockEngine {
                 x: 24.9384,
                 y: 60.1699,
                 t: times,
+                z: None,
             },
             parameters,
             ranges,
@@ -90,9 +91,10 @@ impl EdrEngine for MockEngine {
         location_id: &str,
         _datetime: Option<(DateTime<Utc>, DateTime<Utc>)>,
         _parameters: Option<&[String]>,
-    ) -> Result<QueryResult, DataServerError> {
+        _z: Option<&[f64]>,
+    ) -> Result<CoverageResponse, DataServerError> {
         if location_id == "helsinki" || location_id == "tampere" {
-            Ok(Self::sample_query_result())
+            Ok(CoverageResponse::Single(Self::sample_query_result()))
         } else {
             Err(DataServerError::LocationNotFound(location_id.into()))
         }
@@ -122,7 +124,8 @@ impl EdrEngine for MockEngine {
         coords: &str,
         _datetime: Option<(DateTime<Utc>, DateTime<Utc>)>,
         _parameters: Option<&[String]>,
-    ) -> Result<AreaQueryResult, DataServerError> {
+        _z: Option<&[f64]>,
+    ) -> Result<CoverageResponse, DataServerError> {
         let polygon = ds_core::feature::parse_area_coords(coords)?;
         let mut coverages = Vec::new();
         for loc in Self::sample_locations() {
@@ -135,7 +138,7 @@ impl EdrEngine for MockEngine {
                 "No locations found within the requested area".into(),
             ));
         }
-        Ok(AreaQueryResult::Collection(coverages))
+        Ok(CoverageResponse::Collection(coverages))
     }
 
     fn query_position(
@@ -143,7 +146,8 @@ impl EdrEngine for MockEngine {
         coords: &str,
         _datetime: Option<(DateTime<Utc>, DateTime<Utc>)>,
         _parameters: Option<&[String]>,
-    ) -> Result<QueryResult, DataServerError> {
+        _z: Option<&[f64]>,
+    ) -> Result<CoverageResponse, DataServerError> {
         // Accept any well-formed POINT(lon lat). Parsing is handled here to
         // exercise the handler's MULTIPOINT fan-out (which normalizes each
         // sub-point to POINT before calling the engine).
@@ -165,7 +169,7 @@ impl EdrEngine for MockEngine {
         let _lat: f64 = parts[1].parse().map_err(|_| {
             DataServerError::InvalidParameter(format!("bad latitude: {}", parts[1]))
         })?;
-        Ok(Self::sample_query_result())
+        Ok(CoverageResponse::Single(Self::sample_query_result()))
     }
 }
 

--- a/crates/api-edr/tests/performance_tests.rs
+++ b/crates/api-edr/tests/performance_tests.rs
@@ -81,7 +81,8 @@ impl EdrEngine for ScalableEngine {
         location_id: &str,
         _datetime: Option<(DateTime<Utc>, DateTime<Utc>)>,
         _parameters: Option<&[String]>,
-    ) -> Result<QueryResult, DataServerError> {
+        _z: Option<&[f64]>,
+    ) -> Result<CoverageResponse, DataServerError> {
         let idx: usize = location_id
             .strip_prefix("loc_")
             .and_then(|s| s.parse().ok())
@@ -121,15 +122,16 @@ impl EdrEngine for ScalableEngine {
             );
         }
 
-        Ok(QueryResult {
+        Ok(CoverageResponse::Single(QueryResult {
             domain: DomainDescription::PointSeries {
                 x: 24.0 + (idx as f64 * 0.01),
                 y: 60.0 + (idx as f64 * 0.01),
                 t: times,
+                z: None,
             },
             parameters,
             ranges,
-        })
+        }))
     }
 
     fn get_parameters(&self) -> Vec<String> {

--- a/crates/api-edr/tests/security_tests.rs
+++ b/crates/api-edr/tests/security_tests.rs
@@ -35,7 +35,8 @@ impl EdrEngine for MockEngine {
         location_id: &str,
         _datetime: Option<(DateTime<Utc>, DateTime<Utc>)>,
         _parameters: Option<&[String]>,
-    ) -> Result<QueryResult, DataServerError> {
+        _z: Option<&[f64]>,
+    ) -> Result<CoverageResponse, DataServerError> {
         if location_id != "helsinki" {
             return Err(DataServerError::LocationNotFound(location_id.to_string()));
         }
@@ -60,15 +61,16 @@ impl EdrEngine for MockEngine {
             },
         );
 
-        Ok(QueryResult {
+        Ok(CoverageResponse::Single(QueryResult {
             domain: DomainDescription::PointSeries {
                 x: 24.9384,
                 y: 60.1699,
                 t: vec![time],
+                z: None,
             },
             parameters,
             ranges,
-        })
+        }))
     }
 
     fn get_parameters(&self) -> Vec<String> {

--- a/crates/api-edr/tests/spec_compliance_tests.rs
+++ b/crates/api-edr/tests/spec_compliance_tests.rs
@@ -53,7 +53,8 @@ impl EdrEngine for MockEngine {
         location_id: &str,
         _datetime: Option<(DateTime<Utc>, DateTime<Utc>)>,
         _parameters: Option<&[String]>,
-    ) -> Result<QueryResult, DataServerError> {
+        _z: Option<&[f64]>,
+    ) -> Result<CoverageResponse, DataServerError> {
         if location_id != "station1" && location_id != "station2" {
             return Err(DataServerError::LocationNotFound(location_id.to_string()));
         }
@@ -78,15 +79,16 @@ impl EdrEngine for MockEngine {
                 values: vec![Some(-2.5), Some(-2.8), Some(-3.1)],
             },
         );
-        Ok(QueryResult {
+        Ok(CoverageResponse::Single(QueryResult {
             domain: DomainDescription::PointSeries {
                 x: 24.9384,
                 y: 60.1699,
                 t: times,
+                z: None,
             },
             parameters,
             ranges,
-        })
+        }))
     }
 
     fn get_parameters(&self) -> Vec<String> {

--- a/crates/api-maps/src/handlers.rs
+++ b/crates/api-maps/src/handlers.rs
@@ -178,6 +178,19 @@ fn build_collection_metadata(
         }
     }
 
+    if let Some(vertical) = &info.vertical {
+        let vertical_json = json!({
+            "interval": vertical.extent().map(|(lo, hi)| [[lo, hi]]),
+            "values": vertical.levels,
+            "vrs": format!("{} ({})", vertical.label, vertical.unit)
+        });
+        if let Some(extent) = metadata.get_mut("extent") {
+            extent["vertical"] = vertical_json;
+        } else {
+            metadata["extent"] = json!({ "vertical": vertical_json });
+        }
+    }
+
     metadata
 }
 
@@ -263,7 +276,8 @@ pub async fn api_definition(State(state): State<AppState>) -> impl IntoResponse 
                     {"$ref": "#/components/parameters/datetime"},
                     {"$ref": "#/components/parameters/transparent"},
                     {"$ref": "#/components/parameters/f"},
-                    {"$ref": "#/components/parameters/bbox-crs"}
+                    {"$ref": "#/components/parameters/bbox-crs"},
+                    {"$ref": "#/components/parameters/elevation"}
                 ],
                 "responses": {
                     "200": {
@@ -331,7 +345,8 @@ pub async fn api_definition(State(state): State<AppState>) -> impl IntoResponse 
                     {"$ref": "#/components/parameters/datetime"},
                     {"$ref": "#/components/parameters/transparent"},
                     {"$ref": "#/components/parameters/f"},
-                    {"$ref": "#/components/parameters/bbox-crs"}
+                    {"$ref": "#/components/parameters/bbox-crs"},
+                    {"$ref": "#/components/parameters/elevation"}
                 ],
                 "responses": {
                     "200": {
@@ -477,6 +492,13 @@ pub async fn api_definition(State(state): State<AppState>) -> impl IntoResponse 
                     "required": false,
                     "schema": {"type": "string"},
                     "description": "CRS for bbox coordinates. Only CRS:84 supported."
+                },
+                "elevation": {
+                    "name": "elevation",
+                    "in": "query",
+                    "required": false,
+                    "schema": {"type": "number"},
+                    "description": "Vertical level (e.g. radar elevation angle). Only valid for collections with a vertical dimension."
                 }
             },
             "schemas": {
@@ -735,6 +757,15 @@ async fn render_map(
         .clone()
         .or_else(|| style_info.parameter.clone());
 
+    // Reject an `elevation` against a collection with no vertical axis
+    // rather than silently rendering the default layer.
+    if validated.z.is_some() && raster_info.vertical.is_none() {
+        return Err(MapsError::BadRequest(format!(
+            "collection '{collection_id}' has no vertical dimension; \
+             the `elevation` parameter is not supported"
+        )));
+    }
+
     // Build cache key
     let cache_key = CacheKey {
         layer: collection_id.to_string(),
@@ -750,6 +781,7 @@ async fn render_map(
         height: validated.height,
         time,
         parameter: effective_parameter.clone(),
+        z: validated.z.map(ds_render::quantize_z),
     };
 
     let cache_control = cache_control_value(has_explicit_time);
@@ -812,6 +844,7 @@ async fn render_map(
     let rendered_cache = state.rendered_cache.clone();
 
     let render_parameter = effective_parameter;
+    let render_z = validated.z;
 
     let render_result = tokio::task::spawn_blocking(move || {
         let tile = engine.get_raster_tile(
@@ -821,6 +854,7 @@ async fn render_map(
             time,
             &output_crs,
             render_parameter.as_deref(),
+            render_z,
         )?;
         // If every pixel is nodata, skip colorization + encoding entirely.
         if tile.is_empty() {

--- a/crates/api-maps/src/handlers.rs
+++ b/crates/api-maps/src/handlers.rs
@@ -178,11 +178,12 @@ fn build_collection_metadata(
         }
     }
 
+    // `vrs` is omitted — no standard OGC vertical-CRS URI exists for
+    // kinds like radar elevation angle, and `vrs` is optional.
     if let Some(vertical) = &info.vertical {
         let vertical_json = json!({
             "interval": vertical.extent().map(|(lo, hi)| [[lo, hi]]),
             "values": vertical.levels,
-            "vrs": format!("{} ({})", vertical.label, vertical.unit)
         });
         if let Some(extent) = metadata.get_mut("extent") {
             extent["vertical"] = vertical_json;

--- a/crates/api-maps/src/params.rs
+++ b/crates/api-maps/src/params.rs
@@ -151,9 +151,16 @@ impl MapQueryParams {
             .map(str::trim)
             .filter(|s| !s.is_empty())
         {
-            Some(raw) => Some(raw.parse::<f64>().map_err(|_| {
-                MapsError::BadRequest(format!("elevation '{raw}' is not a number"))
-            })?),
+            Some(raw) => Some(
+                raw.parse::<f64>()
+                    .ok()
+                    .filter(|v| v.is_finite())
+                    .ok_or_else(|| {
+                        MapsError::BadRequest(format!(
+                            "elevation '{raw}' is not a finite number"
+                        ))
+                    })?,
+            ),
             None => None,
         };
 

--- a/crates/api-maps/src/params.rs
+++ b/crates/api-maps/src/params.rs
@@ -36,6 +36,9 @@ pub struct MapQueryParams {
     /// path/query form is on the OGC Maps roadmap and will replace this.
     #[serde(rename = "parameter-name")]
     pub parameter_name: Option<String>,
+    /// Vertical level selector (e.g. a radar elevation angle). Ignored by
+    /// collections with no vertical dimension.
+    pub elevation: Option<String>,
 }
 
 /// Validated map request parameters.
@@ -48,6 +51,8 @@ pub struct ValidatedMapParams {
     pub output_crs: ds_core::map_engine::OutputCrs,
     pub format: ds_render::ImageFormat,
     pub parameter_name: Option<String>,
+    /// Vertical level, parsed from the `elevation` query parameter.
+    pub z: Option<f64>,
 }
 
 impl MapQueryParams {
@@ -138,6 +143,20 @@ impl MapQueryParams {
             .filter(|s| !s.is_empty())
             .map(str::to_string);
 
+        // ELEVATION — a single vertical level. Multi-value selection is an
+        // EDR concern; a map renders exactly one layer.
+        let z = match self
+            .elevation
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+        {
+            Some(raw) => Some(raw.parse::<f64>().map_err(|_| {
+                MapsError::BadRequest(format!("elevation '{raw}' is not a number"))
+            })?),
+            None => None,
+        };
+
         Ok(ValidatedMapParams {
             bbox,
             width,
@@ -147,6 +166,7 @@ impl MapQueryParams {
             output_crs,
             format,
             parameter_name,
+            z,
         })
     }
 }

--- a/crates/api-maps/src/params.rs
+++ b/crates/api-maps/src/params.rs
@@ -36,8 +36,8 @@ pub struct MapQueryParams {
     /// path/query form is on the OGC Maps roadmap and will replace this.
     #[serde(rename = "parameter-name")]
     pub parameter_name: Option<String>,
-    /// Vertical level selector (e.g. a radar elevation angle). Ignored by
-    /// collections with no vertical dimension.
+    /// Vertical level selector (e.g. a radar elevation angle). Rejected
+    /// with HTTP 400 for collections with no vertical dimension.
     pub elevation: Option<String>,
 }
 

--- a/crates/api-maps/src/params.rs
+++ b/crates/api-maps/src/params.rs
@@ -156,9 +156,7 @@ impl MapQueryParams {
                     .ok()
                     .filter(|v| v.is_finite())
                     .ok_or_else(|| {
-                        MapsError::BadRequest(format!(
-                            "elevation '{raw}' is not a finite number"
-                        ))
+                        MapsError::BadRequest(format!("elevation '{raw}' is not a finite number"))
                     })?,
             ),
             None => None,

--- a/crates/api-maps/tests/integration.rs
+++ b/crates/api-maps/tests/integration.rs
@@ -410,6 +410,14 @@ mod get_map {
         assert!(headers.contains_key("etag"));
     }
 
+    /// `elevation` against a collection with no vertical dimension
+    /// (`MockMapEngine.raster_info().vertical` is `None`) is a 400.
+    #[tokio::test]
+    async fn elevation_against_non_vertical_collection_returns_400() {
+        let (status, _, _) = get_raw("/collections/radar/map?bbox=10,55,30,70&elevation=0.5").await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+    }
+
     #[tokio::test]
     async fn explicit_time_immutable_cache() {
         let (_, headers, _) =

--- a/crates/api-maps/tests/integration.rs
+++ b/crates/api-maps/tests/integration.rs
@@ -40,6 +40,7 @@ impl MockMapEngine {
             parameter: "reflectivity".to_string(),
             unit: "dBZ".to_string(),
             parameters: vec![],
+            vertical: None,
         }
     }
 }
@@ -53,6 +54,7 @@ impl MapEngine for MockMapEngine {
         _time: Option<chrono::DateTime<chrono::Utc>>,
         _output_crs: &OutputCrs,
         _parameter: Option<&str>,
+        _z: Option<f64>,
     ) -> Result<RasterTile, DataServerError> {
         let pixel_count = (width * height) as usize;
         let values: Vec<Option<f64>> = (0..pixel_count)
@@ -777,6 +779,7 @@ impl MapEngine for EmptyMockMapEngine {
         _time: Option<chrono::DateTime<chrono::Utc>>,
         _output_crs: &OutputCrs,
         _parameter: Option<&str>,
+        _z: Option<f64>,
     ) -> Result<RasterTile, DataServerError> {
         let pixel_count = (width * height) as usize;
         Ok(RasterTile {
@@ -858,6 +861,7 @@ impl MapEngine for MultiParamMockEngine {
         _time: Option<chrono::DateTime<chrono::Utc>>,
         _output_crs: &ds_core::map_engine::OutputCrs,
         parameter: Option<&str>,
+        _z: Option<f64>,
     ) -> Result<ds_core::map_engine::RasterTile, ds_core::error::DataServerError> {
         // Vary the pixel values by parameter so the `parameter` field on the
         // cache key actually changes the rendered bytes — the cross-parameter
@@ -894,6 +898,7 @@ impl MapEngine for MultiParamMockEngine {
                 ("2t".into(), "Temperature".into()),
                 ("10u".into(), "U Wind".into()),
             ],
+            vertical: None,
         }
     }
 }

--- a/crates/api-tiles/src/handlers.rs
+++ b/crates/api-tiles/src/handlers.rs
@@ -201,6 +201,19 @@ fn build_collection_metadata(
                 }
             }
         }
+
+        if let Some(vertical) = &info.vertical {
+            let vertical_json = json!({
+                "interval": vertical.extent().map(|(lo, hi)| [[lo, hi]]),
+                "values": vertical.levels,
+                "vrs": format!("{} ({})", vertical.label, vertical.unit)
+            });
+            if let Some(extent) = metadata.get_mut("extent") {
+                extent["vertical"] = vertical_json;
+            } else {
+                metadata["extent"] = json!({ "vertical": vertical_json });
+            }
+        }
     }
 
     metadata
@@ -361,7 +374,8 @@ pub async fn api_definition(State(state): State<AppState>) -> impl IntoResponse 
                         "description": "Column index"
                     },
                     {"$ref": "#/components/parameters/datetime"},
-                    {"$ref": "#/components/parameters/f"}
+                    {"$ref": "#/components/parameters/f"},
+                    {"$ref": "#/components/parameters/elevation"}
                 ],
                 "responses": {
                     "200": {
@@ -465,6 +479,13 @@ pub async fn api_definition(State(state): State<AppState>) -> impl IntoResponse 
                         ]
                     },
                     "description": "Output format. `mvt` selects Mapbox Vector Tile (only on collections with a FeatureEngine)."
+                },
+                "elevation": {
+                    "name": "elevation",
+                    "in": "query",
+                    "required": false,
+                    "schema": {"type": "number"},
+                    "description": "Vertical level (e.g. radar elevation angle). Only valid for collections with a vertical dimension."
                 }
             }
         }
@@ -1086,6 +1107,14 @@ async fn render_tile(
         .clone()
         .or_else(|| style_info.parameter.clone());
 
+    // Reject an `elevation` against a collection with no vertical axis.
+    if validated.z.is_some() && raster_info.vertical.is_none() {
+        return Err(TilesError::BadRequest(format!(
+            "collection '{collection_id}' has no vertical dimension; \
+             the `elevation` parameter is not supported"
+        )));
+    }
+
     // Build cache key
     let cache_key = CacheKey {
         layer: collection_id.to_string(),
@@ -1101,6 +1130,7 @@ async fn render_tile(
         height: tile_size,
         time,
         parameter: effective_parameter.clone(),
+        z: validated.z.map(ds_render::quantize_z),
     };
 
     let cache_control = cache_control_value(has_explicit_time);
@@ -1161,6 +1191,7 @@ async fn render_tile(
     // The blocking closure returns Ok(None) for empty (all-nodata) tiles,
     // or Ok(Some(bytes)) for tiles with data.
     let render_parameter = effective_parameter;
+    let render_z = validated.z;
 
     let render_result = tokio::task::spawn_blocking(move || {
         let tile = engine.get_raster_tile(
@@ -1170,6 +1201,7 @@ async fn render_tile(
             time,
             &output_crs,
             render_parameter.as_deref(),
+            render_z,
         )?;
 
         // If every pixel is nodata, skip colorization + encoding entirely.

--- a/crates/api-tiles/src/handlers.rs
+++ b/crates/api-tiles/src/handlers.rs
@@ -202,11 +202,12 @@ fn build_collection_metadata(
             }
         }
 
+        // `vrs` is omitted — no standard OGC vertical-CRS URI exists for
+        // kinds like radar elevation angle, and `vrs` is optional.
         if let Some(vertical) = &info.vertical {
             let vertical_json = json!({
                 "interval": vertical.extent().map(|(lo, hi)| [[lo, hi]]),
                 "values": vertical.levels,
-                "vrs": format!("{} ({})", vertical.label, vertical.unit)
             });
             if let Some(extent) = metadata.get_mut("extent") {
                 extent["vertical"] = vertical_json;

--- a/crates/api-tiles/src/params.rs
+++ b/crates/api-tiles/src/params.rs
@@ -38,6 +38,9 @@ pub struct TileQueryParams {
     /// Ignored for MVT (`?f=mvt`) responses.
     #[serde(rename = "parameter-name")]
     pub parameter_name: Option<String>,
+    /// Vertical level selector (e.g. a radar elevation angle). Ignored by
+    /// collections with no vertical dimension and for MVT responses.
+    pub elevation: Option<String>,
 }
 
 impl TileQueryParams {
@@ -55,6 +58,8 @@ pub struct ValidatedTileParams {
     pub time: Option<DateTime<Utc>>,
     pub format: ds_render::ImageFormat,
     pub parameter_name: Option<String>,
+    /// Vertical level, parsed from the `elevation` query parameter.
+    pub z: Option<f64>,
 }
 
 impl TileQueryParams {
@@ -81,10 +86,23 @@ impl TileQueryParams {
             .filter(|s| !s.is_empty())
             .map(str::to_string);
 
+        let z = match self
+            .elevation
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+        {
+            Some(raw) => Some(raw.parse::<f64>().map_err(|_| {
+                TilesError::BadRequest(format!("elevation '{raw}' is not a number"))
+            })?),
+            None => None,
+        };
+
         Ok(ValidatedTileParams {
             time,
             format,
             parameter_name,
+            z,
         })
     }
 }
@@ -118,6 +136,7 @@ mod tests {
             datetime: None,
             format: None,
             parameter_name: None,
+            elevation: None,
         };
         let validated = params.validate().unwrap();
         assert!(matches!(validated.format, ds_render::ImageFormat::Png));
@@ -129,6 +148,7 @@ mod tests {
             datetime: None,
             format: Some("image/jpeg".to_string()),
             parameter_name: None,
+            elevation: None,
         };
         let validated = params.validate().unwrap();
         assert!(matches!(validated.format, ds_render::ImageFormat::Jpeg));
@@ -140,6 +160,7 @@ mod tests {
             datetime: None,
             format: Some("text/html".to_string()),
             parameter_name: None,
+            elevation: None,
         };
         assert!(params.validate().is_err());
     }

--- a/crates/api-tiles/src/params.rs
+++ b/crates/api-tiles/src/params.rs
@@ -92,9 +92,16 @@ impl TileQueryParams {
             .map(str::trim)
             .filter(|s| !s.is_empty())
         {
-            Some(raw) => Some(raw.parse::<f64>().map_err(|_| {
-                TilesError::BadRequest(format!("elevation '{raw}' is not a number"))
-            })?),
+            Some(raw) => Some(
+                raw.parse::<f64>()
+                    .ok()
+                    .filter(|v| v.is_finite())
+                    .ok_or_else(|| {
+                        TilesError::BadRequest(format!(
+                            "elevation '{raw}' is not a finite number"
+                        ))
+                    })?,
+            ),
             None => None,
         };
 

--- a/crates/api-tiles/src/params.rs
+++ b/crates/api-tiles/src/params.rs
@@ -38,8 +38,9 @@ pub struct TileQueryParams {
     /// Ignored for MVT (`?f=mvt`) responses.
     #[serde(rename = "parameter-name")]
     pub parameter_name: Option<String>,
-    /// Vertical level selector (e.g. a radar elevation angle). Ignored by
-    /// collections with no vertical dimension and for MVT responses.
+    /// Vertical level selector (e.g. a radar elevation angle). Rejected
+    /// with HTTP 400 for collections with no vertical dimension; ignored
+    /// for MVT responses.
     pub elevation: Option<String>,
 }
 

--- a/crates/api-tiles/src/params.rs
+++ b/crates/api-tiles/src/params.rs
@@ -97,9 +97,7 @@ impl TileQueryParams {
                     .ok()
                     .filter(|v| v.is_finite())
                     .ok_or_else(|| {
-                        TilesError::BadRequest(format!(
-                            "elevation '{raw}' is not a finite number"
-                        ))
+                        TilesError::BadRequest(format!("elevation '{raw}' is not a finite number"))
                     })?,
             ),
             None => None,

--- a/crates/api-tiles/tests/integration.rs
+++ b/crates/api-tiles/tests/integration.rs
@@ -41,6 +41,7 @@ impl MockMapEngine {
             parameter: "reflectivity".to_string(),
             unit: "dBZ".to_string(),
             parameters: vec![],
+            vertical: None,
         }
     }
 }
@@ -54,6 +55,7 @@ impl MapEngine for MockMapEngine {
         _time: Option<chrono::DateTime<chrono::Utc>>,
         _output_crs: &OutputCrs,
         _parameter: Option<&str>,
+        _z: Option<f64>,
     ) -> Result<RasterTile, DataServerError> {
         let pixel_count = (width * height) as usize;
         let values: Vec<Option<f64>> = (0..pixel_count)
@@ -799,6 +801,7 @@ impl MapEngine for EmptyMockMapEngine {
         _time: Option<chrono::DateTime<chrono::Utc>>,
         _output_crs: &OutputCrs,
         _parameter: Option<&str>,
+        _z: Option<f64>,
     ) -> Result<RasterTile, DataServerError> {
         let pixel_count = (width * height) as usize;
         Ok(RasterTile {
@@ -883,6 +886,7 @@ impl MapEngine for MultiParamMockEngine {
         _time: Option<chrono::DateTime<chrono::Utc>>,
         _output_crs: &OutputCrs,
         parameter: Option<&str>,
+        _z: Option<f64>,
     ) -> Result<RasterTile, DataServerError> {
         // Vary the pixel values by parameter so the `parameter` field on
         // the cache key actually changes the rendered bytes — the
@@ -919,6 +923,7 @@ impl MapEngine for MultiParamMockEngine {
                 ("2t".into(), "Temperature".into()),
                 ("10u".into(), "U Wind".into()),
             ],
+            vertical: None,
         }
     }
 }

--- a/crates/api-tiles/tests/integration.rs
+++ b/crates/api-tiles/tests/integration.rs
@@ -434,6 +434,15 @@ mod get_tile {
         assert!(headers.contains_key("cache-control"));
     }
 
+    /// `elevation` against a collection with no vertical dimension
+    /// (`MockMapEngine.raster_info().vertical` is `None`) is a 400.
+    #[tokio::test]
+    async fn elevation_against_non_vertical_collection_returns_400() {
+        let (status, _, _) =
+            get_raw("/collections/radar/tiles/WebMercatorQuad/0/0/0?elevation=0.5").await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+    }
+
     #[tokio::test]
     async fn explicit_datetime_gets_immutable_cache() {
         let (_, headers, _) =

--- a/crates/api-wms/src/capabilities.rs
+++ b/crates/api-wms/src/capabilities.rs
@@ -245,7 +245,7 @@ fn write_layer_metadata(writer: &mut Writer<Vec<u8>>, info: &RasterInfo) {
         if !vertical.levels.is_empty() {
             let mut dim = BytesStart::new("Dimension");
             dim.push_attribute(("name", "elevation"));
-            dim.push_attribute(("units", vertical.unit.as_str()));
+            dim.push_attribute(("units", vertical.unit()));
             let default = format!("{}", vertical.levels[0]);
             dim.push_attribute(("default", default.as_str()));
             dim.push_attribute(("nearestValue", "1"));

--- a/crates/api-wms/src/capabilities.rs
+++ b/crates/api-wms/src/capabilities.rs
@@ -239,6 +239,24 @@ fn write_layer_metadata(writer: &mut Writer<Vec<u8>>, info: &RasterInfo) {
 
         let _ = writer.write_event(Event::End(BytesEnd::new("Dimension")));
     }
+
+    // Elevation dimension — advertised only for layers with a vertical axis.
+    if let Some(vertical) = &info.vertical {
+        if !vertical.levels.is_empty() {
+            let mut dim = BytesStart::new("Dimension");
+            dim.push_attribute(("name", "elevation"));
+            dim.push_attribute(("units", vertical.unit.as_str()));
+            let default = format!("{}", vertical.levels[0]);
+            dim.push_attribute(("default", default.as_str()));
+            dim.push_attribute(("nearestValue", "1"));
+            let _ = writer.write_event(Event::Start(dim));
+
+            let level_values: Vec<String> = vertical.levels.iter().map(|v| v.to_string()).collect();
+            let _ = writer.write_event(Event::Text(BytesText::new(&level_values.join(","))));
+
+            let _ = writer.write_event(Event::End(BytesEnd::new("Dimension")));
+        }
+    }
 }
 
 /// Write style elements for a layer.

--- a/crates/api-wms/src/handlers.rs
+++ b/crates/api-wms/src/handlers.rs
@@ -132,6 +132,13 @@ pub async fn wms_handler(
                 }
             }
 
+            // Reject an `ELEVATION` against a layer with no vertical axis.
+            if params.elevation.is_some() && engine.raster_info().vertical.is_none() {
+                return Err(WmsError::invalid_parameter(&format!(
+                    "Layer '{collection_id}' has no ELEVATION dimension"
+                )));
+            }
+
             let colormap = style_info.colormap.clone();
             let content_type = params.format.content_type();
             let has_explicit_time = params.time.is_some();
@@ -157,6 +164,7 @@ pub async fn wms_handler(
                 parameter: layer_parameter
                     .clone()
                     .or_else(|| style_info.parameter.clone()),
+                z: params.elevation.map(ds_render::quantize_z),
             };
 
             let cache_control = cache_control_value(has_explicit_time);
@@ -221,6 +229,7 @@ pub async fn wms_handler(
             let time = params.time;
             let output_crs = params.output_crs;
             let format = params.format;
+            let elevation = params.elevation;
             let rendered_cache = state.rendered_cache.clone();
 
             // Layer parameter (from "collection/param") takes priority over style parameter
@@ -235,6 +244,7 @@ pub async fn wms_handler(
                     time,
                     &output_crs,
                     style_parameter.as_deref(),
+                    elevation,
                 )?;
                 // If every pixel is nodata, skip colorization + encoding entirely.
                 if tile.is_empty() {

--- a/crates/api-wms/src/params.rs
+++ b/crates/api-wms/src/params.rs
@@ -204,9 +204,16 @@ impl WmsQuery {
             .map(str::trim)
             .filter(|s| !s.is_empty())
         {
-            Some(raw) => Some(raw.parse::<f64>().map_err(|_| {
-                WmsError::invalid_parameter(&format!("ELEVATION '{raw}' is not a number"))
-            })?),
+            Some(raw) => Some(
+                raw.parse::<f64>()
+                    .ok()
+                    .filter(|v| v.is_finite())
+                    .ok_or_else(|| {
+                        WmsError::invalid_parameter(&format!(
+                            "ELEVATION '{raw}' is not a finite number"
+                        ))
+                    })?,
+            ),
             None => None,
         };
 

--- a/crates/api-wms/src/params.rs
+++ b/crates/api-wms/src/params.rs
@@ -71,6 +71,8 @@ pub struct WmsQuery {
     pub bgcolor: Option<String>,
     #[serde(alias = "TIME", alias = "Time")]
     pub time: Option<String>,
+    #[serde(alias = "ELEVATION", alias = "Elevation")]
+    pub elevation: Option<String>,
 }
 
 /// Validated GetMap parameters.
@@ -88,6 +90,8 @@ pub struct GetMapParams {
     pub output_crs: OutputCrs,
     /// Output image format.
     pub format: ds_render::ImageFormat,
+    /// Vertical level from the WMS `ELEVATION` dimension, when supplied.
+    pub elevation: Option<f64>,
 }
 
 impl WmsQuery {
@@ -193,6 +197,19 @@ impl WmsQuery {
         // TIME
         let time = self.time.as_deref().map(parse_time).transpose()?;
 
+        // ELEVATION — a single vertical level (WMS 1.3.0 dimension).
+        let elevation = match self
+            .elevation
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+        {
+            Some(raw) => Some(raw.parse::<f64>().map_err(|_| {
+                WmsError::invalid_parameter(&format!("ELEVATION '{raw}' is not a number"))
+            })?),
+            None => None,
+        };
+
         let output_crs = match crs.as_str() {
             "EPSG:3857" => OutputCrs::WebMercator,
             _ => OutputCrs::Wgs84,
@@ -221,6 +238,7 @@ impl WmsQuery {
             time,
             output_crs,
             format: image_format,
+            elevation,
         })
     }
 }

--- a/crates/api-wms/src/params.rs
+++ b/crates/api-wms/src/params.rs
@@ -197,13 +197,20 @@ impl WmsQuery {
         // TIME
         let time = self.time.as_deref().map(parse_time).transpose()?;
 
-        // ELEVATION — a single vertical level (WMS 1.3.0 dimension).
+        // ELEVATION — a single vertical level. WMS 1.3.0 permits a
+        // comma-separated list, but this server renders one layer per
+        // request, so a list is rejected with an explicit message.
         let elevation = match self
             .elevation
             .as_deref()
             .map(str::trim)
             .filter(|s| !s.is_empty())
         {
+            Some(raw) if raw.contains(',') => {
+                return Err(WmsError::invalid_parameter(
+                    "ELEVATION must be a single value; comma-separated lists are not supported",
+                ));
+            }
             Some(raw) => Some(
                 raw.parse::<f64>()
                     .ok()

--- a/crates/api-wms/tests/integration.rs
+++ b/crates/api-wms/tests/integration.rs
@@ -36,6 +36,7 @@ impl MapEngine for EmptyMockMapEngine {
         _time: Option<chrono::DateTime<chrono::Utc>>,
         _output_crs: &OutputCrs,
         _parameter: Option<&str>,
+        _z: Option<f64>,
     ) -> Result<RasterTile, DataServerError> {
         let pixel_count = (width * height) as usize;
         Ok(RasterTile {
@@ -55,6 +56,7 @@ impl MapEngine for EmptyMockMapEngine {
             parameter: "reflectivity".into(),
             unit: "dBZ".into(),
             parameters: vec![],
+            vertical: None,
         }
     }
 }
@@ -187,6 +189,7 @@ impl MapEngine for FailingMockMapEngine {
         _time: Option<chrono::DateTime<chrono::Utc>>,
         _output_crs: &OutputCrs,
         _parameter: Option<&str>,
+        _z: Option<f64>,
     ) -> Result<RasterTile, DataServerError> {
         Err(DataServerError::Engine("intentional render failure".into()))
     }
@@ -201,6 +204,7 @@ impl MapEngine for FailingMockMapEngine {
             parameter: "reflectivity".into(),
             unit: "dBZ".into(),
             parameters: vec![],
+            vertical: None,
         }
     }
 }
@@ -314,6 +318,7 @@ impl MapEngine for PopulatedMockMapEngine {
         _time: Option<chrono::DateTime<chrono::Utc>>,
         _output_crs: &OutputCrs,
         _parameter: Option<&str>,
+        _z: Option<f64>,
     ) -> Result<RasterTile, DataServerError> {
         let pixel_count = (width * height) as usize;
         // Linear gradient — yields a non-uniform PNG so the test isn't
@@ -338,6 +343,7 @@ impl MapEngine for PopulatedMockMapEngine {
             parameter: "reflectivity".into(),
             unit: "dBZ".into(),
             parameters: vec![],
+            vertical: None,
         }
     }
 }

--- a/crates/api-wms/tests/integration.rs
+++ b/crates/api-wms/tests/integration.rs
@@ -408,6 +408,19 @@ const GETMAP_URI: &str = "/?SERVICE=WMS&REQUEST=GetMap&VERSION=1.3.0&LAYERS=rada
                           &CRS=CRS:84&BBOX=10,55,30,70&WIDTH=64&HEIGHT=64\
                           &FORMAT=image/png";
 
+/// `ELEVATION` against a layer with no vertical dimension
+/// (`raster_info().vertical` is `None`) is a 400 ServiceException.
+#[tokio::test]
+async fn elevation_against_non_vertical_layer_returns_400() {
+    let app = build_populated_router();
+    let req = Request::builder()
+        .uri(format!("{GETMAP_URI}&ELEVATION=0.5"))
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
 /// Regression for #145: the WMS GetMap ETag must be FNV-1a over the
 /// rendered bytes — not over the cache key — so a server-side fix
 /// that produces different pixels under the same key surfaces a

--- a/crates/core/src/edr_engine.rs
+++ b/crates/core/src/edr_engine.rs
@@ -3,17 +3,25 @@ use std::collections::HashMap;
 use chrono::{DateTime, Utc};
 
 use crate::error::DataServerError;
-use crate::model::{AreaQueryResult, Location, ParameterDescription, QueryResult};
+use crate::model::{CoverageResponse, Location, ParameterDescription};
+use crate::vertical::VerticalDimension;
 
 pub trait EdrEngine: Send + Sync {
     fn get_locations(&self) -> Result<Vec<Location>, DataServerError>;
 
+    /// Execute a query for a named location.
+    ///
+    /// `z` selects vertical levels: `None` returns every level (a profile),
+    /// `Some([v])` pins one level, `Some([v1, v2, …])` selects several.
+    /// Engines with no vertical dimension ignore it (the API layer rejects
+    /// a `z` against a collection that has no vertical extent).
     fn query_location(
         &self,
         location_id: &str,
         datetime: Option<(DateTime<Utc>, DateTime<Utc>)>,
         parameters: Option<&[String]>,
-    ) -> Result<QueryResult, DataServerError>;
+        z: Option<&[f64]>,
+    ) -> Result<CoverageResponse, DataServerError>;
 
     fn get_parameters(&self) -> Vec<String>;
 
@@ -45,6 +53,12 @@ pub trait EdrEngine: Send + Sync {
 
     fn get_spatial_extent(&self) -> Option<[f64; 4]>;
 
+    /// Returns the collection's vertical axis, when it has one.
+    /// Default: None (the collection has no vertical dimension).
+    fn get_vertical_extent(&self) -> Option<VerticalDimension> {
+        None
+    }
+
     /// Returns the EDR query types this engine supports.
     /// Default: `["locations"]`. Override for engines that support position, area, etc.
     fn supported_query_types(&self) -> Vec<String> {
@@ -58,8 +72,9 @@ pub trait EdrEngine: Send + Sync {
         coords: &str,
         datetime: Option<(DateTime<Utc>, DateTime<Utc>)>,
         parameters: Option<&[String]>,
-    ) -> Result<AreaQueryResult, DataServerError> {
-        let _ = (coords, datetime, parameters);
+        z: Option<&[f64]>,
+    ) -> Result<CoverageResponse, DataServerError> {
+        let _ = (coords, datetime, parameters, z);
         Err(DataServerError::InvalidParameter(
             "Area query not supported by this engine".into(),
         ))
@@ -72,8 +87,9 @@ pub trait EdrEngine: Send + Sync {
         coords: &str,
         datetime: Option<(DateTime<Utc>, DateTime<Utc>)>,
         parameters: Option<&[String]>,
-    ) -> Result<QueryResult, DataServerError> {
-        let _ = (coords, datetime, parameters);
+        z: Option<&[f64]>,
+    ) -> Result<CoverageResponse, DataServerError> {
+        let _ = (coords, datetime, parameters, z);
         Err(DataServerError::InvalidParameter(
             "Position query not supported by this engine".into(),
         ))

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -8,3 +8,4 @@ pub mod geo;
 pub mod map_engine;
 pub mod model;
 pub mod openapi;
+pub mod vertical;

--- a/crates/core/src/map_engine.rs
+++ b/crates/core/src/map_engine.rs
@@ -1,6 +1,7 @@
 use chrono::{DateTime, Utc};
 
 use crate::error::DataServerError;
+use crate::vertical::VerticalDimension;
 
 /// The output CRS for map rendering, determining how pixels map to coordinates.
 #[derive(Debug, Clone, PartialEq)]
@@ -42,6 +43,10 @@ pub struct RasterInfo {
     /// All available parameters. Empty means single-parameter engine (use `parameter`).
     /// For multi-parameter engines (e.g., querydata), each entry is a (short_name, title) pair.
     pub parameters: Vec<(String, String)>,
+    /// The collection's vertical axis, when it has one (e.g. radar elevation
+    /// sweeps, pressure levels). `None` for collections with no vertical
+    /// dimension.
+    pub vertical: Option<VerticalDimension>,
 }
 
 /// Trait for serving raster data as map images.
@@ -62,7 +67,12 @@ pub trait MapEngine: Send + Sync {
     /// Engines that serve a single parameter (e.g., GeoTIFF) ignore this.
     /// The value comes from the style's `parameter` config field.
     ///
+    /// The optional `z` selects a vertical level (e.g. radar elevation angle,
+    /// pressure level). Engines with no vertical dimension ignore it; engines
+    /// that have one resolve it against `raster_info().vertical`.
+    ///
     /// The engine handles CRS reprojection to source data internally.
+    #[allow(clippy::too_many_arguments)] // bbox/size/time/crs/parameter/z are all genuine selectors
     fn get_raster_tile(
         &self,
         bbox: [f64; 4],
@@ -71,6 +81,7 @@ pub trait MapEngine: Send + Sync {
         time: Option<DateTime<Utc>>,
         output_crs: &OutputCrs,
         parameter: Option<&str>,
+        z: Option<f64>,
     ) -> Result<RasterTile, DataServerError>;
 
     /// Return metadata for capabilities documents.

--- a/crates/core/src/model.rs
+++ b/crates/core/src/model.rs
@@ -1,6 +1,8 @@
 use chrono::{DateTime, Utc};
 use std::collections::HashMap;
 
+use crate::vertical::VerticalKind;
+
 #[derive(Debug, Clone)]
 pub struct Location {
     pub id: String,
@@ -9,19 +11,37 @@ pub struct Location {
     pub longitude: f64,
 }
 
+/// A vertical coordinate carried by a domain: the kind of level plus the
+/// concrete level values selected for this coverage.
+#[derive(Debug, Clone)]
+pub struct VerticalCoord {
+    pub kind: VerticalKind,
+    pub values: Vec<f64>,
+}
+
 #[derive(Debug, Clone)]
 pub enum DomainDescription {
-    /// A time series at a single point (x, y fixed, t varies).
+    /// A time series at a single point (x, y fixed, t varies). `z`, when
+    /// present, pins the series to a single vertical level.
     PointSeries {
         x: f64,
         y: f64,
         t: Vec<DateTime<Utc>>,
+        z: Option<VerticalCoord>,
     },
-    /// A regular grid, optionally with a time dimension.
+    /// A regular grid, optionally with time and vertical dimensions.
     Grid {
         x: Vec<f64>,
         y: Vec<f64>,
         t: Option<Vec<DateTime<Utc>>>,
+        z: Option<VerticalCoord>,
+    },
+    /// A vertical profile at a single point and time (x, y, t fixed, z varies).
+    VerticalProfile {
+        x: f64,
+        y: f64,
+        t: Option<DateTime<Utc>>,
+        z: VerticalCoord,
     },
 }
 
@@ -46,11 +66,13 @@ pub struct QueryResult {
     pub ranges: HashMap<String, NdArray>,
 }
 
-/// Result of an area query — either a single coverage (grid) or a collection of coverages (stations).
+/// Result of an EDR position / area / location query — either a single
+/// coverage (e.g. a Grid) or a collection of coverages (e.g. one PointSeries
+/// per station, or one VerticalProfile per timestep).
 #[derive(Debug, Clone)]
-pub enum AreaQueryResult {
-    /// A single coverage, e.g. a Grid from GeoTIFF.
+pub enum CoverageResponse {
+    /// A single coverage.
     Single(QueryResult),
-    /// Multiple coverages (one per location), e.g. PointSeries from CSV stations.
+    /// Multiple coverages, serialised as a CoverageJSON `CoverageCollection`.
     Collection(Vec<QueryResult>),
 }

--- a/crates/core/src/vertical.rs
+++ b/crates/core/src/vertical.rs
@@ -60,27 +60,32 @@ impl VerticalKind {
 
 /// A collection's single vertical axis: the kind of coordinate plus the
 /// discrete levels available for querying.
+///
+/// The label and unit are derived from [`VerticalKind`] (see
+/// [`label`](Self::label) / [`unit`](Self::unit)) so there is a single
+/// source of truth — the CoverageJSON `VerticalCRS` description and the
+/// advertised collection metadata can never disagree.
 #[derive(Debug, Clone, PartialEq)]
 pub struct VerticalDimension {
     pub kind: VerticalKind,
-    /// Human-readable axis label (e.g. `"Elevation angle"`).
-    pub label: String,
-    /// Unit symbol (e.g. `"deg"`, `"hPa"`).
-    pub unit: String,
     /// Available level values, in the engine's natural order.
     pub levels: Vec<f64>,
 }
 
 impl VerticalDimension {
-    /// Build a descriptor for `kind`, taking the label and unit from the
-    /// kind's defaults.
+    /// Build a descriptor for `kind` over the given `levels`.
     pub fn new(kind: VerticalKind, levels: Vec<f64>) -> Self {
-        Self {
-            kind,
-            label: kind.default_label().to_string(),
-            unit: kind.default_unit().to_string(),
-            levels,
-        }
+        Self { kind, levels }
+    }
+
+    /// Human-readable axis label (e.g. `"Elevation angle"`).
+    pub fn label(&self) -> &'static str {
+        self.kind.default_label()
+    }
+
+    /// Unit symbol (e.g. `"deg"`, `"hPa"`).
+    pub fn unit(&self) -> &'static str {
+        self.kind.default_unit()
     }
 
     /// The `[min, max]` extent of the available levels, or `None` when there

--- a/crates/core/src/vertical.rs
+++ b/crates/core/src/vertical.rs
@@ -1,0 +1,93 @@
+//! Shared vertical-dimension descriptor.
+//!
+//! A collection exposes at most one vertical axis (issue #185). The same
+//! [`VerticalDimension`] value is surfaced on both the Map surface
+//! (`RasterInfo`) and the EDR surface (`EdrEngine::get_vertical_extent`) so
+//! the two never diverge.
+
+/// The kind of vertical coordinate a collection's levels represent.
+///
+/// Vertical coordinates are heterogeneous in *kind*, not just value, so the
+/// kind has to be carried explicitly: WMS needs a `units=` on the
+/// `ELEVATION` dimension and CoverageJSON needs a vertical CRS in the domain
+/// `referencing`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VerticalKind {
+    /// Pressure level (hPa). Increasing value is downward.
+    Pressure,
+    /// Height above ground or mean sea level (m). Increasing value is upward.
+    Height,
+    /// Radar beam elevation angle (degrees). Increasing value is upward.
+    ElevationAngle,
+    /// Ordinal model / hybrid level. Increasing value is downward.
+    ModelLevel,
+    /// Isentropic (potential-temperature) level (K). Increasing value is upward.
+    Isentropic,
+}
+
+impl VerticalKind {
+    /// Canonical unit symbol — also the WMS `Dimension units=` value.
+    pub fn default_unit(self) -> &'static str {
+        match self {
+            VerticalKind::Pressure => "hPa",
+            VerticalKind::Height => "m",
+            VerticalKind::ElevationAngle => "deg",
+            VerticalKind::ModelLevel => "1",
+            VerticalKind::Isentropic => "K",
+        }
+    }
+
+    /// Default human-readable axis label.
+    pub fn default_label(self) -> &'static str {
+        match self {
+            VerticalKind::Pressure => "Pressure",
+            VerticalKind::Height => "Height",
+            VerticalKind::ElevationAngle => "Elevation angle",
+            VerticalKind::ModelLevel => "Model level",
+            VerticalKind::Isentropic => "Isentropic level",
+        }
+    }
+
+    /// Direction of increasing coordinate value, as used by a CoverageJSON
+    /// `VerticalCRS` coordinate-system axis.
+    pub fn direction(self) -> &'static str {
+        match self {
+            VerticalKind::Pressure | VerticalKind::ModelLevel => "down",
+            VerticalKind::Height | VerticalKind::ElevationAngle | VerticalKind::Isentropic => "up",
+        }
+    }
+}
+
+/// A collection's single vertical axis: the kind of coordinate plus the
+/// discrete levels available for querying.
+#[derive(Debug, Clone, PartialEq)]
+pub struct VerticalDimension {
+    pub kind: VerticalKind,
+    /// Human-readable axis label (e.g. `"Elevation angle"`).
+    pub label: String,
+    /// Unit symbol (e.g. `"deg"`, `"hPa"`).
+    pub unit: String,
+    /// Available level values, in the engine's natural order.
+    pub levels: Vec<f64>,
+}
+
+impl VerticalDimension {
+    /// Build a descriptor for `kind`, taking the label and unit from the
+    /// kind's defaults.
+    pub fn new(kind: VerticalKind, levels: Vec<f64>) -> Self {
+        Self {
+            kind,
+            label: kind.default_label().to_string(),
+            unit: kind.default_unit().to_string(),
+            levels,
+        }
+    }
+
+    /// The `[min, max]` extent of the available levels, or `None` when there
+    /// are no levels.
+    pub fn extent(&self) -> Option<(f64, f64)> {
+        let mut iter = self.levels.iter().copied();
+        let first = iter.next()?;
+        Some(iter.fold((first, first), |(lo, hi), v| (lo.min(v), hi.max(v))))
+    }
+}

--- a/crates/engine-csv/benches/csv_engine.rs
+++ b/crates/engine-csv/benches/csv_engine.rs
@@ -26,7 +26,7 @@ fn bench_query_location(c: &mut Criterion) {
         b.iter(|| {
             black_box(
                 engine
-                    .query_location(black_box(loc_id), None, None)
+                    .query_location(black_box(loc_id), None, None, None)
                     .unwrap(),
             )
         })
@@ -37,7 +37,7 @@ fn bench_query_location(c: &mut Criterion) {
         b.iter(|| {
             black_box(
                 engine
-                    .query_location(black_box(loc_id), None, Some(&params))
+                    .query_location(black_box(loc_id), None, Some(&params), None)
                     .unwrap(),
             )
         })
@@ -66,7 +66,13 @@ fn bench_query_area(c: &mut Criterion) {
     let coords = "POLYGON((24.0 60.0, 26.0 60.0, 26.0 61.0, 24.0 61.0, 24.0 60.0))";
 
     c.bench_function("csv_query_area", |b| {
-        b.iter(|| black_box(engine.query_area(black_box(coords), None, None).unwrap()))
+        b.iter(|| {
+            black_box(
+                engine
+                    .query_area(black_box(coords), None, None, None)
+                    .unwrap(),
+            )
+        })
     });
 }
 

--- a/crates/engine-csv/src/engine.rs
+++ b/crates/engine-csv/src/engine.rs
@@ -21,30 +21,10 @@ impl CsvEngine {
     pub fn new(store: CsvDataStore) -> Self {
         Self { store }
     }
-}
 
-impl EdrEngine for CsvEngine {
-    fn get_locations(&self) -> Result<Vec<Location>, DataServerError> {
-        let mut locations = Vec::new();
-        let mut seen = HashMap::new();
-
-        for row in &self.store.rows {
-            if seen.contains_key(&row.location) {
-                continue;
-            }
-            seen.insert(&row.location, true);
-            locations.push(Location {
-                id: row.location.clone(),
-                label: row.location.clone(),
-                latitude: row.latitude,
-                longitude: row.longitude,
-            });
-        }
-
-        Ok(locations)
-    }
-
-    fn query_location(
+    /// Build a `PointSeries` coverage for one location. Shared by
+    /// `query_location` and `query_area`.
+    fn location_series(
         &self,
         location_id: &str,
         datetime: Option<(DateTime<Utc>, DateTime<Utc>)>,
@@ -100,6 +80,7 @@ impl EdrEngine for CsvEngine {
             x: first_row.longitude,
             y: first_row.latitude,
             t: times.clone(),
+            z: None,
         };
 
         // Build parameter descriptions
@@ -153,6 +134,42 @@ impl EdrEngine for CsvEngine {
             parameters: param_descs,
             ranges,
         })
+    }
+}
+
+impl EdrEngine for CsvEngine {
+    fn get_locations(&self) -> Result<Vec<Location>, DataServerError> {
+        let mut locations = Vec::new();
+        let mut seen = HashMap::new();
+
+        for row in &self.store.rows {
+            if seen.contains_key(&row.location) {
+                continue;
+            }
+            seen.insert(&row.location, true);
+            locations.push(Location {
+                id: row.location.clone(),
+                label: row.location.clone(),
+                latitude: row.latitude,
+                longitude: row.longitude,
+            });
+        }
+
+        Ok(locations)
+    }
+
+    fn query_location(
+        &self,
+        location_id: &str,
+        datetime: Option<(DateTime<Utc>, DateTime<Utc>)>,
+        parameters: Option<&[String]>,
+        _z: Option<&[f64]>,
+    ) -> Result<CoverageResponse, DataServerError> {
+        Ok(CoverageResponse::Single(self.location_series(
+            location_id,
+            datetime,
+            parameters,
+        )?))
     }
 
     fn get_parameters(&self) -> Vec<String> {
@@ -211,7 +228,8 @@ impl EdrEngine for CsvEngine {
         coords: &str,
         datetime: Option<(DateTime<Utc>, DateTime<Utc>)>,
         parameters: Option<&[String]>,
-    ) -> Result<AreaQueryResult, DataServerError> {
+        _z: Option<&[f64]>,
+    ) -> Result<CoverageResponse, DataServerError> {
         const MAX_LOCATIONS: usize = 500;
 
         let polygon = parse_area_coords(coords)?;
@@ -247,10 +265,10 @@ impl EdrEngine for CsvEngine {
         // Build a PointSeries QueryResult for each matching location
         let mut coverages = Vec::with_capacity(matching_locations.len());
         for loc_id in &matching_locations {
-            coverages.push(self.query_location(loc_id, datetime, parameters)?);
+            coverages.push(self.location_series(loc_id, datetime, parameters)?);
         }
 
-        Ok(AreaQueryResult::Collection(coverages))
+        Ok(CoverageResponse::Collection(coverages))
     }
 
     fn get_spatial_extent(&self) -> Option<[f64; 4]> {

--- a/crates/engine-geotiff/benches/geotiff_engine.rs
+++ b/crates/engine-geotiff/benches/geotiff_engine.rs
@@ -50,7 +50,7 @@ fn bench_query_position(c: &mut Criterion) {
         b.iter(|| {
             black_box(
                 engine
-                    .query_position(black_box(coords), None, None)
+                    .query_position(black_box(coords), None, None, None)
                     .unwrap(),
             )
         })
@@ -62,13 +62,13 @@ fn bench_query_position_cached(c: &mut Criterion) {
     let coords = "POINT(25.0 60.5)";
 
     // Warm the cache
-    let _ = engine.query_position(coords, None, None);
+    let _ = engine.query_position(coords, None, None, None);
 
     c.bench_function("geotiff_query_position_cached", |b| {
         b.iter(|| {
             black_box(
                 engine
-                    .query_position(black_box(coords), None, None)
+                    .query_position(black_box(coords), None, None, None)
                     .unwrap(),
             )
         })
@@ -81,10 +81,16 @@ fn bench_query_area_small(c: &mut Criterion) {
     let coords = "POLYGON((24.5 60.0, 25.0 60.0, 25.0 60.5, 24.5 60.5, 24.5 60.0))";
 
     // Warm cache
-    let _ = engine.query_area(coords, None, None);
+    let _ = engine.query_area(coords, None, None, None);
 
     c.bench_function("geotiff_query_area_small", |b| {
-        b.iter(|| black_box(engine.query_area(black_box(coords), None, None).unwrap()))
+        b.iter(|| {
+            black_box(
+                engine
+                    .query_area(black_box(coords), None, None, None)
+                    .unwrap(),
+            )
+        })
     });
 }
 
@@ -94,10 +100,16 @@ fn bench_query_area_large(c: &mut Criterion) {
     let coords = "POLYGON((22.0 59.0, 26.0 59.0, 26.0 62.0, 22.0 62.0, 22.0 59.0))";
 
     // Warm cache
-    let _ = engine.query_area(coords, None, None);
+    let _ = engine.query_area(coords, None, None, None);
 
     c.bench_function("geotiff_query_area_large", |b| {
-        b.iter(|| black_box(engine.query_area(black_box(coords), None, None).unwrap()))
+        b.iter(|| {
+            black_box(
+                engine
+                    .query_area(black_box(coords), None, None, None)
+                    .unwrap(),
+            )
+        })
     });
 }
 

--- a/crates/engine-geotiff/benches/geotiff_remote.rs
+++ b/crates/engine-geotiff/benches/geotiff_remote.rs
@@ -73,7 +73,7 @@ fn bench_position_cache_comparison(c: &mut Criterion) {
         b.iter(|| {
             black_box(
                 engine_nocache
-                    .query_position(black_box(coords), None, None)
+                    .query_position(black_box(coords), None, None, None)
                     .unwrap(),
             )
         })
@@ -87,19 +87,19 @@ fn bench_position_cache_comparison(c: &mut Criterion) {
             let engine = load_engine(64);
             black_box(
                 engine
-                    .query_position(black_box(coords), None, None)
+                    .query_position(black_box(coords), None, None, None)
                     .unwrap(),
             )
         })
     });
 
     // With cache, warm
-    let _ = engine_cached.query_position(coords, None, None);
+    let _ = engine_cached.query_position(coords, None, None, None);
     group.bench_function("cache_warm", |b| {
         b.iter(|| {
             black_box(
                 engine_cached
-                    .query_position(black_box(coords), None, None)
+                    .query_position(black_box(coords), None, None, None)
                     .unwrap(),
             )
         })
@@ -140,7 +140,13 @@ fn bench_area_scaling(c: &mut Criterion) {
 
     for (label, coords) in &areas {
         group.bench_with_input(BenchmarkId::new("no_cache", label), coords, |b, coords| {
-            b.iter(|| black_box(engine.query_area(black_box(coords), None, None).unwrap()))
+            b.iter(|| {
+                black_box(
+                    engine
+                        .query_area(black_box(coords), None, None, None)
+                        .unwrap(),
+                )
+            })
         });
     }
 
@@ -159,7 +165,7 @@ fn bench_concurrent_position(c: &mut Criterion) {
     let coords = "POINT(25.0 60.5)";
 
     // Warm cache
-    let _ = engine.query_position(coords, None, None);
+    let _ = engine.query_position(coords, None, None, None);
 
     for concurrency in [1, 2, 4, 8, 16] {
         group.bench_with_input(
@@ -172,8 +178,13 @@ fn bench_concurrent_position(c: &mut Criterion) {
                             let eng = engine.clone();
                             std::thread::spawn(move || {
                                 black_box(
-                                    eng.query_position(black_box("POINT(25.0 60.5)"), None, None)
-                                        .unwrap(),
+                                    eng.query_position(
+                                        black_box("POINT(25.0 60.5)"),
+                                        None,
+                                        None,
+                                        None,
+                                    )
+                                    .unwrap(),
                                 )
                             })
                         })

--- a/crates/engine-geotiff/src/lib.rs
+++ b/crates/engine-geotiff/src/lib.rs
@@ -990,6 +990,7 @@ impl GeoTiffEngine {
             x: lon,
             y: lat,
             t: times,
+            z: None,
         };
 
         let mut param_descs = HashMap::new();
@@ -1122,12 +1123,14 @@ impl GeoTiffEngine {
                 x: x_values.clone(),
                 y: y_values.clone(),
                 t: Some(times),
+                z: None,
             }
         } else {
             DomainDescription::Grid {
                 x: x_values.clone(),
                 y: y_values.clone(),
                 t: None,
+                z: None,
             }
         };
 
@@ -1189,9 +1192,10 @@ impl ds_core::map_engine::MapEngine for GeoTiffEngine {
         time: Option<DateTime<Utc>>,
         output_crs: &ds_core::map_engine::OutputCrs,
         parameter: Option<&str>,
+        z: Option<f64>,
     ) -> Result<ds_core::map_engine::RasterTile, DataServerError> {
-        let _ = parameter; // GeoTIFF engine serves a single band per collection
-                           // For STAC: ensure we have items around the requested time
+        let _ = (parameter, z); // GeoTIFF engine serves a single 2-D band per collection
+                                // For STAC: ensure we have items around the requested time
         if let StoreMode::RemoteStac { ref client, .. } = self.store_mode {
             self.check_stac_circuit_breaker()?;
 
@@ -1460,6 +1464,7 @@ impl ds_core::map_engine::MapEngine for GeoTiffEngine {
             parameter: self.parameter.clone(),
             unit: self.unit.clone(),
             parameters: vec![], // single-parameter engine
+            vertical: None,     // single-layer raster, no vertical dimension
         }
     }
 }
@@ -1474,7 +1479,8 @@ impl EdrEngine for GeoTiffEngine {
         _location_id: &str,
         _datetime: Option<(DateTime<Utc>, DateTime<Utc>)>,
         _parameters: Option<&[String]>,
-    ) -> Result<QueryResult, DataServerError> {
+        _z: Option<&[f64]>,
+    ) -> Result<CoverageResponse, DataServerError> {
         Err(DataServerError::InvalidParameter(
             "GeoTIFF engine does not support named location queries. \
              Use the position query endpoint instead (e.g., /position?coords=POINT(lon lat))."
@@ -1487,9 +1493,12 @@ impl EdrEngine for GeoTiffEngine {
         coords: &str,
         datetime: Option<(DateTime<Utc>, DateTime<Utc>)>,
         parameters: Option<&[String]>,
-    ) -> Result<QueryResult, DataServerError> {
+        _z: Option<&[f64]>,
+    ) -> Result<CoverageResponse, DataServerError> {
         let (lat, lon) = parse_coords(coords)?;
-        self.query_point(lat, lon, datetime, parameters)
+        Ok(CoverageResponse::Single(
+            self.query_point(lat, lon, datetime, parameters)?,
+        ))
     }
 
     fn query_area(
@@ -1497,7 +1506,8 @@ impl EdrEngine for GeoTiffEngine {
         coords: &str,
         datetime: Option<(DateTime<Utc>, DateTime<Utc>)>,
         parameters: Option<&[String]>,
-    ) -> Result<AreaQueryResult, DataServerError> {
+        _z: Option<&[f64]>,
+    ) -> Result<CoverageResponse, DataServerError> {
         let polygon = ds_core::feature::parse_area_coords(coords)?;
 
         // Get pixel range and geo_transform for accurate per-pixel coordinates.
@@ -1534,6 +1544,7 @@ impl EdrEngine for GeoTiffEngine {
             ref x,
             ref y,
             ref t,
+            ..
         } = result.domain
         {
             let nt = t.as_ref().map_or(1, |tv| tv.len());
@@ -1572,7 +1583,7 @@ impl EdrEngine for GeoTiffEngine {
             }
         }
 
-        Ok(AreaQueryResult::Single(result))
+        Ok(CoverageResponse::Single(result))
     }
 
     fn supported_query_types(&self) -> Vec<String> {

--- a/crates/engine-grib/src/lib.rs
+++ b/crates/engine-grib/src/lib.rs
@@ -745,7 +745,8 @@ impl EdrEngine for GribEngine {
         _location_id: &str,
         _datetime: Option<(DateTime<Utc>, DateTime<Utc>)>,
         _parameters: Option<&[String]>,
-    ) -> Result<QueryResult, DataServerError> {
+        _z: Option<&[f64]>,
+    ) -> Result<CoverageResponse, DataServerError> {
         Err(DataServerError::InvalidParameter(
             "GRIB engine does not support location queries; use position or area instead"
                 .to_string(),
@@ -805,7 +806,8 @@ impl EdrEngine for GribEngine {
         coords: &str,
         datetime: Option<(DateTime<Utc>, DateTime<Utc>)>,
         parameters: Option<&[String]>,
-    ) -> Result<QueryResult, DataServerError> {
+        _z: Option<&[f64]>,
+    ) -> Result<CoverageResponse, DataServerError> {
         let (lon, lat) = parse_coords(coords)?;
         let catalog = self.catalog.load();
 
@@ -930,15 +932,16 @@ impl EdrEngine for GribEngine {
             );
         }
 
-        Ok(QueryResult {
+        Ok(CoverageResponse::Single(QueryResult {
             domain: DomainDescription::PointSeries {
                 x: lon,
                 y: lat,
                 t: valid_times,
+                z: None,
             },
             parameters: param_descs,
             ranges,
-        })
+        }))
     }
 
     fn query_area(
@@ -946,7 +949,8 @@ impl EdrEngine for GribEngine {
         coords: &str,
         datetime: Option<(DateTime<Utc>, DateTime<Utc>)>,
         parameters: Option<&[String]>,
-    ) -> Result<AreaQueryResult, DataServerError> {
+        _z: Option<&[f64]>,
+    ) -> Result<CoverageResponse, DataServerError> {
         let bbox = parse_bbox_from_wkt(coords)?;
         let (_step, step_file) = self.resolve_time(datetime)?;
 
@@ -1042,11 +1046,12 @@ impl EdrEngine for GribEngine {
             );
         }
 
-        Ok(AreaQueryResult::Single(QueryResult {
+        Ok(CoverageResponse::Single(QueryResult {
             domain: DomainDescription::Grid {
                 x: x_coords,
                 y: y_coords,
                 t: None,
+                z: None,
             },
             parameters: param_descs,
             ranges,
@@ -1067,7 +1072,9 @@ impl MapEngine for GribEngine {
         time: Option<DateTime<Utc>>,
         output_crs: &OutputCrs,
         parameter: Option<&str>,
+        z: Option<f64>,
     ) -> Result<RasterTile, DataServerError> {
+        let _ = z; // GRIB collections expose no vertical dimension yet (#185)
         let datetime = time.map(|t| (t, t));
         let (_step, step_file) = self.resolve_time(datetime)?;
 
@@ -1147,6 +1154,7 @@ impl MapEngine for GribEngine {
             parameter: default_param,
             unit: default_unit,
             parameters: params,
+            vertical: None,
         }
     }
 }

--- a/crates/engine-odim/src/edr.rs
+++ b/crates/engine-odim/src/edr.rs
@@ -36,7 +36,7 @@ use ds_core::edr_engine::EdrEngine;
 use ds_core::error::DataServerError;
 use ds_core::feature::{parse_area_coords, QueryPolygon};
 use ds_core::model::{
-    AreaQueryResult, DomainDescription, Location, NdArray, ParameterDescription, QueryResult,
+    CoverageResponse, DomainDescription, Location, NdArray, ParameterDescription, QueryResult,
 };
 
 use crate::catalog::CatalogEntry;
@@ -286,6 +286,7 @@ impl OdimEngine {
                 x: lon,
                 y: lat,
                 t: times,
+                z: None,
             },
             parameters: self.parameter_map(),
             ranges,
@@ -402,6 +403,7 @@ impl OdimEngine {
                     x: x_values,
                     y: y_values,
                     t: Some(times),
+                    z: None,
                 },
                 vec![entries.len(), ny, nx],
                 vec!["t".to_string(), "y".to_string(), "x".to_string()],
@@ -412,6 +414,7 @@ impl OdimEngine {
                     x: x_values,
                     y: y_values,
                     t: None,
+                    z: None,
                 },
                 vec![ny, nx],
                 vec!["y".to_string(), "x".to_string()],
@@ -447,7 +450,8 @@ impl EdrEngine for OdimEngine {
         _location_id: &str,
         _datetime: Option<(DateTime<Utc>, DateTime<Utc>)>,
         _parameters: Option<&[String]>,
-    ) -> Result<QueryResult, DataServerError> {
+        _z: Option<&[f64]>,
+    ) -> Result<CoverageResponse, DataServerError> {
         // An ODIM composite is a gridded field with no named
         // locations, so any location id is genuinely "not found" →
         // HTTP 404 (`LocationNotFound`), not "bad request" (400).
@@ -504,9 +508,12 @@ impl EdrEngine for OdimEngine {
         coords: &str,
         datetime: Option<(DateTime<Utc>, DateTime<Utc>)>,
         parameters: Option<&[String]>,
-    ) -> Result<QueryResult, DataServerError> {
+        _z: Option<&[f64]>,
+    ) -> Result<CoverageResponse, DataServerError> {
         let (lat, lon) = parse_point_coords(coords)?;
-        self.query_point(lat, lon, datetime, parameters)
+        Ok(CoverageResponse::Single(
+            self.query_point(lat, lon, datetime, parameters)?,
+        ))
     }
 
     fn query_area(
@@ -514,10 +521,11 @@ impl EdrEngine for OdimEngine {
         coords: &str,
         datetime: Option<(DateTime<Utc>, DateTime<Utc>)>,
         parameters: Option<&[String]>,
-    ) -> Result<AreaQueryResult, DataServerError> {
+        _z: Option<&[f64]>,
+    ) -> Result<CoverageResponse, DataServerError> {
         let polygon = parse_area_coords(coords)?;
         let result = self.query_polygon(&polygon, datetime, parameters)?;
-        Ok(AreaQueryResult::Single(result))
+        Ok(CoverageResponse::Single(result))
     }
 }
 

--- a/crates/engine-odim/src/engine.rs
+++ b/crates/engine-odim/src/engine.rs
@@ -666,6 +666,7 @@ impl MapEngine for OdimEngine {
         time: Option<DateTime<Utc>>,
         output_crs: &OutputCrs,
         _parameter: Option<&str>,
+        _z: Option<f64>,
     ) -> Result<RasterTile, DataServerError> {
         let entry = self.select_entry(time).ok_or_else(|| {
             DataServerError::Engine(format!(
@@ -753,6 +754,7 @@ impl MapEngine for OdimEngine {
             parameter: self.parameter.clone(),
             unit: self.unit.clone(),
             parameters: vec![],
+            vertical: None, // 2-D composite, no vertical dimension
         }
     }
 }

--- a/crates/engine-odim/src/volume_engine.rs
+++ b/crates/engine-odim/src/volume_engine.rs
@@ -1418,10 +1418,12 @@ fn finalize_single_site(covs: Vec<QueryResult>, levels: &Option<Vec<f64>>) -> Co
             1,
             "a single-level query must produce exactly one coverage"
         );
-        if let Some(qr) = covs.into_iter().next() {
-            return CoverageResponse::Single(qr);
-        }
-        return CoverageResponse::Collection(Vec::new());
+        return covs
+            .into_iter()
+            .next()
+            .map_or(CoverageResponse::Collection(Vec::new()), |qr| {
+                CoverageResponse::Single(qr)
+            });
     }
     CoverageResponse::Collection(covs)
 }

--- a/crates/engine-odim/src/volume_engine.rs
+++ b/crates/engine-odim/src/volume_engine.rs
@@ -58,8 +58,10 @@ use ds_core::error::DataServerError;
 use ds_core::feature::{parse_area_coords, parse_point_coords};
 use ds_core::map_engine::{MapEngine, OutputCrs, RasterInfo, RasterTile};
 use ds_core::model::{
-    AreaQueryResult, DomainDescription, Location, NdArray, ParameterDescription, QueryResult,
+    CoverageResponse, DomainDescription, Location, NdArray, ParameterDescription, QueryResult,
+    VerticalCoord,
 };
+use ds_core::vertical::{VerticalDimension, VerticalKind};
 use tokio::sync::Notify;
 
 use ds_storage::discovery::{expand_prefix_for_dates, expand_prefix_pattern, TimeWindow};
@@ -276,6 +278,16 @@ struct Catalog {
     times: Vec<DateTime<Utc>>,
     /// Union of per-site coverage bboxes `[w, s, e, n]` in WGS84.
     spatial_extent: Option<[f64; 4]>,
+    /// The collection's vertical axis — elevation angle (degrees), the
+    /// union of every site's sweep angles. `None` until the catalog has
+    /// at least one volume.
+    vertical: Option<VerticalDimension>,
+}
+
+/// Round an elevation angle to 0.1° so near-identical sweep angles from
+/// different sites or volumes collapse to one catalogue level.
+fn round_elevation(deg: f64) -> f64 {
+    (deg * 10.0).round() / 10.0
 }
 
 /// WGS84 bounding box `[w, s, e, n]` of the circular coverage area of
@@ -682,12 +694,25 @@ fn derive_catalog(
         });
     }
 
+    // Vertical axis: the union of every site's sweep elevation angles
+    // (from each site's most-recent volume), rounded and sorted ascending.
+    let mut levels: Vec<f64> = by_site
+        .values()
+        .filter_map(|list| list.last())
+        .flat_map(|e| e.volume.sweeps.iter().map(|s| round_elevation(s.elangle)))
+        .collect();
+    levels.sort_by(f64::total_cmp);
+    levels.dedup();
+    let vertical =
+        (!levels.is_empty()).then(|| VerticalDimension::new(VerticalKind::ElevationAngle, levels));
+
     Catalog {
         by_site,
         parameters,
         quantities,
         times,
         spatial_extent,
+        vertical,
     }
 }
 
@@ -941,6 +966,16 @@ fn sample_sweep_moment(
     )
 }
 
+/// The sweep whose elevation angle is nearest `target` degrees. `None`
+/// only when the volume has no sweeps.
+fn nearest_sweep(volume: &PolarVolume, target: f64) -> Option<&Sweep> {
+    volume.sweeps.iter().min_by(|a, b| {
+        (a.elangle - target)
+            .abs()
+            .total_cmp(&(b.elangle - target).abs())
+    })
+}
+
 /// Resample one polar moment of a sweep into a Cartesian output grid.
 ///
 /// `bbox` is `[west, south, east, north]` in WGS84 degrees. For
@@ -960,6 +995,9 @@ fn sample_sweep_moment(
 /// 4⁄3-Earth ground-range correction is deferred — for the lowest
 /// elevation sweep this M2 interim, the near-horizon geometry keeps the
 /// slant-vs-ground discrepancy small.
+///
+/// `z` selects the elevation sweep: `Some(angle)` renders the sweep
+/// nearest that angle, `None` renders the lowest sweep.
 fn polar_sample(
     volume: &PolarVolume,
     quantity: &str,
@@ -967,9 +1005,14 @@ fn polar_sample(
     width: u32,
     height: u32,
     output_crs: &OutputCrs,
+    z: Option<f64>,
 ) -> Result<RasterTile, DataServerError> {
-    // Lowest elevation sweep — M1 sorts `sweeps` ascending by elangle.
-    let sweep = volume.sweeps.first().ok_or_else(|| {
+    // M1 sorts `sweeps` ascending by elangle, so `first()` is the lowest.
+    let sweep = match z {
+        Some(target) => nearest_sweep(volume, target),
+        None => volume.sweeps.first(),
+    }
+    .ok_or_else(|| {
         DataServerError::Engine(format!(
             "PVOL site `{}` has no elevation sweeps",
             volume.site.nod.as_deref().unwrap_or("?")
@@ -1048,6 +1091,7 @@ impl MapEngine for PolarVolumeEngine {
         time: Option<DateTime<Utc>>,
         output_crs: &OutputCrs,
         parameter: Option<&str>,
+        z: Option<f64>,
     ) -> Result<RasterTile, DataServerError> {
         // A PVOL collection is inherently multi-parameter — the caller
         // must name a `<nod>:<quantity>` layer.
@@ -1089,7 +1133,7 @@ impl MapEngine for PolarVolumeEngine {
             ))
         })?;
 
-        polar_sample(&entry.volume, quantity, bbox, width, height, output_crs)
+        polar_sample(&entry.volume, quantity, bbox, width, height, output_crs, z)
     }
 
     fn raster_info(&self) -> RasterInfo {
@@ -1110,6 +1154,7 @@ impl MapEngine for PolarVolumeEngine {
             // constant, so leave it blank.
             unit: String::new(),
             parameters,
+            vertical: catalog.vertical.clone(),
         }
     }
 }
@@ -1145,40 +1190,13 @@ fn nearest_site(catalog: &Catalog, lon: f64, lat: f64) -> Option<&str> {
         .map(|(nod, _)| nod)
 }
 
-/// Build a `PointSeries` coverage for one radar site: sample the lowest
-/// sweep of every volume in `volumes` (time-sorted) at WGS84
-/// `(lon, lat)` — one value per quantity per timestep.
-///
-/// `(lon, lat)` is both the coverage's domain point and the sample
-/// point: for a location query it is the radar site itself; for a
-/// position query it is the requested point against the nearest site.
-///
-/// **M3a interim** — only the lowest elevation sweep is sampled. The
-/// vertical (`z`) dimension that turns a no-`z` query into a profile
-/// across all sweeps arrives with M3b (#185).
-fn build_site_point_series(
-    volumes: &[VolumeEntry],
-    lon: f64,
-    lat: f64,
-    datetime: Option<(DateTime<Utc>, DateTime<Utc>)>,
+/// Resolve the quantity set for a PVOL site query: the lowest sweep's
+/// moments of the most recent selected volume (stable across a site's
+/// volumes), intersected with the optional `parameters` filter.
+fn resolve_quantities(
+    selected: &[&VolumeEntry],
     parameters: Option<&[String]>,
-) -> Result<QueryResult, DataServerError> {
-    let selected: Vec<&VolumeEntry> = match datetime {
-        Some((start, end)) => volumes
-            .iter()
-            .filter(|e| e.volume.time >= start && e.volume.time <= end)
-            .collect(),
-        None => volumes.iter().collect(),
-    };
-    if selected.is_empty() {
-        return Err(DataServerError::LocationNotFound(
-            "No PVOL data available for the requested time range".into(),
-        ));
-    }
-
-    // The lowest sweep of the most recent volume defines the available
-    // quantity set (stable across a site's volumes); intersect it with
-    // the optional `parameters` filter.
+) -> Result<Vec<String>, DataServerError> {
     let available: Vec<String> = selected
         .last()
         .and_then(|e| e.volume.sweeps.first())
@@ -1196,16 +1214,93 @@ fn build_site_point_series(
             "No requested parameter is available at this PVOL site".into(),
         ));
     }
+    Ok(quantities)
+}
 
-    let times: Vec<DateTime<Utc>> = selected.iter().map(|e| e.volume.time).collect();
+/// Snap requested elevation angles to the catalog's canonical sweep-angle
+/// set, dropping duplicates while preserving request order.
+fn snap_levels(requested: &[f64], canonical: &[f64]) -> Vec<f64> {
+    let mut out: Vec<f64> = Vec::new();
+    for &want in requested {
+        if let Some(&lvl) = canonical
+            .iter()
+            .min_by(|a, b| (**a - want).abs().total_cmp(&(**b - want).abs()))
+        {
+            if !out.contains(&lvl) {
+                out.push(lvl);
+            }
+        }
+    }
+    out
+}
+
+/// One `VerticalProfile` coverage: every elevation sweep of `entry`'s
+/// volume sampled at WGS84 `(lon, lat)`, with the sweep angles as the
+/// `z` axis.
+fn volume_profile(entry: &VolumeEntry, lon: f64, lat: f64, quantities: &[String]) -> QueryResult {
+    let levels: Vec<f64> = entry
+        .volume
+        .sweeps
+        .iter()
+        .map(|s| round_elevation(s.elangle))
+        .collect();
+    let (site_lon, site_lat) = (entry.volume.site.lon, entry.volume.site.lat);
 
     let mut ranges = HashMap::new();
     let mut param_descs = HashMap::new();
-    for quantity in &quantities {
+    for quantity in quantities {
+        let values: Vec<Option<f64>> = entry
+            .volume
+            .sweeps
+            .iter()
+            .map(|sweep| {
+                let moment = sweep.moments.iter().find(|m| &m.quantity == quantity)?;
+                sample_sweep_moment(sweep, moment, site_lon, site_lat, lon, lat)
+            })
+            .collect();
+        ranges.insert(
+            quantity.clone(),
+            NdArray {
+                shape: vec![levels.len()],
+                axis_names: vec!["z".to_string()],
+                values,
+            },
+        );
+        param_descs.insert(quantity.clone(), quantity_description(quantity));
+    }
+
+    QueryResult {
+        domain: DomainDescription::VerticalProfile {
+            x: lon,
+            y: lat,
+            t: Some(entry.volume.time),
+            z: VerticalCoord {
+                kind: VerticalKind::ElevationAngle,
+                values: levels,
+            },
+        },
+        parameters: param_descs,
+        ranges,
+    }
+}
+
+/// One `PointSeries` coverage pinned to elevation angle `level`: the
+/// sweep nearest `level` in each selected volume, sampled at `(lon, lat)`.
+fn level_series(
+    selected: &[&VolumeEntry],
+    lon: f64,
+    lat: f64,
+    level: f64,
+    quantities: &[String],
+    times: &[DateTime<Utc>],
+) -> QueryResult {
+    let mut ranges = HashMap::new();
+    let mut param_descs = HashMap::new();
+    for quantity in quantities {
         let values: Vec<Option<f64>> = selected
             .iter()
             .map(|e| {
-                let sweep = e.volume.sweeps.first()?;
+                let sweep = nearest_sweep(&e.volume, level)?;
                 let moment = sweep.moments.iter().find(|m| &m.quantity == quantity)?;
                 sample_sweep_moment(
                     sweep,
@@ -1228,15 +1323,100 @@ fn build_site_point_series(
         param_descs.insert(quantity.clone(), quantity_description(quantity));
     }
 
-    Ok(QueryResult {
+    QueryResult {
         domain: DomainDescription::PointSeries {
             x: lon,
             y: lat,
-            t: times,
+            t: times.to_vec(),
+            z: Some(VerticalCoord {
+                kind: VerticalKind::ElevationAngle,
+                values: vec![level],
+            }),
         },
         parameters: param_descs,
         ranges,
-    })
+    }
+}
+
+/// Build the EDR coverages for one radar site at WGS84 `(lon, lat)`.
+///
+/// `(lon, lat)` is both the coverage's domain point and the sample
+/// point: for a location query it is the radar site itself; for a
+/// position query it is the requested point against the nearest site.
+///
+/// With `levels = None` the result is one `VerticalProfile` per timestep
+/// (reflectivity vs. elevation angle); with `levels = Some(..)` it is one
+/// `PointSeries` per requested level (a time series at that sweep).
+fn site_coverages(
+    volumes: &[VolumeEntry],
+    lon: f64,
+    lat: f64,
+    datetime: Option<(DateTime<Utc>, DateTime<Utc>)>,
+    parameters: Option<&[String]>,
+    levels: Option<&[f64]>,
+) -> Result<Vec<QueryResult>, DataServerError> {
+    let selected: Vec<&VolumeEntry> = match datetime {
+        Some((start, end)) => volumes
+            .iter()
+            .filter(|e| e.volume.time >= start && e.volume.time <= end)
+            .collect(),
+        None => volumes.iter().collect(),
+    };
+    if selected.is_empty() {
+        return Err(DataServerError::LocationNotFound(
+            "No PVOL data available for the requested time range".into(),
+        ));
+    }
+
+    let quantities = resolve_quantities(&selected, parameters)?;
+
+    match levels {
+        None => Ok(selected
+            .iter()
+            .map(|e| volume_profile(e, lon, lat, &quantities))
+            .collect()),
+        Some(lvls) => {
+            let times: Vec<DateTime<Utc>> = selected.iter().map(|e| e.volume.time).collect();
+            Ok(lvls
+                .iter()
+                .map(|&lvl| level_series(&selected, lon, lat, lvl, &quantities, &times))
+                .collect())
+        }
+    }
+}
+
+/// Resolve a requested EDR `z` selector against the catalog's vertical
+/// axis. `None` (or an empty selector) means "every level — a profile".
+fn resolve_levels(
+    catalog: &Catalog,
+    z: Option<&[f64]>,
+) -> Result<Option<Vec<f64>>, DataServerError> {
+    let Some(zs) = z.filter(|s| !s.is_empty()) else {
+        return Ok(None);
+    };
+    let canonical = catalog
+        .vertical
+        .as_ref()
+        .map(|v| v.levels.as_slice())
+        .ok_or_else(|| {
+            DataServerError::InvalidParameter(
+                "this PVOL collection has no elevation sweeps to select with `z`".into(),
+            )
+        })?;
+    let snapped = snap_levels(zs, canonical);
+    Ok((!snapped.is_empty()).then_some(snapped))
+}
+
+/// Wrap one site's coverages: a request pinned to exactly one level is a
+/// single `PointSeries` (`Single`); every other shape is a `Collection`.
+fn finalize_single_site(covs: Vec<QueryResult>, levels: &Option<Vec<f64>>) -> CoverageResponse {
+    if matches!(levels, Some(l) if l.len() == 1) {
+        if let Some(qr) = covs.into_iter().next() {
+            return CoverageResponse::Single(qr);
+        }
+        return CoverageResponse::Collection(Vec::new());
+    }
+    CoverageResponse::Collection(covs)
 }
 
 impl EdrEngine for PolarVolumeEngine {
@@ -1261,14 +1441,16 @@ impl EdrEngine for PolarVolumeEngine {
         Ok(locations)
     }
 
-    /// Query one radar site by NOD code — a `PointSeries` of every
-    /// quantity at the site, sampled from the lowest sweep.
+    /// Query one radar site by NOD code. With no `z` the result is a
+    /// `CoverageCollection` of `VerticalProfile`s (one per timestep);
+    /// with `z` it is a `PointSeries` per selected elevation sweep.
     fn query_location(
         &self,
         location_id: &str,
         datetime: Option<(DateTime<Utc>, DateTime<Utc>)>,
         parameters: Option<&[String]>,
-    ) -> Result<QueryResult, DataServerError> {
+        z: Option<&[f64]>,
+    ) -> Result<CoverageResponse, DataServerError> {
         let catalog = self.catalog.load();
         let volumes = catalog
             .by_site
@@ -1281,11 +1463,24 @@ impl EdrEngine for PolarVolumeEngine {
             .ok_or_else(|| DataServerError::LocationNotFound(location_id.to_string()))?
             .volume
             .site;
-        build_site_point_series(volumes, site.lon, site.lat, datetime, parameters)
+        let levels = resolve_levels(&catalog, z)?;
+        let covs = site_coverages(
+            volumes,
+            site.lon,
+            site.lat,
+            datetime,
+            parameters,
+            levels.as_deref(),
+        )?;
+        Ok(finalize_single_site(covs, &levels))
     }
 
     fn get_parameters(&self) -> Vec<String> {
         self.catalog.load().quantities.clone()
+    }
+
+    fn get_vertical_extent(&self) -> Option<VerticalDimension> {
+        self.catalog.load().vertical.clone()
     }
 
     fn get_temporal_extent(&self) -> Option<(DateTime<Utc>, DateTime<Utc>)> {
@@ -1313,14 +1508,15 @@ impl EdrEngine for PolarVolumeEngine {
         ]
     }
 
-    /// Position query — a `PointSeries` sampled from the radar site
-    /// nearest the requested point.
+    /// Position query against the radar site nearest the requested
+    /// point — same `z`-driven shape as [`query_location`].
     fn query_position(
         &self,
         coords: &str,
         datetime: Option<(DateTime<Utc>, DateTime<Utc>)>,
         parameters: Option<&[String]>,
-    ) -> Result<QueryResult, DataServerError> {
+        z: Option<&[f64]>,
+    ) -> Result<CoverageResponse, DataServerError> {
         let (lat, lon) = parse_point_coords(coords)?;
         let catalog = self.catalog.load();
         let nod = nearest_site(&catalog, lon, lat).ok_or_else(|| {
@@ -1332,19 +1528,24 @@ impl EdrEngine for PolarVolumeEngine {
         let volumes = catalog.by_site.get(nod).ok_or_else(|| {
             DataServerError::Engine("internal: nearest_site returned a missing by_site key".into())
         })?;
-        build_site_point_series(volumes, lon, lat, datetime, parameters)
+        let levels = resolve_levels(&catalog, z)?;
+        let covs = site_coverages(volumes, lon, lat, datetime, parameters, levels.as_deref())?;
+        Ok(finalize_single_site(covs, &levels))
     }
 
-    /// Area query — a `CoverageCollection` of one `PointSeries` per
-    /// radar site whose antenna falls inside the polygon.
+    /// Area query — a `CoverageCollection` flattening every in-polygon
+    /// radar site's coverages (a `VerticalProfile` per timestep with no
+    /// `z`, a `PointSeries` per level with `z`).
     fn query_area(
         &self,
         coords: &str,
         datetime: Option<(DateTime<Utc>, DateTime<Utc>)>,
         parameters: Option<&[String]>,
-    ) -> Result<AreaQueryResult, DataServerError> {
+        z: Option<&[f64]>,
+    ) -> Result<CoverageResponse, DataServerError> {
         let polygon = parse_area_coords(coords)?;
         let catalog = self.catalog.load();
+        let levels = resolve_levels(&catalog, z)?;
 
         // Stable, sorted iteration so the collection order is
         // deterministic across requests.
@@ -1360,8 +1561,15 @@ impl EdrEngine for PolarVolumeEngine {
             if !polygon.contains(site.lon, site.lat) {
                 continue;
             }
-            match build_site_point_series(volumes, site.lon, site.lat, datetime, parameters) {
-                Ok(qr) => coverages.push(qr),
+            match site_coverages(
+                volumes,
+                site.lon,
+                site.lat,
+                datetime,
+                parameters,
+                levels.as_deref(),
+            ) {
+                Ok(covs) => coverages.extend(covs),
                 // A site inside the polygon is skipped — not fatal to
                 // the whole area query — when it has no data in the
                 // requested window (`LocationNotFound`) or none of the
@@ -1381,7 +1589,7 @@ impl EdrEngine for PolarVolumeEngine {
                 "No radar sites with data found within the requested area".into(),
             ));
         }
-        Ok(AreaQueryResult::Collection(coverages))
+        Ok(CoverageResponse::Collection(coverages))
     }
 }
 
@@ -1486,7 +1694,7 @@ mod tests {
             site_lon + dlon_50km,
             site_lat + 0.001,
         ];
-        let tile = polar_sample(&vol, "DBZH", bbox, 50, 1, &OutputCrs::Wgs84).unwrap();
+        let tile = polar_sample(&vol, "DBZH", bbox, 50, 1, &OutputCrs::Wgs84, None).unwrap();
 
         assert_eq!(tile.values.len(), 50);
         // Leftmost pixel ≈ at the site → bin 0.
@@ -1519,7 +1727,7 @@ mod tests {
             site_lon + dlon + 0.01,
             site_lat + 0.001,
         ];
-        let tile = polar_sample(&vol, "DBZH", bbox, 4, 1, &OutputCrs::Wgs84).unwrap();
+        let tile = polar_sample(&vol, "DBZH", bbox, 4, 1, &OutputCrs::Wgs84, None).unwrap();
         assert!(
             tile.values.iter().all(Option::is_none),
             "pixels past max range must be None"
@@ -1538,6 +1746,7 @@ mod tests {
             4,
             4,
             &OutputCrs::Wgs84,
+            None,
         ) {
             Err(DataServerError::InvalidParameter(_)) => {}
             Err(other) => panic!("expected InvalidParameter, got {other:?}"),
@@ -1695,43 +1904,72 @@ mod tests {
         }
     }
 
-    /// `build_site_point_series` yields a `PointSeries` at the queried
-    /// point, with one time-aligned range per quantity.
+    /// With a pinned `z` level, `site_coverages` yields one `PointSeries`
+    /// at the queried point, with one time-aligned range per quantity.
     #[test]
-    fn build_site_point_series_yields_point_series() {
+    fn site_coverages_level_yields_point_series() {
         let (site_lon, site_lat) = (25.0, 60.0);
         let volumes = vec![entry(synthetic_volume(site_lon, site_lat), "v0")];
         // 10.5 km due east — safely mid-bin 10 of the 1 km-spaced sweep,
         // so the sampled bin index is robust against rounding.
         let dlon = 10_500.0 / (EARTH_RADIUS_M * site_lat.to_radians().cos()) * 180.0
             / std::f64::consts::PI;
-        let result =
-            build_site_point_series(&volumes, site_lon + dlon, site_lat, None, None).unwrap();
-        match result.domain {
-            DomainDescription::PointSeries { x, y, t } => {
+        let covs = site_coverages(
+            &volumes,
+            site_lon + dlon,
+            site_lat,
+            None,
+            None,
+            Some(&[0.5]),
+        )
+        .unwrap();
+        assert_eq!(covs.len(), 1);
+        match &covs[0].domain {
+            DomainDescription::PointSeries { x, y, t, z } => {
                 assert!((x - (site_lon + dlon)).abs() < 1e-9);
                 assert!((y - site_lat).abs() < 1e-9);
                 assert_eq!(t.len(), 1);
+                assert_eq!(z.as_ref().expect("z axis").values, vec![0.5]);
             }
             _ => panic!("expected PointSeries"),
         }
-        let dbzh = result.ranges.get("DBZH").expect("DBZH range");
+        let dbzh = covs[0].ranges.get("DBZH").expect("DBZH range");
         assert_eq!(dbzh.shape, vec![1]);
         assert_eq!(dbzh.axis_names, vec!["t".to_string()]);
         // raw[ray][bin] = bin, gain 1 → the sampled value is the bin
         // index, i.e. ground distance / 1 km.
         assert_eq!(dbzh.values[0], Some(10.0));
-        assert!(result.parameters.contains_key("DBZH"));
+        assert!(covs[0].parameters.contains_key("DBZH"));
+    }
+
+    /// With no `z`, `site_coverages` yields one `VerticalProfile` per
+    /// timestep, with the sweep angles as the `z` axis.
+    #[test]
+    fn site_coverages_no_z_yields_vertical_profile() {
+        let (site_lon, site_lat) = (25.0, 60.0);
+        let volumes = vec![entry(synthetic_volume(site_lon, site_lat), "v0")];
+        let covs = site_coverages(&volumes, site_lon, site_lat, None, None, None).unwrap();
+        assert_eq!(covs.len(), 1);
+        match &covs[0].domain {
+            DomainDescription::VerticalProfile { z, .. } => {
+                assert_eq!(z.values, vec![0.5]);
+            }
+            _ => panic!("expected VerticalProfile"),
+        }
+        assert_eq!(
+            covs[0].ranges.get("DBZH").expect("DBZH range").shape,
+            vec![1]
+        );
     }
 
     /// An out-of-window `datetime` range yields `LocationNotFound`.
     #[test]
-    fn build_site_point_series_empty_window_errors() {
+    fn site_coverages_empty_window_errors() {
         let volumes = vec![entry(synthetic_volume(25.0, 60.0), "v0")];
         let past = DateTime::parse_from_rfc3339("2000-01-01T00:00:00Z")
             .unwrap()
             .with_timezone(&Utc);
-        match build_site_point_series(&volumes, 25.0, 60.0, Some((past, past)), None) {
+        match site_coverages(&volumes, 25.0, 60.0, Some((past, past)), None, None) {
             Err(DataServerError::LocationNotFound(_)) => {}
             other => panic!("expected LocationNotFound, got {other:?}"),
         }
@@ -1739,10 +1977,10 @@ mod tests {
 
     /// A `parameters` filter naming no real quantity is rejected.
     #[test]
-    fn build_site_point_series_unknown_parameter_errors() {
+    fn site_coverages_unknown_parameter_errors() {
         let volumes = vec![entry(synthetic_volume(25.0, 60.0), "v0")];
         let filter = ["NONESUCH".to_string()];
-        match build_site_point_series(&volumes, 25.0, 60.0, None, Some(&filter)) {
+        match site_coverages(&volumes, 25.0, 60.0, None, Some(&filter), None) {
             Err(DataServerError::InvalidParameter(_)) => {}
             other => panic!("expected InvalidParameter, got {other:?}"),
         }
@@ -1766,6 +2004,7 @@ mod tests {
             quantities: vec![],
             times: vec![],
             spatial_extent: None,
+            vertical: None,
         };
         assert_eq!(nearest_site(&catalog, 29.0, 60.0), Some("east"));
         assert_eq!(nearest_site(&catalog, 21.0, 60.0), Some("west"));
@@ -1780,6 +2019,7 @@ mod tests {
             quantities: vec![],
             times: vec![],
             spatial_extent: None,
+            vertical: None,
         };
         assert_eq!(nearest_site(&catalog, 25.0, 60.0), None);
     }

--- a/crates/engine-odim/src/volume_engine.rs
+++ b/crates/engine-odim/src/volume_engine.rs
@@ -1411,6 +1411,13 @@ fn resolve_levels(
 /// single `PointSeries` (`Single`); every other shape is a `Collection`.
 fn finalize_single_site(covs: Vec<QueryResult>, levels: &Option<Vec<f64>>) -> CoverageResponse {
     if matches!(levels, Some(l) if l.len() == 1) {
+        // `site_coverages` builds exactly one coverage per requested
+        // level, so a single-level request always yields exactly one.
+        debug_assert_eq!(
+            covs.len(),
+            1,
+            "a single-level query must produce exactly one coverage"
+        );
         if let Some(qr) = covs.into_iter().next() {
             return CoverageResponse::Single(qr);
         }

--- a/crates/engine-odim/src/volume_engine.rs
+++ b/crates/engine-odim/src/volume_engine.rs
@@ -1409,19 +1409,26 @@ fn resolve_levels(
 
 /// Wrap one site's coverages: a request pinned to exactly one level is a
 /// single `PointSeries` (`Single`); every other shape is a `Collection`.
-fn finalize_single_site(covs: Vec<QueryResult>, levels: &Option<Vec<f64>>) -> CoverageResponse {
+fn finalize_single_site(
+    covs: Vec<QueryResult>,
+    levels: &Option<Vec<f64>>,
+) -> Result<CoverageResponse, DataServerError> {
     if matches!(levels, Some(l) if l.len() == 1) {
         // `site_coverages` builds exactly one coverage per requested
-        // level, so a single-level request yields exactly one. `expect`
-        // (not `debug_assert`) so a future contract violation fails
-        // loudly in release rather than silently returning no data.
-        return CoverageResponse::Single(
-            covs.into_iter()
-                .next()
-                .expect("a single-level query must produce exactly one coverage"),
-        );
+        // level, so a single-level request yields exactly one. A missing
+        // coverage would be an internal invariant violation — surface it
+        // as a logged 500, not an opaque `spawn_blocking` panic.
+        return covs
+            .into_iter()
+            .next()
+            .map(CoverageResponse::Single)
+            .ok_or_else(|| {
+                DataServerError::Engine(
+                    "internal: single-level query produced no coverage (invariant violated)".into(),
+                )
+            });
     }
-    CoverageResponse::Collection(covs)
+    Ok(CoverageResponse::Collection(covs))
 }
 
 impl EdrEngine for PolarVolumeEngine {
@@ -1477,7 +1484,7 @@ impl EdrEngine for PolarVolumeEngine {
             parameters,
             levels.as_deref(),
         )?;
-        Ok(finalize_single_site(covs, &levels))
+        finalize_single_site(covs, &levels)
     }
 
     fn get_parameters(&self) -> Vec<String> {
@@ -1535,7 +1542,7 @@ impl EdrEngine for PolarVolumeEngine {
         })?;
         let levels = resolve_levels(&catalog, z)?;
         let covs = site_coverages(volumes, lon, lat, datetime, parameters, levels.as_deref())?;
-        Ok(finalize_single_site(covs, &levels))
+        finalize_single_site(covs, &levels)
     }
 
     /// Area query — a `CoverageCollection` flattening every in-polygon

--- a/crates/engine-odim/src/volume_engine.rs
+++ b/crates/engine-odim/src/volume_engine.rs
@@ -1190,18 +1190,27 @@ fn nearest_site(catalog: &Catalog, lon: f64, lat: f64) -> Option<&str> {
         .map(|(nod, _)| nod)
 }
 
-/// Resolve the quantity set for a PVOL site query: the lowest sweep's
-/// moments of the most recent selected volume (stable across a site's
-/// volumes), intersected with the optional `parameters` filter.
+/// Resolve the quantity set for a PVOL site query: the union of every
+/// sweep's moments in the most recent selected volume — a profile
+/// samples all sweeps, and a quantity may be present only on higher
+/// elevations (e.g. dual-PRF `VRADH`/`WRADH`) — intersected with the
+/// optional `parameters` filter.
 fn resolve_quantities(
     selected: &[&VolumeEntry],
     parameters: Option<&[String]>,
 ) -> Result<Vec<String>, DataServerError> {
-    let available: Vec<String> = selected
+    let mut available: Vec<String> = selected
         .last()
-        .and_then(|e| e.volume.sweeps.first())
-        .map(|s| s.moments.iter().map(|m| m.quantity.clone()).collect())
+        .map(|e| {
+            e.volume
+                .sweeps
+                .iter()
+                .flat_map(|s| s.moments.iter().map(|m| m.quantity.clone()))
+                .collect()
+        })
         .unwrap_or_default();
+    available.sort();
+    available.dedup();
     let quantities: Vec<String> = match parameters {
         Some(req) => available
             .into_iter()

--- a/crates/engine-odim/src/volume_engine.rs
+++ b/crates/engine-odim/src/volume_engine.rs
@@ -1412,18 +1412,14 @@ fn resolve_levels(
 fn finalize_single_site(covs: Vec<QueryResult>, levels: &Option<Vec<f64>>) -> CoverageResponse {
     if matches!(levels, Some(l) if l.len() == 1) {
         // `site_coverages` builds exactly one coverage per requested
-        // level, so a single-level request always yields exactly one.
-        debug_assert_eq!(
-            covs.len(),
-            1,
-            "a single-level query must produce exactly one coverage"
+        // level, so a single-level request yields exactly one. `expect`
+        // (not `debug_assert`) so a future contract violation fails
+        // loudly in release rather than silently returning no data.
+        return CoverageResponse::Single(
+            covs.into_iter()
+                .next()
+                .expect("a single-level query must produce exactly one coverage"),
         );
-        return covs
-            .into_iter()
-            .next()
-            .map_or(CoverageResponse::Collection(Vec::new()), |qr| {
-                CoverageResponse::Single(qr)
-            });
     }
     CoverageResponse::Collection(covs)
 }

--- a/crates/engine-odim/tests/integration.rs
+++ b/crates/engine-odim/tests/integration.rs
@@ -14,7 +14,7 @@ use std::path::Path;
 use ds_core::config::OdimConfig;
 use ds_core::edr_engine::EdrEngine;
 use ds_core::map_engine::{MapEngine, OutputCrs};
-use ds_core::model::{AreaQueryResult, DomainDescription};
+use ds_core::model::{CoverageResponse, DomainDescription};
 
 /// Construct an `OdimEngine` over `testdata/odim-dmi-fixture.h5`
 /// (a real DMI v2.0 ODIM_H5 composite shipped in this repo). Returns
@@ -119,6 +119,7 @@ fn get_raster_tile_over_denmark_renders() {
             None,
             &OutputCrs::Wgs84,
             None,
+            None,
         )
         .expect("render succeeds");
 
@@ -143,6 +144,7 @@ fn get_raster_tile_in_web_mercator_renders() {
             None,
             &OutputCrs::WebMercator,
             None,
+            None,
         )
         .expect("Mercator render succeeds");
 
@@ -166,7 +168,7 @@ fn get_raster_tile_full_extent_does_not_panic() {
     let bbox = info.spatial_extent.expect("fixture has spatial extent");
 
     let tile = engine
-        .get_raster_tile(bbox, 32, 32, None, &OutputCrs::Wgs84, None)
+        .get_raster_tile(bbox, 32, 32, None, &OutputCrs::Wgs84, None, None)
         .expect("full-extent render succeeds");
 
     assert_eq!(tile.values.len(), 32 * 32);
@@ -207,7 +209,7 @@ fn edr_metadata_is_consistent() {
     // ODIM has no station list — locations is empty, query_location
     // is unsupported.
     assert!(engine.get_locations().unwrap().is_empty());
-    assert!(engine.query_location("anything", None, None).is_err());
+    assert!(engine.query_location("anything", None, None, None).is_err());
 }
 
 /// `query_position` over central Denmark returns a `PointSeries`
@@ -217,12 +219,16 @@ fn edr_metadata_is_consistent() {
 #[test]
 fn edr_query_position_returns_point_series() {
     let (engine, _guard) = dmi_engine();
-    let result = engine
-        .query_position("POINT(10.5 56.0)", None, None)
+    let response = engine
+        .query_position("POINT(10.5 56.0)", None, None, None)
         .expect("position query succeeds");
+    let result = match response {
+        CoverageResponse::Single(qr) => qr,
+        CoverageResponse::Collection(_) => panic!("a no-vertical COMP query must return Single"),
+    };
 
     match result.domain {
-        DomainDescription::PointSeries { x, y, ref t } => {
+        DomainDescription::PointSeries { x, y, ref t, .. } => {
             assert_eq!((x, y), (10.5, 56.0));
             assert_eq!(t.len(), 1);
         }
@@ -243,9 +249,13 @@ fn edr_query_position_returns_point_series() {
 #[test]
 fn edr_query_position_off_grid_is_none() {
     let (engine, _guard) = dmi_engine();
-    let result = engine
-        .query_position("POINT(-140.0 12.0)", None, None)
+    let response = engine
+        .query_position("POINT(-140.0 12.0)", None, None, None)
         .expect("off-grid position query still succeeds");
+    let result = match response {
+        CoverageResponse::Single(qr) => qr,
+        CoverageResponse::Collection(_) => panic!("expected Single"),
+    };
     let range = &result.ranges["reflectivity"];
     assert_eq!(range.values, vec![None]);
 }
@@ -255,7 +265,12 @@ fn edr_query_position_off_grid_is_none() {
 fn edr_query_position_rejects_unknown_parameter() {
     let (engine, _guard) = dmi_engine();
     let err = engine
-        .query_position("POINT(10.5 56.0)", None, Some(&["temperature".to_string()]))
+        .query_position(
+            "POINT(10.5 56.0)",
+            None,
+            Some(&["temperature".to_string()]),
+            None,
+        )
         .unwrap_err();
     assert!(format!("{err}").contains("Unknown parameter"));
 }
@@ -267,12 +282,12 @@ fn edr_query_position_rejects_unknown_parameter() {
 fn edr_query_area_returns_grid() {
     let (engine, _guard) = dmi_engine();
     let result = engine
-        .query_area("9.0,55.0,12.0,57.5", None, None)
+        .query_area("9.0,55.0,12.0,57.5", None, None, None)
         .expect("area query succeeds");
 
     let coverage = match result {
-        AreaQueryResult::Single(qr) => qr,
-        AreaQueryResult::Collection(_) => panic!("ODIM area query must return Single"),
+        CoverageResponse::Single(qr) => qr,
+        CoverageResponse::Collection(_) => panic!("ODIM area query must return Single"),
     };
 
     let (nx, ny) = match coverage.domain {
@@ -280,6 +295,7 @@ fn edr_query_area_returns_grid() {
             ref x,
             ref y,
             ref t,
+            ..
         } => {
             assert!(t.is_none(), "single-file fixture → no time axis");
             (x.len(), y.len())
@@ -345,7 +361,7 @@ fn edr_query_area_rejects_too_many_timesteps() {
 
     // No datetime filter → all 65 entries → over the cap → error.
     let err = engine
-        .query_area("9.0,55.0,12.0,57.5", None, None)
+        .query_area("9.0,55.0,12.0,57.5", None, None, None)
         .unwrap_err();
     assert!(
         format!("{err}").contains("maximum is 64"),
@@ -358,7 +374,7 @@ fn edr_query_area_rejects_too_many_timesteps() {
     let end = Utc.with_ymd_and_hms(2026, 5, 14, 0, 30, 0).unwrap();
     assert!(
         engine
-            .query_area("9.0,55.0,12.0,57.5", Some((start, end)), None)
+            .query_area("9.0,55.0,12.0,57.5", Some((start, end)), None, None)
             .is_ok(),
         "a 7-timestep window must stay under the cap"
     );
@@ -375,11 +391,12 @@ fn edr_query_area_masks_outside_polygon() {
             "POLYGON((9.0 55.0, 12.0 55.0, 9.0 57.0, 9.0 55.0))",
             None,
             None,
+            None,
         )
         .expect("polygon area query succeeds");
     let coverage = match result {
-        AreaQueryResult::Single(qr) => qr,
-        AreaQueryResult::Collection(_) => panic!("expected Single"),
+        CoverageResponse::Single(qr) => qr,
+        CoverageResponse::Collection(_) => panic!("expected Single"),
     };
     let range = &coverage.ranges["reflectivity"];
     let masked = range.values.iter().filter(|v| v.is_none()).count();
@@ -475,7 +492,15 @@ fn pvol_engine_renders_fmi_anjalankoski_volume() {
     // the ~250 km sweep, so a real volume must produce some echoes.
     let bbox = [26.0, 60.0, 28.2, 61.8];
     let tile = engine
-        .get_raster_tile(bbox, 128, 128, None, &OutputCrs::Wgs84, Some(&render_param))
+        .get_raster_tile(
+            bbox,
+            128,
+            128,
+            None,
+            &OutputCrs::Wgs84,
+            Some(&render_param),
+            None,
+        )
         .expect("PVOL get_raster_tile over the coverage bbox");
 
     assert_eq!(tile.width, 128);
@@ -578,6 +603,7 @@ fn pvol_engine_remote_scan_discovers_fmi_volume() {
             None,
             &OutputCrs::Wgs84,
             Some(&render_param),
+            None,
         )
         .expect("render of the remotely-scanned volume succeeds");
     assert_eq!(tile.values.len(), 64 * 64);
@@ -624,6 +650,7 @@ fn pvol_engine_rejects_missing_parameter() {
         8,
         None,
         &OutputCrs::Wgs84,
+        None,
         None,
     ) {
         Err(ds_core::error::DataServerError::InvalidParameter(_)) => {}
@@ -697,59 +724,96 @@ fn pvol_edr_get_locations_lists_sites() {
     assert!(!fianj.label.is_empty(), "a location carries a label");
 }
 
-/// A position query near a radar samples its lowest sweep and returns
-/// a `PointSeries` whose ranges are aligned with the time axis.
+/// A position query with no `z` returns a `CoverageCollection` of
+/// `VerticalProfile`s — one per timestep — sampling every sweep.
 #[test]
-fn pvol_edr_query_position_returns_point_series() {
+fn pvol_edr_query_position_returns_vertical_profiles() {
     let Some(engine) = pvol_fixture_engine() else {
-        eprintln!("skipping pvol_edr_query_position_returns_point_series: fixture absent");
+        eprintln!("skipping pvol_edr_query_position_returns_vertical_profiles: fixture absent");
         return;
     };
     // ~30 km north of Anjalankoski — inside the lowest sweep.
-    let result = EdrEngine::query_position(&engine, "POINT(27.1 61.2)", None, None)
+    let response = EdrEngine::query_position(&engine, "POINT(27.1 61.2)", None, None, None)
         .expect("position query inside radar coverage");
-    match &result.domain {
-        DomainDescription::PointSeries { x, y, t } => {
-            assert!((*x - 27.1).abs() < 1e-9 && (*y - 61.2).abs() < 1e-9);
-            assert!(!t.is_empty(), "PointSeries must carry a time axis");
-            for arr in result.ranges.values() {
-                assert_eq!(arr.shape, vec![t.len()]);
-                assert_eq!(arr.axis_names, vec!["t".to_string()]);
-                assert_eq!(arr.values.len(), t.len());
+    let coverages = match response {
+        CoverageResponse::Collection(c) => c,
+        CoverageResponse::Single(_) => panic!("a no-z PVOL query must return a Collection"),
+    };
+    assert!(!coverages.is_empty(), "fixture has at least one timestep");
+    for qr in &coverages {
+        match &qr.domain {
+            DomainDescription::VerticalProfile { x, y, z, .. } => {
+                assert!((*x - 27.1).abs() < 1e-9 && (*y - 61.2).abs() < 1e-9);
+                assert!(!z.values.is_empty(), "a profile spans the sweep angles");
+                for arr in qr.ranges.values() {
+                    assert_eq!(arr.shape, vec![z.values.len()]);
+                    assert_eq!(arr.axis_names, vec!["z".to_string()]);
+                }
             }
+            other => panic!("expected VerticalProfile, got {other:?}"),
         }
-        other => panic!("position query must yield a PointSeries, got {other:?}"),
+        assert!(
+            !qr.ranges.is_empty(),
+            "a sweep exposes at least one quantity"
+        );
     }
-    assert!(
-        !result.ranges.is_empty(),
-        "the volume's lowest sweep exposes at least one quantity"
-    );
 }
 
-/// `query_location` by NOD code returns the site's `PointSeries`; an
-/// unknown id is `LocationNotFound` (HTTP 404), not a panic.
+/// A position query pinned to a single `z` level returns one
+/// `PointSeries` (a `Single` coverage).
+#[test]
+fn pvol_edr_query_position_with_z_returns_point_series() {
+    let Some(engine) = pvol_fixture_engine() else {
+        eprintln!("skipping pvol_edr_query_position_with_z_returns_point_series: fixture absent");
+        return;
+    };
+    let vertical = EdrEngine::get_vertical_extent(&engine).expect("PVOL has a vertical extent");
+    let level = vertical.levels[0];
+    let response =
+        EdrEngine::query_position(&engine, "POINT(27.1 61.2)", None, None, Some(&[level]))
+            .expect("z-pinned position query");
+    let result = match response {
+        CoverageResponse::Single(qr) => qr,
+        CoverageResponse::Collection(_) => panic!("a single-z query must return Single"),
+    };
+    match &result.domain {
+        DomainDescription::PointSeries { z, .. } => {
+            assert_eq!(z.as_ref().expect("z axis").values, vec![level]);
+        }
+        other => panic!("expected PointSeries, got {other:?}"),
+    }
+}
+
+/// `query_location` by NOD code returns the site's vertical profiles;
+/// an unknown id is `LocationNotFound` (HTTP 404), not a panic.
 #[test]
 fn pvol_edr_query_location_by_nod() {
     let Some(engine) = pvol_fixture_engine() else {
         eprintln!("skipping pvol_edr_query_location_by_nod: fixture absent");
         return;
     };
-    let result = EdrEngine::query_location(&engine, "fianj", None, None)
+    let response = EdrEngine::query_location(&engine, "fianj", None, None, None)
         .expect("query_location for the fianj site");
-    assert!(matches!(
-        result.domain,
-        DomainDescription::PointSeries { .. }
-    ));
-    assert!(!result.ranges.is_empty());
+    let coverages = match response {
+        CoverageResponse::Collection(c) => c,
+        CoverageResponse::Single(_) => panic!("a no-z site query must return a Collection"),
+    };
+    assert!(!coverages.is_empty());
+    for qr in &coverages {
+        assert!(matches!(
+            qr.domain,
+            DomainDescription::VerticalProfile { .. }
+        ));
+    }
 
-    match EdrEngine::query_location(&engine, "nosuchsite", None, None) {
+    match EdrEngine::query_location(&engine, "nosuchsite", None, None, None) {
         Err(ds_core::error::DataServerError::LocationNotFound(_)) => {}
         other => panic!("unknown location id must be LocationNotFound, got {other:?}"),
     }
 }
 
-/// An area query collects one `PointSeries` per radar site inside the
-/// polygon; a polygon far from any radar is `LocationNotFound`.
+/// An area query collects every in-polygon radar site's coverages; a
+/// polygon far from any radar is `LocationNotFound`.
 #[test]
 fn pvol_edr_query_area_collects_sites() {
     let Some(engine) = pvol_fixture_engine() else {
@@ -757,25 +821,28 @@ fn pvol_edr_query_area_collects_sites() {
         return;
     };
     // A bbox enclosing Anjalankoski (27.1E, 60.9N).
-    let result = EdrEngine::query_area(&engine, "25.0,59.0,29.0,62.5", None, None)
+    let result = EdrEngine::query_area(&engine, "25.0,59.0,29.0,62.5", None, None, None)
         .expect("area query enclosing the fianj site");
     match result {
-        AreaQueryResult::Collection(coverages) => {
+        CoverageResponse::Collection(coverages) => {
             assert!(
                 !coverages.is_empty(),
                 "the polygon encloses fianj, so the collection is non-empty"
             );
             for qr in &coverages {
-                assert!(matches!(qr.domain, DomainDescription::PointSeries { .. }));
+                assert!(matches!(
+                    qr.domain,
+                    DomainDescription::VerticalProfile { .. }
+                ));
             }
         }
-        AreaQueryResult::Single(_) => {
+        CoverageResponse::Single(_) => {
             panic!("a point/observation area query must return a Collection")
         }
     }
 
     // A polygon far from any FMI radar matches nothing.
-    match EdrEngine::query_area(&engine, "0.0,0.0,1.0,1.0", None, None) {
+    match EdrEngine::query_area(&engine, "0.0,0.0,1.0,1.0", None, None, None) {
         Err(ds_core::error::DataServerError::LocationNotFound(_)) => {}
         other => panic!("an empty area must be LocationNotFound, got {other:?}"),
     }

--- a/crates/engine-postgis/src/engine.rs
+++ b/crates/engine-postgis/src/engine.rs
@@ -15,7 +15,7 @@ use deadpool_postgres::Pool;
 use ds_core::edr_engine::EdrEngine;
 use ds_core::error::DataServerError;
 use ds_core::model::{
-    AreaQueryResult, DomainDescription, Location, NdArray, ParameterDescription, QueryResult,
+    CoverageResponse, DomainDescription, Location, NdArray, ParameterDescription, QueryResult,
 };
 use tokio_postgres::Row;
 
@@ -147,7 +147,8 @@ impl EdrEngine for PostgisEngine {
         location_id: &str,
         datetime: Option<(DateTime<Utc>, DateTime<Utc>)>,
         parameters: Option<&[String]>,
-    ) -> Result<QueryResult, DataServerError> {
+        _z: Option<&[f64]>,
+    ) -> Result<CoverageResponse, DataServerError> {
         let source_keys = resolve_source_keys(&self.config, parameters)?;
         let key_refs: Vec<&str> = source_keys.iter().map(String::as_str).collect();
 
@@ -156,14 +157,14 @@ impl EdrEngine for PostgisEngine {
 
         let (lon, lat) = lookup_station_coords(&self.load_meta(), location_id)?;
         let rows_per_query = run_queries_sync(&self.pool, &queries)?;
-        assemble_query_result(
+        Ok(CoverageResponse::Single(assemble_query_result(
             &self.config,
             location_id,
             lon,
             lat,
             &queries,
             rows_per_query,
-        )
+        )?))
     }
 
     fn query_position(
@@ -171,10 +172,11 @@ impl EdrEngine for PostgisEngine {
         coords: &str,
         datetime: Option<(DateTime<Utc>, DateTime<Utc>)>,
         parameters: Option<&[String]>,
-    ) -> Result<QueryResult, DataServerError> {
+        z: Option<&[f64]>,
+    ) -> Result<CoverageResponse, DataServerError> {
         let (lon, lat) = parse_coords(coords)?;
         let station_id = resolve_nearest_station(&self.pool, &self.config, lon, lat)?;
-        self.query_location(&station_id, datetime, parameters)
+        self.query_location(&station_id, datetime, parameters, z)
     }
 
     fn query_area(
@@ -182,14 +184,15 @@ impl EdrEngine for PostgisEngine {
         coords: &str,
         datetime: Option<(DateTime<Utc>, DateTime<Utc>)>,
         parameters: Option<&[String]>,
-    ) -> Result<AreaQueryResult, DataServerError> {
+        _z: Option<&[f64]>,
+    ) -> Result<CoverageResponse, DataServerError> {
         let polygon_wkt = normalize_area_wkt(coords)?;
         let source_keys = resolve_source_keys(&self.config, parameters)?;
         let key_refs: Vec<&str> = source_keys.iter().map(String::as_str).collect();
 
         let stations = run_stations_in_polygon_sync(&self.pool, &self.config, &polygon_wkt)?;
         if stations.is_empty() {
-            return Ok(AreaQueryResult::Collection(vec![]));
+            return Ok(CoverageResponse::Collection(vec![]));
         }
         if stations.len() >= MAX_STATIONS_IN_POLYGON {
             return Err(DataServerError::Engine(format!(
@@ -220,7 +223,7 @@ impl EdrEngine for PostgisEngine {
                 Err(e) => return Err(e),
             }
         }
-        Ok(AreaQueryResult::Collection(results))
+        Ok(CoverageResponse::Collection(results))
     }
 }
 
@@ -458,6 +461,7 @@ fn assemble_long(
         x: lon,
         y: lat,
         t: all_times.clone(),
+        z: None,
     };
 
     let mut param_descs = HashMap::new();
@@ -560,6 +564,7 @@ fn assemble_wide(
         x: lon,
         y: lat,
         t: times.clone(),
+        z: None,
     };
 
     let mut param_descs = HashMap::new();
@@ -643,6 +648,7 @@ fn assemble_per_parameter(
         x: lon,
         y: lat,
         t: all_times.clone(),
+        z: None,
     };
 
     let mut param_descs = HashMap::new();

--- a/crates/engine-querydata/src/engine.rs
+++ b/crates/engine-querydata/src/engine.rs
@@ -10,7 +10,9 @@ use tokio::sync::watch;
 use ds_core::edr_engine::EdrEngine;
 use ds_core::error::DataServerError;
 use ds_core::map_engine::{MapEngine, OutputCrs, RasterInfo, RasterTile};
-use ds_core::model::{DomainDescription, Location, NdArray, ParameterDescription, QueryResult};
+use ds_core::model::{
+    CoverageResponse, DomainDescription, Location, NdArray, ParameterDescription, QueryResult,
+};
 
 use crate::parse::QueryData;
 
@@ -175,7 +177,8 @@ impl EdrEngine for QueryDataEngine {
         _location_id: &str,
         _datetime: Option<(DateTime<Utc>, DateTime<Utc>)>,
         _parameters: Option<&[String]>,
-    ) -> Result<QueryResult, DataServerError> {
+        _z: Option<&[f64]>,
+    ) -> Result<CoverageResponse, DataServerError> {
         Err(DataServerError::InvalidParameter(
             "QueryData engine does not support location queries (use position query)".into(),
         ))
@@ -226,7 +229,8 @@ impl EdrEngine for QueryDataEngine {
         coords: &str,
         datetime: Option<(DateTime<Utc>, DateTime<Utc>)>,
         parameters: Option<&[String]>,
-    ) -> Result<QueryResult, DataServerError> {
+        _z: Option<&[f64]>,
+    ) -> Result<CoverageResponse, DataServerError> {
         let (lat, lon) = parse_coords(coords)?;
         let data = self.load_data();
 
@@ -259,6 +263,7 @@ impl EdrEngine for QueryDataEngine {
             x: lon,
             y: lat,
             t: times,
+            z: None,
         };
 
         let mut params_map = HashMap::new();
@@ -289,11 +294,11 @@ impl EdrEngine for QueryDataEngine {
             );
         }
 
-        Ok(QueryResult {
+        Ok(CoverageResponse::Single(QueryResult {
             domain,
             parameters: params_map,
             ranges,
-        })
+        }))
     }
 }
 
@@ -306,7 +311,9 @@ impl MapEngine for QueryDataEngine {
         time: Option<DateTime<Utc>>,
         output_crs: &OutputCrs,
         parameter: Option<&str>,
+        z: Option<f64>,
     ) -> Result<RasterTile, DataServerError> {
+        let _ = z; // QueryData collections expose no vertical dimension yet (#185)
         let data = self.load_data();
         let param_idx = if let Some(param_name) = parameter {
             data.param_index_by_name(param_name)
@@ -389,6 +396,7 @@ impl MapEngine for QueryDataEngine {
             parameter: param_name,
             unit: String::new(),
             parameters,
+            vertical: None,
         }
     }
 }
@@ -643,9 +651,13 @@ mod tests {
         }
         let engine = QueryDataEngine::new(&test_dir(), "test", None, 30).unwrap();
 
-        let result = engine
-            .query_position("POINT(36.8 -1.3)", None, None)
+        let response = engine
+            .query_position("POINT(36.8 -1.3)", None, None, None)
             .unwrap();
+        let result = match response {
+            CoverageResponse::Single(qr) => qr,
+            CoverageResponse::Collection(_) => panic!("expected Single"),
+        };
 
         assert_eq!(result.parameters.len(), 10);
         assert_eq!(result.ranges.len(), 10);
@@ -663,9 +675,13 @@ mod tests {
         let engine = QueryDataEngine::new(&test_dir(), "test", None, 30).unwrap();
 
         let params = vec!["2 Metre Temperature (2t)".to_string()];
-        let result = engine
-            .query_position("POINT(36.8 -1.3)", None, Some(&params))
+        let response = engine
+            .query_position("POINT(36.8 -1.3)", None, Some(&params), None)
             .unwrap();
+        let result = match response {
+            CoverageResponse::Single(qr) => qr,
+            CoverageResponse::Collection(_) => panic!("expected Single"),
+        };
 
         assert_eq!(result.parameters.len(), 1);
         assert!(result.parameters.contains_key("2 Metre Temperature (2t)"));
@@ -687,6 +703,7 @@ mod tests {
                 16,
                 None,
                 &OutputCrs::Wgs84,
+                None,
                 None,
             )
             .unwrap();

--- a/crates/render/src/lib.rs
+++ b/crates/render/src/lib.rs
@@ -72,6 +72,15 @@ pub struct CacheKey {
     /// Distinct cache entries for the same (layer, style, bbox, time) when
     /// the caller asks for a different parameter than the style's default.
     pub parameter: Option<String>,
+    /// Optional vertical level, quantized to millidegrees/milli-units so the
+    /// key stays `Hash`/`Eq`. Use [`quantize_z`] to build it.
+    pub z: Option<i64>,
+}
+
+/// Quantize a vertical level for use in a [`CacheKey`] — millidegrees /
+/// milli-units, enough to keep distinct elevation sweeps apart.
+pub fn quantize_z(z: f64) -> i64 {
+    (z * 1000.0).round() as i64
 }
 
 /// FNV-1a 64-bit mix. Fixed algorithm — safe to serialise into HTTP `ETag`
@@ -123,6 +132,13 @@ impl CacheKey {
             Some(p) => {
                 fnv1a_mix(&mut h, &[1u8]);
                 fnv1a_mix(&mut h, p.as_bytes());
+            }
+            None => fnv1a_mix(&mut h, &[0u8]),
+        }
+        match self.z {
+            Some(z) => {
+                fnv1a_mix(&mut h, &[1u8]);
+                fnv1a_mix(&mut h, &z.to_le_bytes());
             }
             None => fnv1a_mix(&mut h, &[0u8]),
         }
@@ -502,6 +518,7 @@ mod tests {
                     .with_timezone(&chrono::Utc),
             ),
             parameter: None,
+            z: None,
         };
         let mut later = base.clone();
         later.time = Some(
@@ -524,6 +541,7 @@ mod tests {
             height: 256,
             time: None,
             parameter: Some("2t".into()),
+            z: None,
         };
         let mut other = base.clone();
         other.parameter = Some("10u".into());
@@ -550,9 +568,10 @@ mod tests {
             height: 256,
             time: None,
             parameter: None,
+            z: None,
         };
-        // Pinned after introducing the `parameter` field (cache-bust event).
-        assert_eq!(key.etag(), "\"074133840641acde\"");
+        // Pinned after introducing the `z` field (cache-bust event).
+        assert_eq!(key.etag(), "\"95776756a198bd3a\"");
     }
 
     #[test]

--- a/crates/render/src/lib.rs
+++ b/crates/render/src/lib.rs
@@ -79,7 +79,11 @@ pub struct CacheKey {
 
 /// Quantize a vertical level for use in a [`CacheKey`] — millidegrees /
 /// milli-units, enough to keep distinct elevation sweeps apart.
+///
+/// `z` must be finite; a non-finite value would saturate the `as i64`
+/// cast to a meaningless key. Callers validate `z` at the API boundary.
 pub fn quantize_z(z: f64) -> i64 {
+    debug_assert!(z.is_finite(), "quantize_z requires a finite z value");
     (z * 1000.0).round() as i64
 }
 

--- a/crates/server/src/preview.rs
+++ b/crates/server/src/preview.rs
@@ -768,7 +768,7 @@ mod tests {
     use ds_core::feature::{Feature, FeaturePage, FeatureQuery};
     use ds_core::feature_engine::FeatureEngine;
     use ds_core::map_engine::{MapEngine, OutputCrs, RasterInfo, RasterTile};
-    use ds_core::model::{Location, QueryResult};
+    use ds_core::model::{CoverageResponse, Location};
 
     use crate::admin::ServerState;
 
@@ -788,7 +788,8 @@ mod tests {
             _location_id: &str,
             _datetime: Option<(DateTime<Utc>, DateTime<Utc>)>,
             _parameters: Option<&[String]>,
-        ) -> Result<QueryResult, DataServerError> {
+            _z: Option<&[f64]>,
+        ) -> Result<CoverageResponse, DataServerError> {
             unimplemented!()
         }
         fn get_parameters(&self) -> Vec<String> {
@@ -838,6 +839,7 @@ mod tests {
             _t: Option<DateTime<Utc>>,
             _crs: &OutputCrs,
             _param: Option<&str>,
+            _z: Option<f64>,
         ) -> Result<RasterTile, DataServerError> {
             unimplemented!()
         }
@@ -849,6 +851,7 @@ mod tests {
                 parameter: self.parameter.clone(),
                 unit: self.unit.clone(),
                 parameters: self.parameters.clone(),
+                vertical: None,
             }
         }
     }
@@ -1235,7 +1238,8 @@ mod tests {
                 _: &str,
                 _: Option<(DateTime<Utc>, DateTime<Utc>)>,
                 _: Option<&[String]>,
-            ) -> Result<QueryResult, DataServerError> {
+                _: Option<&[f64]>,
+            ) -> Result<CoverageResponse, DataServerError> {
                 unimplemented!()
             }
             fn get_parameters(&self) -> Vec<String> {
@@ -1307,7 +1311,8 @@ mod tests {
                 _: &str,
                 _: Option<(DateTime<Utc>, DateTime<Utc>)>,
                 _: Option<&[String]>,
-            ) -> Result<QueryResult, DataServerError> {
+                _: Option<&[f64]>,
+            ) -> Result<CoverageResponse, DataServerError> {
                 unimplemented!()
             }
             fn get_parameters(&self) -> Vec<String> {
@@ -1599,7 +1604,8 @@ mod tests {
                 _: &str,
                 _: Option<(DateTime<Utc>, DateTime<Utc>)>,
                 _: Option<&[String]>,
-            ) -> Result<QueryResult, DataServerError> {
+                _: Option<&[f64]>,
+            ) -> Result<CoverageResponse, DataServerError> {
                 unimplemented!()
             }
             fn get_parameters(&self) -> Vec<String> {
@@ -1699,7 +1705,8 @@ mod tests {
                 _: &str,
                 _: Option<(DateTime<Utc>, DateTime<Utc>)>,
                 _: Option<&[String]>,
-            ) -> Result<QueryResult, DataServerError> {
+                _: Option<&[f64]>,
+            ) -> Result<CoverageResponse, DataServerError> {
                 unimplemented!()
             }
             fn get_parameters(&self) -> Vec<String> {
@@ -1795,7 +1802,8 @@ mod tests {
                 _: &str,
                 _: Option<(DateTime<Utc>, DateTime<Utc>)>,
                 _: Option<&[String]>,
-            ) -> Result<QueryResult, DataServerError> {
+                _: Option<&[f64]>,
+            ) -> Result<CoverageResponse, DataServerError> {
                 unimplemented!()
             }
             fn get_parameters(&self) -> Vec<String> {
@@ -1848,6 +1856,7 @@ mod tests {
                 _: Option<DateTime<Utc>>,
                 _: &OutputCrs,
                 _: Option<&str>,
+                _: Option<f64>,
             ) -> Result<RasterTile, DataServerError> {
                 unimplemented!()
             }
@@ -1863,6 +1872,7 @@ mod tests {
                         ("2t".into(), "Temperature".into()),
                         ("msl".into(), "Mean SLP".into()),
                     ],
+                    vertical: None,
                 }
             }
         }

--- a/crates/server/tests/middleware.rs
+++ b/crates/server/tests/middleware.rs
@@ -34,6 +34,7 @@ impl MapEngine for MockMapEngine {
         _time: Option<chrono::DateTime<chrono::Utc>>,
         _output_crs: &OutputCrs,
         _parameter: Option<&str>,
+        _z: Option<f64>,
     ) -> Result<RasterTile, DataServerError> {
         let n = (width * height) as usize;
         Ok(RasterTile {
@@ -53,6 +54,7 @@ impl MapEngine for MockMapEngine {
             parameter: "reflectivity".to_string(),
             unit: "dBZ".to_string(),
             parameters: vec![],
+            vertical: None,
         }
     }
 }


### PR DESCRIPTION
## Summary

Implements #185 — a single cross-cutting vertical dimension shared by both the Map and EDR surfaces.

- **ds-core**: new `VerticalKind` enum + `VerticalDimension` descriptor (`crates/core/src/vertical.rs`). `MapEngine::get_raster_tile` gains `z: Option<f64>`; `RasterInfo` gains `vertical`. `EdrEngine` query methods gain `z: Option<&[f64]>`, gain `get_vertical_extent()`, and now return a unified `CoverageResponse` (renamed from `AreaQueryResult`). New `VerticalProfile` CoverageJSON domain plus optional `z` axes on `PointSeries`/`Grid`.
- **api-wms**: parses the WMS 1.3.0 `ELEVATION` dimension and emits `<Dimension name="elevation">` in GetCapabilities.
- **api-maps / api-tiles**: accept an `elevation` query parameter; advertise the vertical extent in collection metadata; OpenAPI updated.
- **api-edr**: parses the `z` query parameter, advertises the vertical extent, emits a `z` axis / `VerticalCRS` referencing, and follows the issue's EDR query→CoverageJSON response table.
- **engine-odim `odim-volume`**: drops the lowest-sweep interim — `z` selects the elevation sweep for rendering; a no-`z` EDR query returns a `CoverageCollection` of `VerticalProfile`s (reflectivity vs. elevation angle), a `z` query a `PointSeries` per sweep.
- Engines with no vertical dimension ignore the selector; the API layer returns HTTP 400 when `z`/`ELEVATION` is passed against them.

## Test plan

- [x] `cargo test --workspace` — 47/47 test binaries pass
- [x] `cargo clippy --workspace --all-targets` — clean
- [x] New CoverageJSON schema-validation tests for `VerticalProfile`, `Grid`-with-`z`, `PointSeries`-with-`z`, and a `VerticalProfile` `CoverageCollection`
- [x] `engine-odim` integration tests updated to assert the new PVOL EDR shapes

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Notes for operators

`CoverageCollection` responses no longer carry a top-level `referencing` array — each coverage's domain now carries its own (a `VerticalProfile` needs a `VerticalCRS` reference that a `PointSeries` does not, so a collection may mix domain shapes). The CoverageJSON schema permits this. Any client reading `collection.referencing` directly should read it per-coverage at `coverages[].domain.referencing` instead.
