### PR TITLE
perf(server): wire IntegerLutColorMap into the WMS/Maps/Tiles colorize path

### DIFF
--- a/crates/render/src/colormap.rs
+++ b/crates/render/src/colormap.rs
@@ -89,6 +89,14 @@ impl ColorMap for LutColorMap {
     fn color(&self, value: Option<f64>) -> [u8; 4] {
         match value {
             None => self.nodata_color,
+            // NaN/±∞ are not real data — colour them as nodata, matching
+            // `IntegerLutColorMap` and `LinearColorMap`. Without this guard
+            // the normalised index goes through `NaN as usize = 0` (Rust 1.45+
+            // saturating cast) and returns `lut[0]` (the first stop's colour),
+            // which the integer-LUT wrap (#207) would silently switch to
+            // `nodata_color` — a real divergence for any pipeline that lets
+            // NaN reach the colorizer.
+            Some(v) if !v.is_finite() => self.nodata_color,
             Some(v) => {
                 if self.max <= self.min {
                     return self.lut[0];
@@ -202,6 +210,10 @@ impl ColorMap for LinearColorMap {
     fn color(&self, value: Option<f64>) -> [u8; 4] {
         match value {
             None => self.nodata_color,
+            // Match the NaN guard in LutColorMap / IntegerLutColorMap — otherwise
+            // a NaN falls through every comparison in `interpolate_stops` and
+            // returns the LAST stop's colour, diverging from the other paths.
+            Some(v) if !v.is_finite() => self.nodata_color,
             Some(v) => interpolate_stops(&self.stops, v),
         }
     }
@@ -793,6 +805,35 @@ mod tests {
         // Out of range above → last entry.
         assert_eq!(lut.color(Some(11.0)), linear.color(Some(10.0)));
         assert_eq!(lut.color(Some(1e9)), linear.color(Some(10.0)));
+    }
+
+    #[test]
+    fn test_all_colormaps_treat_nan_and_infinity_as_nodata() {
+        // All three colormap types must agree on non-finite inputs — otherwise
+        // `maybe_wrap_integer_lut` (the #207 wrap) silently changes behaviour
+        // when an engine lets NaN reach the colorizer.
+        let stops = vec![
+            ColorStop {
+                value: 0.0,
+                color: [255, 0, 0, 255],
+            },
+            ColorStop {
+                value: 10.0,
+                color: [0, 255, 0, 255],
+            },
+        ];
+        let lut = LutColorMap::from_stops(&stops, 0.0, 10.0);
+        let lin = LinearColorMap::new(stops);
+        let int_lut = IntegerLutColorMap::from_colormap(&lin, 0, 10).unwrap();
+        for v in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+            assert_eq!(lut.color(Some(v)), [0, 0, 0, 0], "LutColorMap on {v}");
+            assert_eq!(lin.color(Some(v)), [0, 0, 0, 0], "LinearColorMap on {v}");
+            assert_eq!(
+                int_lut.color(Some(v)),
+                [0, 0, 0, 0],
+                "IntegerLutColorMap on {v}"
+            );
+        }
     }
 
     #[test]

--- a/crates/render/src/colormap.rs
+++ b/crates/render/src/colormap.rs
@@ -2,6 +2,13 @@
 pub trait ColorMap: Send + Sync {
     /// Map a value to an RGBA color. None = nodata → transparent.
     fn color(&self, value: Option<f64>) -> [u8; 4];
+
+    /// Colour returned for `None` / NaN / ±∞ inputs. Defaults to fully transparent.
+    /// Overridden by concrete impls that carry an explicit nodata colour so
+    /// wrappers like `IntegerLutColorMap::from_colormap` can preserve it.
+    fn nodata_color(&self) -> [u8; 4] {
+        [0, 0, 0, 0]
+    }
 }
 
 /// A color stop for defining gradient colormaps.
@@ -86,6 +93,10 @@ impl LutColorMap {
 }
 
 impl ColorMap for LutColorMap {
+    fn nodata_color(&self) -> [u8; 4] {
+        self.nodata_color
+    }
+
     fn color(&self, value: Option<f64>) -> [u8; 4] {
         match value {
             None => self.nodata_color,
@@ -137,11 +148,12 @@ impl IntegerLutColorMap {
     ///
     /// Returns `None` if the range exceeds 65,536 entries.
     pub fn from_colormap(source: &dyn ColorMap, min_val: i64, max_val: i64) -> Option<Self> {
+        let nodata_color = source.nodata_color();
         if max_val < min_val {
             return Some(Self {
                 lut: Vec::new(),
                 offset: 0,
-                nodata_color: [0, 0, 0, 0],
+                nodata_color,
             });
         }
         let range = (max_val - min_val + 1) as usize;
@@ -156,12 +168,16 @@ impl IntegerLutColorMap {
         Some(Self {
             lut,
             offset: min_val,
-            nodata_color: [0, 0, 0, 0],
+            nodata_color,
         })
     }
 }
 
 impl ColorMap for IntegerLutColorMap {
+    fn nodata_color(&self) -> [u8; 4] {
+        self.nodata_color
+    }
+
     fn color(&self, value: Option<f64>) -> [u8; 4] {
         // Round-nearest + saturate-clamp, matching `LutColorMap`/`LinearColorMap`
         // semantics. `v as i64` would truncate toward zero (23.6 → 23, -0.7 → 0)
@@ -207,6 +223,10 @@ impl LinearColorMap {
 }
 
 impl ColorMap for LinearColorMap {
+    fn nodata_color(&self) -> [u8; 4] {
+        self.nodata_color
+    }
+
     fn color(&self, value: Option<f64>) -> [u8; 4] {
         match value {
             None => self.nodata_color,
@@ -881,6 +901,37 @@ mod tests {
         ]);
         let lut = IntegerLutColorMap::from_colormap(&linear, 0, 10).unwrap();
         assert_eq!(lut.color(None), [0, 0, 0, 0]);
+    }
+
+    /// `from_colormap` must copy the source's `nodata_color`, not hardcode
+    /// transparent — otherwise a colormap with grey/opaque nodata would
+    /// silently flip to transparent when wrapped.
+    #[test]
+    fn test_integer_lut_preserves_source_nodata_color() {
+        // Mock colormap with a non-default (opaque grey) nodata colour.
+        struct GreyNodata;
+        impl ColorMap for GreyNodata {
+            fn color(&self, value: Option<f64>) -> [u8; 4] {
+                match value {
+                    None => self.nodata_color(),
+                    Some(v) if !v.is_finite() => self.nodata_color(),
+                    Some(_) => [255, 0, 0, 255],
+                }
+            }
+            fn nodata_color(&self) -> [u8; 4] {
+                [128, 128, 128, 255]
+            }
+        }
+
+        let lut = IntegerLutColorMap::from_colormap(&GreyNodata, 0, 10).unwrap();
+        assert_eq!(lut.color(None), [128, 128, 128, 255]);
+        assert_eq!(lut.color(Some(f64::NAN)), [128, 128, 128, 255]);
+        assert_eq!(lut.nodata_color(), [128, 128, 128, 255]);
+
+        // Empty-range path (max < min) must propagate it too.
+        let empty = IntegerLutColorMap::from_colormap(&GreyNodata, 10, 5).unwrap();
+        assert_eq!(empty.color(None), [128, 128, 128, 255]);
+        assert_eq!(empty.color(Some(0.0)), [128, 128, 128, 255]);
     }
 
     #[test]

--- a/crates/render/src/colormap.rs
+++ b/crates/render/src/colormap.rs
@@ -89,13 +89,13 @@ impl ColorMap for LutColorMap {
     fn color(&self, value: Option<f64>) -> [u8; 4] {
         match value {
             None => self.nodata_color,
-            // NaN/±∞ are not real data — colour them as nodata, matching
-            // `IntegerLutColorMap` and `LinearColorMap`. Without this guard
-            // the normalised index goes through `NaN as usize = 0` (Rust 1.45+
-            // saturating cast) and returns `lut[0]` (the first stop's colour),
-            // which the integer-LUT wrap (#207) would silently switch to
-            // `nodata_color` — a real divergence for any pipeline that lets
-            // NaN reach the colorizer.
+            // NaN/±∞ are not real data — colour them as nodata. Deliberate
+            // behaviour change: before #250, NaN here hit the saturating cast
+            // `NaN as usize = 0` and returned `lut[0]` (opaque for built-ins
+            // like Viridis/Temperature); `LinearColorMap` returned the LAST
+            // stop. The two were quietly inconsistent. This guard unifies all
+            // three colormap impls on `nodata_color`, which is what a NaN
+            // pixel actually means.
             Some(v) if !v.is_finite() => self.nodata_color,
             Some(v) => {
                 if self.max <= self.min {

--- a/crates/render/src/colormap.rs
+++ b/crates/render/src/colormap.rs
@@ -105,10 +105,11 @@ impl ColorMap for LutColorMap {
 
 /// Pre-computed integer LUT colormap. O(1) per pixel with direct indexing.
 ///
-/// For integer data types (UInt8, UInt16, Int16), all possible output colors
-/// are pre-computed into a flat array. Lookup is a single index operation
-/// with no floating-point math — significantly faster than even the
-/// normalized LUT approach for integer raster data.
+/// All colors over the configured integer range are pre-computed into a flat
+/// array. Per-pixel lookup is one subtract + one `.round()` + clamp + index —
+/// matching [`LutColorMap`]'s round-nearest + saturate-clamp semantics at
+/// integer entries, while replacing its `(v - min) / (max - min) * (len - 1)`
+/// normalisation with a single offset shift.
 ///
 /// Maximum supported range: 65,536 entries (~256 KB for UInt16/Int16).
 pub struct IntegerLutColorMap {
@@ -154,15 +155,22 @@ impl IntegerLutColorMap {
 
 impl ColorMap for IntegerLutColorMap {
     fn color(&self, value: Option<f64>) -> [u8; 4] {
+        // Round-nearest + saturate-clamp, matching `LutColorMap`/`LinearColorMap`
+        // semantics. `v as i64` would truncate toward zero (23.6 → 23, -0.7 → 0)
+        // which diverges from the float path's `.round()` (24 and -1). Out-of-range
+        // values clamp to the first/last entry rather than fall to transparent,
+        // also matching the float path; transparent here would silently hide
+        // pixels just outside the configured range.
         match value {
             None => self.nodata_color,
+            Some(v) if !v.is_finite() => self.nodata_color,
             Some(v) => {
-                let index = (v as i64 - self.offset) as usize;
-                if index < self.lut.len() {
-                    self.lut[index]
-                } else {
-                    [0, 0, 0, 0] // transparent for out-of-range
+                if self.lut.is_empty() {
+                    return self.nodata_color;
                 }
+                let last = (self.lut.len() - 1) as i64;
+                let idx = (v - self.offset as f64).round() as i64;
+                self.lut[idx.clamp(0, last) as usize]
             }
         }
     }
@@ -766,7 +774,7 @@ mod tests {
     }
 
     #[test]
-    fn test_integer_lut_out_of_range_transparent() {
+    fn test_integer_lut_out_of_range_saturates() {
         let linear = LinearColorMap::new(vec![
             ColorStop {
                 value: 0.0,
@@ -779,10 +787,43 @@ mod tests {
         ]);
         let lut = IntegerLutColorMap::from_colormap(&linear, 0, 10).unwrap();
 
-        // Out of range below
-        assert_eq!(lut.color(Some(-1.0)), [0, 0, 0, 0]);
-        // Out of range above
-        assert_eq!(lut.color(Some(11.0)), [0, 0, 0, 0]);
+        // Out of range below → first entry (saturate, matching LutColorMap clamp).
+        assert_eq!(lut.color(Some(-1.0)), linear.color(Some(0.0)));
+        assert_eq!(lut.color(Some(-100.0)), linear.color(Some(0.0)));
+        // Out of range above → last entry.
+        assert_eq!(lut.color(Some(11.0)), linear.color(Some(10.0)));
+        assert_eq!(lut.color(Some(1e9)), linear.color(Some(10.0)));
+    }
+
+    #[test]
+    fn test_integer_lut_rounds_nearest_not_toward_zero() {
+        // Pins round-nearest in IntegerLutColorMap (not truncate-toward-zero,
+        // which would diverge for negative values). We pin behaviour INTERNAL
+        // to the LUT here — IntegerLutColorMap has 1 entry per integer unit
+        // while LutColorMap uses a fixed 4096-entry table, so the two paths
+        // can't be expected to match at non-integer inputs.
+        let linear = LinearColorMap::new(vec![
+            ColorStop {
+                value: -10.0,
+                color: [0, 0, 0, 255],
+            },
+            ColorStop {
+                value: 10.0,
+                color: [255, 255, 255, 255],
+            },
+        ]);
+        let lut = IntegerLutColorMap::from_colormap(&linear, -10, 10).unwrap();
+        // 4.7 rounds up to 5, NOT toward zero (which would yield 4).
+        assert_eq!(lut.color(Some(4.7)), lut.color(Some(5.0)));
+        assert_ne!(lut.color(Some(4.7)), lut.color(Some(4.0)));
+        // -0.7 rounds to the nearer integer (-1), NOT toward zero (which would
+        // collapse it onto entry 0 — the bug the rounding fix prevents).
+        assert_ne!(lut.color(Some(-0.7)), lut.color(Some(0.0)));
+        assert_eq!(lut.color(Some(-0.7)), lut.color(Some(-1.0)));
+        // -0.5 is half-way; Rust's `.round()` rounds away from zero in the
+        // (non-negative) index-space coordinate after the offset shift, so in
+        // value space it rounds toward `max` here.
+        assert_eq!(lut.color(Some(-0.5)), lut.color(Some(0.0)));
     }
 
     #[test]
@@ -815,9 +856,9 @@ mod tests {
         ]);
         let lut = IntegerLutColorMap::from_colormap(&linear, 50, 50).unwrap();
         assert_eq!(lut.color(Some(50.0)), linear.color(Some(50.0)));
-        // Out of range
-        assert_eq!(lut.color(Some(49.0)), [0, 0, 0, 0]);
-        assert_eq!(lut.color(Some(51.0)), [0, 0, 0, 0]);
+        // Out of range → saturate to the single available entry.
+        assert_eq!(lut.color(Some(49.0)), linear.color(Some(50.0)));
+        assert_eq!(lut.color(Some(51.0)), linear.color(Some(50.0)));
     }
 
     #[test]

--- a/crates/server/src/admin.rs
+++ b/crates/server/src/admin.rs
@@ -1693,7 +1693,7 @@ fn register_parameter_layer_styles(
 
 /// Wrap `cmap` in [`ds_render::IntegerLutColorMap`] when the value range fits
 /// a small precomputed LUT (#207). Skipped for non-finite/inverted bounds,
-/// spans below 16 entries (≥1-unit-per-stop is too coarse for sub-unit
+/// spans below 16 integer steps (≥1-unit-per-stop is too coarse for sub-unit
 /// gradients like viridis 0..1), or spans over the 65 536-entry cap.
 fn maybe_wrap_integer_lut(
     cmap: Arc<dyn ds_render::ColorMap>,

--- a/crates/server/src/admin.rs
+++ b/crates/server/src/admin.rs
@@ -1717,6 +1717,10 @@ fn maybe_wrap_integer_lut(
             );
             Arc::new(lut)
         }
+        // Currently unreachable given the (16..65_536) gate above (max span 65 535
+        // → range 65 536, which `from_colormap` accepts since its check is
+        // `range > MAX_INTEGER_LUT_SIZE`). Kept as a safe fallback for the day
+        // either bound is loosened.
         None => cmap,
     }
 }

--- a/crates/server/src/admin.rs
+++ b/crates/server/src/admin.rs
@@ -1691,6 +1691,46 @@ fn register_parameter_layer_styles(
     }
 }
 
+/// Wrap a colormap with [`ds_render::IntegerLutColorMap`] when the value range
+/// fits in a small precomputed LUT, replacing 3 FP ops/pixel with a direct
+/// array index (#207). Skips:
+///   * non-finite or inverted ranges,
+///   * ranges narrower than 16 integers — the truncation `v as i64` would map
+///     many distinct sub-unit values to the same LUT entry, visibly degrading
+///     a fine-resolution gradient (e.g. viridis on 0..1),
+///   * ranges over the 65 536-entry cap — too big to be useful as a LUT.
+///
+/// Values outside `[min, max]` after the wrap fall to fully-transparent,
+/// matching the pre-wrap clamp behaviour for nodata. Sub-unit data inside the
+/// range truncates toward `min` (e.g. fmi radar dBZ with `scale = 0.5` shows
+/// the same colour for -31.5 and -31), which is invisible at the dBZ class
+/// granularity the colormaps are designed around.
+fn maybe_wrap_integer_lut(
+    cmap: Arc<dyn ds_render::ColorMap>,
+    min: f64,
+    max: f64,
+) -> Arc<dyn ds_render::ColorMap> {
+    if !min.is_finite() || !max.is_finite() {
+        return cmap;
+    }
+    let lo = min.floor() as i64;
+    let hi = max.ceil() as i64;
+    let span = match hi.checked_sub(lo) {
+        Some(s) if (16..65_536).contains(&s) => s,
+        _ => return cmap,
+    };
+    match ds_render::IntegerLutColorMap::from_colormap(cmap.as_ref(), lo, hi) {
+        Some(lut) => {
+            tracing::debug!(
+                "Wired IntegerLutColorMap [{lo}..{hi}] ({} entries) for colorize",
+                span + 1
+            );
+            Arc::new(lut)
+        }
+        None => cmap,
+    }
+}
+
 /// Build a colormap and value range from WMS config fields.
 fn build_colormap_from_wms_config(
     colormap_name: Option<&str>,
@@ -1714,7 +1754,9 @@ fn build_colormap_from_wms_config(
         if !stops.is_empty() {
             let min = min_override.unwrap_or_else(|| stops.first().map(|s| s.value).unwrap_or(0.0));
             let max = max_override.unwrap_or_else(|| stops.last().map(|s| s.value).unwrap_or(1.0));
-            return (Arc::new(ds_render::LinearColorMap::new(stops)), min, max);
+            let cmap: Arc<dyn ds_render::ColorMap> =
+                Arc::new(ds_render::LinearColorMap::new(stops));
+            return (maybe_wrap_integer_lut(cmap, min, max), min, max);
         }
     }
 
@@ -1724,25 +1766,20 @@ fn build_colormap_from_wms_config(
         let stops = ds_render::colormap::builtin_stops(&builtin);
         let min = min_override.unwrap_or_else(|| stops.first().map(|s| s.value).unwrap_or(0.0));
         let max = max_override.unwrap_or_else(|| stops.last().map(|s| s.value).unwrap_or(1.0));
-        return (
-            Arc::new(ds_render::LutColorMap::from_builtin(builtin, min, max)),
-            min,
-            max,
-        );
+        let cmap: Arc<dyn ds_render::ColorMap> =
+            Arc::new(ds_render::LutColorMap::from_builtin(builtin, min, max));
+        return (maybe_wrap_integer_lut(cmap, min, max), min, max);
     }
 
     // Default: viridis 0..1
     let min = min_override.unwrap_or(0.0);
     let max = max_override.unwrap_or(1.0);
-    (
-        Arc::new(ds_render::LutColorMap::from_builtin(
-            ds_render::BuiltinColormap::Viridis,
-            min,
-            max,
-        )),
+    let cmap: Arc<dyn ds_render::ColorMap> = Arc::new(ds_render::LutColorMap::from_builtin(
+        ds_render::BuiltinColormap::Viridis,
         min,
         max,
-    )
+    ));
+    (maybe_wrap_integer_lut(cmap, min, max), min, max)
 }
 
 /// Update the health gauges from the current health vector.
@@ -2476,9 +2513,83 @@ pub async fn request_logging_middleware(
 
 #[cfg(test)]
 mod tests {
-    use super::{build_styles, classify_route, is_safe_request_id};
+    use super::{build_styles, classify_route, is_safe_request_id, maybe_wrap_integer_lut};
     use ds_core::config::{CollectionConfig, StyleBundle};
     use std::collections::HashMap;
+    use std::sync::Arc;
+
+    // --- maybe_wrap_integer_lut (#207) ---
+
+    #[test]
+    fn integer_lut_wraps_when_range_fits_and_is_wide_enough() {
+        let src: Arc<dyn ds_render::ColorMap> = Arc::new(ds_render::LutColorMap::from_builtin(
+            ds_render::BuiltinColormap::RadarDbz,
+            -32.0,
+            95.0,
+        ));
+        let wrapped = maybe_wrap_integer_lut(src.clone(), -32.0, 95.0);
+        // It was replaced (no longer the same Arc).
+        assert!(
+            !Arc::ptr_eq(&src, &wrapped),
+            "expected wrap on the radar_dbz -32..95 range"
+        );
+        // Colour at integer values matches the source — the LUT just precomputes.
+        for v in [-32i64, -16, 0, 25, 50, 95] {
+            assert_eq!(
+                wrapped.color(Some(v as f64)),
+                src.color(Some(v as f64)),
+                "colour mismatch at v={v}"
+            );
+        }
+    }
+
+    #[test]
+    fn integer_lut_skips_narrow_range() {
+        // viridis 0..1 → only 2 integer entries → truncation would collapse the
+        // gradient. Must NOT wrap.
+        let src: Arc<dyn ds_render::ColorMap> = Arc::new(ds_render::LutColorMap::from_builtin(
+            ds_render::BuiltinColormap::Viridis,
+            0.0,
+            1.0,
+        ));
+        let wrapped = maybe_wrap_integer_lut(src.clone(), 0.0, 1.0);
+        assert!(
+            Arc::ptr_eq(&src, &wrapped),
+            "expected no wrap for a narrow (<16-entry) range"
+        );
+    }
+
+    #[test]
+    fn integer_lut_skips_huge_range() {
+        // > 65 535 entries can't fit the integer LUT; fall back to the source.
+        let src: Arc<dyn ds_render::ColorMap> = Arc::new(ds_render::LutColorMap::from_builtin(
+            ds_render::BuiltinColormap::Viridis,
+            -100_000.0,
+            100_000.0,
+        ));
+        let wrapped = maybe_wrap_integer_lut(src.clone(), -100_000.0, 100_000.0);
+        assert!(
+            Arc::ptr_eq(&src, &wrapped),
+            "expected no wrap for an over-cap range"
+        );
+    }
+
+    #[test]
+    fn integer_lut_skips_non_finite_bounds() {
+        let src: Arc<dyn ds_render::ColorMap> = Arc::new(ds_render::LutColorMap::from_builtin(
+            ds_render::BuiltinColormap::Viridis,
+            0.0,
+            1.0,
+        ));
+        assert!(Arc::ptr_eq(
+            &src,
+            &maybe_wrap_integer_lut(src.clone(), f64::NAN, 1.0)
+        ));
+        assert!(Arc::ptr_eq(
+            &src,
+            &maybe_wrap_integer_lut(src.clone(), 0.0, f64::INFINITY)
+        ));
+    }
 
     #[test]
     fn accepts_typical_uuid() {

--- a/crates/server/src/admin.rs
+++ b/crates/server/src/admin.rs
@@ -1691,20 +1691,10 @@ fn register_parameter_layer_styles(
     }
 }
 
-/// Wrap a colormap with [`ds_render::IntegerLutColorMap`] when the value range
-/// fits in a small precomputed LUT, replacing 3 FP ops/pixel with a direct
-/// array index (#207). Skips:
-///   * non-finite or inverted ranges,
-///   * ranges narrower than 16 integers — the truncation `v as i64` would map
-///     many distinct sub-unit values to the same LUT entry, visibly degrading
-///     a fine-resolution gradient (e.g. viridis on 0..1),
-///   * ranges over the 65 536-entry cap — too big to be useful as a LUT.
-///
-/// Values outside `[min, max]` after the wrap fall to fully-transparent,
-/// matching the pre-wrap clamp behaviour for nodata. Sub-unit data inside the
-/// range truncates toward `min` (e.g. fmi radar dBZ with `scale = 0.5` shows
-/// the same colour for -31.5 and -31), which is invisible at the dBZ class
-/// granularity the colormaps are designed around.
+/// Wrap `cmap` in [`ds_render::IntegerLutColorMap`] when the value range fits
+/// a small precomputed LUT (#207). Skipped for non-finite/inverted bounds,
+/// spans <16 entries (`v as i64` rounds toward zero, so a fine-resolution
+/// gradient would collapse), or spans over the 65 535-entry cap.
 fn maybe_wrap_integer_lut(
     cmap: Arc<dyn ds_render::ColorMap>,
     min: f64,

--- a/crates/server/src/admin.rs
+++ b/crates/server/src/admin.rs
@@ -1693,8 +1693,8 @@ fn register_parameter_layer_styles(
 
 /// Wrap `cmap` in [`ds_render::IntegerLutColorMap`] when the value range fits
 /// a small precomputed LUT (#207). Skipped for non-finite/inverted bounds,
-/// spans <16 entries (`v as i64` rounds toward zero, so a fine-resolution
-/// gradient would collapse), or spans over the 65 535-entry cap.
+/// spans below 16 entries (≥1-unit-per-stop is too coarse for sub-unit
+/// gradients like viridis 0..1), or spans over the 65 536-entry cap.
 fn maybe_wrap_integer_lut(
     cmap: Arc<dyn ds_render::ColorMap>,
     min: f64,
@@ -2531,6 +2531,15 @@ mod tests {
                 "colour mismatch at v={v}"
             );
         }
+        // Out-of-range saturates to the boundary entry (not transparent),
+        // matching the float path's clamp — at integer endpoints we CAN
+        // compare to src by construction.
+        assert_eq!(wrapped.color(Some(-100.0)), src.color(Some(-32.0)));
+        assert_eq!(wrapped.color(Some(200.0)), src.color(Some(95.0)));
+        // (The non-integer rounding direction — round-nearest, not toward
+        // zero — is pinned in ds-render's IntegerLutColorMap tests where the
+        // colormap has distinct colours per integer. radar_dbz's low end is
+        // transparent so it can't distinguish the directions here.)
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`IntegerLutColorMap` (in `ds-render`) provides **O(1) direct-index** colour lookup — replacing the ~3 FP ops/pixel of the float-path `LutColorMap`/`LinearColorMap` with a single `(v - offset).round() as i64` index. It was implemented, exported, and used in tests, but **never used in production**: the WMS/Maps/Tiles handlers always built a float-path colormap. Closes **#207**.

## Fix

Wired in `build_colormap_from_wms_config` (`server/src/admin.rs`), the one place WMS/Maps/Tiles `StyleInfo` colormaps are built from config. A small `maybe_wrap_integer_lut(cmap, min, max)` helper replaces the float-path colormap with an integer LUT when:

- bounds are finite and `min ≤ max`,
- the integer span is **≥ 16 steps** — narrower would be coarser than 1 LUT entry per unit, visibly degrading a fine-resolution gradient (e.g. viridis on 0..1),
- the span fits the **65 536-entry cap** (`IntegerLutColorMap::from_colormap` returns `None` otherwise).

| Colormap example | Range | Wrapped? |
|---|---|---|
| `radar_dbz` | -32..95 (128 entries) | ✅ |
| `temperature`, `wind_speed`, `precipitation_rate` | 0..40+ | ✅ |
| `viridis` default 0..1 | 2 entries | ❌ (preserves gradient) |
| user-configured huge range (>65 535 span) | — | ❌ |

## Behaviour notes

- The wrap is **transparent** to callers — `Arc<dyn ColorMap>` in, `Arc<dyn ColorMap>` out.
- `IntegerLutColorMap::color()` now rounds-nearest (`(v - offset).round() as i64`) and **saturate-clamps** out-of-range to the first/last LUT entry — matching `LutColorMap`'s `.round()` + `.clamp()` behaviour exactly at integer entries.
- Sub-unit-precision data (e.g. fmi radar's `scale = 0.5` → 0.5-step physical dBZ) snaps to the nearest integer dBZ in the LUT. Invisible at the class granularity radar colormaps are designed around.
- **NaN / ±∞ now uniformly colour as `nodata_color`** across all three colormap impls. Prior to this PR `LutColorMap` returned `lut[0]` (an artefact of `NaN as usize = 0`) and `LinearColorMap` returned the *last* stop — inconsistent and accidental. Deliberate fix.

## Expected impact

~10 ms saved per 2 MP fullscreen render at integer-LUT depths (per #207's estimate). At the prod 7.9 MP retina request size that's ~40 ms/render — compounds on the 10-timestep prefetch (~400 ms/view change) and helps every direct-path GeoTIFF render of integer-typed data.

## Tests

- `admin.rs`: wrap-when-wide-enough (radar_dbz integer-match + saturate-clamp at boundaries), skip-narrow (viridis), skip-over-cap, skip-non-finite.
- `colormap.rs`: out-of-range saturates (rename of the old `_transparent` test), single-value-range saturates, rounds-nearest-not-toward-zero (separate, on a distinct-per-integer LinearColorMap), all-colormaps-agree-on-NaN.

Full `cargo test -p ds-render -p server` green; clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)