### PR TITLE
perf(render,api-wms): internal meta-tiling for Web Mercator WMS GetMap (#202)

### DIFF
--- a/README.md
+++ b/README.md
@@ -853,7 +853,7 @@ Or attach a reusable `[[style_bundles]]` block defined in top-level `config.toml
 | `styles` | no | — | Array of named styles |
 | `parameters` | no | — | Per-parameter default-style overrides (multi-parameter engines) |
 | `rendered_cache_mb` | no | `512` | Shared rendered-image cache size in MB. Set to 0 to disable. |
-| `metatile_cache_mb` | no | `512` | Web Mercator meta-tile (decoded-RGBA) cache size in MB. Set to 0 to disable meta-tiling (direct render). |
+| `metatile_cache_mb` | no | `1024` | Web Mercator meta-tile (decoded-RGBA) cache size in MB. Set to 0 to disable meta-tiling (direct render). Global cache: the **minimum** across WMS collections wins, so `0` on any collection disables meta-tiling server-wide. |
 
 ### Limits
 
@@ -1000,7 +1000,7 @@ Separate from the GeoTIFF source tile cache (Tier 1). Caches final PNG/JPEG/WebP
 
 A fullscreen WMS client requests an arbitrary bbox + size per pan/zoom, so the Tier-2 rendered cache (keyed on the exact bbox) rarely hits. For EPSG:3857 GetMap, the WMS handler instead decomposes each request into fixed 256×256 tiles aligned to the WebMercatorQuad grid, renders and caches *those* (decoded RGBA), and resamples them to the exact viewport — so the expensive decode/projection/colorize work is cached at tile granularity and reused across overlapping views.
 
-- Default size: 512 MB (configurable via `metatile_cache_mb`); **set to 0 to disable** meta-tiling (reverts to a direct single-shot render, reload-reversible).
+- Default size: 1024 MB (configurable via `metatile_cache_mb`); **set to 0 to disable** meta-tiling (reverts to a direct single-shot render, reload-reversible). The cache is global; the size is the **minimum** `metatile_cache_mb` across WMS collections, so `0` anywhere disables it server-wide (unlike `rendered_cache_mb`, which takes the first value).
 - Cache key: layer + parameter + style + time + elevation + ladder level + tile col/row.
 - Resolution ladder: half-octave steps coinciding with standard WebMercator zooms; snaps to the finest step ≤ the request resolution (always downsampled, never upscaled).
 - Web Mercator only; other CRSs and degenerate/oversized requests fall back to the direct render.

--- a/README.md
+++ b/README.md
@@ -853,6 +853,7 @@ Or attach a reusable `[[style_bundles]]` block defined in top-level `config.toml
 | `styles` | no | — | Array of named styles |
 | `parameters` | no | — | Per-parameter default-style overrides (multi-parameter engines) |
 | `rendered_cache_mb` | no | `512` | Shared rendered-image cache size in MB. Set to 0 to disable. |
+| `metatile_cache_mb` | no | `512` | Web Mercator meta-tile (decoded-RGBA) cache size in MB. Set to 0 to disable meta-tiling (direct render). |
 
 ### Limits
 
@@ -995,6 +996,16 @@ Separate from the GeoTIFF source tile cache (Tier 1). Caches final PNG/JPEG/WebP
 - Error tiles and empty tiles (all nodata) are NOT cached.
 - MVT vector tiles use a separate `VectorTileCache` (content-derived ETag, `Cache-Control: max-age=300`); they are NOT subject to `rendered_cache_mb`.
 
+### Meta-Tile Cache (Web Mercator WMS)
+
+A fullscreen WMS client requests an arbitrary bbox + size per pan/zoom, so the Tier-2 rendered cache (keyed on the exact bbox) rarely hits. For EPSG:3857 GetMap, the WMS handler instead decomposes each request into fixed 256×256 tiles aligned to the WebMercatorQuad grid, renders and caches *those* (decoded RGBA), and resamples them to the exact viewport — so the expensive decode/projection/colorize work is cached at tile granularity and reused across overlapping views.
+
+- Default size: 512 MB (configurable via `metatile_cache_mb`); **set to 0 to disable** meta-tiling (reverts to a direct single-shot render, reload-reversible).
+- Cache key: layer + parameter + style + time + elevation + ladder level + tile col/row.
+- Resolution ladder: half-octave steps coinciding with standard WebMercator zooms; snaps to the finest step ≤ the request resolution (always downsampled, never upscaled).
+- Web Mercator only; other CRSs and degenerate/oversized requests fall back to the direct render.
+- Distinct from the per-collection GeoTIFF source tile cache (`tile_cache_*`).
+
 ### HTTP Cache Headers
 
 | Scenario | Cache-Control | ETag |
@@ -1075,6 +1086,16 @@ Returns HTTP 503 only when all collections have failed.
 | `rendered_cache_bytes` | gauge | — | Bytes currently held |
 | `rendered_cache_capacity_bytes` | gauge | — | Configured capacity |
 | `rendered_cache_entries` | gauge | — | Number of cached entries |
+
+**Meta-tile cache** (global, Web Mercator WMS decoded-RGBA tiles):
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `metatile_cache_hits_total` | counter | — | Meta-tile pixel cache hits |
+| `metatile_cache_misses_total` | counter | — | Meta-tile pixel cache misses |
+| `metatile_cache_bytes` | gauge | — | Bytes currently held |
+| `metatile_cache_capacity_bytes` | gauge | — | Configured capacity |
+| `metatile_cache_entries` | gauge | — | Number of cached entries |
 
 **GRIB grid cache** (per-collection, decoded grid cache):
 

--- a/crates/api-wms/README.md
+++ b/crates/api-wms/README.md
@@ -204,7 +204,7 @@ Styles are listed in GetCapabilities and include LegendURL links.
 [collections.wms]
 colormap = "radar_dbz"
 rendered_cache_mb = 512    # Default: 512 MB. Set to 0 to disable.
-metatile_cache_mb = 512    # Default: 512 MB. Set to 0 to disable meta-tiling.
+metatile_cache_mb = 1024   # Default: 1024 MB. Set to 0 to disable meta-tiling.
 ```
 
 The rendered image cache stores final PNG/JPEG bytes keyed by bbox, style, format, dimensions, CRS, and timestamp. No TTL — radar data is immutable once produced. Cache is invalidated on collection reload (`POST /admin/collections/reload`).

--- a/crates/api-wms/README.md
+++ b/crates/api-wms/README.md
@@ -204,9 +204,12 @@ Styles are listed in GetCapabilities and include LegendURL links.
 [collections.wms]
 colormap = "radar_dbz"
 rendered_cache_mb = 512    # Default: 512 MB. Set to 0 to disable.
+metatile_cache_mb = 512    # Default: 512 MB. Set to 0 to disable meta-tiling.
 ```
 
 The rendered image cache stores final PNG/JPEG bytes keyed by bbox, style, format, dimensions, CRS, and timestamp. No TTL — radar data is immutable once produced. Cache is invalidated on collection reload (`POST /admin/collections/reload`).
+
+For EPSG:3857 GetMap, the handler additionally uses an internal **meta-tile cache**: each request is decomposed into fixed 256×256 WebMercatorQuad tiles, rendered+cached as decoded RGBA, and resampled to the exact viewport — so overlapping fullscreen views reuse cached tiles instead of re-rendering. `metatile_cache_mb = 0` disables this and reverts to a direct render (reversible via reload).
 
 Also configure the source tile cache for remote GeoTIFFs:
 

--- a/crates/api-wms/README.md
+++ b/crates/api-wms/README.md
@@ -207,7 +207,7 @@ rendered_cache_mb = 512    # Default: 512 MB. Set to 0 to disable.
 metatile_cache_mb = 1024   # Default: 1024 MB. Set to 0 to disable meta-tiling.
 ```
 
-The rendered image cache stores final PNG/JPEG bytes keyed by bbox, style, format, dimensions, CRS, and timestamp. No TTL — radar data is immutable once produced. Cache is invalidated on collection reload (`POST /admin/collections/reload`).
+The rendered image cache stores final PNG/JPEG/WebP bytes keyed by bbox, style, format, dimensions, CRS, and timestamp. No TTL — radar data is immutable once produced. Cache is invalidated on collection reload (`POST /admin/collections/reload`).
 
 For EPSG:3857 GetMap, the handler additionally uses an internal **meta-tile cache**: each request is decomposed into fixed 256×256 WebMercatorQuad tiles, rendered+cached as decoded RGBA, and resampled to the exact viewport — so overlapping fullscreen views reuse cached tiles instead of re-rendering. `metatile_cache_mb = 0` disables this and reverts to a direct render (reversible via reload).
 

--- a/crates/api-wms/src/handlers.rs
+++ b/crates/api-wms/src/handlers.rs
@@ -7,7 +7,8 @@ use axum::http::{header, HeaderMap, StatusCode};
 use axum::response::IntoResponse;
 
 use ds_core::config::CollectionConfig;
-use ds_core::map_engine::MapEngine;
+use ds_core::error::DataServerError;
+use ds_core::map_engine::{MapEngine, OutputCrs};
 use ds_render::{CacheKey, RenderedCache, StyleInfo};
 
 use crate::error::WmsError;
@@ -21,6 +22,8 @@ pub struct WmsState {
     pub styles: HashMap<String, HashMap<String, StyleInfo>>,
     pub render_semaphore: Arc<tokio::sync::Semaphore>,
     pub rendered_cache: Arc<RenderedCache>,
+    /// Decoded-RGBA meta-tile cache for the Web Mercator GetMap path (#202).
+    pub tile_cache: Arc<ds_render::TilePixelCache>,
     pub base_url: String,
 }
 
@@ -227,33 +230,85 @@ pub async fn wms_handler(
             let width = params.width;
             let height = params.height;
             let time = params.time;
-            let output_crs = params.output_crs;
+            let output_crs = params.output_crs.clone();
             let format = params.format;
             let elevation = params.elevation;
+            let z_q = elevation.map(ds_render::quantize_z);
+            let layer = params.layer.clone();
+            let style = params.style.clone();
             let rendered_cache = state.rendered_cache.clone();
+            let tile_cache = state.tile_cache.clone();
 
             // Layer parameter (from "collection/param") takes priority over style parameter
             let style_parameter =
                 layer_parameter.or_else(|| style_info.parameter.as_deref().map(String::from));
 
-            let render_result = tokio::task::spawn_blocking(move || {
-                let tile = engine.get_raster_tile(
-                    bbox,
-                    width,
-                    height,
-                    time,
-                    &output_crs,
-                    style_parameter.as_deref(),
-                    elevation,
-                )?;
-                // If every pixel is nodata, skip colorization + encoding entirely.
-                if tile.is_empty() {
-                    return Ok(None);
-                }
-                ds_render::render_tile(&tile, colormap.as_ref(), format).map(Some)
-            })
-            .await
-            .map_err(|e| WmsError::Internal(format!("Render task failed: {e}")))?;
+            let render_result =
+                tokio::task::spawn_blocking(move || -> Result<Option<Vec<u8>>, DataServerError> {
+                    // Direct single-shot render: one get_raster_tile → colorize → encode.
+                    let direct = || -> Result<Option<Vec<u8>>, DataServerError> {
+                        let tile = engine.get_raster_tile(
+                            bbox,
+                            width,
+                            height,
+                            time,
+                            &output_crs,
+                            style_parameter.as_deref(),
+                            elevation,
+                        )?;
+                        // If every pixel is nodata, skip colorization + encoding entirely.
+                        if tile.is_empty() {
+                            return Ok(None);
+                        }
+                        ds_render::render_tile(&tile, colormap.as_ref(), format).map(Some)
+                    };
+
+                    // Web Mercator: decompose into cached 256×256 meta-tiles and
+                    // resample to the exact viewport (#202). The expensive
+                    // per-tile work is cached and reused across overlapping
+                    // fullscreen views; other CRSs render directly. A zero-byte
+                    // tile cache (`metatile_cache_mb = 0`) is the kill switch:
+                    // it bypasses meta-tiling so an operator can revert to the
+                    // direct path via config reload, no redeploy.
+                    if output_crs == OutputCrs::WebMercator && tile_cache.capacity() > 0 {
+                        let prefix = ds_render::TileKeyPrefix {
+                            layer,
+                            parameter: style_parameter.clone(),
+                            style,
+                            time,
+                            z: z_q,
+                        };
+                        let outcome = ds_render::render_metatiled(
+                            bbox,
+                            width,
+                            height,
+                            &prefix,
+                            colormap.as_ref(),
+                            format,
+                            tile_cache.as_ref(),
+                            |tbbox, tw, th| {
+                                engine.get_raster_tile(
+                                    tbbox,
+                                    tw,
+                                    th,
+                                    time,
+                                    &OutputCrs::WebMercator,
+                                    style_parameter.as_deref(),
+                                    elevation,
+                                )
+                            },
+                        )?;
+                        match outcome {
+                            ds_render::MetaTile::Image(b) => Ok(Some(b)),
+                            ds_render::MetaTile::Empty => Ok(None),
+                            ds_render::MetaTile::Fallback => direct(),
+                        }
+                    } else {
+                        direct()
+                    }
+                })
+                .await
+                .map_err(|e| WmsError::Internal(format!("Render task failed: {e}")))?;
 
             // The EMPTY and ERROR fast paths skip the format-aware encoder and
             // emit PNG bytes directly. Track the *actual* Content-Type per

--- a/crates/api-wms/src/handlers.rs
+++ b/crates/api-wms/src/handlers.rs
@@ -235,7 +235,10 @@ pub async fn wms_handler(
             let elevation = params.elevation;
             let z_q = elevation.map(ds_render::quantize_z);
             let layer = params.layer.clone();
-            let style = params.style.clone();
+            // Key meta-tiles on the *resolved* style name, not the raw STYLES
+            // param: `STYLES=` (empty → default) and `STYLES=default` resolve to
+            // the same StyleInfo, so they must share cached tiles.
+            let style = style_info.name.clone();
             let rendered_cache = state.rendered_cache.clone();
             let tile_cache = state.tile_cache.clone();
 
@@ -278,6 +281,9 @@ pub async fn wms_handler(
                             time,
                             z: z_q,
                         };
+                        // `bbox` is in WGS84 degrees here — the params layer
+                        // converts EPSG:3857 metres to degrees before this point;
+                        // render_metatiled re-projects back to metres internally.
                         let outcome = ds_render::render_metatiled(
                             bbox,
                             width,

--- a/crates/api-wms/tests/integration.rs
+++ b/crates/api-wms/tests/integration.rs
@@ -114,6 +114,7 @@ fn build_empty_router() -> axum::Router {
         styles: styles_map,
         render_semaphore: Arc::new(tokio::sync::Semaphore::new(4)),
         rendered_cache: Arc::new(RenderedCache::new(16)),
+        tile_cache: Arc::new(ds_render::TilePixelCache::new(16)),
         base_url: String::new(),
     }));
     api_wms::router(state)
@@ -261,6 +262,7 @@ fn build_failing_router() -> axum::Router {
         styles: styles_map,
         render_semaphore: Arc::new(tokio::sync::Semaphore::new(4)),
         rendered_cache: Arc::new(RenderedCache::new(16)),
+        tile_cache: Arc::new(ds_render::TilePixelCache::new(16)),
         base_url: String::new(),
     }));
     api_wms::router(state)
@@ -399,6 +401,7 @@ fn build_populated_router() -> axum::Router {
         styles: styles_map,
         render_semaphore: Arc::new(tokio::sync::Semaphore::new(4)),
         rendered_cache: Arc::new(RenderedCache::new(16)),
+        tile_cache: Arc::new(ds_render::TilePixelCache::new(16)),
         base_url: String::new(),
     }));
     api_wms::router(state)
@@ -640,5 +643,224 @@ async fn if_none_match_on_error_tile_returns_304_with_x_cache_error() {
         Some("ERROR"),
         "post-render 304 must forward the `x_cache` label — error \
          tiles revalidating must remain visible as ERROR on dashboards"
+    );
+}
+
+// --- Meta-tiling (#202) ----------------------------------------------------
+
+/// Data-producing engine that counts every `get_raster_tile` call. Lets the
+/// meta-tiling tests prove that overlapping viewports reuse cached tiles
+/// (fewer fresh engine renders) and that the non-3857 / kill-switch paths
+/// bypass meta-tiling entirely.
+struct CountingMockMapEngine {
+    calls: Arc<std::sync::atomic::AtomicUsize>,
+}
+
+impl MapEngine for CountingMockMapEngine {
+    fn get_raster_tile(
+        &self,
+        _bbox: [f64; 4],
+        width: u32,
+        height: u32,
+        _time: Option<chrono::DateTime<chrono::Utc>>,
+        _output_crs: &OutputCrs,
+        _parameter: Option<&str>,
+        _z: Option<f64>,
+    ) -> Result<RasterTile, DataServerError> {
+        self.calls
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        // All in-range, opaque pixels so tiles are cached (have_data) and
+        // colorize to a non-transparent image.
+        Ok(RasterTile {
+            width,
+            height,
+            values: vec![Some(0.5); (width * height) as usize],
+        })
+    }
+
+    fn raster_info(&self) -> RasterInfo {
+        RasterInfo {
+            native_crs: "EPSG:3857".into(),
+            spatial_extent: Some([-20.0, 30.0, 40.0, 80.0]),
+            times: vec![chrono::DateTime::parse_from_rfc3339("2024-01-01T00:00:00Z")
+                .unwrap()
+                .with_timezone(&chrono::Utc)],
+            parameter: "reflectivity".into(),
+            unit: "dBZ".into(),
+            parameters: vec![],
+            vertical: None,
+        }
+    }
+}
+
+/// Build a WMS router over a single `data` collection backed by a counting
+/// engine, returning handles to the shared meta-tile cache and the engine's
+/// call counter so tests can assert reuse. `metatile_mb = 0` exercises the
+/// kill switch (meta-tiling bypassed).
+fn build_counting_router(
+    metatile_mb: u64,
+) -> (
+    axum::Router,
+    Arc<ds_render::TilePixelCache>,
+    Arc<std::sync::atomic::AtomicUsize>,
+) {
+    let calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let engine: Arc<dyn MapEngine> = Arc::new(CountingMockMapEngine {
+        calls: calls.clone(),
+    });
+    let mut engines = HashMap::new();
+    let mut collections = HashMap::new();
+    let mut styles_map = HashMap::new();
+
+    engines.insert("data".to_string(), engine);
+    collections.insert(
+        "data".to_string(),
+        CollectionConfig {
+            id: "data".to_string(),
+            title: "Data".to_string(),
+            description: "Data-producing fixture for meta-tiling (#202)".to_string(),
+            data_path: None,
+            apis: vec!["wms".to_string()],
+            engine_type: "geotiff".to_string(),
+            geotiff: None,
+            querydata: None,
+            wms: None,
+            grib: None,
+            odim: None,
+            postgis: None,
+            preview: None,
+        },
+    );
+
+    let cmap = Arc::new(LutColorMap::from_builtin(
+        BuiltinColormap::Viridis,
+        0.0,
+        1.0,
+    ));
+    let mut layer_styles = HashMap::new();
+    layer_styles.insert(
+        "default".to_string(),
+        StyleInfo {
+            name: "default".to_string(),
+            title: "Default".to_string(),
+            colormap: cmap,
+            min: 0.0,
+            max: 1.0,
+            parameter: None,
+        },
+    );
+    styles_map.insert("data".to_string(), layer_styles);
+
+    let tile_cache = Arc::new(ds_render::TilePixelCache::new(metatile_mb));
+    let state = Arc::new(ArcSwap::from_pointee(WmsState {
+        engines,
+        collections,
+        styles: styles_map,
+        render_semaphore: Arc::new(tokio::sync::Semaphore::new(4)),
+        rendered_cache: Arc::new(RenderedCache::new(16)),
+        tile_cache: tile_cache.clone(),
+        base_url: String::new(),
+    }));
+    (api_wms::router(state), tile_cache, calls)
+}
+
+async fn get_map(app: &axum::Router, crs: &str, bbox: &str, w: u32, h: u32) -> StatusCode {
+    let uri = format!(
+        "/?SERVICE=WMS&REQUEST=GetMap&VERSION=1.3.0&LAYERS=data&STYLES=\
+         &FORMAT=image/png&CRS={crs}&BBOX={bbox}&WIDTH={w}&HEIGHT={h}"
+    );
+    let resp = app
+        .clone()
+        .oneshot(Request::builder().uri(uri).body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    resp.status()
+}
+
+/// Two overlapping EPSG:3857 fullscreen requests at the same resolution must
+/// reuse cached meta-tiles: the second request hits the tile cache and renders
+/// strictly fewer fresh tiles than the first. This is the core #202 win.
+#[tokio::test]
+async fn meta_tiling_reuses_tiles_across_overlapping_viewports() {
+    let (app, tile_cache, calls) = build_counting_router(64);
+
+    // Request A.
+    let s1 = get_map(
+        &app,
+        "EPSG:3857",
+        "2000000,8000000,3000000,9000000",
+        512,
+        512,
+    )
+    .await;
+    assert_eq!(s1, StatusCode::OK);
+    let calls_a = calls.load(std::sync::atomic::Ordering::Relaxed);
+    let (hits_a, misses_a) = tile_cache.stats();
+    assert!(calls_a > 0, "first request renders tiles");
+    assert_eq!(
+        misses_a as usize, calls_a,
+        "every fresh tile is a cache miss"
+    );
+    assert_eq!(hits_a, 0, "no hits on a cold cache");
+
+    // Request B: panned east by 200 km, same size/resolution → overlaps A.
+    let s2 = get_map(
+        &app,
+        "EPSG:3857",
+        "2200000,8000000,3200000,9000000",
+        512,
+        512,
+    )
+    .await;
+    assert_eq!(s2, StatusCode::OK);
+    let calls_b_delta = calls.load(std::sync::atomic::Ordering::Relaxed) - calls_a;
+    let (hits_b, _) = tile_cache.stats();
+    assert!(hits_b > 0, "overlapping viewport must hit cached tiles");
+    assert!(
+        calls_b_delta < calls_a,
+        "panned request must render fewer fresh tiles ({calls_b_delta}) than the cold first one ({calls_a})"
+    );
+}
+
+/// Non-Web-Mercator requests (here CRS:84) bypass meta-tiling and render
+/// directly: the meta-tile cache is never touched.
+#[tokio::test]
+async fn non_web_mercator_bypasses_meta_tiling() {
+    let (app, tile_cache, calls) = build_counting_router(64);
+    let status = get_map(&app, "CRS:84", "10,55,30,70", 256, 256).await;
+    assert_eq!(status, StatusCode::OK);
+    let (hits, misses) = tile_cache.stats();
+    assert_eq!(
+        (hits, misses),
+        (0, 0),
+        "CRS:84 must not touch the meta-tile cache"
+    );
+    assert_eq!(
+        calls.load(std::sync::atomic::Ordering::Relaxed),
+        1,
+        "direct render makes exactly one engine call"
+    );
+}
+
+/// Kill switch: `metatile_cache_mb = 0` disables meta-tiling even for EPSG:3857,
+/// reverting to a single direct render. Reversible via config reload.
+#[tokio::test]
+async fn zero_metatile_cache_disables_meta_tiling() {
+    let (app, tile_cache, calls) = build_counting_router(0);
+    let status = get_map(
+        &app,
+        "EPSG:3857",
+        "2000000,8000000,3000000,9000000",
+        512,
+        512,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let (hits, misses) = tile_cache.stats();
+    assert_eq!((hits, misses), (0, 0), "disabled cache is never consulted");
+    assert_eq!(
+        calls.load(std::sync::atomic::Ordering::Relaxed),
+        1,
+        "kill switch must fall back to a single direct render"
     );
 }

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -108,6 +108,12 @@ pub struct WmsConfig {
     /// Rendered image cache size in MB. Default: 128.
     #[serde(default = "default_rendered_cache_mb")]
     pub rendered_cache_mb: u64,
+    /// Meta-tile pixel cache size in MB (decoded 256×256 RGBA tiles shared by
+    /// the Web Mercator WMS meta-tiling path, #202). Default: 512. Set to `0`
+    /// to disable meta-tiling entirely (kill switch): the Web Mercator GetMap
+    /// path reverts to a direct single-shot render, reversible via config reload.
+    #[serde(default = "default_metatile_cache_mb")]
+    pub metatile_cache_mb: u64,
 }
 
 /// Per-parameter default colormap configuration for WMS.
@@ -154,6 +160,10 @@ pub struct ColorStop {
 }
 
 fn default_rendered_cache_mb() -> u64 {
+    512
+}
+
+fn default_metatile_cache_mb() -> u64 {
     512
 }
 

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -109,7 +109,7 @@ pub struct WmsConfig {
     #[serde(default = "default_rendered_cache_mb")]
     pub rendered_cache_mb: u64,
     /// Meta-tile pixel cache size in MB (decoded 256×256 RGBA tiles shared by
-    /// the Web Mercator WMS meta-tiling path, #202). Default: 512. Set to `0`
+    /// the Web Mercator WMS meta-tiling path, #202). Default: 1024. Set to `0`
     /// to disable meta-tiling entirely (kill switch): the Web Mercator GetMap
     /// path reverts to a direct single-shot render, reversible via config reload.
     #[serde(default = "default_metatile_cache_mb")]
@@ -164,7 +164,7 @@ fn default_rendered_cache_mb() -> u64 {
 }
 
 fn default_metatile_cache_mb() -> u64 {
-    512
+    1024
 }
 
 /// Shared WMS style set: one default + zero or more named extras.

--- a/crates/render/src/lib.rs
+++ b/crates/render/src/lib.rs
@@ -1,11 +1,13 @@
 pub mod colormap;
 mod encode;
+pub mod metatile;
 
 pub use colormap::{
     parse_hex_color, BuiltinColormap, ColorMap, ColorStop, IntegerLutColorMap, LinearColorMap,
     LutColorMap,
 };
 pub use encode::{encode_jpeg, encode_png, encode_webp};
+pub use metatile::{render_metatiled, MetaTile, TileKeyPrefix, TilePixelCache};
 
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
@@ -388,7 +390,7 @@ pub fn render_legend(
 }
 
 /// Colorize a raster tile into an RGBA buffer using a colormap.
-fn colorize(tile: &RasterTile, colormap: &dyn ColorMap) -> Vec<u8> {
+pub(crate) fn colorize(tile: &RasterTile, colormap: &dyn ColorMap) -> Vec<u8> {
     let mut rgba = Vec::with_capacity((tile.width * tile.height * 4) as usize);
     for value in &tile.values {
         let color = colormap.color(*value);

--- a/crates/render/src/metatile.rs
+++ b/crates/render/src/metatile.rs
@@ -85,13 +85,20 @@ fn level_res(level: i32) -> f64 {
 /// resolution is still ≤ `res` (i.e. never coarser → the mosaic is downsampled,
 /// never upscaled). A small epsilon makes an exact standard-zoom resolution snap
 /// to its even level instead of one step finer.
+///
+/// Clamped at the **low** end to level 0 (`Z0_RES`, the whole world in one tile);
+/// a request coarser than that still downsamples, so 0 is safe. The **high** end
+/// is intentionally *not* clamped: a value `> MAX_LEVEL` means the request is
+/// finer than the deepest ladder step (~9 mm/px — an absurd over-zoom), and the
+/// caller declines to meta-tiling [`MetaTile::Fallback`] rather than clamp (which
+/// would render coarser-than-requested tiles and silently upscale).
 fn snap_level(res_m_per_px: f64) -> i32 {
     if !res_m_per_px.is_finite() || res_m_per_px <= 0.0 {
-        return MAX_LEVEL;
+        return MAX_LEVEL + 1; // decline → Fallback
     }
     // L_level = Z0_RES / 2^(level/2) ≤ res  ⇔  level ≥ 2·log2(Z0_RES / res)
     let level = (2.0 * (Z0_RES / res_m_per_px).log2() - 1e-6).ceil() as i32;
-    level.clamp(0, MAX_LEVEL)
+    level.max(0)
 }
 
 /// The fixed part of a tile's cache key (everything but the tile's grid
@@ -250,6 +257,12 @@ where
     // axis is upscaled), then derive the tile grid at that level.
     let res = ((east_m - west_m) / width as f64).min((north_m - south_m) / height as f64);
     let level = snap_level(res);
+    if level > MAX_LEVEL {
+        // Requested resolution is finer than the deepest ladder step (~9 mm/px —
+        // an absurd over-zoom). Meta-tiling would have to upscale; render
+        // directly at the exact requested resolution instead.
+        return Ok(MetaTile::Fallback);
+    }
     let span = TILE_PX as f64 * level_res(level); // tile edge length in metres
 
     // Covering tile index range. Origin is the world top-left (-ORIGIN, +ORIGIN);
@@ -597,6 +610,43 @@ mod tests {
             [-179.0, -85.0, 179.0, 85.0],
             8192,
             8192,
+            &prefix,
+            &SolidRed,
+            ImageFormat::Png,
+            &cache,
+            solid_tile,
+        )
+        .unwrap();
+        assert!(matches!(out, MetaTile::Fallback));
+    }
+
+    #[test]
+    fn extreme_resolution_declines_to_fallback() {
+        // A resolution finer than the deepest ladder step (~9 mm/px) would force
+        // upscaling; snap_level must signal it and render_metatiled must decline
+        // to Fallback rather than clamp + upscale.
+        assert!(
+            snap_level(0.001) > MAX_LEVEL,
+            "1 mm/px is finer than the ladder"
+        );
+        assert_eq!(
+            snap_level(Z0_RES / 2f64.powi(20)),
+            40,
+            "in-range still snaps"
+        );
+        let cache = TilePixelCache::new(16);
+        let prefix = TileKeyPrefix {
+            layer: "l".into(),
+            parameter: None,
+            style: "default".into(),
+            time: None,
+            z: None,
+        };
+        // ~1 µm/px viewport (tiny bbox, large image).
+        let out = render_metatiled(
+            [24.9400, 60.1700, 24.9401, 60.1701],
+            2048,
+            2048,
             &prefix,
             &SolidRed,
             ImageFormat::Png,

--- a/crates/render/src/metatile.rs
+++ b/crates/render/src/metatile.rs
@@ -119,14 +119,14 @@ pub struct TileKey {
     row: i64,
 }
 
-/// A cached tile's decoded, colorized pixels: `TILE_PX × TILE_PX × 4` RGBA.
+/// A cached tile's decoded, colorized pixels. `Some` holds the
+/// `TILE_PX × TILE_PX × 4` RGBA buffer; `None` marks an all-nodata tile, cached
+/// as a lightweight marker so a sparse extent (e.g. radar outside coverage) is
+/// neither re-decoded on every request nor allowed to crowd the cache with
+/// 256 KB zero buffers. A `None` marker is still a cache *hit*.
 #[derive(Clone)]
 pub struct CachedTilePixels {
-    rgba: Arc<[u8]>,
-    /// Whether the tile has any non-nodata pixels. Lets an all-transparent
-    /// region take the [`MetaTile::Empty`] fast path even when every covering
-    /// tile is a cache hit.
-    has_data: bool,
+    rgba: Option<Arc<[u8]>>,
 }
 
 #[derive(Clone)]
@@ -134,8 +134,9 @@ struct TilePixelWeighter;
 
 impl quick_cache::Weighter<TileKey, CachedTilePixels> for TilePixelWeighter {
     fn weight(&self, key: &TileKey, val: &CachedTilePixels) -> u64 {
-        // Pixel bytes + a flat allowance for the owned key strings + node overhead.
-        val.rgba.len() as u64
+        // Pixel bytes (zero for a nodata marker) + a flat allowance for the
+        // owned key strings + node overhead.
+        val.rgba.as_ref().map_or(0, |r| r.len()) as u64
             + key.layer.len() as u64
             + key.parameter.as_ref().map_or(0, String::len) as u64
             + key.style.len() as u64
@@ -266,8 +267,9 @@ where
         return Ok(MetaTile::Fallback);
     }
 
-    // Render or fetch each covering tile's RGBA pixels.
-    let mut tiles: HashMap<(i64, i64), Arc<[u8]>> = HashMap::with_capacity(ncols * nrows);
+    // Render or fetch each covering tile's RGBA pixels. `None` = an all-nodata
+    // tile (cached as a marker, drawn transparent at assembly time).
+    let mut tiles: HashMap<(i64, i64), Option<Arc<[u8]>>> = HashMap::with_capacity(ncols * nrows);
     let mut any_data = false;
     for row in row0..=row1 {
         for col in col0..=col1 {
@@ -283,7 +285,7 @@ where
             };
             let rgba = if let Some(c) = cache.cache.get(&key) {
                 cache.hits.fetch_add(1, Ordering::Relaxed);
-                any_data |= c.has_data;
+                any_data |= c.rgba.is_some();
                 c.rgba
             } else {
                 cache.misses.fetch_add(1, Ordering::Relaxed);
@@ -299,21 +301,24 @@ where
                     y_to_lat(ty_top),
                 ];
                 let tile = render_tile(tbbox, TILE_PX, TILE_PX)?;
-                let has_data = !tile.is_empty();
-                let rgba: Arc<[u8]> = if has_data {
-                    any_data = true;
-                    Arc::from(colorize(&tile, colormap).into_boxed_slice())
+                // All-nodata tiles are cached as a `None` marker: cheap to store
+                // (no 256 KB buffer) yet still a cache hit, so a sparse extent is
+                // not re-decoded every request nor crowds out real-data tiles.
+                let entry: Option<Arc<[u8]>> = if tile.is_empty() {
+                    None
                 } else {
-                    Arc::from(vec![0u8; (TILE_PX * TILE_PX * 4) as usize].into_boxed_slice())
+                    any_data = true;
+                    Some(Arc::<[u8]>::from(
+                        colorize(&tile, colormap).into_boxed_slice(),
+                    ))
                 };
                 cache.cache.insert(
                     key,
                     CachedTilePixels {
-                        rgba: rgba.clone(),
-                        has_data,
+                        rgba: entry.clone(),
                     },
                 );
-                rgba
+                entry
             };
             tiles.insert((col, row), rgba);
         }
@@ -356,24 +361,26 @@ where
 /// Fetch one global tile-pixel (nearest) from the covering set; transparent if
 /// the pixel falls outside the rendered tiles (only possible ≤1px past an edge).
 #[inline]
-fn global_pixel(tiles: &HashMap<(i64, i64), Arc<[u8]>>, xi: i64, yi: i64) -> [u8; 4] {
+fn global_pixel(tiles: &HashMap<(i64, i64), Option<Arc<[u8]>>>, xi: i64, yi: i64) -> [u8; 4] {
     let col = xi.div_euclid(TILE_PX as i64);
     let row = yi.div_euclid(TILE_PX as i64);
     let lx = xi.rem_euclid(TILE_PX as i64) as usize;
     let ly = yi.rem_euclid(TILE_PX as i64) as usize;
     match tiles.get(&(col, row)) {
-        Some(rgba) => {
+        // Present with data; nodata markers (`Some(None)`) and absent tiles
+        // (≤1px past an edge) are transparent.
+        Some(Some(rgba)) => {
             let o = (ly * TILE_PX as usize + lx) * 4;
             [rgba[o], rgba[o + 1], rgba[o + 2], rgba[o + 3]]
         }
-        None => [0, 0, 0, 0],
+        _ => [0, 0, 0, 0],
     }
 }
 
 /// Premultiplied-alpha bilinear sample of the mosaic at global tile-pixel
 /// coordinates `(gx, gy)` (pixel centres at integer + 0.5).
 #[inline]
-fn sample_bilinear(tiles: &HashMap<(i64, i64), Arc<[u8]>>, gx: f64, gy: f64) -> [u8; 4] {
+fn sample_bilinear(tiles: &HashMap<(i64, i64), Option<Arc<[u8]>>>, gx: f64, gy: f64) -> [u8; 4] {
     let fx = gx - 0.5;
     let fy = gy - 0.5;
     let x0 = fx.floor();

--- a/crates/render/src/metatile.rs
+++ b/crates/render/src/metatile.rs
@@ -83,8 +83,15 @@ fn level_res(level: i32) -> f64 {
 
 /// Snap a ground resolution to the finest half-octave ladder level whose
 /// resolution is still ≤ `res` (i.e. never coarser → the mosaic is downsampled,
-/// never upscaled). A small epsilon makes an exact standard-zoom resolution snap
-/// to its even level instead of one step finer.
+/// never upscaled).
+///
+/// A small epsilon (`1e-6` in log2 space) makes an *exact* standard-zoom
+/// resolution snap to its own level instead of one step finer — without it,
+/// floating-point noise would round every discrete-zoom request up a half-octave
+/// and force a needless 1.41× over-render. The bounded cost: a resolution that
+/// falls *just below* a step, within the epsilon band, can snap down to it and
+/// upscale by at most `2^(5e-7) ≈ 1.0000003×` (sub-nanometre per pixel) — visually
+/// nil, and well worth avoiding the per-request over-render.
 ///
 /// Clamped at the **low** end to level 0 (`Z0_RES`, the whole world in one tile);
 /// a request coarser than that still downsamples, so 0 is safe. The **high** end
@@ -350,7 +357,11 @@ where
     let to_global_x = |x_m: f64| (x_m + ORIGIN) / span * TILE_PX as f64;
     let to_global_y = |y_m: f64| (ORIGIN - y_m) / span * TILE_PX as f64;
 
-    let mut out = vec![0u8; (width * height * 4) as usize];
+    // usize arithmetic throughout: `width * height * 4` overflows `u32` past
+    // ~46 340 px/side. Callers must keep `width * height` within a sane bound
+    // (the WMS handler enforces MAX_MAP_PIXELS = 64M, MAX_MAP_DIMENSION = 8000).
+    let (w_us, h_us) = (width as usize, height as usize);
+    let mut out = vec![0u8; w_us * h_us * 4];
     for py in 0..height {
         let y_m = north_m - (py as f64 + 0.5) * res_y;
         let gy = to_global_y(y_m);
@@ -358,7 +369,7 @@ where
             let x_m = west_m + (px as f64 + 0.5) * res_x;
             let gx = to_global_x(x_m);
             let rgba = sample_bilinear(&tiles, gx, gy);
-            let o = ((py * width + px) * 4) as usize;
+            let o = (py as usize * w_us + px as usize) * 4;
             out[o..o + 4].copy_from_slice(&rgba);
         }
     }
@@ -463,8 +474,9 @@ mod tests {
 
     #[test]
     fn snap_never_upscales_and_is_bounded() {
-        // For a resolution between zoom 8 and 9, the chosen level must be finer
-        // (≤ res) and at most one half-octave finer than the floor.
+        // For a resolution well between zoom 8 and 9 (outside the snap_level
+        // epsilon band — see its doc for the bounded ~2^(5e-7) exception), the
+        // chosen level must be finer (≤ res) and at most one half-octave finer.
         let res8 = Z0_RES / 2f64.powi(8);
         let res9 = Z0_RES / 2f64.powi(9);
         let res = (res8 + res9) / 2.0; // between two standard zooms

--- a/crates/render/src/metatile.rs
+++ b/crates/render/src/metatile.rs
@@ -1,0 +1,765 @@
+//! Internal meta-tiling for arbitrary-bbox Web Mercator WMS GetMap renders (#202).
+//!
+//! A fullscreen WMS client (e.g. OpenLayers `ImageWMS`) requests an arbitrary
+//! bbox + width + height per pan/zoom event, so the rendered-image cache — keyed
+//! on the exact bbox — almost never hits (≈3% in production). Meta-tiling fixes
+//! the *strategy*: decompose each Web Mercator GetMap into a grid of fixed
+//! 256×256 tiles aligned to the WebMercatorQuad grid, render and cache *those*
+//! (fixed bbox + fixed size → repeating key → high hit rate), then resample the
+//! covered tiles into the client's exact viewport. The expensive per-source work
+//! (TIFF decode, per-pixel projection, colorize) is cached at tile granularity
+//! and reused across overlapping viewports; the final crop/resample is cheap.
+//!
+//! ## Resolution ladder
+//!
+//! Tiles are rendered at one of a **half-octave** ladder of resolutions whose
+//! even steps coincide with the standard integer WebMercator zoom levels
+//! (`Z0_RES / 2^(level/2)`). For each request we snap to the *finest* ladder
+//! step whose resolution is still ≤ the request's ground resolution, so the
+//! mosaic is always **downsampled** to the viewport (crisp, never upscaled).
+//! A discrete-zoom OpenLayers view lands exactly on an even step → pure crop, no
+//! resample. A smooth-zoom view snaps at most one half-octave finer (≤ 1.41×
+//! linear over-render, paid only on a tile cache miss; ≤ 1.19× perceived
+//! softening relative to a nearest-neighbour snap).
+//!
+//! ## Scope
+//!
+//! Web Mercator (EPSG:3857) requests only — that is the production hot path and
+//! it keeps assembly a pure affine resample in Mercator metres (no reprojection;
+//! the engine already reprojects source→Mercator inside each tile render). Other
+//! CRSs fall back to a direct single-shot render. Degenerate or pathologically
+//! large requests return [`MetaTile::Fallback`] so the caller renders directly.
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+use chrono::{DateTime, Utc};
+use quick_cache::sync::Cache;
+
+use ds_core::error::DataServerError;
+use ds_core::map_engine::RasterTile;
+
+use crate::colorize;
+use crate::{ColorMap, ImageFormat};
+
+/// Tile edge length in pixels (WebMercatorQuad standard).
+const TILE_PX: u32 = 256;
+/// EPSG:3857 sphere radius (metres).
+const R: f64 = 6_378_137.0;
+/// Half the Web Mercator world span in metres (`π·R`). The grid origin is the
+/// top-left corner `(-ORIGIN, +ORIGIN)`.
+const ORIGIN: f64 = std::f64::consts::PI * R;
+/// Ground resolution at zoom 0 (metres/pixel): `2·ORIGIN / 256 ≈ 156543.034`.
+const Z0_RES: f64 = (2.0 * ORIGIN) / TILE_PX as f64;
+/// Maximum half-octave ladder level (`level/2 ≈ zoom`, so ~zoom 24).
+const MAX_LEVEL: i32 = 48;
+/// Web Mercator latitude limit in radians (~±85.0511°).
+const LAT_LIMIT_RAD: f64 = 1.484_422_229_745_332_4;
+/// Safety cap on covering tiles per request. A request that would need more
+/// (tiny resolution over a huge bbox) declines to [`MetaTile::Fallback`].
+const MAX_TILES: usize = 256;
+
+// --- Web Mercator metre <-> WGS84 degree helpers (standard EPSG:3857) --------
+
+fn lon_to_x(lon_deg: f64) -> f64 {
+    R * lon_deg.to_radians()
+}
+fn lat_to_y(lat_deg: f64) -> f64 {
+    let lat = lat_deg.to_radians().clamp(-LAT_LIMIT_RAD, LAT_LIMIT_RAD);
+    R * (std::f64::consts::FRAC_PI_4 + lat / 2.0).tan().ln()
+}
+fn x_to_lon(x: f64) -> f64 {
+    (x / R).to_degrees()
+}
+fn y_to_lat(y: f64) -> f64 {
+    (2.0 * (y / R).exp().atan() - std::f64::consts::FRAC_PI_2).to_degrees()
+}
+
+/// Resolution (metres/pixel) of a half-octave ladder level.
+fn level_res(level: i32) -> f64 {
+    Z0_RES / 2f64.powf(level as f64 / 2.0)
+}
+
+/// Snap a ground resolution to the finest half-octave ladder level whose
+/// resolution is still ≤ `res` (i.e. never coarser → the mosaic is downsampled,
+/// never upscaled). A small epsilon makes an exact standard-zoom resolution snap
+/// to its even level instead of one step finer.
+fn snap_level(res_m_per_px: f64) -> i32 {
+    if !res_m_per_px.is_finite() || res_m_per_px <= 0.0 {
+        return MAX_LEVEL;
+    }
+    // L_level = Z0_RES / 2^(level/2) ≤ res  ⇔  level ≥ 2·log2(Z0_RES / res)
+    let level = (2.0 * (Z0_RES / res_m_per_px).log2() - 1e-6).ceil() as i32;
+    level.clamp(0, MAX_LEVEL)
+}
+
+/// The fixed part of a tile's cache key (everything but the tile's grid
+/// position). Built once per request and cloned into each tile's [`TileKey`].
+#[derive(Clone, Debug)]
+pub struct TileKeyPrefix {
+    pub layer: String,
+    pub parameter: Option<String>,
+    pub style: String,
+    pub time: Option<DateTime<Utc>>,
+    /// Vertical level, pre-quantized via [`crate::quantize_z`].
+    pub z: Option<i64>,
+}
+
+/// Cache key for one rendered+colorized meta-tile.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct TileKey {
+    layer: String,
+    parameter: Option<String>,
+    style: String,
+    time: Option<DateTime<Utc>>,
+    z: Option<i64>,
+    level: i32,
+    col: i64,
+    row: i64,
+}
+
+/// A cached tile's decoded, colorized pixels: `TILE_PX × TILE_PX × 4` RGBA.
+#[derive(Clone)]
+pub struct CachedTilePixels {
+    rgba: Arc<[u8]>,
+    /// Whether the tile has any non-nodata pixels. Lets an all-transparent
+    /// region take the [`MetaTile::Empty`] fast path even when every covering
+    /// tile is a cache hit.
+    has_data: bool,
+}
+
+#[derive(Clone)]
+struct TilePixelWeighter;
+
+impl quick_cache::Weighter<TileKey, CachedTilePixels> for TilePixelWeighter {
+    fn weight(&self, key: &TileKey, val: &CachedTilePixels) -> u64 {
+        // Pixel bytes + a flat allowance for the owned key strings + node overhead.
+        val.rgba.len() as u64
+            + key.layer.len() as u64
+            + key.parameter.as_ref().map_or(0, String::len) as u64
+            + key.style.len() as u64
+            + 96
+    }
+}
+
+/// LRU cache of decoded, colorized meta-tiles (RGBA), weighted by byte size.
+///
+/// Distinct from the per-collection GeoTIFF *compressed-byte* tile cache and
+/// from the request-keyed [`crate::RenderedCache`]. This one is keyed on the
+/// fixed tile grid so overlapping fullscreen viewports reuse the same entries.
+pub struct TilePixelCache {
+    cache: Cache<TileKey, CachedTilePixels, TilePixelWeighter>,
+    capacity_bytes: u64,
+    hits: AtomicU64,
+    misses: AtomicU64,
+}
+
+impl TilePixelCache {
+    pub fn new(capacity_mb: u64) -> Self {
+        let max_bytes = capacity_mb * 1024 * 1024;
+        // ~256 KB per RGBA tile for initial map sizing.
+        let estimated_items = if capacity_mb == 0 {
+            0
+        } else {
+            (max_bytes / (256 * 1024)).max(1) as usize
+        };
+        Self {
+            cache: Cache::with_weighter(estimated_items, max_bytes, TilePixelWeighter),
+            capacity_bytes: max_bytes,
+            hits: AtomicU64::new(0),
+            misses: AtomicU64::new(0),
+        }
+    }
+
+    /// (hits, misses) counters.
+    pub fn stats(&self) -> (u64, u64) {
+        (
+            self.hits.load(Ordering::Relaxed),
+            self.misses.load(Ordering::Relaxed),
+        )
+    }
+    pub fn weight(&self) -> u64 {
+        self.cache.weight()
+    }
+    pub fn capacity(&self) -> u64 {
+        self.capacity_bytes
+    }
+    pub fn len(&self) -> usize {
+        self.cache.len()
+    }
+    pub fn is_empty(&self) -> bool {
+        self.cache.len() == 0
+    }
+}
+
+/// Outcome of a meta-tiled render.
+pub enum MetaTile {
+    /// Assembled, encoded image bytes in the requested format.
+    Image(Vec<u8>),
+    /// Every covered pixel is nodata — the caller should emit its own
+    /// transparent tile (matching the existing all-nodata fast path).
+    Empty,
+    /// Meta-tiling declined (degenerate bbox or > `MAX_TILES` tiles); the caller
+    /// should fall back to a direct single-shot render.
+    Fallback,
+}
+
+/// Render a Web Mercator GetMap by decomposing it into cached 256×256 tiles and
+/// resampling them to the exact viewport.
+///
+/// `bbox_deg` is the viewport in WGS84 degrees `[west, south, east, north]`
+/// (already converted from EPSG:3857 metres by the handler). `render_tile` must
+/// render one tile at the given WGS84-degree bbox and pixel size in Web Mercator
+/// (i.e. call `get_raster_tile(bbox, w, h, OutputCrs::WebMercator, …)`); the
+/// helper colorizes and caches its result.
+#[allow(clippy::too_many_arguments)]
+pub fn render_metatiled<F>(
+    bbox_deg: [f64; 4],
+    width: u32,
+    height: u32,
+    prefix: &TileKeyPrefix,
+    colormap: &dyn ColorMap,
+    format: ImageFormat,
+    cache: &TilePixelCache,
+    render_tile: F,
+) -> Result<MetaTile, DataServerError>
+where
+    F: Fn([f64; 4], u32, u32) -> Result<RasterTile, DataServerError>,
+{
+    let [w, s, e, n] = bbox_deg;
+    if width == 0
+        || height == 0
+        || !(w.is_finite() && s.is_finite() && e.is_finite() && n.is_finite())
+    {
+        return Ok(MetaTile::Fallback);
+    }
+
+    // Viewport in Web Mercator metres. Mercator Y increases northward.
+    let west_m = lon_to_x(w);
+    let east_m = lon_to_x(e);
+    let north_m = lat_to_y(n);
+    let south_m = lat_to_y(s);
+    if !(east_m > west_m && north_m > south_m) {
+        // Antimeridian crossing or degenerate extent — let the caller render directly.
+        return Ok(MetaTile::Fallback);
+    }
+
+    // Snap to the ladder using the finer of the two axis resolutions (so neither
+    // axis is upscaled), then derive the tile grid at that level.
+    let res = ((east_m - west_m) / width as f64).min((north_m - south_m) / height as f64);
+    let level = snap_level(res);
+    let span = TILE_PX as f64 * level_res(level); // tile edge length in metres
+
+    // Covering tile index range. Origin is the world top-left (-ORIGIN, +ORIGIN);
+    // column grows eastward, row grows southward. Sample points sit strictly
+    // inside the viewport, so a tiny epsilon trims a spurious tile when an edge
+    // lands exactly on a grid line.
+    let eps = span * 1e-9;
+    let col0 = ((west_m + ORIGIN) / span).floor() as i64;
+    let col1 = ((east_m + ORIGIN - eps) / span).floor() as i64;
+    let row0 = ((ORIGIN - north_m) / span).floor() as i64;
+    let row1 = ((ORIGIN - south_m - eps) / span).floor() as i64;
+    let ncols = (col1 - col0 + 1).max(1) as usize;
+    let nrows = (row1 - row0 + 1).max(1) as usize;
+    if ncols.saturating_mul(nrows) > MAX_TILES {
+        return Ok(MetaTile::Fallback);
+    }
+
+    // Render or fetch each covering tile's RGBA pixels.
+    let mut tiles: HashMap<(i64, i64), Arc<[u8]>> = HashMap::with_capacity(ncols * nrows);
+    let mut any_data = false;
+    for row in row0..=row1 {
+        for col in col0..=col1 {
+            let key = TileKey {
+                layer: prefix.layer.clone(),
+                parameter: prefix.parameter.clone(),
+                style: prefix.style.clone(),
+                time: prefix.time,
+                z: prefix.z,
+                level,
+                col,
+                row,
+            };
+            let rgba = if let Some(c) = cache.cache.get(&key) {
+                cache.hits.fetch_add(1, Ordering::Relaxed);
+                any_data |= c.has_data;
+                c.rgba
+            } else {
+                cache.misses.fetch_add(1, Ordering::Relaxed);
+                // Tile bbox in metres → WGS84 degrees for the engine call.
+                let tx0 = -ORIGIN + col as f64 * span;
+                let tx1 = tx0 + span;
+                let ty_top = ORIGIN - row as f64 * span;
+                let ty_bot = ty_top - span;
+                let tbbox = [
+                    x_to_lon(tx0),
+                    y_to_lat(ty_bot),
+                    x_to_lon(tx1),
+                    y_to_lat(ty_top),
+                ];
+                let tile = render_tile(tbbox, TILE_PX, TILE_PX)?;
+                let has_data = !tile.is_empty();
+                let rgba: Arc<[u8]> = if has_data {
+                    any_data = true;
+                    Arc::from(colorize(&tile, colormap).into_boxed_slice())
+                } else {
+                    Arc::from(vec![0u8; (TILE_PX * TILE_PX * 4) as usize].into_boxed_slice())
+                };
+                cache.cache.insert(
+                    key,
+                    CachedTilePixels {
+                        rgba: rgba.clone(),
+                        has_data,
+                    },
+                );
+                rgba
+            };
+            tiles.insert((col, row), rgba);
+        }
+    }
+
+    if !any_data {
+        return Ok(MetaTile::Empty);
+    }
+
+    // Resample the tile mosaic into the exact viewport. Output pixels are
+    // uniform in Mercator metres, so this is a pure affine map into global
+    // tile-pixel space, sampled with premultiplied-alpha bilinear (avoids dark
+    // fringes bleeding from transparent nodata pixels).
+    let res_x = (east_m - west_m) / width as f64;
+    let res_y = (north_m - south_m) / height as f64;
+    let to_global_x = |x_m: f64| (x_m + ORIGIN) / span * TILE_PX as f64;
+    let to_global_y = |y_m: f64| (ORIGIN - y_m) / span * TILE_PX as f64;
+
+    let mut out = vec![0u8; (width * height * 4) as usize];
+    for py in 0..height {
+        let y_m = north_m - (py as f64 + 0.5) * res_y;
+        let gy = to_global_y(y_m);
+        for px in 0..width {
+            let x_m = west_m + (px as f64 + 0.5) * res_x;
+            let gx = to_global_x(x_m);
+            let rgba = sample_bilinear(&tiles, gx, gy);
+            let o = ((py * width + px) * 4) as usize;
+            out[o..o + 4].copy_from_slice(&rgba);
+        }
+    }
+
+    let bytes = match format {
+        ImageFormat::Png => crate::encode_png(&out, width, height)?,
+        ImageFormat::Jpeg => crate::encode_jpeg(&out, width, height)?,
+        ImageFormat::Webp => crate::encode_webp(&out, width, height)?,
+    };
+    Ok(MetaTile::Image(bytes))
+}
+
+/// Fetch one global tile-pixel (nearest) from the covering set; transparent if
+/// the pixel falls outside the rendered tiles (only possible ≤1px past an edge).
+#[inline]
+fn global_pixel(tiles: &HashMap<(i64, i64), Arc<[u8]>>, xi: i64, yi: i64) -> [u8; 4] {
+    let col = xi.div_euclid(TILE_PX as i64);
+    let row = yi.div_euclid(TILE_PX as i64);
+    let lx = xi.rem_euclid(TILE_PX as i64) as usize;
+    let ly = yi.rem_euclid(TILE_PX as i64) as usize;
+    match tiles.get(&(col, row)) {
+        Some(rgba) => {
+            let o = (ly * TILE_PX as usize + lx) * 4;
+            [rgba[o], rgba[o + 1], rgba[o + 2], rgba[o + 3]]
+        }
+        None => [0, 0, 0, 0],
+    }
+}
+
+/// Premultiplied-alpha bilinear sample of the mosaic at global tile-pixel
+/// coordinates `(gx, gy)` (pixel centres at integer + 0.5).
+#[inline]
+fn sample_bilinear(tiles: &HashMap<(i64, i64), Arc<[u8]>>, gx: f64, gy: f64) -> [u8; 4] {
+    let fx = gx - 0.5;
+    let fy = gy - 0.5;
+    let x0 = fx.floor();
+    let y0 = fy.floor();
+    let dx = fx - x0;
+    let dy = fy - y0;
+    let (x0, y0) = (x0 as i64, y0 as i64);
+
+    let c00 = premul(global_pixel(tiles, x0, y0));
+    let c10 = premul(global_pixel(tiles, x0 + 1, y0));
+    let c01 = premul(global_pixel(tiles, x0, y0 + 1));
+    let c11 = premul(global_pixel(tiles, x0 + 1, y0 + 1));
+
+    let mut acc = [0.0f64; 4];
+    for i in 0..4 {
+        let top = c00[i] * (1.0 - dx) + c10[i] * dx;
+        let bot = c01[i] * (1.0 - dx) + c11[i] * dx;
+        acc[i] = top * (1.0 - dy) + bot * dy;
+    }
+    unpremul(acc)
+}
+
+/// RGBA u8 → premultiplied f64 (RGB scaled by alpha; alpha kept in 0..255).
+#[inline]
+fn premul(c: [u8; 4]) -> [f64; 4] {
+    let a = c[3] as f64 / 255.0;
+    [
+        c[0] as f64 * a,
+        c[1] as f64 * a,
+        c[2] as f64 * a,
+        c[3] as f64,
+    ]
+}
+
+/// Premultiplied f64 → straight RGBA u8.
+#[inline]
+fn unpremul(c: [f64; 4]) -> [u8; 4] {
+    let a = c[3];
+    if a <= 0.0 {
+        return [0, 0, 0, 0];
+    }
+    let inv = 255.0 / a;
+    let r = (c[0] * inv).round().clamp(0.0, 255.0) as u8;
+    let g = (c[1] * inv).round().clamp(0.0, 255.0) as u8;
+    let b = (c[2] * inv).round().clamp(0.0, 255.0) as u8;
+    [r, g, b, a.round().clamp(0.0, 255.0) as u8]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn standard_zoom_resolutions_snap_exactly() {
+        // Resolution at integer WebMercator zoom z is Z0_RES / 2^z, which must
+        // snap to even ladder level 2z with no over-render (level_res == res).
+        for z in 0..=20 {
+            let res = Z0_RES / 2f64.powi(z);
+            let level = snap_level(res);
+            assert_eq!(level, 2 * z, "zoom {z} should snap to even level {}", 2 * z);
+            assert!(
+                (level_res(level) - res).abs() / res < 1e-9,
+                "level_res must equal the standard-zoom resolution"
+            );
+        }
+    }
+
+    #[test]
+    fn snap_never_upscales_and_is_bounded() {
+        // For a resolution between zoom 8 and 9, the chosen level must be finer
+        // (≤ res) and at most one half-octave finer than the floor.
+        let res8 = Z0_RES / 2f64.powi(8);
+        let res9 = Z0_RES / 2f64.powi(9);
+        let res = (res8 + res9) / 2.0; // between two standard zooms
+        let level = snap_level(res);
+        assert!(
+            level_res(level) <= res,
+            "must never upscale (≤ requested res)"
+        );
+        assert!(
+            level_res(level) >= res / std::f64::consts::SQRT_2 - 1e-6,
+            "≤ one half-octave finer"
+        );
+        assert!((16..=18).contains(&level));
+    }
+
+    #[test]
+    fn mercator_roundtrip() {
+        for &(lon, lat) in &[(0.0, 0.0), (24.94, 60.17), (-122.4, 37.8), (180.0, 85.0)] {
+            let x = lon_to_x(lon);
+            let y = lat_to_y(lat);
+            assert!((x_to_lon(x) - lon).abs() < 1e-6, "lon roundtrip");
+            assert!((y_to_lat(y) - lat).abs() < 1e-4, "lat roundtrip");
+        }
+        // Grid corners.
+        assert!((lon_to_x(-180.0) + ORIGIN).abs() < 1e-3);
+        assert!((lat_to_y(85.0511287798066) - ORIGIN).abs() < 1.0);
+    }
+
+    /// A solid colormap so every in-extent pixel is opaque red; lets us assert
+    /// the assembled output without depending on a real engine.
+    struct SolidRed;
+    impl ColorMap for SolidRed {
+        fn color(&self, value: Option<f64>) -> [u8; 4] {
+            match value {
+                Some(_) => [255, 0, 0, 255],
+                None => [0, 0, 0, 0],
+            }
+        }
+    }
+
+    fn solid_tile(_b: [f64; 4], w: u32, h: u32) -> Result<RasterTile, DataServerError> {
+        Ok(RasterTile {
+            width: w,
+            height: h,
+            values: vec![Some(1.0); (w * h) as usize],
+        })
+    }
+
+    #[test]
+    fn assembles_solid_region_and_caches_tiles() {
+        let cache = TilePixelCache::new(64);
+        let prefix = TileKeyPrefix {
+            layer: "l".into(),
+            parameter: None,
+            style: "default".into(),
+            time: None,
+            z: None,
+        };
+        // A modest viewport around Helsinki at ~zoom 6.
+        let bbox = [20.0, 58.0, 30.0, 64.0];
+        let out = render_metatiled(
+            bbox,
+            512,
+            512,
+            &prefix,
+            &SolidRed,
+            ImageFormat::Png,
+            &cache,
+            solid_tile,
+        )
+        .unwrap();
+        let bytes = match out {
+            MetaTile::Image(b) => b,
+            _ => panic!("expected an image"),
+        };
+        assert!(
+            bytes.starts_with(&[0x89, b'P', b'N', b'G']),
+            "valid PNG header"
+        );
+        let (misses_first, _) = (cache.stats().1, ());
+        assert!(misses_first > 0, "first render populates the tile cache");
+
+        // A second, overlapping viewport must reuse cached tiles (hits > 0).
+        let bbox2 = [21.0, 59.0, 31.0, 65.0];
+        let _ = render_metatiled(
+            bbox2,
+            512,
+            512,
+            &prefix,
+            &SolidRed,
+            ImageFormat::Png,
+            &cache,
+            solid_tile,
+        )
+        .unwrap();
+        let (hits, _) = cache.stats();
+        assert!(hits > 0, "overlapping viewport should hit cached tiles");
+    }
+
+    #[test]
+    fn all_nodata_returns_empty() {
+        let cache = TilePixelCache::new(16);
+        let prefix = TileKeyPrefix {
+            layer: "l".into(),
+            parameter: None,
+            style: "default".into(),
+            time: None,
+            z: None,
+        };
+        let empty_tile = |_b: [f64; 4], w: u32, h: u32| {
+            Ok(RasterTile {
+                width: w,
+                height: h,
+                values: vec![None; (w * h) as usize],
+            })
+        };
+        let out = render_metatiled(
+            [20.0, 58.0, 30.0, 64.0],
+            256,
+            256,
+            &prefix,
+            &SolidRed,
+            ImageFormat::Png,
+            &cache,
+            empty_tile,
+        )
+        .unwrap();
+        assert!(matches!(out, MetaTile::Empty));
+    }
+
+    #[test]
+    fn huge_tile_count_falls_back() {
+        let cache = TilePixelCache::new(16);
+        let prefix = TileKeyPrefix {
+            layer: "l".into(),
+            parameter: None,
+            style: "default".into(),
+            time: None,
+            z: None,
+        };
+        // Whole-world bbox at a tiny resolution forces > MAX_TILES → fallback.
+        let out = render_metatiled(
+            [-179.0, -85.0, 179.0, 85.0],
+            8192,
+            8192,
+            &prefix,
+            &SolidRed,
+            ImageFormat::Png,
+            &cache,
+            solid_tile,
+        )
+        .unwrap();
+        assert!(matches!(out, MetaTile::Fallback));
+    }
+
+    /// Linearly encode one Web Mercator metre coordinate into the red channel,
+    /// over `[lo, hi]`, so a decoded pixel's red reveals which ground coordinate
+    /// it was assembled from. Always opaque.
+    struct AxisEncode {
+        lo: f64,
+        hi: f64,
+    }
+    impl ColorMap for AxisEncode {
+        fn color(&self, value: Option<f64>) -> [u8; 4] {
+            match value {
+                Some(v) => {
+                    let r = ((v - self.lo) / (self.hi - self.lo) * 255.0)
+                        .round()
+                        .clamp(0.0, 255.0) as u8;
+                    [r, 0, 0, 255]
+                }
+                None => [0, 0, 0, 0],
+            }
+        }
+    }
+
+    /// Decode the RGBA pixels of a PNG produced by [`render_metatiled`].
+    fn decode_rgba(bytes: &[u8]) -> (u32, u32, Vec<u8>) {
+        let decoder = png::Decoder::new(bytes);
+        let mut reader = decoder.read_info().unwrap();
+        let mut buf = vec![0u8; reader.output_buffer_size()];
+        let info = reader.next_frame(&mut buf).unwrap();
+        assert_eq!(info.color_type, png::ColorType::Rgba, "expected RGBA PNG");
+        buf.truncate(info.buffer_size());
+        (info.width, info.height, buf)
+    }
+
+    /// The strongest fidelity guard: assemble a field whose value at every pixel
+    /// is that pixel's own Web Mercator X (longitude axis), encoded into red.
+    /// The decoded output's red at pixel `px` must match the colormap of that
+    /// output pixel's *own* mercator-X — i.e. the assembly places data at the
+    /// geographically correct location. A column shift, transpose, or wrong-tile
+    /// bug moves the gradient and fails the check. A separate run does the same
+    /// for the Y (latitude) axis to catch row shifts / vertical flips.
+    #[test]
+    fn assembled_pixels_track_geography() {
+        let bbox = [10.0, 55.0, 30.0, 65.0];
+        let (w, h) = (400u32, 300u32);
+        let west_m = lon_to_x(bbox[0]);
+        let east_m = lon_to_x(bbox[2]);
+        let north_m = lat_to_y(bbox[3]);
+        let south_m = lat_to_y(bbox[1]);
+        let prefix = TileKeyPrefix {
+            layer: "l".into(),
+            parameter: None,
+            style: "default".into(),
+            time: None,
+            z: None,
+        };
+
+        // --- X axis: value = mercator-X, constant down each column. ---
+        let x_render = |b: [f64; 4], tw: u32, th: u32| {
+            let tw_west = lon_to_x(b[0]);
+            let tw_east = lon_to_x(b[2]);
+            let mut values = Vec::with_capacity((tw * th) as usize);
+            for _row in 0..th {
+                for i in 0..tw {
+                    values.push(Some(
+                        tw_west + (i as f64 + 0.5) / tw as f64 * (tw_east - tw_west),
+                    ));
+                }
+            }
+            Ok(RasterTile {
+                width: tw,
+                height: th,
+                values,
+            })
+        };
+        let cmap = AxisEncode {
+            lo: west_m,
+            hi: east_m,
+        };
+        let cache = TilePixelCache::new(64);
+        let out = render_metatiled(
+            bbox,
+            w,
+            h,
+            &prefix,
+            &cmap,
+            ImageFormat::Png,
+            &cache,
+            x_render,
+        )
+        .unwrap();
+        let bytes = match out {
+            MetaTile::Image(b) => b,
+            _ => panic!("expected image"),
+        };
+        let (dw, dh, rgba) = decode_rgba(&bytes);
+        assert_eq!((dw, dh), (w, h));
+        let mut max_diff = 0i32;
+        // Skip a 2px border: bilinear neighbours there can fall in uncovered tiles.
+        for py in 2..h - 2 {
+            for px in 2..w - 2 {
+                let x_m = west_m + (px as f64 + 0.5) / w as f64 * (east_m - west_m);
+                let expected = cmap.color(Some(x_m))[0] as i32;
+                let got = rgba[((py * w + px) * 4) as usize] as i32;
+                max_diff = max_diff.max((expected - got).abs());
+            }
+        }
+        assert!(
+            max_diff <= 3,
+            "X gradient mismatch: max diff {max_diff} (geometry/shift bug?)"
+        );
+
+        // --- Y axis: value = mercator-Y, constant across each row. ---
+        let y_render = |b: [f64; 4], tw: u32, th: u32| {
+            let tn = lat_to_y(b[3]);
+            let ts = lat_to_y(b[1]);
+            let mut values = Vec::with_capacity((tw * th) as usize);
+            for row in 0..th {
+                let y_m = tn - (row as f64 + 0.5) / th as f64 * (tn - ts);
+                for _i in 0..tw {
+                    values.push(Some(y_m));
+                }
+            }
+            Ok(RasterTile {
+                width: tw,
+                height: th,
+                values,
+            })
+        };
+        let cmap_y = AxisEncode {
+            lo: south_m,
+            hi: north_m,
+        };
+        let cache_y = TilePixelCache::new(64);
+        let out_y = render_metatiled(
+            bbox,
+            w,
+            h,
+            &prefix,
+            &cmap_y,
+            ImageFormat::Png,
+            &cache_y,
+            y_render,
+        )
+        .unwrap();
+        let bytes_y = match out_y {
+            MetaTile::Image(b) => b,
+            _ => panic!("expected image"),
+        };
+        let (_, _, rgba_y) = decode_rgba(&bytes_y);
+        let mut max_diff_y = 0i32;
+        for py in 2..h - 2 {
+            let y_m = north_m - (py as f64 + 0.5) / h as f64 * (north_m - south_m);
+            let expected = cmap_y.color(Some(y_m))[0] as i32;
+            for px in 2..w - 2 {
+                let got = rgba_y[((py * w + px) * 4) as usize] as i32;
+                max_diff_y = max_diff_y.max((expected - got).abs());
+            }
+        }
+        assert!(
+            max_diff_y <= 3,
+            "Y gradient mismatch: max diff {max_diff_y} (row shift / vertical flip?)"
+        );
+    }
+}

--- a/crates/server/src/admin.rs
+++ b/crates/server/src/admin.rs
@@ -201,6 +201,56 @@ static RENDERED_CACHE_ENTRIES: LazyLock<IntGauge> = LazyLock::new(|| {
     gauge
 });
 
+// Meta-tile pixel cache (#202) — global, decoded-RGBA tiles for the Web
+// Mercator WMS meta-tiling path. Distinct from the per-collection GeoTIFF
+// compressed-byte tile cache (`tile_cache_*`).
+static METATILE_CACHE_HITS: LazyLock<IntCounter> = LazyLock::new(|| {
+    let counter =
+        IntCounter::new("metatile_cache_hits_total", "Meta-tile pixel cache hits").unwrap();
+    REGISTRY.register(Box::new(counter.clone())).unwrap();
+    counter
+});
+
+static METATILE_CACHE_MISSES: LazyLock<IntCounter> = LazyLock::new(|| {
+    let counter = IntCounter::new(
+        "metatile_cache_misses_total",
+        "Meta-tile pixel cache misses",
+    )
+    .unwrap();
+    REGISTRY.register(Box::new(counter.clone())).unwrap();
+    counter
+});
+
+static METATILE_CACHE_BYTES: LazyLock<IntGauge> = LazyLock::new(|| {
+    let gauge = IntGauge::new(
+        "metatile_cache_bytes",
+        "Bytes currently held in the meta-tile pixel cache",
+    )
+    .unwrap();
+    REGISTRY.register(Box::new(gauge.clone())).unwrap();
+    gauge
+});
+
+static METATILE_CACHE_CAPACITY_BYTES: LazyLock<IntGauge> = LazyLock::new(|| {
+    let gauge = IntGauge::new(
+        "metatile_cache_capacity_bytes",
+        "Configured meta-tile pixel cache capacity in bytes",
+    )
+    .unwrap();
+    REGISTRY.register(Box::new(gauge.clone())).unwrap();
+    gauge
+});
+
+static METATILE_CACHE_ENTRIES: LazyLock<IntGauge> = LazyLock::new(|| {
+    let gauge = IntGauge::new(
+        "metatile_cache_entries",
+        "Number of entries currently in the meta-tile pixel cache",
+    )
+    .unwrap();
+    REGISTRY.register(Box::new(gauge.clone())).unwrap();
+    gauge
+});
+
 // GRIB grid cache (per-collection).
 static GRID_CACHE_HITS: LazyLock<IntCounterVec> = LazyLock::new(|| {
     let counter = IntCounterVec::new(
@@ -276,6 +326,7 @@ struct CacheCounterState {
     tile: HashMap<String, (u64, u64)>,
     grid: HashMap<String, (u64, u64)>,
     rendered: (u64, u64),
+    metatile: (u64, u64),
 }
 
 static RENDER_SEMAPHORE_AVAILABLE: LazyLock<IntGauge> = LazyLock::new(|| {
@@ -1366,6 +1417,15 @@ pub fn load_collections(
         .next()
         .unwrap_or(128);
 
+    // Meta-tile pixel cache size (#202) — same selection rule as above.
+    let metatile_cache_mb = map_collections
+        .values()
+        .chain(maps_collections.values())
+        .filter_map(|c| c.wms.as_ref())
+        .map(|w| w.metatile_cache_mb)
+        .next()
+        .unwrap_or(512);
+
     // 2× cores (min 8) — the render slot's "ownership" of a CPU is loose
     // because decode/encode interleaves with bilinear passes; configurable
     // knob tracked in #147.
@@ -1377,6 +1437,7 @@ pub fn load_collections(
     tracing::info!("Render concurrency: {render_concurrency} (2× available CPUs, min 8)");
     let render_semaphore = Arc::new(tokio::sync::Semaphore::new(render_concurrency));
     let rendered_cache = Arc::new(ds_render::RenderedCache::new(rendered_cache_mb));
+    let tile_cache = Arc::new(ds_render::TilePixelCache::new(metatile_cache_mb));
     // Vector-tile (MVT) cache is independent of the raster cache because the
     // workloads differ (1–50 KB vs 30–200 KB per tile). 128 MB matches the
     // raster default; a config knob lands when an operator asks for it.
@@ -1402,6 +1463,7 @@ pub fn load_collections(
             styles: map_styles,
             render_semaphore: render_semaphore.clone(),
             rendered_cache: rendered_cache.clone(),
+            tile_cache,
             base_url: base_url.to_string(),
         },
         maps_state: MapsState {
@@ -2060,6 +2122,22 @@ pub async fn metrics_handler(State(state): State<AdminState>) -> impl IntoRespon
     RENDERED_CACHE_BYTES.set(wms.rendered_cache.weight() as i64);
     RENDERED_CACHE_CAPACITY_BYTES.set(wms.rendered_cache.capacity() as i64);
     RENDERED_CACHE_ENTRIES.set(wms.rendered_cache.len() as i64);
+
+    // Meta-tile pixel cache: global, same delta-tracking as the rendered cache.
+    let (m_hits, m_misses) = wms.tile_cache.stats();
+    let (last_mh, last_mm) = counter_state.metatile;
+    if m_hits < last_mh || m_misses < last_mm {
+        counter_state.metatile = (m_hits, m_misses);
+        METATILE_CACHE_HITS.inc_by(0);
+        METATILE_CACHE_MISSES.inc_by(0);
+    } else {
+        METATILE_CACHE_HITS.inc_by(m_hits - last_mh);
+        METATILE_CACHE_MISSES.inc_by(m_misses - last_mm);
+        counter_state.metatile = (m_hits, m_misses);
+    }
+    METATILE_CACHE_BYTES.set(wms.tile_cache.weight() as i64);
+    METATILE_CACHE_CAPACITY_BYTES.set(wms.tile_cache.capacity() as i64);
+    METATILE_CACHE_ENTRIES.set(wms.tile_cache.len() as i64);
 
     // Tile cache: per-collection
     if let Ok(engines) = state.geotiff_engines.read() {

--- a/crates/server/src/admin.rs
+++ b/crates/server/src/admin.rs
@@ -1417,13 +1417,16 @@ pub fn load_collections(
         .next()
         .unwrap_or(128);
 
-    // Meta-tile pixel cache size (#202) — same selection rule as above.
+    // Meta-tile pixel cache size (#202). Take the MINIMUM across WMS
+    // collections (not the first) so the `metatile_cache_mb = 0` kill switch
+    // wins if any collection sets it — the cache is global, so one collection
+    // must be able to disable meta-tiling server-wide.
     let metatile_cache_mb = map_collections
         .values()
         .chain(maps_collections.values())
         .filter_map(|c| c.wms.as_ref())
         .map(|w| w.metatile_cache_mb)
-        .next()
+        .min()
         .unwrap_or(512);
 
     // 2× cores (min 8) — the render slot's "ownership" of a CPU is loose

--- a/crates/server/src/admin.rs
+++ b/crates/server/src/admin.rs
@@ -1417,13 +1417,14 @@ pub fn load_collections(
         .next()
         .unwrap_or(128);
 
-    // Meta-tile pixel cache size (#202). Take the MINIMUM across WMS
-    // collections (not the first) so the `metatile_cache_mb = 0` kill switch
-    // wins if any collection sets it — the cache is global, so one collection
-    // must be able to disable meta-tiling server-wide.
+    // Meta-tile pixel cache size (#202). Read only from WMS-registered
+    // collections (`map_collections`) — meta-tiling is a WMS-only path, so a
+    // Maps-only collection's `[wms]` block must not influence it. Take the
+    // MINIMUM (not the first) so the `metatile_cache_mb = 0` kill switch wins if
+    // any WMS collection sets it — the cache is global, so one collection must be
+    // able to disable meta-tiling server-wide.
     let metatile_cache_mb = map_collections
         .values()
-        .chain(maps_collections.values())
         .filter_map(|c| c.wms.as_ref())
         .map(|w| w.metatile_cache_mb)
         .min()

--- a/crates/server/src/admin.rs
+++ b/crates/server/src/admin.rs
@@ -1427,7 +1427,7 @@ pub fn load_collections(
         .filter_map(|c| c.wms.as_ref())
         .map(|w| w.metatile_cache_mb)
         .min()
-        .unwrap_or(512);
+        .unwrap_or(1024);
 
     // 2× cores (min 8) — the render slot's "ownership" of a CPU is loose
     // because decode/encode interleaves with bilinear passes; configurable

--- a/crates/server/src/preview.rs
+++ b/crates/server/src/preview.rs
@@ -900,6 +900,7 @@ mod tests {
             styles: HashMap::new(),
             render_semaphore: Arc::new(tokio::sync::Semaphore::new(1)),
             rendered_cache: Arc::new(ds_render::RenderedCache::new(1)),
+            tile_cache: Arc::new(ds_render::TilePixelCache::new(1)),
             base_url: String::new(),
         }
     }

--- a/crates/server/tests/middleware.rs
+++ b/crates/server/tests/middleware.rs
@@ -117,6 +117,7 @@ fn build_wms_router() -> axum::Router {
         styles,
         render_semaphore: Arc::new(tokio::sync::Semaphore::new(4)),
         rendered_cache: Arc::new(RenderedCache::new(16)),
+        tile_cache: Arc::new(ds_render::TilePixelCache::new(16)),
         base_url: String::new(),
     }));
     api_wms::router(state)
@@ -315,6 +316,7 @@ mod load_shedding {
             styles,
             render_semaphore: Arc::new(tokio::sync::Semaphore::new(0)), // 0 permits!
             rendered_cache: Arc::new(RenderedCache::new(16)),
+            tile_cache: Arc::new(ds_render::TilePixelCache::new(16)),
             base_url: String::new(),
         }));
         let app = api_wms::router(state);

--- a/grafana/dashboards/meteocore-overview.json
+++ b/grafana/dashboards/meteocore-overview.json
@@ -245,7 +245,7 @@
     {
       "title": "Tile Cache Hit Rate",
       "type": "gauge",
-      "gridPos": { "h": 6, "w": 6, "x": 0, "y": 31 },
+      "gridPos": { "h": 6, "w": 5, "x": 0, "y": 31 },
       "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
       "fieldConfig": {
         "defaults": {
@@ -271,7 +271,7 @@
     {
       "title": "Rendered Cache Hit Rate",
       "type": "gauge",
-      "gridPos": { "h": 6, "w": 6, "x": 6, "y": 31 },
+      "gridPos": { "h": 6, "w": 5, "x": 5, "y": 31 },
       "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
       "fieldConfig": {
         "defaults": {
@@ -295,9 +295,35 @@
       ]
     },
     {
+      "title": "Meta-Tile Cache Hit Rate",
+      "type": "gauge",
+      "gridPos": { "h": 6, "w": 5, "x": 10, "y": 31 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "thresholds": {
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "yellow", "value": 0.5 },
+              { "color": "green", "value": 0.8 }
+            ]
+          }
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(metatile_cache_hits_total[5m])) / clamp_min(sum(rate(metatile_cache_hits_total[5m])) + sum(rate(metatile_cache_misses_total[5m])), 0.0001)",
+          "legendFormat": "Hit Rate"
+        }
+      ]
+    },
+    {
       "title": "GRIB Grid Cache Hit Rate",
       "type": "gauge",
-      "gridPos": { "h": 6, "w": 6, "x": 12, "y": 31 },
+      "gridPos": { "h": 6, "w": 5, "x": 15, "y": 31 },
       "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
       "fieldConfig": {
         "defaults": {
@@ -323,7 +349,7 @@
     {
       "title": "Render Semaphore",
       "type": "gauge",
-      "gridPos": { "h": 6, "w": 6, "x": 18, "y": 31 },
+      "gridPos": { "h": 6, "w": 4, "x": 20, "y": 31 },
       "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
       "fieldConfig": {
         "defaults": {
@@ -393,6 +419,14 @@
         {
           "expr": "sum(rate(grid_cache_misses_total[5m]))",
           "legendFormat": "Grid Misses"
+        },
+        {
+          "expr": "sum(rate(metatile_cache_hits_total[5m]))",
+          "legendFormat": "Meta-Tile Hits"
+        },
+        {
+          "expr": "sum(rate(metatile_cache_misses_total[5m]))",
+          "legendFormat": "Meta-Tile Misses"
         }
       ]
     },
@@ -456,6 +490,10 @@
         {
           "expr": "sum(rate(grid_cache_hits_total[5m])) / clamp_min(sum(rate(grid_cache_hits_total[5m])) + sum(rate(grid_cache_misses_total[5m])), 0.0001)",
           "legendFormat": "GRIB Grid Cache"
+        },
+        {
+          "expr": "sum(rate(metatile_cache_hits_total[5m])) / clamp_min(sum(rate(metatile_cache_hits_total[5m])) + sum(rate(metatile_cache_misses_total[5m])), 0.0001)",
+          "legendFormat": "Meta-Tile Cache"
         }
       ]
     },


### PR DESCRIPTION
## What & why

Closes #202 (part of the #201 GeoTIFF radar WMS performance epic).

The rendered-image cache is keyed on the exact request bbox, so a fullscreen OpenLayers `ImageWMS` client — arbitrary bbox + width + height per pan/zoom — almost never hits it (**~3% in production**). Result: ~100% of WMS GetMap requests run the full render pipeline (TIFF decode, per-pixel projection, colorize, encode).

This fixes the **strategy**, not the key. Each Web Mercator GetMap is decomposed into a grid of fixed 256×256 tiles aligned to the WebMercatorQuad grid; those are rendered and cached (fixed bbox + fixed size → repeating key → high hit rate), then resampled into the client's exact viewport. The expensive per-source work is cached at tile granularity and reused across overlapping viewports; the final crop/resample is cheap. This is GeoServer's GeoWebCache meta-tiling model.

## Design

- **`ds_render::metatile`** — `TilePixelCache` (decoded-RGBA LRU) + `render_metatiled`.
  - **Resolution ladder:** half-octave steps whose *even* steps coincide with the standard integer WebMercator zooms. Snap to the **finest step ≤ the request resolution**, so the mosaic is always *downsampled* (crisp, never upscaled). A discrete-zoom OpenLayers view lands exactly on a step (pure crop, no resample); a smooth-zoom view snaps ≤ 1.41× finer (≤ 1.19× perceived softening).
  - **Assembly:** premultiplied-alpha bilinear, so transparent nodata edges don't bleed dark fringes. Tiles render in the request CRS, so assembly is a pure affine resample in Mercator metres — **no reprojection in the hot path** (the engine already reprojects source→Mercator inside each tile).
  - **Cache key:** `(layer, parameter, style, time, elevation, level, col, row)` — mirrors the request-level `CacheKey` plus grid position, so STYLES / TIME / ELEVATION / parameter never cross-contaminate.
- **api-wms GetMap** routes EPSG:3857 through meta-tiling; **other CRSs, degenerate bboxes, and >256-tile requests fall back to the unchanged direct render**.
- **Kill switch:** `metatile_cache_mb = 0` bypasses meta-tiling entirely (direct render), reversible via config reload with **no redeploy**. Default 512 MB.
- **Metrics:** new `metatile_cache_{hits,misses,bytes,capacity_bytes,entries}` (distinct from the per-collection GeoTIFF compressed-byte `tile_cache_*`).

## Risk & fidelity

Output is **visually equivalent but not bit-identical** to the old path — it's a resample-based strategy. Blast radius is confined to the EPSG:3857 path (the production hot path); every other CRS is byte-for-byte unchanged. To de-risk:

- **Fidelity test** assembles a field whose value at each pixel is that pixel's own Web Mercator X (then Y), encoded into the red channel, and asserts the decoded output tracks it — a column/row shift, transpose, or wrong-tile bug fails the check.
- **Kill switch** (`metatile_cache_mb = 0`) reverts to the direct render instantly via reload.
- Recommended rollout: deploy, watch `metatile_cache_hits_total` climb and WMS p99 drop; flip the kill switch if anything looks off.

## Tests

- `ds-render`: snap-ladder exactness at standard zooms, mercator roundtrip, snap bounds, cache reuse, empty/fallback outcomes, geographic-fidelity guard (X and Y).
- `api-wms` integration: tile reuse across a panned viewport (fewer fresh renders + cache hits), non-3857 bypass, and the kill switch.
- `cargo fmt`, `cargo clippy` (clean), and `cargo test` for ds-core / ds-render / api-wms / server all green.

## Follow-up

Maps + Tiles share the render+cache code and can be wired to the same helper in a follow-up (Tiles benefits least — it is already tile-aligned).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
