### PR TITLE
chore(engine-geotiff): address review comments from #214

### DIFF
--- a/crates/core/src/geo.rs
+++ b/crates/core/src/geo.rs
@@ -283,7 +283,7 @@ impl GeoTransform {
     /// lies outside the raster. This exposes the raw projection primitive so
     /// callers that need many nearby points can sample the (expensive) CRS
     /// forward transform on a coarse grid and bilinearly interpolate the
-    /// result — see `engine-geotiff`'s coarse-grid resampler (issue #203).
+    /// result — see `engine-geotiff`'s coarse-grid resampler.
     pub fn world_to_pixel_f64(&self, lon: f64, lat: f64) -> (f64, f64) {
         let (x, y) = self.crs.forward(lon, lat);
         let col = (x - self.origin_x) / self.pixel_width;

--- a/crates/engine-geotiff/src/lib.rs
+++ b/crates/engine-geotiff/src/lib.rs
@@ -1366,7 +1366,7 @@ impl ds_core::map_engine::MapEngine for GeoTiffEngine {
 
             // Map output pixels to source pixels through a coarse projection
             // grid instead of projecting every pixel: the CRS forward transform
-            // dominates render CPU for projected sources (issue #203).
+            // dominates render CPU for projected sources.
             let to_web_mercator = *output_crs == ds_core::map_engine::OutputCrs::WebMercator;
             let (merc_y_north, merc_y_south) = if to_web_mercator {
                 (lat_to_merc_y(north), lat_to_merc_y(south))

--- a/crates/engine-geotiff/src/resample.rs
+++ b/crates/engine-geotiff/src/resample.rs
@@ -4,7 +4,7 @@
 //! grid. The naive approach projects every output pixel through the CRS forward
 //! transform, which for a projected source (e.g. EPSG:3067 Transverse Mercator)
 //! costs roughly a dozen transcendental ops *per pixel* — the dominant
-//! per-render CPU cost (issue #203).
+//! per-render CPU cost.
 //!
 //! The output→source pixel mapping is smooth, so [`ProjectionGrid`] evaluates
 //! the exact projection only at the nodes of a coarse grid and bilinearly
@@ -93,8 +93,21 @@ impl ProjectionGrid {
         let mut cells_y = height.div_ceil(GRID_STEP_PX).clamp(MIN_CELLS, MAX_CELLS);
         loop {
             let grid = Self::with_cells(gt, width, height, cells_x, cells_y, &lon_at, &lat_at);
-            let at_cap = cells_x >= MAX_CELLS && cells_y >= MAX_CELLS;
-            if at_cap || grid.estimate_error(gt, &lon_at, &lat_at) <= MAX_INTERP_ERROR_PX {
+            let error = grid.estimate_error(gt, &lon_at, &lat_at);
+            if error <= MAX_INTERP_ERROR_PX {
+                return grid;
+            }
+            if cells_x >= MAX_CELLS && cells_y >= MAX_CELLS {
+                // Extreme viewport: even the densest grid cannot meet the
+                // budget. Accept it, but make the degradation observable
+                // rather than letting it pass silently.
+                tracing::warn!(
+                    estimated_error_px = error,
+                    budget_px = MAX_INTERP_ERROR_PX,
+                    "projection grid hit the MAX_CELLS cap with interpolation \
+                     error above budget; rendered output may be slightly \
+                     misregistered for this viewport"
+                );
                 return grid;
             }
             // Halving the cell size quarters the bilinear error.

--- a/crates/engine-geotiff/tests/render_projection.rs
+++ b/crates/engine-geotiff/tests/render_projection.rs
@@ -52,6 +52,15 @@ fn count_data(tile: &ds_core::map_engine::RasterTile) -> usize {
 // of pixels carry data — the resampler must still place that data correctly.
 const COVERED_BBOX: [f64; 4] = [20.0, 60.0, 32.0, 67.0];
 
+// Lower bound on the share of output pixels that must carry data for a render
+// over `COVERED_BBOX`. This is intentionally coupled to the committed fixture:
+// the FMI composite in `testdata/radar-tm35fin/` has dense echo over southern
+// Finland and fills well over half of this bbox. The 25% floor sits far below
+// that actual coverage, so the assertion proves the resampler placed a broad
+// swath of projected data without being brittle to the exact echo pattern. If
+// the fixture is ever regenerated from a clearer-sky scan, revisit this floor.
+const MIN_DATA_FRACTION_DENOM: usize = 4;
+
 #[test]
 fn renders_projected_geotiff_to_wgs84() {
     let engine = tm35fin_engine();
@@ -65,9 +74,9 @@ fn renders_projected_geotiff_to_wgs84() {
     assert_eq!(tile.values.len() as u32, w * h);
     let data = count_data(&tile);
     // The coarse-grid resampler must pull a substantial amount of the
-    // projected source data into the output (not just a stray pixel).
+    // projected source data into the output (see MIN_DATA_FRACTION_DENOM).
     assert!(
-        data > (w * h) as usize / 4,
+        data > (w * h) as usize / MIN_DATA_FRACTION_DENOM,
         "expected broad data coverage, got {data}/{} pixels",
         w * h
     );
@@ -131,6 +140,8 @@ fn renders_via_overview_for_small_output() {
         .get_raster_tile(bbox, w, h, None, &OutputCrs::Wgs84, None, None)
         .expect("overview render should succeed");
     assert_eq!(tile.values.len() as u32, w * h);
+    // The whole-extent render of this echo-dense fixture always has data;
+    // the assertion's job is to confirm the overview path renders at all.
     assert!(
         count_data(&tile) > 0,
         "overview render must still place projected data"
@@ -140,10 +151,13 @@ fn renders_via_overview_for_small_output() {
 #[test]
 fn partially_overlapping_bbox_is_partially_filled() {
     let engine = tm35fin_engine();
-    // Straddles the western edge of coverage: the left part of the bbox is
-    // off-raster, the right part is on it — so the resampler must place data
-    // on one side only. This catches gross projection mis-placement.
-    let bbox = [-30.0, 60.0, 15.0, 68.0];
+    // Straddles the southern edge of coverage: the lat 50–56 strip is below
+    // the raster (its bottom edge runs near lat ~56), the lat 56–62 strip is
+    // on it and over echo-dense southern Finland. So the resampler must place
+    // data on one side and nodata on the other — catching gross projection
+    // mis-placement. The on-raster half is the same dense region the
+    // COVERED_BBOX tests use, so `data > 0` is not brittle to the echo pattern.
+    let bbox = [20.0, 50.0, 32.0, 62.0];
     let (w, h) = (128, 128);
     let tile = engine
         .get_raster_tile(bbox, w, h, None, &OutputCrs::Wgs84, None, None)


### PR DESCRIPTION
Follow-up to the merged coarse-grid projection PR (#214), addressing the `claude-review` comments left on it:

- **Drop `issue #203` references from code comments** (`geo.rs`, `resample.rs`, `lib.rs`) — issue-tracker references belong in the PR description, not in code where they go stale (per CLAUDE.md).
- **`ProjectionGrid::build` emits a `tracing::warn!`** when it returns at the `MAX_CELLS` cap with interpolation error still above budget, so extreme-viewport degradation is observable instead of silent.
- **Document the fixture-coupled test thresholds** in `render_projection.rs` (named `MIN_DATA_FRACTION_DENOM`), and move the partial-overlap test's bbox to straddle the *southern* raster edge over echo-dense southern Finland so its `data > 0` assertion no longer depends on the echo pattern of a sparse map edge.

No behaviour change to the resampler. `cargo test -p ds-core -p engine-geotiff` green; clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
