### PR TITLE
docs: add #214 perf change to the v0.5.0 changelog

### DIFF
--- a/crates/server/CHANGELOG.md
+++ b/crates/server/CHANGELOG.md
@@ -7,6 +7,11 @@
 
 * vertical (elevation/level) dimension for MapEngine + EdrEngine ([#200](https://github.com/mrauhala/meteocore/issues/200)) ([cbd4abd](https://github.com/mrauhala/meteocore/commit/cbd4abd8becb3085ccdf0a1ae780fa814f0b4f75))
 
+
+### Performance Improvements
+
+* **engine-geotiff:** coarse-grid projection for raster resampling — replaces per-pixel CRS projection in the WMS/Maps/Tiles resampler; ~10× faster TM35FIN renders (68.3 ms → 6.8 ms for a 1024² tile) ([#214](https://github.com/mrauhala/meteocore/issues/214))
+
 ## [0.4.0](https://github.com/mrauhala/meteocore/compare/v0.3.0...v0.4.0) (2026-05-18)
 
 


### PR DESCRIPTION
The TM35FIN coarse-grid projection change (#214) ships in v0.5.0 but was missing from its changelog (it lives entirely outside `crates/server`, so release-please didn't attribute it). This adds the Performance Improvements entry to the v0.5.0 section; the v0.5.0 GitHub Release notes were already amended directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)