### PR TITLE
perf(engine-geotiff): bounded-upscale overview selection to kill the render cliff

### DIFF
--- a/crates/engine-geotiff/src/lib.rs
+++ b/crates/engine-geotiff/src/lib.rs
@@ -1289,9 +1289,11 @@ impl ds_core::map_engine::MapEngine for GeoTiffEngine {
                 {
                     let full_pixels = ((c1 - c0) as usize) * ((r1 - r0) as usize);
                     if full_pixels > reader::max_map_pixels() {
-                        // Find the finest overview that fits under the limit
-                        // (overviews are sorted coarsest-last, iterate in reverse)
-                        for ov in metadata.overviews.iter().rev() {
+                        // Pick the finest overview that fits under the limit.
+                        // Overviews are sorted finest-first, so iterate in order
+                        // and take the first that fits — the highest quality
+                        // within the pixel budget.
+                        for ov in &metadata.overviews {
                             let ov_gt = metadata.overview_geo_transform(ov);
                             if let Some((oc0, or0, oc1, or1)) =
                                 ov_gt.bbox_to_pixels(west, south, east, north)
@@ -1302,7 +1304,8 @@ impl ds_core::map_engine::MapEngine for GeoTiffEngine {
                                 }
                             }
                         }
-                        // All overviews still exceed limit — use coarsest
+                        // Even the coarsest overview exceeds the limit — use it
+                        // anyway as the smallest available source.
                         metadata.overviews.last()
                     } else {
                         None

--- a/crates/engine-geotiff/src/lib.rs
+++ b/crates/engine-geotiff/src/lib.rs
@@ -1273,10 +1273,16 @@ impl ds_core::map_engine::MapEngine for GeoTiffEngine {
         let overview = metadata
             .select_overview(west, south, east, north, width, height)
             .or_else(|| {
-                // select_overview returned None — either no overviews exist,
-                // or all overviews have enough pixels. Check if full resolution
-                // exceeds the source pixel limit, and if so pick the finest
-                // overview that fits under the limit.
+                // select_overview returned None, which now means one of: no
+                // overviews exist; full resolution already fits the output; or
+                // the output exceeds the biggest overview by more than the
+                // bounded-upscale factor (i.e. it is at/near native resolution).
+                // In the last two cases we'd read full resolution — but if that
+                // would blow the MAX_MAP_PIXELS decode budget we must fall back
+                // to an overview regardless of the upscale bound: the hard pixel
+                // cap overrides the soft 2× quality preference (an over-cap
+                // upscale is still logged by the `Using overview …` debug below).
+                // Pick the finest overview that fits under the limit.
                 if let Some((c0, r0, c1, r1)) = metadata
                     .geo_transform
                     .bbox_to_pixels(west, south, east, north)

--- a/crates/engine-geotiff/src/reader.rs
+++ b/crates/engine-geotiff/src/reader.rs
@@ -542,9 +542,24 @@ impl TiffMetadata {
             return None;
         }
 
-        // Find the smallest overview where the bbox still covers enough
-        // source pixels to fill the output without upscaling.
-        // Overviews are sorted by decreasing resolution (largest first).
+        // Pick the coarsest overview that still provides at least
+        // `MIN_OVERVIEW_FRACTION` of the requested resolution — i.e. tolerate a
+        // bounded bilinear upscale (at most `1 / MIN_OVERVIEW_FRACTION`).
+        //
+        // A strict never-upscale rule (`>= output_*`) creates a latency cliff:
+        // any output only slightly wider than the largest overview falls all the
+        // way through to full resolution. On the production FMI composite (base
+        // 4963×7316, largest overview 2481 px) a 2650-px-wide retina GetMap
+        // decoded the entire 36 MP base (~770 ms) instead of the 9 MP overview
+        // (~350 ms) — for what is only a 1.07× upscale. Measured live: render
+        // jumped from 348 ms at 2481 px to 653 ms at 2550 px.
+        //
+        // Overviews are sorted by decreasing resolution (largest first), so the
+        // last level to clear the floor is the coarsest acceptable one (least
+        // data to decode).
+        const MIN_OVERVIEW_FRACTION: f64 = 0.5; // accept up to a 2× bilinear upscale
+        let min_cols = (output_width as f64 * MIN_OVERVIEW_FRACTION).ceil() as u32;
+        let min_rows = (output_height as f64 * MIN_OVERVIEW_FRACTION).ceil() as u32;
         let mut best: Option<&OverviewLevel> = None;
         for ov in &self.overviews {
             let ov_gt = self.overview_geo_transform(ov);
@@ -553,11 +568,11 @@ impl TiffMetadata {
             {
                 let ov_cols = c1 - c0;
                 let ov_rows = r1 - r0;
-                if ov_cols >= output_width && ov_rows >= output_height {
-                    // This overview has enough pixels — it's a candidate
+                if ov_cols >= min_cols && ov_rows >= min_rows {
+                    // Enough pixels (within the upscale tolerance) — a candidate.
                     best = Some(ov);
                 } else {
-                    // Too small — stop, use previous candidate
+                    // Below the floor — stop, use the previous (finer) candidate.
                     break;
                 }
             } else {
@@ -2502,6 +2517,100 @@ mod tests {
             mismatches,
             sequential_result.len()
         );
+    }
+
+    // --- Overview selection (latency-cliff) tests ---
+
+    /// Mirrors the production FMI radar composite COG: a 4963×7316 base with a
+    /// power-of-two overview pyramid whose largest overview is 2481 px wide.
+    /// CRS is WGS84 so bbox-to-pixel is an axis-aligned scale, letting these
+    /// tests reason purely about the overview-selection arithmetic.
+    fn fmi_like_meta() -> TiffMetadata {
+        let ov = |ifd: usize, w: u32, h: u32| OverviewLevel {
+            ifd_index: ifd,
+            width: w,
+            height: h,
+            tile_width: 256,
+            tile_height: 256,
+            tiles_across: w.div_ceil(256),
+            tiles_down: h.div_ceil(256),
+            tile_info: None,
+        };
+        TiffMetadata {
+            width: 4963,
+            height: 7316,
+            tile_width: 256,
+            tile_height: 256,
+            tiles_across: 4963u32.div_ceil(256),
+            tiles_down: 7316u32.div_ceil(256),
+            samples_per_pixel: 1,
+            // A valid WGS84 extent (20–30°E, 55–70°N) so bbox→pixel is a clean
+            // affine scale; the absolute geography is irrelevant to the test.
+            geo_transform: ds_core::geo::GeoTransform {
+                origin_x: 20.0,
+                origin_y: 70.0,
+                pixel_width: 10.0 / 4963.0,
+                pixel_height: 15.0 / 7316.0,
+                width: 4963,
+                height: 7316,
+                crs: ds_core::geo::Crs::Wgs84,
+            },
+            nodata: Some(255.0),
+            scale: None,
+            offset: None,
+            overviews: vec![
+                ov(1, 2481, 3658),
+                ov(2, 1240, 1829),
+                ov(3, 620, 914),
+                ov(4, 310, 457),
+                ov(5, 155, 228),
+            ],
+        }
+    }
+
+    // Full geographic extent of `fmi_like_meta` (west, south, east, north).
+    const FULL: (f64, f64, f64, f64) = (20.0, 55.0, 30.0, 70.0);
+
+    #[test]
+    fn select_overview_just_above_cliff_uses_overview_not_full_res() {
+        let m = fmi_like_meta();
+        // 2650 px is just above the 2481-px largest overview. Under the old
+        // strict never-upscale rule this returned None → full-res 36 MP decode.
+        let ov = m
+            .select_overview(FULL.0, FULL.1, FULL.2, FULL.3, 2650, 2177)
+            .expect("must use an overview, not fall back to full resolution");
+        assert_eq!(ov.ifd_index, 1, "should pick the 2481-px overview");
+    }
+
+    #[test]
+    fn select_overview_largest_retina_still_avoids_full_res() {
+        let m = fmi_like_meta();
+        // 3783 px (a 1.52× upscale off ov0) must still use the overview.
+        let ov = m
+            .select_overview(FULL.0, FULL.1, FULL.2, FULL.3, 3783, 3108)
+            .expect("3783-wide output should still use an overview");
+        assert_eq!(ov.ifd_index, 1);
+    }
+
+    #[test]
+    fn select_overview_full_res_when_output_matches_base() {
+        let m = fmi_like_meta();
+        // At native resolution no coarser level clears the upscale floor, so
+        // full resolution is the correct choice.
+        assert!(m
+            .select_overview(FULL.0, FULL.1, FULL.2, FULL.3, 4963, 7316)
+            .is_none());
+    }
+
+    #[test]
+    fn select_overview_prefers_coarser_within_tolerance() {
+        let m = fmi_like_meta();
+        // 1300-wide output: ov1 (1240) is within the 2× floor (≈1.05× upscale)
+        // and reads ~4× less than ov0, so it is preferred.
+        let ov = m
+            .select_overview(FULL.0, FULL.1, FULL.2, FULL.3, 1300, 1068)
+            .unwrap();
+        assert_eq!(ov.ifd_index, 2);
     }
 
     // --- Nodata comparison tests ---

--- a/crates/engine-geotiff/src/reader.rs
+++ b/crates/engine-geotiff/src/reader.rs
@@ -2657,6 +2657,14 @@ mod tests {
         assert!(m
             .select_overview(FULL.0, FULL.1, FULL.2, FULL.3, 3500, 1000)
             .is_none());
+        // Row axis binds independently: width fits (1500 ≤ 1654) but height needs
+        // a >2× upscale (min_rows = 2500 > 2439), so it must still fall to full
+        // resolution. Guards the `(r1 - r0) >= min_rows` half of Pass 2.
+        assert!(
+            m.select_overview(FULL.0, FULL.1, FULL.2, FULL.3, 3000, 5000)
+                .is_none(),
+            "row axis exceeds 2× overview height → must read full resolution"
+        );
     }
 
     /// Like `fmi_like_meta` but in the production CRS (EPSG:3067 / TM35FIN), so

--- a/crates/engine-geotiff/src/reader.rs
+++ b/crates/engine-geotiff/src/reader.rs
@@ -560,6 +560,12 @@ impl TiffMetadata {
                 {
                     best = Some(ov);
                 }
+                // Stop at the first level that doesn't qualify. Overviews are
+                // visited finest-first and both reasons to fall here are monotone
+                // in that direction: a level with too few source pixels is only
+                // followed by coarser (even smaller) levels, and a level whose
+                // bbox maps to < 1 pixel is only followed by coarser (even more
+                // sub-pixel) levels — so no later level can qualify either.
                 _ => break,
             }
         }

--- a/crates/engine-geotiff/src/reader.rs
+++ b/crates/engine-geotiff/src/reader.rs
@@ -506,15 +506,17 @@ impl TiffMetadata {
         }
     }
 
-    /// Select the best overview level for the given output dimensions.
+    /// Select the overview level to read for the given bbox and output size.
     ///
-    /// Returns the overview whose resolution is closest to (but not less than)
-    /// the output resolution. Returns `None` if full resolution should be used.
-    /// Select the best overview level for the given bbox and output dimensions.
-    ///
-    /// Compares how many source pixels the bbox covers at each level against
-    /// the output dimensions. Picks the smallest level where the source pixel
-    /// coverage still exceeds the output (no upscaling).
+    /// Compares how many source pixels the bbox covers at each level against the
+    /// output dimensions and picks the coarsest level that still covers the
+    /// output without upscaling (least data to decode). If no overview is large
+    /// enough — the output exceeds the biggest overview but is still below full
+    /// resolution — the biggest overview is used anyway provided the implied
+    /// (nearest-neighbour) upscale stays within `MIN_OVERVIEW_FRACTION`; beyond
+    /// that the output is at/near native resolution and `None` is returned so the
+    /// caller reads full resolution. Also returns `None` when the bbox misses the
+    /// raster or full resolution already fits the output.
     pub fn select_overview(
         &self,
         bbox_west: f64,
@@ -542,47 +544,56 @@ impl TiffMetadata {
             return None;
         }
 
-        // Pick the coarsest overview that still provides at least
-        // `MIN_OVERVIEW_FRACTION` of the requested resolution — i.e. tolerate a
-        // bounded bilinear upscale (at most `1 / MIN_OVERVIEW_FRACTION`).
-        //
-        // A strict never-upscale rule (`>= output_*`) creates a latency cliff:
-        // any output only slightly wider than the largest overview falls all the
-        // way through to full resolution. On the production FMI composite (base
-        // 4963×7316, largest overview 2481 px) a 2650-px-wide retina GetMap
-        // decoded the entire 36 MP base (~770 ms) instead of the 9 MP overview
-        // (~350 ms) — for what is only a 1.07× upscale. Measured live: render
-        // jumped from 348 ms at 2481 px to 653 ms at 2550 px.
-        //
-        // Overviews are sorted by decreasing resolution (largest first), so the
-        // last level to clear the floor is the coarsest acceptable one (least
-        // data to decode).
-        const MIN_OVERVIEW_FRACTION: f64 = 0.5; // accept up to a 2× bilinear upscale
-        let min_cols = (output_width as f64 * MIN_OVERVIEW_FRACTION).ceil() as u32;
-        let min_rows = (output_height as f64 * MIN_OVERVIEW_FRACTION).ceil() as u32;
+        // Pass 1 — strict never-upscale. Pick the coarsest overview that still
+        // has at least as many source pixels as the output (least data read, no
+        // upscaling). Overviews are sorted largest-first and both axes shrink
+        // monotonically across levels, so the qualifying levels are a prefix:
+        // once an axis falls short, every coarser level falls short too, so we
+        // can stop. This leaves every output an overview *can* satisfy selected
+        // exactly as before — no change to mid-zoom selection.
         let mut best: Option<&OverviewLevel> = None;
         for ov in &self.overviews {
             let ov_gt = self.overview_geo_transform(ov);
-            if let Some((c0, r0, c1, r1)) =
-                ov_gt.bbox_to_pixels(bbox_west, bbox_south, bbox_east, bbox_north)
-            {
-                let ov_cols = c1 - c0;
-                let ov_rows = r1 - r0;
-                if ov_cols >= min_cols && ov_rows >= min_rows {
-                    // Enough pixels (within the upscale tolerance) — a candidate.
+            match ov_gt.bbox_to_pixels(bbox_west, bbox_south, bbox_east, bbox_north) {
+                Some((c0, r0, c1, r1))
+                    if (c1 - c0) >= output_width && (r1 - r0) >= output_height =>
+                {
                     best = Some(ov);
-                } else {
-                    // Below the floor — stop, use the previous (finer) candidate.
-                    break;
                 }
-            } else {
-                // bbox_to_pixels returned None — this overview's pixels are too
-                // coarse to detect the intersection. Stop and use previous candidate.
-                break;
+                _ => break,
             }
         }
+        if best.is_some() {
+            return best;
+        }
 
-        best
+        // Pass 2 — bounded upscale at the cliff. The output is larger than the
+        // biggest overview but (per the early return above) smaller than full
+        // resolution. A strict never-upscale rule falls straight through to the
+        // full-resolution IFD here — and on the production FMI composite (base
+        // 4963×7316, biggest overview 2481 px) a 2650-px-wide retina GetMap then
+        // decoded the entire 36 MP base (measured ~770 ms) instead of the 9 MP
+        // overview (~350 ms), for what is only a 1.07× upscale. Live, render
+        // jumped from 348 ms at 2481 px to 653 ms at 2550 px.
+        //
+        // So accept the biggest overview as long as the implied upscale stays
+        // within MIN_OVERVIEW_FRACTION (the resample is nearest-neighbour, so an
+        // upscale is blocky pixel replication — bounded to keep it tolerable).
+        // Beyond that bound the output is at/near native resolution, where full
+        // resolution is genuinely the better source, so return None and let the
+        // caller read it. This confines full-resolution decodes to ~native-res
+        // requests instead of every retina viewport just above an overview.
+        const MIN_OVERVIEW_FRACTION: f64 = 0.5; // accept up to a 2× nearest-neighbour upscale
+        let largest = self.overviews.first()?;
+        let lg = self.overview_geo_transform(largest);
+        let (c0, r0, c1, r1) = lg.bbox_to_pixels(bbox_west, bbox_south, bbox_east, bbox_north)?;
+        let min_cols = (output_width as f64 * MIN_OVERVIEW_FRACTION).ceil() as u32;
+        let min_rows = (output_height as f64 * MIN_OVERVIEW_FRACTION).ceil() as u32;
+        if (c1 - c0) >= min_cols && (r1 - r0) >= min_rows {
+            Some(largest)
+        } else {
+            None
+        }
     }
 
     /// Build a GeoTransform for an overview level.
@@ -2603,14 +2614,85 @@ mod tests {
     }
 
     #[test]
-    fn select_overview_prefers_coarser_within_tolerance() {
+    fn select_overview_mid_zoom_unchanged_never_upscales() {
         let m = fmi_like_meta();
-        // 1300-wide output: ov1 (1240) is within the 2× floor (≈1.05× upscale)
-        // and reads ~4× less than ov0, so it is preferred.
+        // 1300-wide output is satisfied by ov0 (2481 ≥ 1300) without upscaling,
+        // so the bounded-upscale pass must NOT engage: selection is identical to
+        // the original strict never-upscale behaviour. Guards against the fix
+        // silently retuning every mid-zoom level to a coarser overview.
         let ov = m
             .select_overview(FULL.0, FULL.1, FULL.2, FULL.3, 1300, 1068)
             .unwrap();
-        assert_eq!(ov.ifd_index, 2);
+        assert_eq!(
+            ov.ifd_index, 1,
+            "mid-zoom must still pick ov0, not a coarser level"
+        );
+    }
+
+    #[test]
+    fn select_overview_bounded_upscale_caps_at_2x() {
+        // Sparse pyramid: biggest overview is a 3× decimation (1654 px), leaving
+        // a >2× gap to full resolution. An output needing more than a 2× upscale
+        // off that overview must read full resolution, not upscale the overview 3×.
+        let ov = |ifd: usize, w: u32, h: u32| OverviewLevel {
+            ifd_index: ifd,
+            width: w,
+            height: h,
+            tile_width: 256,
+            tile_height: 256,
+            tiles_across: w.div_ceil(256),
+            tiles_down: h.div_ceil(256),
+            tile_info: None,
+        };
+        let mut m = fmi_like_meta();
+        m.overviews = vec![ov(1, 1654, 2439), ov(2, 620, 914)];
+        // 3000 px ≤ 2× of 1654 (1.81× upscale) → use the overview.
+        assert_eq!(
+            m.select_overview(FULL.0, FULL.1, FULL.2, FULL.3, 3000, 1000)
+                .unwrap()
+                .ifd_index,
+            1
+        );
+        // 3500 px > 2× of 1654 → full resolution, not a 2.1× upscale.
+        assert!(m
+            .select_overview(FULL.0, FULL.1, FULL.2, FULL.3, 3500, 1000)
+            .is_none());
+    }
+
+    /// Like `fmi_like_meta` but in the production CRS (EPSG:3067 / TM35FIN), so
+    /// `bbox_to_pixels` exercises the 20-samples-per-edge curvature envelope
+    /// rather than a clean axis-aligned scale.
+    fn tm35fin_meta() -> TiffMetadata {
+        let mut m = fmi_like_meta();
+        m.geo_transform = ds_core::geo::GeoTransform {
+            origin_x: 150_000.0,
+            origin_y: 7_780_000.0,
+            pixel_width: 115.0,
+            pixel_height: 153.0,
+            width: 4963,
+            height: 7316,
+            crs: ds_core::geo::Crs::TransverseMercator {
+                lat0: 0.0,
+                lon0: 27.0_f64.to_radians(),
+                k0: 0.9996,
+                false_e: 500_000.0,
+                false_n: 0.0,
+            },
+        };
+        m
+    }
+
+    #[test]
+    fn select_overview_cliff_fix_holds_for_projected_crs() {
+        let m = tm35fin_meta();
+        // Generous Finland lon/lat bbox (covers the grid). Under TM the pixel
+        // counts come from the curvature envelope, not a clean affine scale. A
+        // 2650-px retina GetMap must still use the overview (ifd 1), not the
+        // 36 MP full resolution — the same cliff fix, on the real projection.
+        let ov = m
+            .select_overview(18.0, 58.0, 33.0, 71.0, 2650, 2177)
+            .expect("projected-CRS retina render must use an overview, not full-res");
+        assert_eq!(ov.ifd_index, 1);
     }
 
     // --- Nodata comparison tests ---


### PR DESCRIPTION
## Problem

The long-standing "desktop radar player is slow (long initial wait), iPhone is fast" complaint was **not** encode (PNG vs WebP), **not** rayon/meta-tiling. It's an **overview-selection cliff** in `engine-geotiff`.

`TiffMetadata::select_overview` required an overview to be `>=` the requested output resolution (strict never-upscale). The production FMI composite COG is **4963×7316 (36 MP)**, local, **EPSG:3067 / TM35FIN**, with overviews at **2481**, 1240, … px. Desktop retina GetMaps are **2650–3783 px wide** — just *above* the 2481 px largest overview — so `select_overview` returned `None`, and because 36 MP `< MAX_MAP_PIXELS (64 M)` the engine **decoded the entire 36 MP base every frame**. iPhone (~1 MP) picks a small overview and is fast. With `metatile_cache_mb = 0` (current prod), all WMS GetMaps go through this direct path — confirmed by the `slow WMS direct render` logs.

## Evidence (live, cache-busted loopback renders on prod — local COG, so this is pure server-side render time)

| WIDTH | render | level read |
|---|---|---|
| 2481 | 348 ms | overview (9 MP) |
| **2550** | **653 ms** | **full-res 36 MP** ← +69 px ≈ 2× |
| 2650 | 773 ms | full-res |
| 3783 | 1076 ms | full-res |
| 4963 | 1438 ms | full-res |

## Fix (two-pass, surgical)

- **Pass 1** — the original strict never-upscale selection, unchanged. Every output an overview *can* satisfy is selected exactly as before (no mid-zoom retune).
- **Pass 2** — only when the output exceeds the biggest overview: clamp to that overview if the upscale stays within `MIN_OVERVIEW_FRACTION` (0.5 → ≤ 2×); otherwise `None` → full resolution. This **bounds** the upscale and confines full-res decodes to ~native-resolution requests, rather than relocating the cliff.

The resample is **nearest-neighbour** (`lib.rs:1397`), so an upscale is blocky pixel replication; nodata is `None` before resample and colorize runs after, so there's **no cross-class averaging or nodata blending**. For the user's widths the upscale is 1.07–1.52×. Helps every geotiff collection (opera/dmi/smhi/fmi).

## Tests

Cliff fixed (2650 → ov0), largest retina (3783 → ov0), **mid-zoom unchanged** (1300 → ov0, guards against a global retune), **bounded-upscale cap** (sparse pyramid: >2× → full-res), native (4963 → full-res), and a **TM35FIN (EPSG:3067)** fixture exercising the production curved-CRS path. Full `engine-geotiff` suite + clippy green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #246
