### PR TITLE
perf(server,engine-grib): isolate poll loops from request runtime + skip settled GRIB runs (#221)

### DIFF
--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -382,7 +382,11 @@ pub struct OdimConfig {
 }
 
 fn default_grib_poll_interval() -> u64 {
-    300
+    // 10 minutes. NWP models typically publish a new run every 6 h (some less
+    // often), with steps trickling in over ~1-2 h, so frequent polling mostly
+    // re-lists unchanged runs. Override per collection via `poll_interval_secs`
+    // for the rare model that updates more often.
+    600
 }
 
 fn default_grid_cache_mb() -> u64 {
@@ -401,7 +405,7 @@ pub struct GribConfig {
     pub index_suffix: Option<String>,
     /// Suffix for GRIB data files. Default: ".grib2"
     pub data_suffix: Option<String>,
-    /// Poll interval in seconds. Default: 300 (5 min)
+    /// Poll interval in seconds. Default: 600 (10 min)
     #[serde(default = "default_grib_poll_interval")]
     pub poll_interval_secs: u64,
     /// Maximum number of forecast runs to retain. Default: 4

--- a/crates/engine-grib/src/lib.rs
+++ b/crates/engine-grib/src/lib.rs
@@ -305,8 +305,6 @@ impl GribEngine {
             .is_none_or(|t| t.elapsed() >= SETTLED_REVALIDATE_INTERVAL);
         let settled_snapshot = self.settled_prefixes.lock().unwrap().clone();
         let mut listed_with_hits: Vec<String> = Vec::new();
-        let mut any_list_ok = false;
-        let mut any_list_err = false;
         for (_ref_time, prefix) in &prefixes {
             if let Some(budget) = scan_budget {
                 if runs_with_hits >= budget {
@@ -322,7 +320,6 @@ impl GribEngine {
             let mut hits_in_this_prefix = 0usize;
             match self.store.list(&obj_prefix) {
                 Ok(objects) => {
-                    any_list_ok = true;
                     for obj in objects {
                         let loc = obj.location.as_ref();
                         if !loc.ends_with(index_suffix) {
@@ -338,7 +335,6 @@ impl GribEngine {
                     }
                 }
                 Err(e) => {
-                    any_list_err = true;
                     tracing::debug!(
                         "Collection '{}': failed to list prefix '{}': {}",
                         self.collection_id,
@@ -364,12 +360,16 @@ impl GribEngine {
             settle_completed_runs(&mut settled, &listed_with_hits, &window);
         }
 
-        // Reset the re-validation clock only after a forced full pass in which
-        // every list call succeeded — so neither a total nor a *partial* S3
-        // outage resets the clock while some settled prefixes went unchecked.
-        // On any list error we retry the full scan next poll instead of waiting
-        // another interval (see SETTLED_REVALIDATE_INTERVAL).
-        if force_full && any_list_ok && !any_list_err {
+        // Reset the re-validation clock after a forced full pass. The clock
+        // only *paces* a best-effort hourly re-list of settled runs to catch
+        // late/corrected steps; it is intentionally not conditioned on per-
+        // prefix list success. A transient outage during the one forced scan
+        // in an interval simply defers re-validation to the next interval —
+        // harmless, because the newest (unsettled) run is still listed every
+        // poll regardless. (Conditioning the reset on "no list errors" instead
+        // lets a single chronically-unreachable prefix pin force_full on
+        // forever, defeating the settled-skip optimization entirely.)
+        if force_full {
             *self.last_full_scan.lock().unwrap() = Some(Instant::now());
         }
         tracing::debug!(

--- a/crates/engine-grib/src/lib.rs
+++ b/crates/engine-grib/src/lib.rs
@@ -306,6 +306,7 @@ impl GribEngine {
         let settled_snapshot = self.settled_prefixes.lock().unwrap().clone();
         let mut listed_with_hits: Vec<String> = Vec::new();
         let mut any_list_ok = false;
+        let mut any_list_err = false;
         for (_ref_time, prefix) in &prefixes {
             if let Some(budget) = scan_budget {
                 if runs_with_hits >= budget {
@@ -337,6 +338,7 @@ impl GribEngine {
                     }
                 }
                 Err(e) => {
+                    any_list_err = true;
                     tracing::debug!(
                         "Collection '{}': failed to list prefix '{}': {}",
                         self.collection_id,
@@ -362,11 +364,12 @@ impl GribEngine {
             settle_completed_runs(&mut settled, &listed_with_hits, &window);
         }
 
-        // Reset the re-validation clock only after a forced full pass that
-        // actually listed at least one prefix successfully — so a total S3
-        // outage retries the full scan next poll instead of waiting another
-        // interval (see SETTLED_REVALIDATE_INTERVAL).
-        if force_full && any_list_ok {
+        // Reset the re-validation clock only after a forced full pass in which
+        // every list call succeeded — so neither a total nor a *partial* S3
+        // outage resets the clock while some settled prefixes went unchecked.
+        // On any list error we retry the full scan next poll instead of waiting
+        // another interval (see SETTLED_REVALIDATE_INTERVAL).
+        if force_full && any_list_ok && !any_list_err {
             *self.last_full_scan.lock().unwrap() = Some(Instant::now());
         }
         tracing::debug!(

--- a/crates/engine-grib/src/lib.rs
+++ b/crates/engine-grib/src/lib.rs
@@ -1392,19 +1392,22 @@ fn build_scan_prefixes(
 
 /// Update the set of "settled" run prefixes after a scan.
 ///
-/// `listed_with_hits` are the run prefixes that produced index files this scan,
-/// in newest-first order. Every one except the newest is marked settled (NWP
-/// runs publish sequentially, so once a newer run exists an older one is static
-/// and need not be re-listed). The newest is left unsettled so its still-
-/// trickling steps keep being picked up. `window` is the current scan window;
+/// `listed_with_hits_newest_first` are the run prefixes that produced index
+/// files this scan, **ordered newest-first** — this ordering is load-bearing:
+/// the first element is treated as the still-active newest run and left
+/// unsettled, every other element is marked settled. (NWP runs publish
+/// sequentially, so once a newer run exists an older one is static and need not
+/// be re-listed; the newest stays unsettled so its still-trickling steps keep
+/// being picked up.) The caller derives the order from `build_scan_prefixes`,
+/// which sorts `Reverse` by ref-time. `window` is the current scan window;
 /// settled prefixes outside it are pruned so the set cannot grow unbounded as
 /// old runs age out.
 fn settle_completed_runs(
     settled: &mut HashSet<String>,
-    listed_with_hits: &[String],
+    listed_with_hits_newest_first: &[String],
     window: &HashSet<&str>,
 ) {
-    for prefix in listed_with_hits.iter().skip(1) {
+    for prefix in listed_with_hits_newest_first.iter().skip(1) {
         settled.insert(prefix.clone());
     }
     settled.retain(|p| window.contains(p.as_str()));

--- a/crates/engine-grib/src/lib.rs
+++ b/crates/engine-grib/src/lib.rs
@@ -295,16 +295,17 @@ impl GribEngine {
         // Periodically force a full re-list so late/corrected step files added
         // to an already-settled run are still picked up (bounded by
         // SETTLED_REVALIDATE_INTERVAL).
-        let force_full = {
-            let mut last = self.last_full_scan.lock().unwrap();
-            let due = last.is_none_or(|t| t.elapsed() >= SETTLED_REVALIDATE_INTERVAL);
-            if due {
-                *last = Some(Instant::now());
-            }
-            due
-        };
+        // Only *read* the timer here; reset it after the listing pass actually
+        // succeeds, so an S3 outage (every list errors) doesn't reset the clock
+        // and suppress re-validation for another full interval.
+        let force_full = self
+            .last_full_scan
+            .lock()
+            .unwrap()
+            .is_none_or(|t| t.elapsed() >= SETTLED_REVALIDATE_INTERVAL);
         let settled_snapshot = self.settled_prefixes.lock().unwrap().clone();
         let mut listed_with_hits: Vec<String> = Vec::new();
+        let mut any_list_ok = false;
         for (_ref_time, prefix) in &prefixes {
             if let Some(budget) = scan_budget {
                 if runs_with_hits >= budget {
@@ -320,6 +321,7 @@ impl GribEngine {
             let mut hits_in_this_prefix = 0usize;
             match self.store.list(&obj_prefix) {
                 Ok(objects) => {
+                    any_list_ok = true;
                     for obj in objects {
                         let loc = obj.location.as_ref();
                         if !loc.ends_with(index_suffix) {
@@ -358,6 +360,14 @@ impl GribEngine {
             let window: HashSet<&str> = prefixes.iter().map(|(_, p)| p.as_str()).collect();
             let mut settled = self.settled_prefixes.lock().unwrap();
             settle_completed_runs(&mut settled, &listed_with_hits, &window);
+        }
+
+        // Reset the re-validation clock only after a forced full pass that
+        // actually listed at least one prefix successfully — so a total S3
+        // outage retries the full scan next poll instead of waiting another
+        // interval (see SETTLED_REVALIDATE_INTERVAL).
+        if force_full && any_list_ok {
+            *self.last_full_scan.lock().unwrap() = Some(Instant::now());
         }
         tracing::debug!(
             "Collection '{}': listed {}/{} prefixes ({} settled, skipped), {} runs produced hits, {} candidate index files",

--- a/crates/engine-grib/src/lib.rs
+++ b/crates/engine-grib/src/lib.rs
@@ -8,6 +8,7 @@ pub mod wgrib2_index;
 
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::{Arc, Mutex, RwLock};
+use std::time::{Duration, Instant};
 
 use arc_swap::ArcSwap;
 use chrono::{DateTime, Datelike, Utc};
@@ -81,6 +82,15 @@ const DEFAULT_RUN_HOURS: &[u32] = &[0, 6, 12, 18];
 /// Number of days to scan back (today + yesterday handles overnight transitions).
 const SCAN_DAYS: u32 = 2;
 
+/// How often to force a full re-list of all run prefixes, ignoring the settled
+/// skip. NWP runs publish sequentially so older runs are normally static, but a
+/// provider can append late/corrected step files to an already-scanned run; a
+/// periodic full scan catches those new paths within this bound while still
+/// skipping the per-poll re-list the rest of the time. (Same-key content
+/// rewrites of an existing index file are a separate, pre-existing limitation
+/// of the path-keyed `known_indexes` dedup, not addressed here.)
+const SETTLED_REVALIDATE_INTERVAL: Duration = Duration::from_secs(3600);
+
 /// Engine for serving GRIB2 NWP forecast data.
 ///
 /// Discovers GRIB files via index sidecar files on S3/HTTP, fetches individual
@@ -106,6 +116,10 @@ pub struct GribEngine {
     /// unknown prefixes (new/not-yet-published runs) and the single newest
     /// known run are listed each scan. See `scan_once`.
     settled_prefixes: Mutex<HashSet<String>>,
+    /// When the last full re-list (ignoring `settled_prefixes`) ran. `None`
+    /// until the first scan. Drives the periodic re-validation in `scan_once`
+    /// (see [`SETTLED_REVALIDATE_INTERVAL`]).
+    last_full_scan: Mutex<Option<Instant>>,
     /// Which index file format this collection uses.
     index_format: index::IndexFormat,
     /// Parameter metadata cache keyed by short name. Populated lazily on
@@ -185,6 +199,7 @@ impl GribEngine {
             param_filter: config.parameters.clone(),
             known_indexes: Mutex::new(HashSet::new()),
             settled_prefixes: Mutex::new(HashSet::new()),
+            last_full_scan: Mutex::new(None),
             index_format,
             param_meta: RwLock::new(HashMap::new()),
         };
@@ -277,6 +292,17 @@ impl GribEngine {
         // plus the newest run still gaining steps. Prefixes with hits this scan
         // are collected newest-first; after the loop all but the newest are
         // settled.
+        // Periodically force a full re-list so late/corrected step files added
+        // to an already-settled run are still picked up (bounded by
+        // SETTLED_REVALIDATE_INTERVAL).
+        let force_full = {
+            let mut last = self.last_full_scan.lock().unwrap();
+            let due = last.is_none_or(|t| t.elapsed() >= SETTLED_REVALIDATE_INTERVAL);
+            if due {
+                *last = Some(Instant::now());
+            }
+            due
+        };
         let settled_snapshot = self.settled_prefixes.lock().unwrap().clone();
         let mut listed_with_hits: Vec<String> = Vec::new();
         for (_ref_time, prefix) in &prefixes {
@@ -285,7 +311,7 @@ impl GribEngine {
                     break;
                 }
             }
-            if settled_snapshot.contains(prefix) {
+            if !force_full && settled_snapshot.contains(prefix) {
                 skipped_settled += 1;
                 continue;
             }

--- a/crates/engine-grib/src/lib.rs
+++ b/crates/engine-grib/src/lib.rs
@@ -99,6 +99,13 @@ pub struct GribEngine {
     /// Index files already downloaded and parsed (by S3 path). Avoids
     /// re-downloading unchanged index files on every poll cycle.
     known_indexes: Mutex<HashSet<String>>,
+    /// Run prefixes that have been fully listed in a previous scan and are no
+    /// longer the newest run. Listing a run prefix returns *all* its (often
+    /// hundreds of) step files; once a newer run exists, an older run is
+    /// static (NWP runs publish sequentially), so we skip re-listing it. Only
+    /// unknown prefixes (new/not-yet-published runs) and the single newest
+    /// known run are listed each scan. See `scan_once`.
+    settled_prefixes: Mutex<HashSet<String>>,
     /// Which index file format this collection uses.
     index_format: index::IndexFormat,
     /// Parameter metadata cache keyed by short name. Populated lazily on
@@ -177,6 +184,7 @@ impl GribEngine {
             shutdown_tx,
             param_filter: config.parameters.clone(),
             known_indexes: Mutex::new(HashSet::new()),
+            settled_prefixes: Mutex::new(HashSet::new()),
             index_format,
             param_meta: RwLock::new(HashMap::new()),
         };
@@ -260,11 +268,26 @@ impl GribEngine {
         let mut all_index_paths: Vec<ds_storage::object_store::path::Path> = Vec::new();
         let mut runs_with_hits = 0usize;
         let mut listed_prefixes = 0usize;
+        let mut skipped_settled = 0usize;
+        // Run prefixes we've already fully scanned and that are no longer the
+        // newest run are "settled": NWP runs publish sequentially, so an older
+        // run is static and re-listing its hundreds of step files every poll is
+        // wasted work (and wasted `block_in_place` round-trips — #221). We skip
+        // them and only list unknown prefixes (new / not-yet-published runs)
+        // plus the newest run still gaining steps. Prefixes with hits this scan
+        // are collected newest-first; after the loop all but the newest are
+        // settled.
+        let settled_snapshot = self.settled_prefixes.lock().unwrap().clone();
+        let mut listed_with_hits: Vec<String> = Vec::new();
         for (_ref_time, prefix) in &prefixes {
             if let Some(budget) = scan_budget {
                 if runs_with_hits >= budget {
                     break;
                 }
+            }
+            if settled_snapshot.contains(prefix) {
+                skipped_settled += 1;
+                continue;
             }
             listed_prefixes += 1;
             let obj_prefix = ds_storage::object_store::path::Path::from(prefix.as_str());
@@ -296,13 +319,26 @@ impl GribEngine {
             }
             if hits_in_this_prefix > 0 {
                 runs_with_hits += 1;
+                listed_with_hits.push(prefix.clone());
             }
         }
+
+        // Settle every run we listed with hits except the newest (first in the
+        // newest-first iteration order), which may still be gaining steps.
+        // Prune the settled set to the current scan window so it cannot grow
+        // unbounded as old runs age out (and so a prefix that ever reappears is
+        // rescanned).
+        {
+            let window: HashSet<&str> = prefixes.iter().map(|(_, p)| p.as_str()).collect();
+            let mut settled = self.settled_prefixes.lock().unwrap();
+            settle_completed_runs(&mut settled, &listed_with_hits, &window);
+        }
         tracing::debug!(
-            "Collection '{}': listed {}/{} prefixes, {} runs produced hits, {} candidate index files",
+            "Collection '{}': listed {}/{} prefixes ({} settled, skipped), {} runs produced hits, {} candidate index files",
             self.collection_id,
             listed_prefixes,
             prefixes.len(),
+            skipped_settled,
             runs_with_hits,
             all_index_paths.len()
         );
@@ -1318,9 +1354,101 @@ fn build_scan_prefixes(
     out
 }
 
+/// Update the set of "settled" run prefixes after a scan.
+///
+/// `listed_with_hits` are the run prefixes that produced index files this scan,
+/// in newest-first order. Every one except the newest is marked settled (NWP
+/// runs publish sequentially, so once a newer run exists an older one is static
+/// and need not be re-listed). The newest is left unsettled so its still-
+/// trickling steps keep being picked up. `window` is the current scan window;
+/// settled prefixes outside it are pruned so the set cannot grow unbounded as
+/// old runs age out.
+fn settle_completed_runs(
+    settled: &mut HashSet<String>,
+    listed_with_hits: &[String],
+    window: &HashSet<&str>,
+) {
+    for prefix in listed_with_hits.iter().skip(1) {
+        settled.insert(prefix.clone());
+    }
+    settled.retain(|p| window.contains(p.as_str()));
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn win<'a>(prefixes: &'a [&'a str]) -> HashSet<&'a str> {
+        prefixes.iter().copied().collect()
+    }
+
+    #[test]
+    fn settle_keeps_newest_unsettled() {
+        // First scan lists three runs (newest-first); the two older ones settle,
+        // the newest stays unsettled so its trickling steps keep being scanned.
+        let mut settled = HashSet::new();
+        let listed = [
+            "runN".to_string(),
+            "runN-1".to_string(),
+            "runN-2".to_string(),
+        ];
+        settle_completed_runs(&mut settled, &listed, &win(&["runN", "runN-1", "runN-2"]));
+        assert!(!settled.contains("runN"), "newest run must not be settled");
+        assert!(settled.contains("runN-1"));
+        assert!(settled.contains("runN-2"));
+    }
+
+    #[test]
+    fn settle_evolves_when_new_run_appears() {
+        // Scan 1: runs N-1..N-3 published; N-2/N-3 settle, N-1 newest.
+        let mut settled = HashSet::new();
+        let window = win(&["runN-1", "runN-2", "runN-3"]);
+        settle_completed_runs(
+            &mut settled,
+            &[
+                "runN-1".to_string(),
+                "runN-2".to_string(),
+                "runN-3".to_string(),
+            ],
+            &window,
+        );
+        assert_eq!(
+            settled,
+            ["runN-2", "runN-3"].iter().map(|s| s.to_string()).collect()
+        );
+
+        // Scan 2: nothing new; only the unsettled newest (N-1) was listed.
+        settle_completed_runs(&mut settled, &["runN-1".to_string()], &window);
+        assert!(
+            !settled.contains("runN-1"),
+            "newest still re-listed, not settled"
+        );
+
+        // Scan 3: new run N appears; both N (new) and N-1 (was newest) were
+        // listed → N-1 now settles, N becomes the newest unsettled run.
+        let window3 = win(&["runN", "runN-1", "runN-2", "runN-3"]);
+        settle_completed_runs(
+            &mut settled,
+            &["runN".to_string(), "runN-1".to_string()],
+            &window3,
+        );
+        assert!(
+            !settled.contains("runN"),
+            "new newest run must stay unsettled"
+        );
+        assert!(settled.contains("runN-1"), "previous newest now settled");
+    }
+
+    #[test]
+    fn settle_prunes_out_of_window_prefixes() {
+        // Aged-out prefixes drop from the settled set so it can't grow forever.
+        let mut settled: HashSet<String> = ["old1", "old2", "runN-1"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        settle_completed_runs(&mut settled, &[], &win(&["runN", "runN-1"]));
+        assert_eq!(settled, ["runN-1"].iter().map(|s| s.to_string()).collect());
+    }
 
     #[test]
     fn test_parse_coords_point() {

--- a/crates/server/src/admin.rs
+++ b/crates/server/src/admin.rs
@@ -1824,34 +1824,35 @@ pub async fn reload_handler(
         ));
     }
 
-    // Spawn poll loops for new engines
+    // Spawn poll loops for new engines on the dedicated background runtime
+    // so their blocking I/O never parks a request-serving worker (#221).
     for engine in &result.geotiff_engines {
         let poller = engine.clone();
-        tokio::spawn(async move {
+        crate::poll_runtime().spawn(async move {
             poller.poll_loop().await;
         });
     }
     for engine in &result.querydata_engines {
         let poller = engine.clone();
-        tokio::spawn(async move {
+        crate::poll_runtime().spawn(async move {
             poller.poll_loop().await;
         });
     }
     for engine in &result.grib_engines {
         let poller = engine.clone();
-        tokio::spawn(async move {
+        crate::poll_runtime().spawn(async move {
             poller.poll_loop().await;
         });
     }
     for engine in &result.odim_engines {
         let poller = engine.clone();
-        tokio::spawn(async move {
+        crate::poll_runtime().spawn(async move {
             poller.poll_loop().await;
         });
     }
     for engine in &result.odim_volume_engines {
         let poller = engine.clone();
-        tokio::spawn(async move {
+        crate::poll_runtime().spawn(async move {
             poller.poll_loop().await;
         });
     }

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -14,11 +14,24 @@ use std::sync::{Arc, OnceLock, RwLock};
 /// path. `block_in_place` still works here because this is a multi-thread
 /// runtime; it would panic on a `spawn_blocking` pool thread, which is why we
 /// use a separate runtime rather than wrapping the sync scan in `spawn_blocking`.
+///
+/// The runtime lives in a `OnceLock` for the whole process. On exit it is
+/// leaked (statics are not dropped), so poll tasks are aborted rather than
+/// drained — which is safe here: a poll only reads the (read-only) data store
+/// and swaps an in-memory `ArcSwap` catalog atomically, so an aborted scan
+/// leaves no partial or corrupt state and the catalog is simply rebuilt on the
+/// next start. Poll loops also observe the per-engine shutdown watch channel
+/// and exit their `select!` cleanly when signalled before exit.
+///
+/// `worker_threads(4)` gives headroom so several collections polling at once
+/// (or a reload spawning fresh loops while old scans are still blocked) don't
+/// serialise on too few threads; `block_in_place` additionally lets Tokio spin
+/// up temporary replacement workers while a poll blocks.
 pub(crate) fn poll_runtime() -> &'static tokio::runtime::Handle {
     static RT: OnceLock<tokio::runtime::Runtime> = OnceLock::new();
     RT.get_or_init(|| {
         tokio::runtime::Builder::new_multi_thread()
-            .worker_threads(2)
+            .worker_threads(4)
             .thread_name("mc-poll")
             .enable_all()
             .build()

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -1,7 +1,31 @@
 mod admin;
 mod preview;
 
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, OnceLock, RwLock};
+
+/// Dedicated multi-thread runtime for background collection poll loops.
+///
+/// Poll/scan loops do blocking I/O via `ds_storage::DataStore`, which parks the
+/// calling worker thread (`block_in_place`) for the whole network round-trip.
+/// Running them on the main request-serving runtime lets a slow/heavy poll
+/// (e.g. a GRIB new-run probe doing dozens of sequential byte-range reads)
+/// starve the worker pool and spike WMS latency for every collection (#221).
+/// Isolating polls on their own runtime keeps that blocking off the request
+/// path. `block_in_place` still works here because this is a multi-thread
+/// runtime; it would panic on a `spawn_blocking` pool thread, which is why we
+/// use a separate runtime rather than wrapping the sync scan in `spawn_blocking`.
+pub(crate) fn poll_runtime() -> &'static tokio::runtime::Handle {
+    static RT: OnceLock<tokio::runtime::Runtime> = OnceLock::new();
+    RT.get_or_init(|| {
+        tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(2)
+            .thread_name("mc-poll")
+            .enable_all()
+            .build()
+            .expect("failed to build background poll runtime")
+    })
+    .handle()
+}
 
 use arc_swap::ArcSwap;
 use axum::body::Body;
@@ -199,34 +223,35 @@ async fn main() {
         config.collections.len()
     );
 
-    // Spawn poll loops
+    // Spawn poll loops on the dedicated background runtime so their blocking
+    // I/O never parks a request-serving worker (#221).
     for engine in &result.geotiff_engines {
         let poller = engine.clone();
-        tokio::spawn(async move {
+        poll_runtime().spawn(async move {
             poller.poll_loop().await;
         });
     }
     for engine in &result.querydata_engines {
         let poller = engine.clone();
-        tokio::spawn(async move {
+        poll_runtime().spawn(async move {
             poller.poll_loop().await;
         });
     }
     for engine in &result.grib_engines {
         let poller = engine.clone();
-        tokio::spawn(async move {
+        poll_runtime().spawn(async move {
             poller.poll_loop().await;
         });
     }
     for engine in &result.odim_engines {
         let poller = engine.clone();
-        tokio::spawn(async move {
+        poll_runtime().spawn(async move {
             poller.poll_loop().await;
         });
     }
     for engine in &result.odim_volume_engines {
         let poller = engine.clone();
-        tokio::spawn(async move {
+        poll_runtime().spawn(async move {
             poller.poll_loop().await;
         });
     }


### PR DESCRIPTION
Fixes the periodic multi-second WMS p99 spikes at low load (#221, epic #201).

## Root cause
Collection poll loops do blocking I/O on the **shared request-serving Tokio runtime**: `ds-storage`'s sync bridge parks the worker thread via `block_in_place` for the whole network round-trip (storage/src/lib.rs:109), and the GRIB new-run probe does up to ~35 sequential byte-range reads. With only 12 worker threads, overlapping polls starve the pool and stall unrelated WMS renders — Prometheus showed ~0.3 s baseline p99 jumping to ~4–5 s every few minutes.

## Changes
1. **Dedicated background runtime for poll loops** (`poll_runtime()` in `server/src/main.rs`; used by startup *and* the `admin.rs` reload path). Poll `block_in_place` now parks background threads, never request workers.
   - Note: the obvious "wrap `scan_once` in `spawn_blocking`" would **panic** — `block_in_place` is illegal on a blocking-pool thread — so a separate multi-thread runtime is the correct fix.
2. **GRIB poll default 300 s → 600 s** (NWP models publish ~6-hourly; some less often). Per-collection `poll_interval_secs` still overrides for the rare faster model.
3. **GRIB skips settled run prefixes.** Listing a run prefix returns all its (hundreds of) step files. Once a newer run exists, an older run is static (runs publish sequentially), so each scan now lists only unknown prefixes (new / not-yet-published) plus the single newest run still gaining steps. `settle_completed_runs` settles all-but-newest of the runs listed with hits and prunes to the scan window — unit-tested for the multi-scan evolution (new-run appears, prune, newest-stays-active).

## Tests
`cargo test -p ds-core -p engine-grib` green (incl. 3 new `settle_*` tests); `cargo build -p server` green; clippy clean; fmt applied.

This is the cross-engine fix; ODIM already used `spawn_blocking` correctly and is moved onto the background runtime too (neutral). Geotiff/querydata poll_once (previously #208) are fixed by the runtime isolation as well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)