### PR TITLE
perf(storage,engine-geotiff): reuse runtime for remote tile fetches instead of Runtime-per-tile (#222)

### DIFF
--- a/crates/engine-geotiff/src/reader.rs
+++ b/crates/engine-geotiff/src/reader.rs
@@ -995,6 +995,9 @@ fn read_remote_chunk_f64(
     file_path: &Path,
     band_index: usize,
     ifd_index: u16,
+    // Runtime handle to drive the fetch on when called from a non-Tokio
+    // (rayon) thread; `None` for callers already on a runtime worker. See #222.
+    handle: Option<&tokio::runtime::Handle>,
 ) -> Result<Vec<Option<f64>>, DataServerError> {
     let idx = chunk_index as usize;
     if idx >= tile_info.tile_offsets.len() {
@@ -1037,13 +1040,19 @@ fn read_remote_chunk_f64(
         ))
     })?;
 
+    // Fetch a byte range, reusing the caller's runtime handle when on a rayon
+    // thread (avoids a per-call Runtime::new — see #222).
+    let fetch_range = |range: std::ops::Range<usize>| match handle {
+        Some(h) => store.get_range_on(obj_path, range, h),
+        None => store.get_range(obj_path, range),
+    };
+
     // Check cache for compressed bytes (keyed by file + chunk + IFD level)
     let compressed = if let Some(c) = cache {
         if let Some(cached) = c.get(file_path, chunk_index, ifd_index) {
             cached
         } else {
-            let fetched = store
-                .get_range(obj_path, offset..end)
+            let fetched = fetch_range(offset..end)
                 .map_err(|e| DataServerError::Engine(format!("Failed to read tile range: {e}")))?;
             // Validate response length matches request
             if fetched.len() != byte_count {
@@ -1058,8 +1067,7 @@ fn read_remote_chunk_f64(
             fetched
         }
     } else {
-        let fetched = store
-            .get_range(obj_path, offset..end)
+        let fetched = fetch_range(offset..end)
             .map_err(|e| DataServerError::Engine(format!("Failed to read tile range: {e}")))?;
         if fetched.len() != byte_count {
             return Err(DataServerError::Engine(format!(
@@ -1090,10 +1098,13 @@ fn read_http_range(
     http: &reqwest::Client,
     url: &str,
     range: std::ops::Range<usize>,
+    // Runtime handle to drive the request on when called from a non-Tokio
+    // (rayon) thread; `None` for callers already on a runtime worker. See #222.
+    handle: Option<&tokio::runtime::Handle>,
 ) -> Result<Bytes, DataServerError> {
     let range_header = format!("bytes={}-{}", range.start, range.end.saturating_sub(1));
     let url_owned = url.to_string();
-    block_on_async(async {
+    let fut = async {
         let resp = http
             .get(&url_owned)
             .header(reqwest::header::RANGE, &range_header)
@@ -1109,7 +1120,11 @@ fn read_http_range(
         resp.bytes()
             .await
             .map_err(|e| DataServerError::Engine(format!("Failed to read body: {e}")))
-    })
+    };
+    match handle {
+        Some(h) => h.block_on(fut),
+        None => block_on_async(fut),
+    }
 }
 
 /// Read and decode a tile from an HTTP source via byte-range read (reqwest).
@@ -1125,6 +1140,9 @@ fn read_http_chunk_f64(
     file_path: &Path,
     band_index: usize,
     ifd_index: u16,
+    // Runtime handle for the fetch when on a non-Tokio (rayon) thread; `None`
+    // for callers already on a runtime worker. See #222.
+    handle: Option<&tokio::runtime::Handle>,
 ) -> Result<Vec<Option<f64>>, DataServerError> {
     let idx = chunk_index as usize;
     if idx >= tile_info.tile_offsets.len() {
@@ -1166,7 +1184,7 @@ fn read_http_chunk_f64(
         if let Some(cached) = c.get(file_path, chunk_index, ifd_index) {
             cached
         } else {
-            let fetched = read_http_range(http, url, offset..end)?;
+            let fetched = read_http_range(http, url, offset..end, handle)?;
             if fetched.len() != byte_count {
                 return Err(DataServerError::Engine(format!(
                     "Tile {} truncated: requested {} bytes, got {}",
@@ -1179,7 +1197,7 @@ fn read_http_chunk_f64(
             fetched
         }
     } else {
-        let fetched = read_http_range(http, url, offset..end)?;
+        let fetched = read_http_range(http, url, offset..end, handle)?;
         if fetched.len() != byte_count {
             return Err(DataServerError::Engine(format!(
                 "Tile {} truncated: requested {} bytes, got {}",
@@ -1239,7 +1257,8 @@ pub fn read_pixel(
             cache,
             file_path,
             band_index,
-            0, // full resolution IFD
+            0,    // full resolution IFD
+            None, // single-pixel read: caller is already on a runtime worker
         )?,
         DataSource::HttpDirect {
             url,
@@ -1254,7 +1273,8 @@ pub fn read_pixel(
             cache,
             file_path,
             band_index,
-            0, // full resolution IFD
+            0,    // full resolution IFD
+            None, // single-pixel read: caller is already on a runtime worker
         )?,
         _ => {
             let mut decoder = source.open_decoder()?;
@@ -1706,6 +1726,13 @@ fn read_bbox_parallel(
         .flat_map(|tr| (tile_col_start..tile_col_end).map(move |tc| (tr, tc)))
         .collect();
 
+    // Capture the current runtime handle (we're on a spawn_blocking worker)
+    // so the rayon workers can drive their fetches on the existing runtime
+    // instead of spawning a fresh Runtime per tile (#222). `None` only if no
+    // runtime is current (e.g. tests), in which case the storage layer falls
+    // back to its own temporary runtime.
+    let rt_handle = tokio::runtime::Handle::try_current().ok();
+
     // Fetch all tiles in parallel using the shared thread pool.
     // Failed tiles are logged at error level and replaced with nodata.
     let tile_pixel_count = (metadata.tile_width * metadata.tile_height) as usize;
@@ -1732,6 +1759,7 @@ fn read_bbox_parallel(
                             file_path,
                             band_index,
                             ifd_index,
+                            rt_handle.as_ref(),
                         )
                     },
                     tile_row,
@@ -1796,6 +1824,9 @@ fn read_bbox_parallel_http(
     let http_clone = http.clone();
     let url_owned = url.to_string();
 
+    // Reuse the current runtime for the rayon workers' fetches (#222).
+    let rt_handle = tokio::runtime::Handle::try_current().ok();
+
     let tile_pixel_count = (metadata.tile_width * metadata.tile_height) as usize;
     let tile_results: Vec<TileFetchResult> = TILE_FETCH_POOL.install(|| {
         tile_coords
@@ -1820,6 +1851,7 @@ fn read_bbox_parallel_http(
                             file_path,
                             band_index,
                             ifd_index,
+                            rt_handle.as_ref(),
                         )
                     },
                     tile_row,

--- a/crates/engine-geotiff/src/reader.rs
+++ b/crates/engine-geotiff/src/reader.rs
@@ -1726,11 +1726,12 @@ fn read_bbox_parallel(
         .flat_map(|tr| (tile_col_start..tile_col_end).map(move |tc| (tr, tc)))
         .collect();
 
-    // Capture the current runtime handle (we're on a spawn_blocking worker)
-    // so the rayon workers can drive their fetches on the existing runtime
-    // instead of spawning a fresh Runtime per tile (#222). `None` only if no
-    // runtime is current (e.g. tests), in which case the storage layer falls
-    // back to its own temporary runtime.
+    // Capture the current runtime handle (this runs inside the request
+    // runtime — whether on a spawn_blocking thread or an async task doesn't
+    // matter, we only pass the handle down) so the rayon workers can drive
+    // their fetches on the existing runtime instead of spawning a fresh
+    // Runtime per tile (#222). `None` only if no runtime is current (e.g.
+    // tests), in which case the storage layer falls back to a temporary one.
     let rt_handle = tokio::runtime::Handle::try_current().ok();
 
     // Fetch all tiles in parallel using the shared thread pool.

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -64,6 +64,26 @@ impl DataStore {
         Ok(result)
     }
 
+    /// Like [`Self::get_range`], but drives the fetch on an explicitly-provided
+    /// runtime `Handle` (`handle.block_on`). Use this when calling from a thread
+    /// that is **not** a Tokio worker and has no current handle — e.g. a `rayon`
+    /// pool worker — so the I/O reuses the main runtime instead of `block_on`'s
+    /// `try_current()` fallback that constructs a brand-new `Runtime` per call
+    /// (#222). Must NOT be called from within an async execution context.
+    pub fn get_range_on(
+        &self,
+        path: &ObjectPath,
+        range: Range<usize>,
+        handle: &tokio::runtime::Handle,
+    ) -> Result<Bytes, DataServerError> {
+        let result = self.block_on_with(Some(handle), async {
+            self.inner.get_range(path, range).await
+        })?;
+        self.bytes_read
+            .fetch_add(result.len() as u64, Ordering::Relaxed);
+        Ok(result)
+    }
+
     /// Return total bytes read from this store since creation.
     pub fn bytes_read(&self) -> u64 {
         self.bytes_read.load(Ordering::Relaxed)
@@ -95,6 +115,23 @@ impl DataStore {
     where
         F: std::future::Future<Output = Result<T, object_store::Error>>,
     {
+        self.block_on_with(None, future)
+    }
+
+    /// Core sync→async bridge. With an explicit `handle` (caller is on a
+    /// non-Tokio thread such as a rayon worker) it drives the future on that
+    /// runtime via `handle.block_on` — no `block_in_place` (which would panic
+    /// off a worker thread) and no per-call `Runtime::new`. With `None` it
+    /// uses `block_in_place` when already inside a runtime, else spins up a
+    /// temporary runtime (tests / CLI).
+    fn block_on_with<F, T>(
+        &self,
+        handle: Option<&tokio::runtime::Handle>,
+        future: F,
+    ) -> Result<T, DataServerError>
+    where
+        F: std::future::Future<Output = Result<T, object_store::Error>>,
+    {
         let timed = async {
             match tokio::time::timeout(Self::REQUEST_TIMEOUT, future).await {
                 Ok(result) => result,
@@ -104,19 +141,20 @@ impl DataStore {
                 }),
             }
         };
-        match tokio::runtime::Handle::try_current() {
-            Ok(handle) => {
-                let result = tokio::task::block_in_place(|| handle.block_on(timed));
-                result.map_err(|e| DataServerError::from(StorageError::from(e)))
-            }
-            Err(_) => {
-                // No runtime — create a temporary one (e.g., in tests or CLI tools)
-                let rt = tokio::runtime::Runtime::new()
-                    .map_err(|e| DataServerError::Storage(format!("Cannot create runtime: {e}")))?;
-                let result = rt.block_on(timed);
-                result.map_err(|e| DataServerError::from(StorageError::from(e)))
-            }
-        }
+        let result = match handle {
+            Some(h) => h.block_on(timed),
+            None => match tokio::runtime::Handle::try_current() {
+                Ok(handle) => tokio::task::block_in_place(|| handle.block_on(timed)),
+                Err(_) => {
+                    // No runtime — create a temporary one (e.g., tests / CLI tools)
+                    let rt = tokio::runtime::Runtime::new().map_err(|e| {
+                        DataServerError::Storage(format!("Cannot create runtime: {e}"))
+                    })?;
+                    rt.block_on(timed)
+                }
+            },
+        };
+        result.map_err(|e| DataServerError::from(StorageError::from(e)))
     }
 
     /// Get the underlying async ObjectStore for use in async contexts
@@ -353,6 +391,28 @@ mod tests {
         let first = &entries[0].location;
         let header = store.get_range(first, 0..4).unwrap();
         // TIFF magic: II (little-endian) = 0x49 0x49 0x2A 0x00
+        assert_eq!(&header[0..2], b"II", "Expected little-endian TIFF header");
+    }
+
+    // get_range_on must work when called from a thread that is NOT a Tokio
+    // worker (mirrors the rayon tile-fetch pool): it should drive the fetch on
+    // the supplied handle, not panic via block_in_place, and not spin up a new
+    // Runtime per call (#222).
+    #[tokio::test(flavor = "multi_thread")]
+    async fn get_range_on_from_foreign_thread() {
+        let (store, _prefix) = build_store("testdata/radar")
+            .unwrap_or_else(|_| build_store("../../testdata/radar").expect("testdata/radar"));
+        let entries = store.list(&ObjectPath::from("")).unwrap();
+        let first = entries[0].location.clone();
+
+        let handle = tokio::runtime::Handle::current();
+        let store_ref = &store;
+        // A plain OS thread has no current Tokio handle (like a rayon worker).
+        let header = std::thread::scope(|s| {
+            s.spawn(|| store_ref.get_range_on(&first, 0..4, &handle).unwrap())
+                .join()
+                .unwrap()
+        });
         assert_eq!(&header[0..2], b"II", "Expected little-endian TIFF header");
     }
 }

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -69,7 +69,9 @@ impl DataStore {
     /// that is **not** a Tokio worker and has no current handle — e.g. a `rayon`
     /// pool worker — so the I/O reuses the main runtime instead of `block_on`'s
     /// `try_current()` fallback that constructs a brand-new `Runtime` per call
-    /// (#222). Must NOT be called from within an async execution context.
+    /// (#222). Must NOT be called from within an async task (a running future);
+    /// a `spawn_blocking` thread or a rayon worker is fine (`handle.block_on`
+    /// is valid there).
     pub fn get_range_on(
         &self,
         path: &ObjectPath,


### PR DESCRIPTION
Closes #222.

## Problem
Remote GeoTIFF tile reads run on the rayon `TILE_FETCH_POOL`. Rayon workers have **no current Tokio handle**, so `DataStore::block_on` (object_store path) and `block_on_async` (HTTP path) fall through to `Runtime::new()` — constructing and tearing down a whole multi-thread Tokio runtime **per tile fetch**, for every remote render (opera-*, met-norway-radar, fmi-radar S3). Thread/alloc churn that grows with render traffic.

## Fix
Capture the current runtime `Handle` before entering the rayon pool and thread it down so each fetch runs via `handle.block_on` on the existing runtime — no per-call runtime, and no `block_in_place` (which would *panic* off a worker thread; that subtlety is why the issue's original 'enter the handle' suggestion wouldn't work).

- **ds-storage:** new `DataStore::get_range_on(path, range, &Handle)`; `block_on` refactored into `block_on_with(Option<&Handle>, fut)` (the `None` path keeps the existing block_in_place / temp-runtime behaviour for worker-thread and test callers).
- **engine-geotiff reader:** `read_remote_chunk_f64` / `read_http_chunk_f64` / `read_http_range` take `Option<&Handle>`; `read_bbox_parallel` and `read_bbox_parallel_http` capture `Handle::try_current()` and pass it into the rayon closures; single-pixel callers pass `None` (already on a worker).

## Tests
New `get_range_on_from_foreign_thread` proves a fetch from a non-Tokio (foreign/rayon-like) thread returns correct bytes without panicking or creating a runtime. `cargo test -p ds-storage -p engine-geotiff` green; clippy clean.

Note: this is the latent remote-render fire flagged during the spike investigation; it was **not** the local-collection spike (that was #221, shipped). Part of epic #201.

🤖 Generated with [Claude Code](https://claude.com/claude-code)