### PR TITLE
ops(observability,config): meta-tile cache fill panel + move metatile_cache_mb to [server] (#202)

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ host = "0.0.0.0"
 port = 8000
 # base_url = "https://api.example.com"  # optional, for absolute links behind a proxy
 # collections_dir = "collections.d"     # optional, load per-collection .toml files from directory
+# metatile_cache_mb = 1024              # optional, global WMS meta-tile cache (MB); 0 disables meta-tiling
 
 [[collections]]
 id = "weather"
@@ -228,6 +229,7 @@ colormap = "radar_dbz"          # built-in colormap (or use color_stops for cust
 | `port` | yes | — | Bind port |
 | `base_url` | no | `http://{host}:{port}` | External base URL for absolute links (set when behind a reverse proxy) |
 | `collections_dir` | no | — | Directory of per-collection `.toml` config files (see [Per-File Collection Configs](#per-file-collection-configs)) |
+| `metatile_cache_mb` | no | `1024` | Size (MB) of the global Web Mercator meta-tile cache (#202). Server-wide, not per-collection. `0` disables meta-tiling (EPSG:3857 GetMap reverts to a direct render; reload-reversible). Consumed by WMS today; Maps/Tiles will share it when meta-tiling extends to them. |
 
 ### Collection Config Fields
 
@@ -852,8 +854,7 @@ Or attach a reusable `[[style_bundles]]` block defined in top-level `config.toml
 | `max` | no | from colormap | Maximum value for the default style's range |
 | `styles` | no | — | Array of named styles |
 | `parameters` | no | — | Per-parameter default-style overrides (multi-parameter engines) |
-| `rendered_cache_mb` | no | `512` | Shared rendered-image cache size in MB. Set to 0 to disable. |
-| `metatile_cache_mb` | no | `1024` | Web Mercator meta-tile (decoded-RGBA) cache size in MB. Set to 0 to disable meta-tiling (direct render). Global cache: the **minimum** across WMS collections wins, so `0` on any collection disables meta-tiling server-wide. |
+| `rendered_cache_mb` | no | `512` | Shared rendered-image cache size in MB. Set to 0 to disable. (Global cache; lives under `[wms]` for backward compatibility — see note.) |
 
 ### Limits
 
@@ -1000,7 +1001,7 @@ Separate from the GeoTIFF source tile cache (Tier 1). Caches final PNG/JPEG/WebP
 
 A fullscreen WMS client requests an arbitrary bbox + size per pan/zoom, so the Tier-2 rendered cache (keyed on the exact bbox) rarely hits. For EPSG:3857 GetMap, the WMS handler instead decomposes each request into fixed 256×256 tiles aligned to the WebMercatorQuad grid, renders and caches *those* (decoded RGBA), and resamples them to the exact viewport — so the expensive decode/projection/colorize work is cached at tile granularity and reused across overlapping views.
 
-- Default size: 1024 MB (configurable via `metatile_cache_mb`); **set to 0 to disable** meta-tiling (reverts to a direct single-shot render, reload-reversible). The cache is global; the size is the **minimum** `metatile_cache_mb` across WMS collections, so `0` anywhere disables it server-wide (unlike `rendered_cache_mb`, which takes the first value).
+- Default size: 1024 MB, configured server-wide via **`[server] metatile_cache_mb`** (it is a single global cache, not per-collection); **set to 0 to disable** meta-tiling (reverts to a direct single-shot render, reload-reversible). Consumed by the WMS GetMap path today; Maps/Tiles render directly and would share this cache when meta-tiling extends to them.
 - Cache key: layer + parameter + style + time + elevation + ladder level + tile col/row.
 - Resolution ladder: half-octave steps coinciding with standard WebMercator zooms; snaps to the finest step ≤ the request resolution (always downsampled, never upscaled).
 - Web Mercator only; other CRSs and degenerate/oversized requests fall back to the direct render.

--- a/crates/api-wms/README.md
+++ b/crates/api-wms/README.md
@@ -204,12 +204,14 @@ Styles are listed in GetCapabilities and include LegendURL links.
 [collections.wms]
 colormap = "radar_dbz"
 rendered_cache_mb = 512    # Default: 512 MB. Set to 0 to disable.
-metatile_cache_mb = 1024   # Default: 1024 MB. Set to 0 to disable meta-tiling.
+
+[server]
+metatile_cache_mb = 1024   # Global (server-wide). Default: 1024 MB. 0 disables meta-tiling.
 ```
 
 The rendered image cache stores final PNG/JPEG/WebP bytes keyed by bbox, style, format, dimensions, CRS, and timestamp. No TTL — radar data is immutable once produced. Cache is invalidated on collection reload (`POST /admin/collections/reload`).
 
-For EPSG:3857 GetMap, the handler additionally uses an internal **meta-tile cache**: each request is decomposed into fixed 256×256 WebMercatorQuad tiles, rendered+cached as decoded RGBA, and resampled to the exact viewport — so overlapping fullscreen views reuse cached tiles instead of re-rendering. `metatile_cache_mb = 0` disables this and reverts to a direct render (reversible via reload).
+For EPSG:3857 GetMap, the handler additionally uses an internal **meta-tile cache**: each request is decomposed into fixed 256×256 WebMercatorQuad tiles, rendered+cached as decoded RGBA, and resampled to the exact viewport — so overlapping fullscreen views reuse cached tiles instead of re-rendering. This cache is **global** (configured once under `[server] metatile_cache_mb`, not per-collection) and is consumed by WMS today (Maps/Tiles render directly for now). `metatile_cache_mb = 0` disables it and reverts to a direct render (reversible via reload).
 
 Also configure the source tile cache for remote GeoTIFFs:
 

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -25,6 +25,15 @@ pub struct ServerSettings {
     /// Resolved relative to the parent directory of the main config file.
     /// Each file defines one collection using `CollectionConfig` fields directly.
     pub collections_dir: Option<String>,
+    /// Size in MB of the global Web Mercator meta-tile (decoded-RGBA) cache
+    /// (#202). A single server-wide cache, not per-collection. Currently
+    /// consumed only by the WMS GetMap path; api-maps/api-tiles still render
+    /// directly and would share this same cache once meta-tiling is extended to
+    /// them (follow-up). Default: 1024. Set to `0` to disable meta-tiling
+    /// entirely (the EPSG:3857 GetMap path reverts to a direct single-shot
+    /// render), reversible via config reload.
+    #[serde(default = "default_metatile_cache_mb")]
+    pub metatile_cache_mb: u64,
 }
 
 impl ServerSettings {
@@ -106,14 +115,12 @@ pub struct WmsConfig {
     #[serde(default)]
     pub parameters: Vec<WmsParameterConfig>,
     /// Rendered image cache size in MB. Default: 128.
+    ///
+    /// NOTE: like the meta-tile cache, this is actually a *global* shared cache,
+    /// not per-collection; it lives here for backward compatibility. New global
+    /// cache knobs (e.g. `[server] metatile_cache_mb`) go under `[server]`.
     #[serde(default = "default_rendered_cache_mb")]
     pub rendered_cache_mb: u64,
-    /// Meta-tile pixel cache size in MB (decoded 256×256 RGBA tiles shared by
-    /// the Web Mercator WMS meta-tiling path, #202). Default: 1024. Set to `0`
-    /// to disable meta-tiling entirely (kill switch): the Web Mercator GetMap
-    /// path reverts to a direct single-shot render, reversible via config reload.
-    #[serde(default = "default_metatile_cache_mb")]
-    pub metatile_cache_mb: u64,
 }
 
 /// Per-parameter default colormap configuration for WMS.

--- a/crates/server/src/admin.rs
+++ b/crates/server/src/admin.rs
@@ -429,6 +429,7 @@ pub fn load_collections(
     collections: &[CollectionConfig],
     style_bundles: &[StyleBundle],
     base_url: &str,
+    metatile_cache_mb: u64,
 ) -> LoadResult {
     let bundle_index: HashMap<&str, &StyleBundle> =
         style_bundles.iter().map(|b| (b.id.as_str(), b)).collect();
@@ -1417,18 +1418,10 @@ pub fn load_collections(
         .next()
         .unwrap_or(128);
 
-    // Meta-tile pixel cache size (#202). Read only from WMS-registered
-    // collections (`map_collections`) — meta-tiling is a WMS-only path, so a
-    // Maps-only collection's `[wms]` block must not influence it. Take the
-    // MINIMUM (not the first) so the `metatile_cache_mb = 0` kill switch wins if
-    // any WMS collection sets it — the cache is global, so one collection must be
-    // able to disable meta-tiling server-wide.
-    let metatile_cache_mb = map_collections
-        .values()
-        .filter_map(|c| c.wms.as_ref())
-        .map(|w| w.metatile_cache_mb)
-        .min()
-        .unwrap_or(1024);
+    // Meta-tile pixel cache size (#202) is a server-wide setting
+    // (`[server] metatile_cache_mb`) — the cache is global to all WMS
+    // collections, so it is passed in as a single value (no per-collection
+    // aggregation). `0` disables meta-tiling.
 
     // 2× cores (min 8) — the render slot's "ownership" of a CPU is loose
     // because decode/encode interleaves with bilinear passes; configurable
@@ -1870,7 +1863,12 @@ pub async fn reload_handler(
         }
     }
 
-    let result = load_collections(&config.collections, &config.style_bundles, &base_url);
+    let result = load_collections(
+        &config.collections,
+        &config.style_bundles,
+        &base_url,
+        config.server.metatile_cache_mb,
+    );
 
     let loaded = result
         .health

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -215,7 +215,12 @@ async fn main() {
     // will see the port open early; probe `/health` over HTTP instead.)
     info!("Socket bound to {addr} — loading collections, not yet serving");
 
-    let result = admin::load_collections(&config.collections, &config.style_bundles, &base_url);
+    let result = admin::load_collections(
+        &config.collections,
+        &config.style_bundles,
+        &base_url,
+        config.server.metatile_cache_mb,
+    );
 
     let loaded = result
         .health

--- a/grafana/dashboards/meteocore-overview.json
+++ b/grafana/dashboards/meteocore-overview.json
@@ -468,7 +468,7 @@
     {
       "title": "Cache Hit Rate Over Time",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 45 },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 45 },
       "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
       "fieldConfig": {
         "defaults": {
@@ -494,6 +494,38 @@
         {
           "expr": "sum(rate(metatile_cache_hits_total[5m])) / clamp_min(sum(rate(metatile_cache_hits_total[5m])) + sum(rate(metatile_cache_misses_total[5m])), 0.0001)",
           "legendFormat": "Meta-Tile Cache"
+        }
+      ]
+    },
+    {
+      "title": "Cache Fill (% of capacity)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 45 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "description": "Bytes held / configured capacity. A line pinned near 100% means the cache is full and evicting on every insert — the working set exceeds capacity (consider raising the *_cache_mb).",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "custom": { "fillOpacity": 5, "lineWidth": 2 },
+          "thresholds": {
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 0.9 },
+              { "color": "red", "value": 0.98 }
+            ]
+          }
+        }
+      },
+      "targets": [
+        {
+          "expr": "metatile_cache_bytes / clamp_min(metatile_cache_capacity_bytes, 1)",
+          "legendFormat": "Meta-Tile"
+        },
+        {
+          "expr": "rendered_cache_bytes / clamp_min(rendered_cache_capacity_bytes, 1)",
+          "legendFormat": "Rendered"
         }
       ]
     },


### PR DESCRIPTION
Two production-tuning follow-ups to #202 (PR #235).

## 1. `metatile_cache_mb` → `[server]` (was per-collection `[wms]`)
The meta-tile cache is a **single, server-wide** resource. Putting `metatile_cache_mb` under each collection's `[wms]` implied a per-collection knob that doesn't exist, and forced awkward cross-collection aggregation (first `min`, then `max`). Now:

```toml
[server]
metatile_cache_mb = 1024   # global; 0 disables meta-tiling
```

Read once and threaded into `load_collections` — no aggregation. Removed from `WmsConfig`; added to `ServerSettings`. (No `deny_unknown_fields`, and the field is one day old, so a stray `[wms] metatile_cache_mb` is silently ignored rather than a parse error.)

Scope note: meta-tiling is currently wired for **WMS only** (the #202 scope). api-maps/api-tiles still render directly; they'd share this same global cache when meta-tiling extends to them. `rendered_cache_mb` has the same per-collection-but-actually-global smell, but stays under `[wms]` for backward compatibility (documented in its doc comment).

## 2. Cache-fill observability (Grafana)
The dashboard had hit-rate + hits/misses but **no view of cache usage / eviction**. Added a **"Cache Fill (% of capacity)"** timeseries (`metatile_cache_bytes / metatile_cache_capacity_bytes`, plus rendered) with thresholds at 90% / 98% — a line pinned near 100% means the working set exceeds capacity and the cache evicts on every insert. "Cache Hit Rate Over Time" narrowed to half-width to sit beside it; no other panels moved. JSON validated. (No eviction *counter* metric exists; fill-at-capacity is the proxy.)

Tested: `cargo fmt`, `cargo clippy -p ds-core -p server` clean, `cargo test -p ds-core` green, dashboard JSON validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)