### PR TITLE
perf(render): single-threaded meta-tile assembly — kill the rayon convoy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -782,7 +782,6 @@ dependencies = [
  "jpeg-encoder",
  "png",
  "quick_cache",
- "rayon",
  "webp",
 ]
 

--- a/crates/render/Cargo.toml
+++ b/crates/render/Cargo.toml
@@ -11,6 +11,3 @@ webp = { version = "0.3", default-features = false }
 quick_cache = "0.6"
 bytes = "1"
 chrono = { version = "0.4", features = ["serde"] }
-# CPU data-parallelism for the meta-tile assembly (per-output-row, pure compute,
-# no I/O). A compute dependency, not a framework.
-rayon = "1"

--- a/crates/render/src/metatile.rs
+++ b/crates/render/src/metatile.rs
@@ -36,7 +36,6 @@ use std::time::Instant;
 
 use chrono::{DateTime, Utc};
 use quick_cache::sync::Cache;
-use rayon::prelude::*;
 
 use ds_core::error::DataServerError;
 use ds_core::map_engine::RasterTile;
@@ -391,8 +390,20 @@ where
     // Resample the tile mosaic into the exact viewport. Output pixels are
     // uniform in Mercator metres, so this is a pure affine map into global
     // tile-pixel space, sampled with premultiplied-alpha bilinear (avoids dark
-    // fringes from transparent nodata). Pure CPU, per-output-row independent,
-    // and touches no engine/DataStore — safe to run on the rayon pool (#240).
+    // fringes from transparent nodata).
+    //
+    // Single-threaded ON PURPOSE. This runs inside a per-request render task and
+    // the WMS handler serves many renders concurrently (a radar player prefetches
+    // ~10 timesteps per view change). Parallelising this per-row loop with rayon
+    // (#240/#242) routed every concurrent render's assembly through the one global
+    // rayon pool, where they convoy: ~10 prefetch renders oversubscribe the pool
+    // and park on its latches, inflating each assembly from ~25 ms (uncontended)
+    // to ~750 ms (measured in prod — even on warm, all-tiles-cached renders),
+    // serialising the burst into ~7 s with the CPU idle (parking, not compute).
+    // Keeping it sequential lets request concurrency be the parallelism: each
+    // assembly uses one core and the renders spread across cores instead of
+    // fighting over one pool. See feedback: no per-request rayon on a concurrent
+    // render path.
     let mosaic = Mosaic {
         tiles: mosaic_tiles,
         col0,
@@ -409,7 +420,7 @@ where
     let (w_us, h_us) = (width as usize, height as usize);
     let t_assemble = Instant::now();
     let mut out = vec![0u8; w_us * h_us * 4];
-    out.par_chunks_mut(w_us * 4)
+    out.chunks_mut(w_us * 4)
         .enumerate()
         .for_each(|(py, row_out)| {
             let y_m = north_m - (py as f64 + 0.5) * res_y;


### PR DESCRIPTION
## Problem

The meta-tile assembly parallelises its per-output-row loop with rayon `par_chunks_mut` (#240/#242). In isolation that's cheap (~25 ms for a retina frame). But the assembly runs **inside a per-request render task**, and the WMS handler serves **many renders concurrently** — a radar player prefetches **~10 timesteps per view change**. Those ~10 concurrent rayon assemblies all route through the **one global rayon pool** and **convoy**: they oversubscribe it and park on its latches, inflating each assembly to ~750 ms and serialising the burst into **~6–8 s** — with the **CPU idle** (parking, not compute), which is why it never looked CPU-bound.

## Evidence (live prod, via the dev radar app, metatile on, southern-Finland zoom)

Pan to a fresh area, then **back to a visited area**. Server logs for the revisit:

```
render_ms=766  misses=0  tile_loop=0  assemble_ms=755  encode_ms=5
render_ms=720  misses=0  tile_loop=0  assemble_ms=709  encode_ms=5
render_ms=714  misses=0  tile_loop=0  assemble_ms=702  encode_ms=5
render_ms=742  misses=0  tile_loop=0  assemble_ms=731  encode_ms=5
```

Every tile cached (`misses=0`, decode free), PNG encode 5 ms — and the render is **still ~750 ms, entirely in `assemble_ms`**. The metatile cache works perfectly and delivers nothing, because the assembly dominates and convoys. Client saw **5.8–8.2 s** per prefetch burst (durations climbing in even steps = serialising). Single-render assembly uncontended is ~25 ms; the 30× inflation is pure pool contention.

## Fix

Make the assembly **sequential** (`chunks_mut`, not `par_chunks_mut`). Each render's assembly now uses one core, and the ~10 concurrent prefetch renders **parallelise across cores via request concurrency** instead of fighting over one pool — the burst collapses from ~7 s toward sub-second. This is the *no per-request rayon on a concurrently-served path* rule; it's the intent of the reverted #243, redone fresh on current main (the rayon `par_chunks_mut` had been reintroduced when #245 merged).

`rayon` is now unused in `ds-render`, so the dependency is dropped.

## Notes
- Independent of the meta cache logic (which is correct — `misses=0` proves it warms).
- `#245` (overview cliff) only affects the **direct** path; the meta path requests 256 px tiles that never hit the cliff, so this is the meta path's separate, dominant cost.
- Orthogonal follow-ups: the client over-requests a ~7.9 MP image (~4× the viewport) which inflates *both* paths; and an all-nodata/transparent fast-path in the assembly would help the oversized-but-mostly-empty render.

Tests: full `ds-render` suite (incl. the `assembled_pixels_track_geography` fidelity test) + clippy green; `cargo check -p server` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)