### PR TITLE
ci: track every workspace crate in release-please for proper changelog attribution

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,3 +1,19 @@
 {
+  "crates/core": "0.4.0",
+  "crates/storage": "0.4.0",
+  "crates/render": "0.4.0",
+  "crates/ds-mvt": "0.4.0",
+  "crates/engine-csv": "0.4.0",
+  "crates/engine-geojson": "0.4.0",
+  "crates/engine-geotiff": "0.4.0",
+  "crates/engine-grib": "0.4.0",
+  "crates/engine-odim": "0.4.0",
+  "crates/engine-postgis": "0.4.0",
+  "crates/engine-querydata": "0.4.0",
+  "crates/api-edr": "0.4.0",
+  "crates/api-features": "0.4.0",
+  "crates/api-wms": "0.4.0",
+  "crates/api-maps": "0.4.0",
+  "crates/api-tiles": "0.4.0",
   "crates/server": "0.4.0"
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,7 +66,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "api-edr"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "arc-swap",
  "axum",
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "api-features"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "arc-swap",
  "axum",
@@ -98,7 +98,7 @@ dependencies = [
 
 [[package]]
 name = "api-maps"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "arc-swap",
  "axum",
@@ -116,7 +116,7 @@ dependencies = [
 
 [[package]]
 name = "api-tiles"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "arc-swap",
  "axum",
@@ -135,7 +135,7 @@ dependencies = [
 
 [[package]]
 name = "api-wms"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "arc-swap",
  "axum",
@@ -752,7 +752,7 @@ dependencies = [
 
 [[package]]
 name = "ds-core"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "chrono",
  "serde",
@@ -763,7 +763,7 @@ dependencies = [
 
 [[package]]
 name = "ds-mvt"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "bytes",
  "ds-core",
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "ds-render"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "ds-storage"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "engine-csv"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "chrono",
  "criterion",
@@ -827,7 +827,7 @@ dependencies = [
 
 [[package]]
 name = "engine-geojson"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "criterion",
  "ds-core",
@@ -838,7 +838,7 @@ dependencies = [
 
 [[package]]
 name = "engine-geotiff"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "arc-swap",
  "axum",
@@ -864,7 +864,7 @@ dependencies = [
 
 [[package]]
 name = "engine-grib"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "arc-swap",
  "chrono",
@@ -881,7 +881,7 @@ dependencies = [
 
 [[package]]
 name = "engine-odim"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "arc-swap",
  "chrono",
@@ -899,7 +899,7 @@ dependencies = [
 
 [[package]]
 name = "engine-postgis"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "arc-swap",
  "chrono",
@@ -915,7 +915,7 @@ dependencies = [
 
 [[package]]
 name = "engine-querydata"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "arc-swap",
  "chrono",

--- a/crates/api-edr/Cargo.toml
+++ b/crates/api-edr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "api-edr"
-version = "0.1.0"
+version = "0.4.0"
 edition = "2021"
 
 [dependencies]

--- a/crates/api-features/Cargo.toml
+++ b/crates/api-features/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "api-features"
-version = "0.1.0"
+version = "0.4.0"
 edition = "2021"
 
 [dependencies]

--- a/crates/api-maps/Cargo.toml
+++ b/crates/api-maps/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "api-maps"
-version = "0.1.0"
+version = "0.4.0"
 edition = "2021"
 
 [dependencies]

--- a/crates/api-tiles/Cargo.toml
+++ b/crates/api-tiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "api-tiles"
-version = "0.1.0"
+version = "0.4.0"
 edition = "2021"
 
 [dependencies]

--- a/crates/api-wms/Cargo.toml
+++ b/crates/api-wms/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "api-wms"
-version = "0.1.0"
+version = "0.4.0"
 edition = "2021"
 
 [dependencies]

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ds-core"
-version = "0.1.0"
+version = "0.4.0"
 edition = "2021"
 
 [dependencies]

--- a/crates/ds-mvt/Cargo.toml
+++ b/crates/ds-mvt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ds-mvt"
-version = "0.1.0"
+version = "0.4.0"
 edition = "2021"
 
 [dependencies]

--- a/crates/engine-csv/Cargo.toml
+++ b/crates/engine-csv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "engine-csv"
-version = "0.1.0"
+version = "0.4.0"
 edition = "2021"
 
 [dependencies]

--- a/crates/engine-geojson/Cargo.toml
+++ b/crates/engine-geojson/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "engine-geojson"
-version = "0.1.0"
+version = "0.4.0"
 edition = "2021"
 
 [dependencies]

--- a/crates/engine-geotiff/Cargo.toml
+++ b/crates/engine-geotiff/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "engine-geotiff"
-version = "0.1.0"
+version = "0.4.0"
 edition = "2021"
 
 [features]

--- a/crates/engine-grib/Cargo.toml
+++ b/crates/engine-grib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "engine-grib"
-version = "0.1.0"
+version = "0.4.0"
 edition = "2021"
 
 [dependencies]

--- a/crates/engine-odim/Cargo.toml
+++ b/crates/engine-odim/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "engine-odim"
-version = "0.1.0"
+version = "0.4.0"
 edition = "2021"
 
 [dependencies]

--- a/crates/engine-postgis/Cargo.toml
+++ b/crates/engine-postgis/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "engine-postgis"
-version = "0.1.0"
+version = "0.4.0"
 edition = "2021"
 
 [dependencies]

--- a/crates/engine-querydata/Cargo.toml
+++ b/crates/engine-querydata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "engine-querydata"
-version = "0.1.0"
+version = "0.4.0"
 edition = "2021"
 
 [dependencies]

--- a/crates/render/Cargo.toml
+++ b/crates/render/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ds-render"
-version = "0.1.0"
+version = "0.4.0"
 edition = "2021"
 
 [dependencies]

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ds-storage"
-version = "0.1.0"
+version = "0.4.0"
 edition = "2021"
 
 [dependencies]

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -21,15 +21,48 @@
     { "type": "style", "section": "Styles", "hidden": true }
   ],
   "plugins": [
+    { "type": "cargo-workspace", "merge": true },
     {
-      "type": "cargo-workspace",
-      "merge": true
+      "type": "linked-versions",
+      "groupName": "meteocore",
+      "components": [
+        "meteocore",
+        "ds-core",
+        "ds-storage",
+        "ds-render",
+        "ds-mvt",
+        "engine-csv",
+        "engine-geojson",
+        "engine-geotiff",
+        "engine-grib",
+        "engine-odim",
+        "engine-postgis",
+        "engine-querydata",
+        "api-edr",
+        "api-features",
+        "api-wms",
+        "api-maps",
+        "api-tiles"
+      ]
     }
   ],
   "packages": {
-    "crates/server": {
-      "package-name": "meteocore",
-      "component": "meteocore"
-    }
+    "crates/core":             { "package-name": "ds-core",          "component": "ds-core",          "bootstrap-sha": "fb12a38bf5414d807c351b2daebc41deb072e85e" },
+    "crates/storage":          { "package-name": "ds-storage",       "component": "ds-storage",       "bootstrap-sha": "fb12a38bf5414d807c351b2daebc41deb072e85e" },
+    "crates/render":           { "package-name": "ds-render",        "component": "ds-render",        "bootstrap-sha": "fb12a38bf5414d807c351b2daebc41deb072e85e" },
+    "crates/ds-mvt":           { "package-name": "ds-mvt",           "component": "ds-mvt",           "bootstrap-sha": "fb12a38bf5414d807c351b2daebc41deb072e85e" },
+    "crates/engine-csv":       { "package-name": "engine-csv",       "component": "engine-csv",       "bootstrap-sha": "fb12a38bf5414d807c351b2daebc41deb072e85e" },
+    "crates/engine-geojson":   { "package-name": "engine-geojson",   "component": "engine-geojson",   "bootstrap-sha": "fb12a38bf5414d807c351b2daebc41deb072e85e" },
+    "crates/engine-geotiff":   { "package-name": "engine-geotiff",   "component": "engine-geotiff",   "bootstrap-sha": "fb12a38bf5414d807c351b2daebc41deb072e85e" },
+    "crates/engine-grib":      { "package-name": "engine-grib",      "component": "engine-grib",      "bootstrap-sha": "fb12a38bf5414d807c351b2daebc41deb072e85e" },
+    "crates/engine-odim":      { "package-name": "engine-odim",      "component": "engine-odim",      "bootstrap-sha": "fb12a38bf5414d807c351b2daebc41deb072e85e" },
+    "crates/engine-postgis":   { "package-name": "engine-postgis",   "component": "engine-postgis",   "bootstrap-sha": "fb12a38bf5414d807c351b2daebc41deb072e85e" },
+    "crates/engine-querydata": { "package-name": "engine-querydata", "component": "engine-querydata", "bootstrap-sha": "fb12a38bf5414d807c351b2daebc41deb072e85e" },
+    "crates/api-edr":          { "package-name": "api-edr",          "component": "api-edr",          "bootstrap-sha": "fb12a38bf5414d807c351b2daebc41deb072e85e" },
+    "crates/api-features":     { "package-name": "api-features",     "component": "api-features",     "bootstrap-sha": "fb12a38bf5414d807c351b2daebc41deb072e85e" },
+    "crates/api-wms":          { "package-name": "api-wms",          "component": "api-wms",          "bootstrap-sha": "fb12a38bf5414d807c351b2daebc41deb072e85e" },
+    "crates/api-maps":         { "package-name": "api-maps",         "component": "api-maps",         "bootstrap-sha": "fb12a38bf5414d807c351b2daebc41deb072e85e" },
+    "crates/api-tiles":        { "package-name": "api-tiles",        "component": "api-tiles",        "bootstrap-sha": "fb12a38bf5414d807c351b2daebc41deb072e85e" },
+    "crates/server":           { "package-name": "meteocore",        "component": "meteocore" }
   }
 }


### PR DESCRIPTION
Closes the changelog-attribution gap that left the TM35FIN coarse-grid projection change (#214) out of the v0.5.0 release notes ([#215](https://github.com/mrauhala/meteocore/pull/215)).

## Why

release-please attributes commits to packages **strictly by file path inside the package directory**. Until now only `crates/server` was configured as a release-please package, so a commit confined to other crates was attributed to nothing release-tracked and silently dropped from the release notes. Verified by reading the release-please-action log on #214's merge: it filtered the 2 release-triggering commits, called `Updating existing candidate pull request for server, path: crates/server`, and concluded `PR #215 remained the same` because #214's diff lives in `crates/engine-geotiff` + `crates/core`.

The earlier engine-odim entries in v0.4.0's CHANGELOG slipped through only because each one **also** touched `crates/server` (engine registration in `server/main.rs`). Pure within-an-engine changes — exactly what perf optimisations look like — have no such accident.

## What

- **Every non-server crate's `Cargo.toml` is bumped from 0.1.0 to 0.4.0** so the workspace sits at one synchronised baseline.
- **All 17 workspace crates are added to `release-please-config.json::packages`**, each with its own `component` + `package-name` and a `bootstrap-sha` pinned to the v0.4.0 release commit (`fb12a38`) so release-please does not scan pre-0.4.0 history for the newly-tracked crates.
- **`linked-versions` plugin added** so every crate moves to the same version on each release. Combined with the existing `cargo-workspace` plugin's `merge: true`, the per-crate release PRs collapse into one PR with one combined CHANGELOG-summary, one bumped version, and one `vX.Y.Z` tag (no per-component tags, since `include-component-in-tag` stays false).
- Each crate will grow its own `crates/<name>/CHANGELOG.md` on the next release for its own commits; `crates/server/CHANGELOG.md` continues to summarise server-touching changes.

`cargo build --workspace` passes; `cargo.lock` updated.

## Caveats

- **The next release PR (#215, when re-generated by release-please after this merges) is the live test of the configuration.** The `release-please` guard step added in #216 fails loudly if a release PR merges without a release being cut, so any breakage surfaces immediately rather than silently.
- 17 components mapped to a single component-less `v0.5.0` tag is an unusual setup — `linked-versions` + `cargo-workspace { merge: true }` should produce one combined release, but if release-please refuses, this commit is straightforward to revert and we fall back to amending v0.5.0's notes by hand.
- Merging this PR does **not** retroactively add #214 to #215. After this merges I recommend re-running the latest release workflow (or letting the next push trigger it) so release-please regenerates #215 with the perf section now attributed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
