### PR TITLE
fix(server): add WMS latency histogram buckets between 1s and 5s

### DIFF
--- a/crates/server/src/admin.rs
+++ b/crates/server/src/admin.rs
@@ -44,8 +44,13 @@ static HTTP_REQUEST_DURATION: LazyLock<HistogramVec> = LazyLock::new(|| {
             "http_request_duration_seconds",
             "HTTP request duration in seconds",
         )
+        // Buckets include 1.5/2/3/4 between 1s and 5s: without them, any
+        // request in (1, 5] is linearly interpolated by histogram_quantile
+        // across that wide bucket, so a handful of ~1.5s requests at low
+        // traffic read as a ~4-5s p99 in Grafana. 10s separates genuine
+        // >5s outliers from the merely-slow.
         .buckets(vec![
-            0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 5.0,
+            0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 5.0, 10.0,
         ]),
         &["method", "path"],
     )


### PR DESCRIPTION
## Problem
The `http_request_duration_seconds` histogram buckets jumped straight from `le=1` to `le=5`. With no buckets in between, `histogram_quantile` linearly interpolates any request in the `(1, 5]` bucket across that whole range — so at low traffic a handful of genuinely ~1.5s requests read as a **~4–5s p99** in Grafana. That's a metric artifact, not real latency: production logs during such a 'spike' showed the slowest actual requests were ~1.6s.

## Fix
Add `1.5, 2.0, 3.0, 4.0` (and `10.0` to separate true >5s outliers) to the bucket set. p99 now reflects reality (~1.6s) instead of the interpolated ~4.7s.

Surfaced while validating the #221 poll-isolation fix in production (deployed v0.5.1): the poll-induced multi-second stalls are gone; the residual ~1.6s is fullscreen cache-miss render cost (tracked by #202/#206/#207), and this PR makes the dashboards show it accurately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)