### PR TITLE
docs: align 'Adding a New Engine' step 7 with the background-runtime rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,7 @@ The core crate is named `ds-core` in Cargo.toml (imported as `ds_core` in Rust).
 4. Add the crate as a dependency of `crates/server/Cargo.toml`
 5. Add a match arm for the new `engine_type` in `server/src/main.rs`
 6. Wire it into the appropriate registries based on the collection's `apis` config
-7. **Obey the Engine Performance & Concurrency Rules below** — especially: the poll loop must `spawn_blocking`, and the render/decode path must not project per output pixel.
+7. **Obey the Engine Performance & Concurrency Rules below** — especially: spawn the poll loop on the dedicated background runtime (not the request runtime), and the render/decode path must not project per output pixel.
 
 ## Engine Performance & Concurrency Rules
 


### PR DESCRIPTION
Follow-up to #223 (merged). The `Adding a New Engine` step-7 teaser still said the poll loop "must `spawn_blocking`", contradicting the corrected rule body (poll loops run on the dedicated background runtime; `spawn_blocking` + `block_in_place` panics). Points it at the background runtime instead.

Note: #223's re-review also flagged `poll_runtime()` as nonexistent — that review ran before #226 merged; `poll_runtime()` now exists on main (server/src/main.rs), so the reference is accurate.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)