### PR TITLE
feat(api): align OGC API Maps/Tiles collection metadata with the spec

### DIFF
--- a/crates/api-edr/src/handlers.rs
+++ b/crates/api-edr/src/handlers.rs
@@ -769,7 +769,6 @@ fn build_collection_metadata(
         "id": config.id,
         "title": config.title,
         "description": config.description,
-        "apis": config.apis,
         "links": [
             {
                 "href": format!("{base_url}/edr/collections/{}", config.id),

--- a/crates/api-edr/tests/ogc_edr_api_tests.rs
+++ b/crates/api-edr/tests/ogc_edr_api_tests.rs
@@ -564,10 +564,11 @@ mod collections {
     }
 
     #[tokio::test]
-    async fn collection_exposes_apis_array() {
+    async fn collection_omits_nonstandard_apis_field() {
+        // `apis` is a vendor extension with no OGC schema; it must not leak
+        // into the standard collection JSON.
         let (_, json) = get("/collections/weather").await;
-        let apis = json["apis"].as_array().expect("apis must be present");
-        assert!(apis.iter().any(|a| a == "edr"));
+        assert!(json.get("apis").is_none() || json["apis"].is_null());
     }
 }
 

--- a/crates/api-edr/tests/ogc_edr_api_tests.rs
+++ b/crates/api-edr/tests/ogc_edr_api_tests.rs
@@ -568,7 +568,10 @@ mod collections {
         // `apis` is a vendor extension with no OGC schema; it must not leak
         // into the standard collection JSON.
         let (_, json) = get("/collections/weather").await;
-        assert!(json.get("apis").is_none() || json["apis"].is_null());
+        assert!(
+            json.get("apis").is_none(),
+            "apis must not be present in the standard collection JSON"
+        );
     }
 }
 

--- a/crates/api-features/src/handlers.rs
+++ b/crates/api-features/src/handlers.rs
@@ -489,7 +489,6 @@ fn build_collection_metadata(
         "id": config.id,
         "title": config.title,
         "description": config.description,
-        "apis": config.apis,
         "itemType": "feature",
         "crs": [
             "http://www.opengis.net/def/crs/OGC/1.3/CRS84"

--- a/crates/api-features/tests/ogc_features_api_tests.rs
+++ b/crates/api-features/tests/ogc_features_api_tests.rs
@@ -392,10 +392,11 @@ mod collections {
     }
 
     #[tokio::test]
-    async fn collection_detail_exposes_apis_array() {
+    async fn collection_detail_omits_nonstandard_apis_field() {
+        // `apis` is a vendor extension with no OGC schema; it must not leak
+        // into the standard collection JSON.
         let (_, json) = get("/collections/cities").await;
-        let apis = json["apis"].as_array().expect("apis must be present");
-        assert!(apis.iter().any(|a| a == "features"));
+        assert!(json.get("apis").is_none() || json["apis"].is_null());
     }
 
     #[tokio::test]
@@ -455,11 +456,12 @@ mod vector_tile_discovery {
     }
 
     #[tokio::test]
-    async fn collection_with_tiles_api_advertises_apis_array() {
+    async fn collection_with_tiles_api_still_omits_apis_array() {
+        // Even when the operator wires both Features and Tiles, the vendor
+        // `apis` field stays out of the standard collection JSON — discovery
+        // is via the `tilesets-vector` link asserted below.
         let json = fetch("/collections/cities").await;
-        let apis = json["apis"].as_array().expect("apis must be present");
-        assert!(apis.iter().any(|a| a == "features"));
-        assert!(apis.iter().any(|a| a == "tiles"));
+        assert!(json.get("apis").is_none() || json["apis"].is_null());
     }
 
     #[tokio::test]

--- a/crates/api-features/tests/ogc_features_api_tests.rs
+++ b/crates/api-features/tests/ogc_features_api_tests.rs
@@ -396,7 +396,10 @@ mod collections {
         // `apis` is a vendor extension with no OGC schema; it must not leak
         // into the standard collection JSON.
         let (_, json) = get("/collections/cities").await;
-        assert!(json.get("apis").is_none() || json["apis"].is_null());
+        assert!(
+            json.get("apis").is_none(),
+            "apis must not be present in the standard collection JSON"
+        );
     }
 
     #[tokio::test]
@@ -461,7 +464,10 @@ mod vector_tile_discovery {
         // `apis` field stays out of the standard collection JSON — discovery
         // is via the `tilesets-vector` link asserted below.
         let json = fetch("/collections/cities").await;
-        assert!(json.get("apis").is_none() || json["apis"].is_null());
+        assert!(
+            json.get("apis").is_none(),
+            "apis must not be present in the standard collection JSON"
+        );
     }
 
     #[tokio::test]

--- a/crates/api-maps/src/handlers.rs
+++ b/crates/api-maps/src/handlers.rs
@@ -167,7 +167,7 @@ fn build_collection_metadata(
     // Engines label projected/rotated grids with internal names ("TM",
     // "LAEA", "projected", "rotated_ll", …) that have no URI; emitting CRS84
     // for those would mislabel the storage grid, so omit it instead.
-    if let Some(storage_crs) = native_crs_to_uri(&info.native_crs) {
+    if let Some(storage_crs) = ds_core::geo::native_crs_uri(&info.native_crs) {
         metadata["storageCrs"] = json!(storage_crs);
     }
 
@@ -176,24 +176,6 @@ fn build_collection_metadata(
     }
 
     metadata
-}
-
-/// Map an engine's native CRS label to an OGC URI for `storageCrs`, or `None`
-/// when there is no stable URI for it. Unlike [`crs_to_uri`] (which serves the
-/// `Content-Crs` header for request-validated CRS values and defaults to
-/// CRS84), this never falls back: engines populate `RasterInfo.native_crs`
-/// with internal labels ("TM", "LAEA", "projected", "rotated_ll", …) for
-/// projections that have no canonical URI, and a wrong `storageCrs` is worse
-/// than an absent one.
-fn native_crs_to_uri(crs: &str) -> Option<&'static str> {
-    match crs {
-        "CRS:84" => Some("http://www.opengis.net/def/crs/OGC/1.3/CRS84"),
-        "EPSG:4326" => Some("http://www.opengis.net/def/crs/EPSG/0/4326"),
-        "EPSG:3857" => Some("http://www.opengis.net/def/crs/EPSG/0/3857"),
-        "EPSG:3067" => Some("http://www.opengis.net/def/crs/EPSG/0/3067"),
-        "EPSG:3035" => Some("http://www.opengis.net/def/crs/EPSG/0/3035"),
-        _ => None,
-    }
 }
 
 /// Build the OGC API Common Part 2 `extent` object (spatial, temporal,
@@ -275,22 +257,11 @@ fn temporal_grid(times: &[chrono::DateTime<chrono::Utc>]) -> Option<serde_json::
         return None;
     }
     let cells = times.len();
-    let gaps: Vec<i64> = times
-        .windows(2)
-        .map(|w| (w[1] - w[0]).num_seconds())
-        .collect();
-    let min = *gaps.iter().min().unwrap();
-    let max = *gaps.iter().max().unwrap();
-    // Regular when every gap agrees within a 2-second spread (absorbs ±1 s
-    // rounding/leap-second jitter on any interval, not just the first) and is
-    // strictly positive. Anchor the advertised resolution to the rounded mean
-    // step so a jittered endpoint can't bias it.
-    if min > 0 && max - min <= 2 {
-        let count = gaps.len() as i64;
-        let avg = (gaps.iter().sum::<i64>() + count / 2) / count;
-        if let Some(resolution) = ds_core::datetime::format_iso8601_duration(avg) {
-            return Some(json!({ "cellsCount": cells, "resolution": resolution }));
-        }
+    // Regular series -> a single ISO 8601 resolution; irregular -> the full
+    // coordinates list. Regularity detection lives in ds-core so the Maps and
+    // Tiles builders can't drift apart.
+    if let Some(resolution) = ds_core::datetime::regular_step_duration(times) {
+        return Some(json!({ "cellsCount": cells, "resolution": resolution }));
     }
     let coordinates: Vec<String> = times.iter().map(|t| t.to_rfc3339()).collect();
     Some(json!({ "cellsCount": cells, "coordinates": coordinates }))

--- a/crates/api-maps/src/handlers.rs
+++ b/crates/api-maps/src/handlers.rs
@@ -241,16 +241,22 @@ fn build_extent(info: &ds_core::map_engine::RasterInfo) -> Option<serde_json::Va
     // omitted: the only kind in use (radar elevation angle) has no standard
     // OGC vertical-CRS URI.
     if let Some(vertical) = &info.vertical {
-        let levels = &vertical.levels;
-        extent.insert(
-            "vertical".to_string(),
-            json!({
-                "interval": vertical.extent().map(|(lo, hi)| [[lo, hi]]),
-                "values": levels,
-                "unit": vertical.unit(),
-                "grid": { "coordinates": levels }
-            }),
-        );
+        // Only emit the vertical extent when there are levels: OGC API Common
+        // Part 2 requires `interval` to be a non-null array when the extent
+        // object is present, so an empty `VerticalDimension` is omitted rather
+        // than emitting `"interval": null`.
+        if let Some((lo, hi)) = vertical.extent() {
+            let levels = &vertical.levels;
+            extent.insert(
+                "vertical".to_string(),
+                json!({
+                    "interval": [[lo, hi]],
+                    "values": levels,
+                    "unit": vertical.unit(),
+                    "grid": { "coordinates": levels }
+                }),
+            );
+        }
     }
 
     if extent.is_empty() {

--- a/crates/api-maps/src/handlers.rs
+++ b/crates/api-maps/src/handlers.rs
@@ -119,80 +119,144 @@ fn build_collection_metadata(
         }
     }
 
+    let mut links = vec![
+        json!({
+            "href": format!("{base_url}/maps/collections/{}", config.id),
+            "rel": "self",
+            "type": "application/json",
+            "title": config.title
+        }),
+        json!({
+            "href": format!("{base_url}/maps/collections/{}/map", config.id),
+            "rel": "map",
+            "type": "image/png",
+            "title": "Map"
+        }),
+        json!({
+            "href": format!("{base_url}/maps/collections/{}/styles", config.id),
+            "rel": "styles",
+            "type": "application/json",
+            "title": "Styles"
+        }),
+    ];
+
+    // Map tilesets — rendered (raster) tiles are an OGC API Maps "map
+    // tileset", discoverable from the maps collection via the `tilesets-map`
+    // relation. Only advertise it when the operator exposed this collection
+    // through the Tiles API (the standalone `/tiles` router still serves it).
+    if config.apis.iter().any(|a| a == "tiles") {
+        links.push(json!({
+            "href": format!("{base_url}/tiles/collections/{}/tiles", config.id),
+            "rel": "http://www.opengis.net/def/rel/ogc/1.0/tilesets-map",
+            "type": "application/json",
+            "title": "Map tilesets"
+        }));
+    }
+
     let mut metadata = json!({
         "id": config.id,
         "title": config.title,
         "description": config.description,
-        "apis": config.apis,
         "dataType": "map",
         "crs": crs_uris,
+        "storageCrs": crs_to_uri(&info.native_crs),
         "styles": style_list,
-        "links": [
-            {
-                "href": format!("{base_url}/maps/collections/{}", config.id),
-                "rel": "self",
-                "type": "application/json",
-                "title": config.title
-            },
-            {
-                "href": format!("{base_url}/maps/collections/{}/map", config.id),
-                "rel": "map",
-                "type": "image/png",
-                "title": "Map"
-            },
-            {
-                "href": format!("{base_url}/maps/collections/{}/styles", config.id),
-                "rel": "styles",
-                "type": "application/json",
-                "title": "Styles"
-            }
-        ]
+        "links": links
     });
 
-    if let Some(bbox) = info.spatial_extent {
-        metadata["extent"] = json!({
-            "spatial": {
-                "bbox": [bbox],
-                "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
-            }
-        });
-    }
-
-    if !info.times.is_empty() {
-        let first = info.times.first().map(|t| t.to_rfc3339());
-        let last = info.times.last().map(|t| t.to_rfc3339());
-        if let (Some(start), Some(end)) = (first, last) {
-            if let Some(extent) = metadata.get_mut("extent") {
-                extent["temporal"] = json!({
-                    "interval": [[start, end]],
-                    "trs": "http://www.opengis.net/def/uom/ISO-8601/0/Gregorian"
-                });
-            } else {
-                metadata["extent"] = json!({
-                    "temporal": {
-                        "interval": [[start, end]],
-                        "trs": "http://www.opengis.net/def/uom/ISO-8601/0/Gregorian"
-                    }
-                });
-            }
-        }
-    }
-
-    // `vrs` is omitted — no standard OGC vertical-CRS URI exists for
-    // kinds like radar elevation angle, and `vrs` is optional.
-    if let Some(vertical) = &info.vertical {
-        let vertical_json = json!({
-            "interval": vertical.extent().map(|(lo, hi)| [[lo, hi]]),
-            "values": vertical.levels,
-        });
-        if let Some(extent) = metadata.get_mut("extent") {
-            extent["vertical"] = vertical_json;
-        } else {
-            metadata["extent"] = json!({ "vertical": vertical_json });
-        }
+    if let Some(extent) = build_extent(info) {
+        metadata["extent"] = extent;
     }
 
     metadata
+}
+
+/// Build the OGC API Common Part 2 `extent` object (spatial, temporal,
+/// vertical) including the `grid` resolution descriptors. Returns `None` when
+/// the collection advertises no spatial, temporal, or vertical extent.
+fn build_extent(info: &ds_core::map_engine::RasterInfo) -> Option<serde_json::Value> {
+    let mut extent = serde_json::Map::new();
+
+    if let Some(bbox) = info.spatial_extent {
+        let mut spatial = json!({
+            "bbox": [bbox],
+            "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+        });
+        // Per-axis grid resolution in CRS84 degrees, derived from the native
+        // cell counts and the WGS84 bbox [west, south, east, north].
+        if let Some([nx, ny]) = info.grid_size {
+            if nx > 0 && ny > 0 {
+                let [w, s, e, n] = bbox;
+                spatial["grid"] = json!([
+                    { "cellsCount": nx, "resolution": (e - w) / nx as f64 },
+                    { "cellsCount": ny, "resolution": (n - s) / ny as f64 }
+                ]);
+            }
+        }
+        extent.insert("spatial".to_string(), spatial);
+    }
+
+    if !info.times.is_empty() {
+        let start = info.times.first().map(|t| t.to_rfc3339());
+        let end = info.times.last().map(|t| t.to_rfc3339());
+        if let (Some(start), Some(end)) = (start, end) {
+            let mut temporal = json!({
+                "interval": [[start, end]],
+                "trs": "http://www.opengis.net/def/uom/ISO-8601/0/Gregorian"
+            });
+            if let Some(grid) = temporal_grid(&info.times) {
+                temporal["grid"] = grid;
+            }
+            extent.insert("temporal".to_string(), temporal);
+        }
+    }
+
+    // Vertical — keep `interval` + `values` (back-compat) and additively add
+    // the OGC API Common Part 2 form (`unit` + `grid.coordinates`). `vrs` is
+    // omitted: the only kind in use (radar elevation angle) has no standard
+    // OGC vertical-CRS URI.
+    if let Some(vertical) = &info.vertical {
+        let levels = &vertical.levels;
+        extent.insert(
+            "vertical".to_string(),
+            json!({
+                "interval": vertical.extent().map(|(lo, hi)| [[lo, hi]]),
+                "values": levels,
+                "unit": vertical.unit(),
+                "grid": { "coordinates": levels }
+            }),
+        );
+    }
+
+    if extent.is_empty() {
+        None
+    } else {
+        Some(serde_json::Value::Object(extent))
+    }
+}
+
+/// Build the `extent.temporal.grid` descriptor from the ordered timestamps. A
+/// regular step yields `{cellsCount, resolution}` (ISO 8601 duration); an
+/// irregular series yields `{cellsCount, coordinates}`. Returns `None` for
+/// fewer than two timestamps.
+fn temporal_grid(times: &[chrono::DateTime<chrono::Utc>]) -> Option<serde_json::Value> {
+    if times.len() < 2 {
+        return None;
+    }
+    let cells = times.len();
+    let step = (times[1] - times[0]).num_seconds();
+    // Allow a 1-second tolerance to absorb leap-second / rounding jitter.
+    let regular = step > 0
+        && times
+            .windows(2)
+            .all(|w| ((w[1] - w[0]).num_seconds() - step).abs() <= 1);
+    if regular {
+        if let Some(resolution) = ds_core::datetime::format_iso8601_duration(step) {
+            return Some(json!({ "cellsCount": cells, "resolution": resolution }));
+        }
+    }
+    let coordinates: Vec<String> = times.iter().map(|t| t.to_rfc3339()).collect();
+    Some(json!({ "cellsCount": cells, "coordinates": coordinates }))
 }
 
 // ---------------------------------------------------------------------------
@@ -560,7 +624,8 @@ pub async fn conformance() -> impl IntoResponse {
             "http://www.opengis.net/spec/ogcapi-maps-1/1.0/conf/datetime",
             "http://www.opengis.net/spec/ogcapi-maps-1/1.0/conf/crs",
             "http://www.opengis.net/spec/ogcapi-maps-1/1.0/conf/png",
-            "http://www.opengis.net/spec/ogcapi-maps-1/1.0/conf/jpeg"
+            "http://www.opengis.net/spec/ogcapi-maps-1/1.0/conf/jpeg",
+            "http://www.opengis.net/spec/ogcapi-maps-1/1.0/conf/tilesets"
         ]
     }))
 }

--- a/crates/api-maps/src/handlers.rs
+++ b/crates/api-maps/src/handlers.rs
@@ -195,8 +195,15 @@ fn build_extent(info: &ds_core::map_engine::RasterInfo) -> Option<serde_json::Va
         // CRS84-degree resolution would imply a regularity that doesn't hold.
         // `crs84_bbox_spans` keeps the spans positive across the anti-meridian.
         if let Some([nx, ny]) = info.grid_size {
-            if nx > 0 && ny > 0 && ds_core::geo::is_geographic_crs(&info.native_crs) {
-                let (lon_span, lat_span) = ds_core::geo::crs84_bbox_spans(bbox);
+            let (lon_span, lat_span) = ds_core::geo::crs84_bbox_spans(bbox);
+            // Skip a degenerate (zero-span) bbox too: 0.0/nx would emit
+            // "resolution": 0.0, which is invalid per OGC API Common Part 2.
+            if nx > 0
+                && ny > 0
+                && lon_span > 0.0
+                && lat_span > 0.0
+                && ds_core::geo::is_geographic_crs(&info.native_crs)
+            {
                 spatial["grid"] = json!([
                     { "cellsCount": nx, "resolution": lon_span / nx as f64 },
                     { "cellsCount": ny, "resolution": lat_span / ny as f64 }

--- a/crates/api-maps/src/handlers.rs
+++ b/crates/api-maps/src/handlers.rs
@@ -194,20 +194,18 @@ fn build_extent(info: &ds_core::map_engine::RasterInfo) -> Option<serde_json::Va
         // for projected sources the cells aren't degree-regular, so a single
         // CRS84-degree resolution would imply a regularity that doesn't hold.
         // `crs84_bbox_spans` keeps the spans positive across the anti-meridian.
+        // Check the CRS first (cheap), then compute spans — mirrors api-tiles.
         if let Some([nx, ny]) = info.grid_size {
-            let (lon_span, lat_span) = ds_core::geo::crs84_bbox_spans(bbox);
-            // Skip a degenerate (zero-span) bbox too: 0.0/nx would emit
-            // "resolution": 0.0, which is invalid per OGC API Common Part 2.
-            if nx > 0
-                && ny > 0
-                && lon_span > 0.0
-                && lat_span > 0.0
-                && ds_core::geo::is_geographic_crs(&info.native_crs)
-            {
-                spatial["grid"] = json!([
-                    { "cellsCount": nx, "resolution": lon_span / nx as f64 },
-                    { "cellsCount": ny, "resolution": lat_span / ny as f64 }
-                ]);
+            if nx > 0 && ny > 0 && ds_core::geo::is_crs84_grid(&info.native_crs) {
+                let (lon_span, lat_span) = ds_core::geo::crs84_bbox_spans(bbox);
+                // Skip a degenerate (zero-span) bbox too: 0.0/nx would emit
+                // "resolution": 0.0, which is invalid per OGC API Common Part 2.
+                if lon_span > 0.0 && lat_span > 0.0 {
+                    spatial["grid"] = json!([
+                        { "cellsCount": nx, "resolution": lon_span / nx as f64 },
+                        { "cellsCount": ny, "resolution": lat_span / ny as f64 }
+                    ]);
+                }
             }
         }
         extent.insert("spatial".to_string(), spatial);

--- a/crates/api-maps/src/handlers.rs
+++ b/crates/api-maps/src/handlers.rs
@@ -159,16 +159,41 @@ fn build_collection_metadata(
         "description": config.description,
         "dataType": "map",
         "crs": crs_uris,
-        "storageCrs": crs_to_uri(&info.native_crs),
         "styles": style_list,
         "links": links
     });
+
+    // Only advertise `storageCrs` when the native CRS has a stable OGC URI.
+    // Engines label projected/rotated grids with internal names ("TM",
+    // "LAEA", "projected", "rotated_ll", …) that have no URI; emitting CRS84
+    // for those would mislabel the storage grid, so omit it instead.
+    if let Some(storage_crs) = native_crs_to_uri(&info.native_crs) {
+        metadata["storageCrs"] = json!(storage_crs);
+    }
 
     if let Some(extent) = build_extent(info) {
         metadata["extent"] = extent;
     }
 
     metadata
+}
+
+/// Map an engine's native CRS label to an OGC URI for `storageCrs`, or `None`
+/// when there is no stable URI for it. Unlike [`crs_to_uri`] (which serves the
+/// `Content-Crs` header for request-validated CRS values and defaults to
+/// CRS84), this never falls back: engines populate `RasterInfo.native_crs`
+/// with internal labels ("TM", "LAEA", "projected", "rotated_ll", …) for
+/// projections that have no canonical URI, and a wrong `storageCrs` is worse
+/// than an absent one.
+fn native_crs_to_uri(crs: &str) -> Option<&'static str> {
+    match crs {
+        "CRS:84" => Some("http://www.opengis.net/def/crs/OGC/1.3/CRS84"),
+        "EPSG:4326" => Some("http://www.opengis.net/def/crs/EPSG/0/4326"),
+        "EPSG:3857" => Some("http://www.opengis.net/def/crs/EPSG/0/3857"),
+        "EPSG:3067" => Some("http://www.opengis.net/def/crs/EPSG/0/3067"),
+        "EPSG:3035" => Some("http://www.opengis.net/def/crs/EPSG/0/3035"),
+        _ => None,
+    }
 }
 
 /// Build the OGC API Common Part 2 `extent` object (spatial, temporal,
@@ -244,14 +269,20 @@ fn temporal_grid(times: &[chrono::DateTime<chrono::Utc>]) -> Option<serde_json::
         return None;
     }
     let cells = times.len();
-    let step = (times[1] - times[0]).num_seconds();
-    // Allow a 1-second tolerance to absorb leap-second / rounding jitter.
-    let regular = step > 0
-        && times
-            .windows(2)
-            .all(|w| ((w[1] - w[0]).num_seconds() - step).abs() <= 1);
-    if regular {
-        if let Some(resolution) = ds_core::datetime::format_iso8601_duration(step) {
+    let gaps: Vec<i64> = times
+        .windows(2)
+        .map(|w| (w[1] - w[0]).num_seconds())
+        .collect();
+    let min = *gaps.iter().min().unwrap();
+    let max = *gaps.iter().max().unwrap();
+    // Regular when every gap agrees within a 2-second spread (absorbs ±1 s
+    // rounding/leap-second jitter on any interval, not just the first) and is
+    // strictly positive. Anchor the advertised resolution to the rounded mean
+    // step so a jittered endpoint can't bias it.
+    if min > 0 && max - min <= 2 {
+        let count = gaps.len() as i64;
+        let avg = (gaps.iter().sum::<i64>() + count / 2) / count;
+        if let Some(resolution) = ds_core::datetime::format_iso8601_duration(avg) {
             return Some(json!({ "cellsCount": cells, "resolution": resolution }));
         }
     }

--- a/crates/api-maps/src/handlers.rs
+++ b/crates/api-maps/src/handlers.rs
@@ -190,10 +190,12 @@ fn build_extent(info: &ds_core::map_engine::RasterInfo) -> Option<serde_json::Va
             "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
         });
         // Per-axis grid resolution in CRS84 degrees, derived from the native
-        // cell counts and the WGS84 bbox. `crs84_bbox_spans` keeps the spans
-        // positive even when the bbox crosses the anti-meridian.
+        // cell counts and the WGS84 bbox. Only for geographic (lon/lat) grids:
+        // for projected sources the cells aren't degree-regular, so a single
+        // CRS84-degree resolution would imply a regularity that doesn't hold.
+        // `crs84_bbox_spans` keeps the spans positive across the anti-meridian.
         if let Some([nx, ny]) = info.grid_size {
-            if nx > 0 && ny > 0 {
+            if nx > 0 && ny > 0 && ds_core::geo::is_geographic_crs(&info.native_crs) {
                 let (lon_span, lat_span) = ds_core::geo::crs84_bbox_spans(bbox);
                 spatial["grid"] = json!([
                     { "cellsCount": nx, "resolution": lon_span / nx as f64 },
@@ -212,8 +214,10 @@ fn build_extent(info: &ds_core::map_engine::RasterInfo) -> Option<serde_json::Va
                 "interval": [[start, end]],
                 "trs": "http://www.opengis.net/def/uom/ISO-8601/0/Gregorian"
             });
-            if let Some(grid) = temporal_grid(&info.times) {
-                temporal["grid"] = grid;
+            // Shared descriptor from ds-core so Maps and Tiles can't drift.
+            if let Some(grid) = ds_core::datetime::temporal_grid(&info.times) {
+                temporal["grid"] =
+                    serde_json::to_value(grid).expect("TemporalGrid serializes to JSON");
             }
             extent.insert("temporal".to_string(), temporal);
         }
@@ -247,25 +251,6 @@ fn build_extent(info: &ds_core::map_engine::RasterInfo) -> Option<serde_json::Va
     } else {
         Some(serde_json::Value::Object(extent))
     }
-}
-
-/// Build the `extent.temporal.grid` descriptor from the ordered timestamps. A
-/// regular step yields `{cellsCount, resolution}` (ISO 8601 duration); an
-/// irregular series yields `{cellsCount, coordinates}`. Returns `None` for
-/// fewer than two timestamps.
-fn temporal_grid(times: &[chrono::DateTime<chrono::Utc>]) -> Option<serde_json::Value> {
-    if times.len() < 2 {
-        return None;
-    }
-    let cells = times.len();
-    // Regular series -> a single ISO 8601 resolution; irregular -> the full
-    // coordinates list. Regularity detection lives in ds-core so the Maps and
-    // Tiles builders can't drift apart.
-    if let Some(resolution) = ds_core::datetime::regular_step_duration(times) {
-        return Some(json!({ "cellsCount": cells, "resolution": resolution }));
-    }
-    let coordinates: Vec<String> = times.iter().map(|t| t.to_rfc3339()).collect();
-    Some(json!({ "cellsCount": cells, "coordinates": coordinates }))
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/api-maps/src/handlers.rs
+++ b/crates/api-maps/src/handlers.rs
@@ -190,13 +190,14 @@ fn build_extent(info: &ds_core::map_engine::RasterInfo) -> Option<serde_json::Va
             "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
         });
         // Per-axis grid resolution in CRS84 degrees, derived from the native
-        // cell counts and the WGS84 bbox [west, south, east, north].
+        // cell counts and the WGS84 bbox. `crs84_bbox_spans` keeps the spans
+        // positive even when the bbox crosses the anti-meridian.
         if let Some([nx, ny]) = info.grid_size {
             if nx > 0 && ny > 0 {
-                let [w, s, e, n] = bbox;
+                let (lon_span, lat_span) = ds_core::geo::crs84_bbox_spans(bbox);
                 spatial["grid"] = json!([
-                    { "cellsCount": nx, "resolution": (e - w) / nx as f64 },
-                    { "cellsCount": ny, "resolution": (n - s) / ny as f64 }
+                    { "cellsCount": nx, "resolution": lon_span / nx as f64 },
+                    { "cellsCount": ny, "resolution": lat_span / ny as f64 }
                 ]);
             }
         }
@@ -632,8 +633,15 @@ pub async fn conformance() -> impl IntoResponse {
             "http://www.opengis.net/spec/ogcapi-maps-1/1.0/conf/datetime",
             "http://www.opengis.net/spec/ogcapi-maps-1/1.0/conf/crs",
             "http://www.opengis.net/spec/ogcapi-maps-1/1.0/conf/png",
-            "http://www.opengis.net/spec/ogcapi-maps-1/1.0/conf/jpeg",
-            "http://www.opengis.net/spec/ogcapi-maps-1/1.0/conf/tilesets"
+            "http://www.opengis.net/spec/ogcapi-maps-1/1.0/conf/jpeg"
+            // NOTE: the OGC API Maps "Map Tilesets" class
+            // (.../conf/tilesets) is intentionally NOT declared. Its abstract
+            // tests require maps-native /collections/{id}/map/tiles endpoints,
+            // which we don't implement — raster tiles are served by the
+            // standalone OGC API Tiles service and merely *discovered* from a
+            // maps collection via the `tilesets-map` link relation. Declaring
+            // the class without the endpoints would be a false conformance
+            // claim.
         ]
     }))
 }

--- a/crates/api-maps/tests/integration.rs
+++ b/crates/api-maps/tests/integration.rs
@@ -1021,7 +1021,7 @@ impl MapEngine for MultiParamMockEngine {
 
     fn raster_info(&self) -> ds_core::map_engine::RasterInfo {
         ds_core::map_engine::RasterInfo {
-            native_crs: "EPSG:4326".into(),
+            native_crs: "CRS:84".into(),
             spatial_extent: Some([0.0, 0.0, 10.0, 10.0]),
             times: vec![],
             parameter: "2t".into(),
@@ -1184,7 +1184,7 @@ mod vertical_extent {
 
         fn raster_info(&self) -> RasterInfo {
             RasterInfo {
-                native_crs: "EPSG:4326".into(),
+                native_crs: "CRS:84".into(),
                 spatial_extent: Some([10.0, 55.0, 30.0, 70.0]),
                 times: vec![],
                 parameter: "DBZH".into(),
@@ -1247,7 +1247,7 @@ mod vertical_extent {
 
         fn raster_info(&self) -> RasterInfo {
             RasterInfo {
-                native_crs: "EPSG:4326".into(),
+                native_crs: "CRS:84".into(),
                 spatial_extent: Some([10.0, 55.0, 30.0, 70.0]),
                 times: vec![],
                 parameter: "DBZH".into(),
@@ -1348,7 +1348,7 @@ mod extent_edge_cases {
                     .with_timezone(&chrono::Utc)
             };
             RasterInfo {
-                native_crs: "EPSG:4326".into(),
+                native_crs: "CRS:84".into(),
                 spatial_extent: Some([10.0, 55.0, 30.0, 70.0]),
                 times: vec![
                     t("2024-01-01T00:00:00Z"),

--- a/crates/api-maps/tests/integration.rs
+++ b/crates/api-maps/tests/integration.rs
@@ -27,7 +27,8 @@ impl MockMapEngine {
 
     fn make_info() -> RasterInfo {
         RasterInfo {
-            native_crs: "EPSG:4326".to_string(),
+            // CRS:84 (lon-first) is what real WGS84 engines emit.
+            native_crs: "CRS:84".to_string(),
             spatial_extent: Some([10.0, 55.0, 30.0, 70.0]),
             times: vec![
                 chrono::DateTime::parse_from_rfc3339("2024-01-01T00:00:00Z")
@@ -307,12 +308,16 @@ mod conformance {
     }
 
     #[tokio::test]
-    async fn declares_map_tilesets() {
+    async fn omits_map_tilesets_conformance_class() {
+        // We link to map tilesets (tilesets-map rel) but do NOT implement the
+        // Map Tilesets class's /map/tiles endpoints, so the class must not be
+        // declared — that would be a false conformance claim. (Tiles are
+        // served by the standalone OGC API Tiles service.)
         let (_, json) = get("/conformance").await;
         let classes = json["conformsTo"].as_array().unwrap();
-        assert!(classes
+        assert!(!classes
             .iter()
-            .any(|c| c.as_str().unwrap().ends_with("conf/tilesets")));
+            .any(|c| c.as_str().unwrap().contains("conf/tilesets")));
     }
 }
 
@@ -403,9 +408,10 @@ mod collections {
     #[tokio::test]
     async fn collection_advertises_storage_crs() {
         let (_, json) = get("/collections/radar").await;
+        // WGS84 data is lon-first -> CRS84 URI, not the lat-first EPSG:4326 one.
         assert_eq!(
             json["storageCrs"],
-            "http://www.opengis.net/def/crs/EPSG/0/4326"
+            "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
         );
     }
 
@@ -1389,5 +1395,54 @@ mod extent_edge_cases {
             grid.get("coordinates").is_none(),
             "regular series must not fall back to a coordinates list"
         );
+    }
+
+    /// Engine whose bbox crosses the anti-meridian (east < west).
+    struct AntiMeridianMockEngine;
+
+    impl MapEngine for AntiMeridianMockEngine {
+        fn get_raster_tile(
+            &self,
+            _bbox: [f64; 4],
+            width: u32,
+            height: u32,
+            _time: Option<chrono::DateTime<chrono::Utc>>,
+            _output_crs: &OutputCrs,
+            _parameter: Option<&str>,
+            _z: Option<f64>,
+        ) -> Result<RasterTile, DataServerError> {
+            Ok(RasterTile {
+                width,
+                height,
+                values: vec![None; (width * height) as usize],
+            })
+        }
+
+        fn raster_info(&self) -> RasterInfo {
+            RasterInfo {
+                native_crs: "CRS:84".into(),
+                // 20°-wide box straddling 180°: east (-170) < west (170).
+                spatial_extent: Some([170.0, 60.0, -170.0, 70.0]),
+                times: vec![],
+                parameter: "reflectivity".into(),
+                unit: "dBZ".into(),
+                parameters: vec![],
+                vertical: None,
+                grid_size: Some([2000, 1000]),
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn spatial_grid_resolution_positive_across_antimeridian() {
+        let json =
+            fetch_collection_json(Arc::new(AntiMeridianMockEngine), "am", vec!["maps".into()])
+                .await;
+        let grid = json["extent"]["spatial"]["grid"].as_array().unwrap();
+        // 20° / 2000 cells = 0.01, positive — not the -340°/2000 a naive
+        // (east - west) would give.
+        let lon_res = grid[0]["resolution"].as_f64().unwrap();
+        assert!(lon_res > 0.0, "resolution must be positive, got {lon_res}");
+        assert!((lon_res - 0.01).abs() < 1e-9);
     }
 }

--- a/crates/api-maps/tests/integration.rs
+++ b/crates/api-maps/tests/integration.rs
@@ -1212,6 +1212,58 @@ mod vertical_extent {
         // vrs is intentionally omitted for radar elevation angle.
         assert!(v.get("vrs").is_none());
     }
+
+    /// A `VerticalDimension` with no levels must not emit `"interval": null`
+    /// (invalid per OGC API Common Part 2) — the whole vertical extent is
+    /// omitted instead.
+    struct EmptyVerticalMockEngine;
+
+    impl MapEngine for EmptyVerticalMockEngine {
+        fn get_raster_tile(
+            &self,
+            _bbox: [f64; 4],
+            width: u32,
+            height: u32,
+            _time: Option<chrono::DateTime<chrono::Utc>>,
+            _output_crs: &OutputCrs,
+            _parameter: Option<&str>,
+            _z: Option<f64>,
+        ) -> Result<RasterTile, DataServerError> {
+            Ok(RasterTile {
+                width,
+                height,
+                values: vec![None; (width * height) as usize],
+            })
+        }
+
+        fn raster_info(&self) -> RasterInfo {
+            RasterInfo {
+                native_crs: "EPSG:4326".into(),
+                spatial_extent: Some([10.0, 55.0, 30.0, 70.0]),
+                times: vec![],
+                parameter: "DBZH".into(),
+                unit: "dBZ".into(),
+                parameters: vec![],
+                vertical: Some(VerticalDimension::new(VerticalKind::ElevationAngle, vec![])),
+                grid_size: None,
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn empty_vertical_dimension_omits_extent() {
+        let json = fetch_collection_json(
+            Arc::new(EmptyVerticalMockEngine),
+            "empty-z",
+            vec!["maps".to_string()],
+        )
+        .await;
+        assert!(
+            json["extent"].get("vertical").is_none(),
+            "vertical extent must be omitted when there are no levels, got {:?}",
+            json["extent"].get("vertical")
+        );
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/api-maps/tests/integration.rs
+++ b/crates/api-maps/tests/integration.rs
@@ -186,6 +186,42 @@ async fn get_raw(uri: &str) -> (StatusCode, axum::http::HeaderMap, Vec<u8>) {
     (status, headers, body)
 }
 
+/// Fetch the collection JSON for an ad-hoc single-engine router. Used by the
+/// extent edge-case tests that need a bespoke `RasterInfo`.
+async fn fetch_collection_json(engine: Arc<dyn MapEngine>, id: &str, apis: Vec<String>) -> Value {
+    let mut engines = HashMap::new();
+    let mut collections = HashMap::new();
+    engines.insert(id.to_string(), engine);
+    collections.insert(
+        id.to_string(),
+        CollectionConfig {
+            id: id.to_string(),
+            title: "Test".to_string(),
+            description: "Test".to_string(),
+            data_path: None,
+            apis,
+            engine_type: "geotiff".to_string(),
+            geotiff: None,
+            querydata: None,
+            wms: None,
+            grib: None,
+            odim: None,
+            postgis: None,
+            preview: None,
+        },
+    );
+    let state = Arc::new(ArcSwap::from_pointee(MapsState {
+        engines,
+        collections,
+        styles: HashMap::new(),
+        render_semaphore: Arc::new(tokio::sync::Semaphore::new(4)),
+        rendered_cache: Arc::new(RenderedCache::new(16)),
+        base_url: String::new(),
+    }));
+    let (_, json) = get_on(api_maps::router(state), &format!("/collections/{id}")).await;
+    json
+}
+
 // ---------------------------------------------------------------------------
 // Landing page tests
 // ---------------------------------------------------------------------------
@@ -1155,38 +1191,12 @@ mod vertical_extent {
     }
 
     async fn fetch_collection() -> Value {
-        let engine: Arc<dyn MapEngine> = Arc::new(VerticalMockEngine);
-        let mut engines = HashMap::new();
-        let mut collections = HashMap::new();
-        engines.insert("pvol".to_string(), engine);
-        collections.insert(
-            "pvol".to_string(),
-            CollectionConfig {
-                id: "pvol".to_string(),
-                title: "Radar Volume".to_string(),
-                description: "PVOL".to_string(),
-                data_path: None,
-                apis: vec!["maps".to_string()],
-                engine_type: "odim".to_string(),
-                geotiff: None,
-                querydata: None,
-                wms: None,
-                grib: None,
-                odim: None,
-                postgis: None,
-                preview: None,
-            },
-        );
-        let state = Arc::new(ArcSwap::from_pointee(MapsState {
-            engines,
-            collections,
-            styles: HashMap::new(),
-            render_semaphore: Arc::new(tokio::sync::Semaphore::new(4)),
-            rendered_cache: Arc::new(RenderedCache::new(16)),
-            base_url: String::new(),
-        }));
-        let (_, json) = get_on(api_maps::router(state), "/collections/pvol").await;
-        json
+        fetch_collection_json(
+            Arc::new(VerticalMockEngine),
+            "pvol",
+            vec!["maps".to_string()],
+        )
+        .await
     }
 
     #[tokio::test]
@@ -1201,5 +1211,128 @@ mod vertical_extent {
         assert_eq!(v["grid"]["coordinates"], serde_json::json!([0.5, 1.5, 5.0]));
         // vrs is intentionally omitted for radar elevation angle.
         assert!(v.get("vrs").is_none());
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Extent edge cases (storageCrs omission, temporal-grid jitter)
+// ---------------------------------------------------------------------------
+
+mod extent_edge_cases {
+    use super::*;
+
+    /// Engine whose native CRS is a projection with no canonical OGC URI
+    /// (engines label these "TM"/"LAEA"/"projected"/…).
+    struct ProjectedMockEngine;
+
+    impl MapEngine for ProjectedMockEngine {
+        fn get_raster_tile(
+            &self,
+            _bbox: [f64; 4],
+            width: u32,
+            height: u32,
+            _time: Option<chrono::DateTime<chrono::Utc>>,
+            _output_crs: &OutputCrs,
+            _parameter: Option<&str>,
+            _z: Option<f64>,
+        ) -> Result<RasterTile, DataServerError> {
+            Ok(RasterTile {
+                width,
+                height,
+                values: vec![None; (width * height) as usize],
+            })
+        }
+
+        fn raster_info(&self) -> RasterInfo {
+            RasterInfo {
+                native_crs: "LAEA".into(),
+                spatial_extent: Some([10.0, 55.0, 30.0, 70.0]),
+                times: vec![],
+                parameter: "reflectivity".into(),
+                unit: "dBZ".into(),
+                parameters: vec![],
+                vertical: None,
+                grid_size: Some([2000, 1500]),
+            }
+        }
+    }
+
+    /// Engine whose timestamps are genuinely hourly but carry ±1 s jitter on
+    /// the first interval — the regression case for the gap-spread check.
+    struct JitteredTimesMockEngine;
+
+    impl MapEngine for JitteredTimesMockEngine {
+        fn get_raster_tile(
+            &self,
+            _bbox: [f64; 4],
+            width: u32,
+            height: u32,
+            _time: Option<chrono::DateTime<chrono::Utc>>,
+            _output_crs: &OutputCrs,
+            _parameter: Option<&str>,
+            _z: Option<f64>,
+        ) -> Result<RasterTile, DataServerError> {
+            Ok(RasterTile {
+                width,
+                height,
+                values: vec![None; (width * height) as usize],
+            })
+        }
+
+        fn raster_info(&self) -> RasterInfo {
+            // Gaps: 3599 s, 3601 s, 3600 s -> spread 2, mean 3600 -> PT1H.
+            let t = |s: &str| {
+                chrono::DateTime::parse_from_rfc3339(s)
+                    .unwrap()
+                    .with_timezone(&chrono::Utc)
+            };
+            RasterInfo {
+                native_crs: "EPSG:4326".into(),
+                spatial_extent: Some([10.0, 55.0, 30.0, 70.0]),
+                times: vec![
+                    t("2024-01-01T00:00:00Z"),
+                    t("2024-01-01T00:59:59Z"),
+                    t("2024-01-01T02:00:00Z"),
+                    t("2024-01-01T03:00:00Z"),
+                ],
+                parameter: "reflectivity".into(),
+                unit: "dBZ".into(),
+                parameters: vec![],
+                vertical: None,
+                grid_size: None,
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn storage_crs_omitted_for_projected_native_crs() {
+        let json =
+            fetch_collection_json(Arc::new(ProjectedMockEngine), "proj", vec!["maps".into()]).await;
+        // Mislabelling a projected grid as CRS84 is worse than omitting it.
+        assert!(
+            json.get("storageCrs").is_none(),
+            "storageCrs must be absent for a native CRS with no OGC URI, got {:?}",
+            json.get("storageCrs")
+        );
+        // Spatial grid is still advertised.
+        assert!(json["extent"]["spatial"]["grid"].is_array());
+    }
+
+    #[tokio::test]
+    async fn temporal_grid_treats_jittered_series_as_regular() {
+        let json = fetch_collection_json(
+            Arc::new(JitteredTimesMockEngine),
+            "jit",
+            vec!["maps".into()],
+        )
+        .await;
+        let grid = &json["extent"]["temporal"]["grid"];
+        assert_eq!(grid["cellsCount"], 4);
+        // Despite the ±1 s jitter on the first interval, the series is regular.
+        assert_eq!(grid["resolution"], "PT1H");
+        assert!(
+            grid.get("coordinates").is_none(),
+            "regular series must not fall back to a coordinates list"
+        );
     }
 }

--- a/crates/api-maps/tests/integration.rs
+++ b/crates/api-maps/tests/integration.rs
@@ -1108,3 +1108,98 @@ mod errors {
         assert!(json["code"].is_string());
     }
 }
+
+// ---------------------------------------------------------------------------
+// Vertical extent tests (radar elevation angle, OGC API Common Part 2 form)
+// ---------------------------------------------------------------------------
+
+mod vertical_extent {
+    use super::*;
+    use ds_core::vertical::{VerticalDimension, VerticalKind};
+
+    struct VerticalMockEngine;
+
+    impl MapEngine for VerticalMockEngine {
+        fn get_raster_tile(
+            &self,
+            _bbox: [f64; 4],
+            width: u32,
+            height: u32,
+            _time: Option<chrono::DateTime<chrono::Utc>>,
+            _output_crs: &OutputCrs,
+            _parameter: Option<&str>,
+            _z: Option<f64>,
+        ) -> Result<RasterTile, DataServerError> {
+            Ok(RasterTile {
+                width,
+                height,
+                values: vec![None; (width * height) as usize],
+            })
+        }
+
+        fn raster_info(&self) -> RasterInfo {
+            RasterInfo {
+                native_crs: "EPSG:4326".into(),
+                spatial_extent: Some([10.0, 55.0, 30.0, 70.0]),
+                times: vec![],
+                parameter: "DBZH".into(),
+                unit: "dBZ".into(),
+                parameters: vec![],
+                vertical: Some(VerticalDimension::new(
+                    VerticalKind::ElevationAngle,
+                    vec![0.5, 1.5, 5.0],
+                )),
+                grid_size: None,
+            }
+        }
+    }
+
+    async fn fetch_collection() -> Value {
+        let engine: Arc<dyn MapEngine> = Arc::new(VerticalMockEngine);
+        let mut engines = HashMap::new();
+        let mut collections = HashMap::new();
+        engines.insert("pvol".to_string(), engine);
+        collections.insert(
+            "pvol".to_string(),
+            CollectionConfig {
+                id: "pvol".to_string(),
+                title: "Radar Volume".to_string(),
+                description: "PVOL".to_string(),
+                data_path: None,
+                apis: vec!["maps".to_string()],
+                engine_type: "odim".to_string(),
+                geotiff: None,
+                querydata: None,
+                wms: None,
+                grib: None,
+                odim: None,
+                postgis: None,
+                preview: None,
+            },
+        );
+        let state = Arc::new(ArcSwap::from_pointee(MapsState {
+            engines,
+            collections,
+            styles: HashMap::new(),
+            render_semaphore: Arc::new(tokio::sync::Semaphore::new(4)),
+            rendered_cache: Arc::new(RenderedCache::new(16)),
+            base_url: String::new(),
+        }));
+        let (_, json) = get_on(api_maps::router(state), "/collections/pvol").await;
+        json
+    }
+
+    #[tokio::test]
+    async fn vertical_extent_has_common_part2_form() {
+        let json = fetch_collection().await;
+        let v = &json["extent"]["vertical"];
+        // Back-compat fields retained.
+        assert_eq!(v["values"], serde_json::json!([0.5, 1.5, 5.0]));
+        assert_eq!(v["interval"], serde_json::json!([[0.5, 5.0]]));
+        // OGC API Common Part 2 additive form.
+        assert_eq!(v["unit"], "deg");
+        assert_eq!(v["grid"]["coordinates"], serde_json::json!([0.5, 1.5, 5.0]));
+        // vrs is intentionally omitted for radar elevation angle.
+        assert!(v.get("vrs").is_none());
+    }
+}

--- a/crates/api-maps/tests/integration.rs
+++ b/crates/api-maps/tests/integration.rs
@@ -1366,7 +1366,7 @@ mod extent_edge_cases {
     }
 
     #[tokio::test]
-    async fn storage_crs_omitted_for_projected_native_crs() {
+    async fn storage_crs_and_spatial_grid_omitted_for_projected_native_crs() {
         let json =
             fetch_collection_json(Arc::new(ProjectedMockEngine), "proj", vec!["maps".into()]).await;
         // Mislabelling a projected grid as CRS84 is worse than omitting it.
@@ -1375,8 +1375,13 @@ mod extent_edge_cases {
             "storageCrs must be absent for a native CRS with no OGC URI, got {:?}",
             json.get("storageCrs")
         );
-        // Spatial grid is still advertised.
-        assert!(json["extent"]["spatial"]["grid"].is_array());
+        // The bbox is still advertised...
+        assert!(json["extent"]["spatial"]["bbox"].is_array());
+        // ...but not a CRS84-degree grid: a projected grid isn't degree-regular.
+        assert!(
+            json["extent"]["spatial"].get("grid").is_none(),
+            "projected grids must not advertise a CRS84-degree spatial.grid"
+        );
     }
 
     #[tokio::test]

--- a/crates/api-maps/tests/integration.rs
+++ b/crates/api-maps/tests/integration.rs
@@ -394,7 +394,10 @@ mod collections {
         // `apis` is a vendor extension with no OGC schema; it must not leak
         // into the standard collection JSON.
         let (_, json) = get("/collections/radar").await;
-        assert!(json.get("apis").is_none() || json["apis"].is_null());
+        assert!(
+            json.get("apis").is_none(),
+            "apis must not be present in the standard collection JSON"
+        );
     }
 
     #[tokio::test]

--- a/crates/api-maps/tests/integration.rs
+++ b/crates/api-maps/tests/integration.rs
@@ -41,6 +41,8 @@ impl MockMapEngine {
             unit: "dBZ".to_string(),
             parameters: vec![],
             vertical: None,
+            // bbox [10,55,30,70] over 2000x1500 cells => 0.01° per cell.
+            grid_size: Some([2000, 1500]),
         }
     }
 }
@@ -77,6 +79,10 @@ impl MapEngine for MockMapEngine {
 // ---------------------------------------------------------------------------
 
 fn build_router() -> axum::Router {
+    build_router_with_apis(vec!["maps".to_string()])
+}
+
+fn build_router_with_apis(apis: Vec<String>) -> axum::Router {
     let engine: Arc<dyn MapEngine> = Arc::new(MockMapEngine::new());
     let mut engines = HashMap::new();
     let mut collections = HashMap::new();
@@ -90,7 +96,7 @@ fn build_router() -> axum::Router {
             title: "Test Radar".to_string(),
             description: "Test radar data".to_string(),
             data_path: None,
-            apis: vec!["maps".to_string()],
+            apis,
             engine_type: "geotiff".to_string(),
             geotiff: None,
             querydata: None,
@@ -148,7 +154,14 @@ fn build_router() -> axum::Router {
 }
 
 async fn get(uri: &str) -> (StatusCode, Value) {
-    let app = build_router();
+    get_on(build_router(), uri).await
+}
+
+async fn get_with_apis(uri: &str, apis: Vec<String>) -> (StatusCode, Value) {
+    get_on(build_router_with_apis(apis), uri).await
+}
+
+async fn get_on(app: axum::Router, uri: &str) -> (StatusCode, Value) {
     let req = Request::builder().uri(uri).body(Body::empty()).unwrap();
     let resp = app.oneshot(req).await.unwrap();
     let status = resp.status();
@@ -256,6 +269,15 @@ mod conformance {
             .iter()
             .any(|c| c.as_str().unwrap().contains("conf/png")));
     }
+
+    #[tokio::test]
+    async fn declares_map_tilesets() {
+        let (_, json) = get("/conformance").await;
+        let classes = json["conformsTo"].as_array().unwrap();
+        assert!(classes
+            .iter()
+            .any(|c| c.as_str().unwrap().ends_with("conf/tilesets")));
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -332,10 +354,67 @@ mod collections {
     }
 
     #[tokio::test]
-    async fn collection_exposes_apis_array() {
+    async fn collection_omits_nonstandard_apis_field() {
+        // `apis` is a vendor extension with no OGC schema; it must not leak
+        // into the standard collection JSON.
         let (_, json) = get("/collections/radar").await;
-        let apis = json["apis"].as_array().expect("apis must be present");
-        assert!(apis.iter().any(|a| a == "maps"));
+        assert!(json.get("apis").is_none() || json["apis"].is_null());
+    }
+
+    #[tokio::test]
+    async fn collection_advertises_storage_crs() {
+        let (_, json) = get("/collections/radar").await;
+        assert_eq!(
+            json["storageCrs"],
+            "http://www.opengis.net/def/crs/EPSG/0/4326"
+        );
+    }
+
+    #[tokio::test]
+    async fn spatial_extent_has_grid_resolution() {
+        let (_, json) = get("/collections/radar").await;
+        let grid = json["extent"]["spatial"]["grid"]
+            .as_array()
+            .expect("spatial.grid must be present");
+        assert_eq!(grid.len(), 2, "one grid axis per spatial dimension");
+        // bbox [10,55,30,70] over 2000x1500 cells => 0.01° per cell.
+        assert_eq!(grid[0]["cellsCount"], 2000);
+        assert_eq!(grid[1]["cellsCount"], 1500);
+        assert!((grid[0]["resolution"].as_f64().unwrap() - 0.01).abs() < 1e-9);
+        assert!((grid[1]["resolution"].as_f64().unwrap() - 0.01).abs() < 1e-9);
+    }
+
+    #[tokio::test]
+    async fn temporal_extent_has_regular_grid_resolution() {
+        let (_, json) = get("/collections/radar").await;
+        let grid = &json["extent"]["temporal"]["grid"];
+        // Two timestamps one hour apart => regular PT1H step.
+        assert_eq!(grid["cellsCount"], 2);
+        assert_eq!(grid["resolution"], "PT1H");
+    }
+
+    #[tokio::test]
+    async fn collection_omits_tilesets_map_link_without_tiles_api() {
+        let (_, json) = get("/collections/radar").await;
+        let links = json["links"].as_array().unwrap();
+        assert!(!links
+            .iter()
+            .any(|l| l["rel"] == "http://www.opengis.net/def/rel/ogc/1.0/tilesets-map"));
+    }
+
+    #[tokio::test]
+    async fn collection_advertises_tilesets_map_link_with_tiles_api() {
+        let (_, json) =
+            get_with_apis("/collections/radar", vec!["maps".into(), "tiles".into()]).await;
+        let links = json["links"].as_array().unwrap();
+        let tileset_link = links
+            .iter()
+            .find(|l| l["rel"] == "http://www.opengis.net/def/rel/ogc/1.0/tilesets-map")
+            .expect("tilesets-map link must be present when tiles API is enabled");
+        assert!(tileset_link["href"]
+            .as_str()
+            .unwrap()
+            .ends_with("/tiles/collections/radar/tiles"));
     }
 
     #[tokio::test]
@@ -907,6 +986,7 @@ impl MapEngine for MultiParamMockEngine {
                 ("10u".into(), "U Wind".into()),
             ],
             vertical: None,
+            grid_size: None,
         }
     }
 }

--- a/crates/api-tiles/src/handlers.rs
+++ b/crates/api-tiles/src/handlers.rs
@@ -203,12 +203,13 @@ fn build_extent(
         });
         // Per-axis grid resolution in CRS84 degrees, derived from the native
         // cell counts (raster collections only) and the WGS84 bbox.
+        // `crs84_bbox_spans` keeps the spans positive across the anti-meridian.
         if let Some([nx, ny]) = raster_info.and_then(|i| i.grid_size) {
             if nx > 0 && ny > 0 {
-                let [w, s, e, n] = bbox;
+                let (lon_span, lat_span) = ds_core::geo::crs84_bbox_spans(bbox);
                 spatial["grid"] = json!([
-                    { "cellsCount": nx, "resolution": (e - w) / nx as f64 },
-                    { "cellsCount": ny, "resolution": (n - s) / ny as f64 }
+                    { "cellsCount": nx, "resolution": lon_span / nx as f64 },
+                    { "cellsCount": ny, "resolution": lat_span / ny as f64 }
                 ]);
             }
         }

--- a/crates/api-tiles/src/handlers.rs
+++ b/crates/api-tiles/src/handlers.rs
@@ -257,14 +257,20 @@ fn temporal_grid(times: &[chrono::DateTime<chrono::Utc>]) -> Option<serde_json::
         return None;
     }
     let cells = times.len();
-    let step = (times[1] - times[0]).num_seconds();
-    // Allow a 1-second tolerance to absorb leap-second / rounding jitter.
-    let regular = step > 0
-        && times
-            .windows(2)
-            .all(|w| ((w[1] - w[0]).num_seconds() - step).abs() <= 1);
-    if regular {
-        if let Some(resolution) = ds_core::datetime::format_iso8601_duration(step) {
+    let gaps: Vec<i64> = times
+        .windows(2)
+        .map(|w| (w[1] - w[0]).num_seconds())
+        .collect();
+    let min = *gaps.iter().min().unwrap();
+    let max = *gaps.iter().max().unwrap();
+    // Regular when every gap agrees within a 2-second spread (absorbs ±1 s
+    // rounding/leap-second jitter on any interval, not just the first) and is
+    // strictly positive. Anchor the advertised resolution to the rounded mean
+    // step so a jittered endpoint can't bias it.
+    if min > 0 && max - min <= 2 {
+        let count = gaps.len() as i64;
+        let avg = (gaps.iter().sum::<i64>() + count / 2) / count;
+        if let Some(resolution) = ds_core::datetime::format_iso8601_duration(avg) {
             return Some(json!({ "cellsCount": cells, "resolution": resolution }));
         }
     }

--- a/crates/api-tiles/src/handlers.rs
+++ b/crates/api-tiles/src/handlers.rs
@@ -211,8 +211,10 @@ fn build_extent(
             .filter(|i| ds_core::geo::is_geographic_crs(&i.native_crs))
             .and_then(|i| i.grid_size)
         {
-            if nx > 0 && ny > 0 {
-                let (lon_span, lat_span) = ds_core::geo::crs84_bbox_spans(bbox);
+            let (lon_span, lat_span) = ds_core::geo::crs84_bbox_spans(bbox);
+            // Skip a degenerate (zero-span) bbox: 0.0/nx would emit
+            // "resolution": 0.0, which is invalid per OGC API Common Part 2.
+            if nx > 0 && ny > 0 && lon_span > 0.0 && lat_span > 0.0 {
                 spatial["grid"] = json!([
                     { "cellsCount": nx, "resolution": lon_span / nx as f64 },
                     { "cellsCount": ny, "resolution": lat_span / ny as f64 }

--- a/crates/api-tiles/src/handlers.rs
+++ b/crates/api-tiles/src/handlers.rs
@@ -228,16 +228,22 @@ fn build_extent(
         // `vrs` is omitted: the only kind in use (radar elevation angle) has
         // no standard OGC vertical-CRS URI.
         if let Some(vertical) = &info.vertical {
-            let levels = &vertical.levels;
-            extent.insert(
-                "vertical".to_string(),
-                json!({
-                    "interval": vertical.extent().map(|(lo, hi)| [[lo, hi]]),
-                    "values": levels,
-                    "unit": vertical.unit(),
-                    "grid": { "coordinates": levels }
-                }),
-            );
+            // Only emit the vertical extent when there are levels: OGC API
+            // Common Part 2 requires `interval` to be a non-null array when the
+            // extent object is present, so an empty `VerticalDimension` is
+            // omitted rather than emitting `"interval": null`.
+            if let Some((lo, hi)) = vertical.extent() {
+                let levels = &vertical.levels;
+                extent.insert(
+                    "vertical".to_string(),
+                    json!({
+                        "interval": [[lo, hi]],
+                        "values": levels,
+                        "unit": vertical.unit(),
+                        "grid": { "coordinates": levels }
+                    }),
+                );
+            }
         }
     }
 

--- a/crates/api-tiles/src/handlers.rs
+++ b/crates/api-tiles/src/handlers.rs
@@ -149,7 +149,6 @@ fn build_collection_metadata(
         "id": config.id,
         "title": config.title,
         "description": config.description,
-        "apis": config.apis,
         "dataType": data_type,
         "tileMatrixSetLinks": tms_links,
         "styles": style_list,
@@ -169,55 +168,108 @@ fn build_collection_metadata(
         ]
     });
 
+    if let Some(extent) = build_extent(raster_info, feature_extent) {
+        metadata["extent"] = extent;
+    }
+
+    metadata
+}
+
+/// Build the OGC API Common Part 2 `extent` object (spatial, temporal,
+/// vertical) including the `grid` resolution descriptors. The spatial bbox
+/// falls back to `feature_extent` for vector collections that have no
+/// `RasterInfo`. Returns `None` when there is no extent to advertise.
+fn build_extent(
+    raster_info: Option<&ds_core::map_engine::RasterInfo>,
+    feature_extent: Option<[f64; 4]>,
+) -> Option<serde_json::Value> {
+    let mut extent = serde_json::Map::new();
+
     let spatial_extent = raster_info
         .and_then(|i| i.spatial_extent)
         .or(feature_extent);
     if let Some(bbox) = spatial_extent {
-        metadata["extent"] = json!({
-            "spatial": {
-                "bbox": [bbox],
-                "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
-            }
+        let mut spatial = json!({
+            "bbox": [bbox],
+            "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
         });
+        // Per-axis grid resolution in CRS84 degrees, derived from the native
+        // cell counts (raster collections only) and the WGS84 bbox.
+        if let Some([nx, ny]) = raster_info.and_then(|i| i.grid_size) {
+            if nx > 0 && ny > 0 {
+                let [w, s, e, n] = bbox;
+                spatial["grid"] = json!([
+                    { "cellsCount": nx, "resolution": (e - w) / nx as f64 },
+                    { "cellsCount": ny, "resolution": (n - s) / ny as f64 }
+                ]);
+            }
+        }
+        extent.insert("spatial".to_string(), spatial);
     }
 
     if let Some(info) = raster_info {
         if !info.times.is_empty() {
-            let first = info.times.first().map(|t| t.to_rfc3339());
-            let last = info.times.last().map(|t| t.to_rfc3339());
-            if let (Some(start), Some(end)) = (first, last) {
-                if let Some(extent) = metadata.get_mut("extent") {
-                    extent["temporal"] = json!({
-                        "interval": [[start, end]],
-                        "trs": "http://www.opengis.net/def/uom/ISO-8601/0/Gregorian"
-                    });
-                } else {
-                    metadata["extent"] = json!({
-                        "temporal": {
-                            "interval": [[start, end]],
-                            "trs": "http://www.opengis.net/def/uom/ISO-8601/0/Gregorian"
-                        }
-                    });
+            let start = info.times.first().map(|t| t.to_rfc3339());
+            let end = info.times.last().map(|t| t.to_rfc3339());
+            if let (Some(start), Some(end)) = (start, end) {
+                let mut temporal = json!({
+                    "interval": [[start, end]],
+                    "trs": "http://www.opengis.net/def/uom/ISO-8601/0/Gregorian"
+                });
+                if let Some(grid) = temporal_grid(&info.times) {
+                    temporal["grid"] = grid;
                 }
+                extent.insert("temporal".to_string(), temporal);
             }
         }
 
-        // `vrs` is omitted — no standard OGC vertical-CRS URI exists for
-        // kinds like radar elevation angle, and `vrs` is optional.
+        // Vertical — keep `interval` + `values` (back-compat) and additively
+        // add the OGC API Common Part 2 form (`unit` + `grid.coordinates`).
+        // `vrs` is omitted: the only kind in use (radar elevation angle) has
+        // no standard OGC vertical-CRS URI.
         if let Some(vertical) = &info.vertical {
-            let vertical_json = json!({
-                "interval": vertical.extent().map(|(lo, hi)| [[lo, hi]]),
-                "values": vertical.levels,
-            });
-            if let Some(extent) = metadata.get_mut("extent") {
-                extent["vertical"] = vertical_json;
-            } else {
-                metadata["extent"] = json!({ "vertical": vertical_json });
-            }
+            let levels = &vertical.levels;
+            extent.insert(
+                "vertical".to_string(),
+                json!({
+                    "interval": vertical.extent().map(|(lo, hi)| [[lo, hi]]),
+                    "values": levels,
+                    "unit": vertical.unit(),
+                    "grid": { "coordinates": levels }
+                }),
+            );
         }
     }
 
-    metadata
+    if extent.is_empty() {
+        None
+    } else {
+        Some(serde_json::Value::Object(extent))
+    }
+}
+
+/// Build the `extent.temporal.grid` descriptor from the ordered timestamps. A
+/// regular step yields `{cellsCount, resolution}` (ISO 8601 duration); an
+/// irregular series yields `{cellsCount, coordinates}`. Returns `None` for
+/// fewer than two timestamps.
+fn temporal_grid(times: &[chrono::DateTime<chrono::Utc>]) -> Option<serde_json::Value> {
+    if times.len() < 2 {
+        return None;
+    }
+    let cells = times.len();
+    let step = (times[1] - times[0]).num_seconds();
+    // Allow a 1-second tolerance to absorb leap-second / rounding jitter.
+    let regular = step > 0
+        && times
+            .windows(2)
+            .all(|w| ((w[1] - w[0]).num_seconds() - step).abs() <= 1);
+    if regular {
+        if let Some(resolution) = ds_core::datetime::format_iso8601_duration(step) {
+            return Some(json!({ "cellsCount": cells, "resolution": resolution }));
+        }
+    }
+    let coordinates: Vec<String> = times.iter().map(|t| t.to_rfc3339()).collect();
+    Some(json!({ "cellsCount": cells, "coordinates": coordinates }))
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/api-tiles/src/handlers.rs
+++ b/crates/api-tiles/src/handlers.rs
@@ -168,6 +168,14 @@ fn build_collection_metadata(
         ]
     });
 
+    // Advertise `storageCrs` for raster collections when the native CRS has a
+    // stable OGC URI (mirrors api-maps). Omitted for vector collections and
+    // for projected grids with no canonical URI.
+    if let Some(storage_crs) = raster_info.and_then(|i| ds_core::geo::native_crs_uri(&i.native_crs))
+    {
+        metadata["storageCrs"] = json!(storage_crs);
+    }
+
     if let Some(extent) = build_extent(raster_info, feature_extent) {
         metadata["extent"] = extent;
     }
@@ -263,22 +271,11 @@ fn temporal_grid(times: &[chrono::DateTime<chrono::Utc>]) -> Option<serde_json::
         return None;
     }
     let cells = times.len();
-    let gaps: Vec<i64> = times
-        .windows(2)
-        .map(|w| (w[1] - w[0]).num_seconds())
-        .collect();
-    let min = *gaps.iter().min().unwrap();
-    let max = *gaps.iter().max().unwrap();
-    // Regular when every gap agrees within a 2-second spread (absorbs ±1 s
-    // rounding/leap-second jitter on any interval, not just the first) and is
-    // strictly positive. Anchor the advertised resolution to the rounded mean
-    // step so a jittered endpoint can't bias it.
-    if min > 0 && max - min <= 2 {
-        let count = gaps.len() as i64;
-        let avg = (gaps.iter().sum::<i64>() + count / 2) / count;
-        if let Some(resolution) = ds_core::datetime::format_iso8601_duration(avg) {
-            return Some(json!({ "cellsCount": cells, "resolution": resolution }));
-        }
+    // Regular series -> a single ISO 8601 resolution; irregular -> the full
+    // coordinates list. Regularity detection lives in ds-core so the Maps and
+    // Tiles builders can't drift apart.
+    if let Some(resolution) = ds_core::datetime::regular_step_duration(times) {
+        return Some(json!({ "cellsCount": cells, "resolution": resolution }));
     }
     let coordinates: Vec<String> = times.iter().map(|t| t.to_rfc3339()).collect();
     Some(json!({ "cellsCount": cells, "coordinates": coordinates }))

--- a/crates/api-tiles/src/handlers.rs
+++ b/crates/api-tiles/src/handlers.rs
@@ -208,7 +208,7 @@ fn build_extent(
         // regularity that doesn't hold. `crs84_bbox_spans` keeps the spans
         // positive across the anti-meridian.
         if let Some([nx, ny]) = raster_info
-            .filter(|i| ds_core::geo::is_geographic_crs(&i.native_crs))
+            .filter(|i| ds_core::geo::is_crs84_grid(&i.native_crs))
             .and_then(|i| i.grid_size)
         {
             let (lon_span, lat_span) = ds_core::geo::crs84_bbox_spans(bbox);

--- a/crates/api-tiles/src/handlers.rs
+++ b/crates/api-tiles/src/handlers.rs
@@ -202,9 +202,15 @@ fn build_extent(
             "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
         });
         // Per-axis grid resolution in CRS84 degrees, derived from the native
-        // cell counts (raster collections only) and the WGS84 bbox.
-        // `crs84_bbox_spans` keeps the spans positive across the anti-meridian.
-        if let Some([nx, ny]) = raster_info.and_then(|i| i.grid_size) {
+        // cell counts (raster collections only) and the WGS84 bbox. Only for
+        // geographic (lon/lat) grids: a projected source's cells aren't
+        // degree-regular, so a single CRS84-degree resolution would imply a
+        // regularity that doesn't hold. `crs84_bbox_spans` keeps the spans
+        // positive across the anti-meridian.
+        if let Some([nx, ny]) = raster_info
+            .filter(|i| ds_core::geo::is_geographic_crs(&i.native_crs))
+            .and_then(|i| i.grid_size)
+        {
             if nx > 0 && ny > 0 {
                 let (lon_span, lat_span) = ds_core::geo::crs84_bbox_spans(bbox);
                 spatial["grid"] = json!([
@@ -225,8 +231,10 @@ fn build_extent(
                     "interval": [[start, end]],
                     "trs": "http://www.opengis.net/def/uom/ISO-8601/0/Gregorian"
                 });
-                if let Some(grid) = temporal_grid(&info.times) {
-                    temporal["grid"] = grid;
+                // Shared descriptor from ds-core so Maps and Tiles can't drift.
+                if let Some(grid) = ds_core::datetime::temporal_grid(&info.times) {
+                    temporal["grid"] =
+                        serde_json::to_value(grid).expect("TemporalGrid serializes to JSON");
                 }
                 extent.insert("temporal".to_string(), temporal);
             }
@@ -261,25 +269,6 @@ fn build_extent(
     } else {
         Some(serde_json::Value::Object(extent))
     }
-}
-
-/// Build the `extent.temporal.grid` descriptor from the ordered timestamps. A
-/// regular step yields `{cellsCount, resolution}` (ISO 8601 duration); an
-/// irregular series yields `{cellsCount, coordinates}`. Returns `None` for
-/// fewer than two timestamps.
-fn temporal_grid(times: &[chrono::DateTime<chrono::Utc>]) -> Option<serde_json::Value> {
-    if times.len() < 2 {
-        return None;
-    }
-    let cells = times.len();
-    // Regular series -> a single ISO 8601 resolution; irregular -> the full
-    // coordinates list. Regularity detection lives in ds-core so the Maps and
-    // Tiles builders can't drift apart.
-    if let Some(resolution) = ds_core::datetime::regular_step_duration(times) {
-        return Some(json!({ "cellsCount": cells, "resolution": resolution }));
-    }
-    let coordinates: Vec<String> = times.iter().map(|t| t.to_rfc3339()).collect();
-    Some(json!({ "cellsCount": cells, "coordinates": coordinates }))
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/api-tiles/tests/integration.rs
+++ b/crates/api-tiles/tests/integration.rs
@@ -957,7 +957,7 @@ impl MapEngine for MultiParamMockEngine {
 
     fn raster_info(&self) -> RasterInfo {
         RasterInfo {
-            native_crs: "EPSG:4326".into(),
+            native_crs: "CRS:84".into(),
             spatial_extent: Some([0.0, 0.0, 10.0, 10.0]),
             times: vec![],
             parameter: "2t".into(),
@@ -1559,7 +1559,7 @@ mod temporal_grid_jitter {
                     .with_timezone(&chrono::Utc)
             };
             RasterInfo {
-                native_crs: "EPSG:4326".into(),
+                native_crs: "CRS:84".into(),
                 spatial_extent: Some([10.0, 55.0, 30.0, 70.0]),
                 times: vec![
                     t("2024-01-01T00:00:00Z"),

--- a/crates/api-tiles/tests/integration.rs
+++ b/crates/api-tiles/tests/integration.rs
@@ -42,6 +42,8 @@ impl MockMapEngine {
             unit: "dBZ".to_string(),
             parameters: vec![],
             vertical: None,
+            // bbox [10,55,30,70] over 2000x1500 cells => 0.01° per cell.
+            grid_size: Some([2000, 1500]),
         }
     }
 }
@@ -368,10 +370,28 @@ mod collections {
     }
 
     #[tokio::test]
-    async fn collection_exposes_apis_array() {
+    async fn collection_omits_nonstandard_apis_field() {
         let (_, json) = get("/collections/radar").await;
-        let apis = json["apis"].as_array().expect("apis must be present");
-        assert!(apis.iter().any(|a| a == "tiles"));
+        assert!(json.get("apis").is_none() || json["apis"].is_null());
+    }
+
+    #[tokio::test]
+    async fn spatial_extent_has_grid_resolution() {
+        let (_, json) = get("/collections/radar").await;
+        let grid = json["extent"]["spatial"]["grid"]
+            .as_array()
+            .expect("spatial.grid must be present for raster collections");
+        assert_eq!(grid.len(), 2);
+        assert_eq!(grid[0]["cellsCount"], 2000);
+        assert_eq!(grid[1]["cellsCount"], 1500);
+    }
+
+    #[tokio::test]
+    async fn temporal_extent_has_regular_grid_resolution() {
+        let (_, json) = get("/collections/radar").await;
+        let grid = &json["extent"]["temporal"]["grid"];
+        assert_eq!(grid["cellsCount"], 2);
+        assert_eq!(grid["resolution"], "PT1H");
     }
 
     #[tokio::test]
@@ -933,6 +953,7 @@ impl MapEngine for MultiParamMockEngine {
                 ("10u".into(), "U Wind".into()),
             ],
             vertical: None,
+            grid_size: None,
         }
     }
 }

--- a/crates/api-tiles/tests/integration.rs
+++ b/crates/api-tiles/tests/integration.rs
@@ -28,7 +28,8 @@ impl MockMapEngine {
 
     fn make_info() -> RasterInfo {
         RasterInfo {
-            native_crs: "EPSG:4326".to_string(),
+            // CRS:84 (lon-first) is what real WGS84 engines emit.
+            native_crs: "CRS:84".to_string(),
             spatial_extent: Some([10.0, 55.0, 30.0, 70.0]),
             times: vec![
                 chrono::DateTime::parse_from_rfc3339("2024-01-01T00:00:00Z")
@@ -392,9 +393,10 @@ mod collections {
     #[tokio::test]
     async fn raster_collection_advertises_storage_crs() {
         let (_, json) = get("/collections/radar").await;
+        // WGS84 data is lon-first -> CRS84 URI, not the lat-first EPSG:4326 one.
         assert_eq!(
             json["storageCrs"],
-            "http://www.opengis.net/def/crs/EPSG/0/4326"
+            "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
         );
     }
 

--- a/crates/api-tiles/tests/integration.rs
+++ b/crates/api-tiles/tests/integration.rs
@@ -1508,3 +1508,106 @@ mod mvt {
         );
     }
 }
+
+// ---------------------------------------------------------------------------
+// Temporal-grid jitter (mirrors the api-maps regression test, since
+// temporal_grid is duplicated across the two crates)
+// ---------------------------------------------------------------------------
+
+mod temporal_grid_jitter {
+    use super::*;
+
+    struct JitteredTimesMockEngine;
+
+    impl MapEngine for JitteredTimesMockEngine {
+        fn get_raster_tile(
+            &self,
+            _bbox: [f64; 4],
+            width: u32,
+            height: u32,
+            _time: Option<chrono::DateTime<chrono::Utc>>,
+            _output_crs: &OutputCrs,
+            _parameter: Option<&str>,
+            _z: Option<f64>,
+        ) -> Result<RasterTile, DataServerError> {
+            Ok(RasterTile {
+                width,
+                height,
+                values: vec![None; (width * height) as usize],
+            })
+        }
+
+        fn raster_info(&self) -> RasterInfo {
+            // Gaps: 3599 s, 3601 s, 3600 s -> spread 2, mean 3600 -> PT1H.
+            let t = |s: &str| {
+                chrono::DateTime::parse_from_rfc3339(s)
+                    .unwrap()
+                    .with_timezone(&chrono::Utc)
+            };
+            RasterInfo {
+                native_crs: "EPSG:4326".into(),
+                spatial_extent: Some([10.0, 55.0, 30.0, 70.0]),
+                times: vec![
+                    t("2024-01-01T00:00:00Z"),
+                    t("2024-01-01T00:59:59Z"),
+                    t("2024-01-01T02:00:00Z"),
+                    t("2024-01-01T03:00:00Z"),
+                ],
+                parameter: "reflectivity".into(),
+                unit: "dBZ".into(),
+                parameters: vec![],
+                vertical: None,
+                grid_size: None,
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn temporal_grid_treats_jittered_series_as_regular() {
+        let engine: Arc<dyn MapEngine> = Arc::new(JitteredTimesMockEngine);
+        let mut engines = HashMap::new();
+        let mut collections = HashMap::new();
+        engines.insert("jit".to_string(), engine);
+        collections.insert(
+            "jit".to_string(),
+            CollectionConfig {
+                id: "jit".to_string(),
+                title: "Jittered".to_string(),
+                description: "Jittered".to_string(),
+                data_path: None,
+                apis: vec!["tiles".to_string()],
+                engine_type: "geotiff".to_string(),
+                geotiff: None,
+                querydata: None,
+                wms: None,
+                grib: None,
+                odim: None,
+                postgis: None,
+                preview: None,
+            },
+        );
+        let state = Arc::new(ArcSwap::from_pointee(TilesState {
+            map_engines: engines,
+            collections,
+            styles: HashMap::new(),
+            feature_engines: HashMap::new(),
+            feature_collections: HashMap::new(),
+            render_semaphore: Arc::new(tokio::sync::Semaphore::new(4)),
+            rendered_cache: Arc::new(RenderedCache::new(16)),
+            vector_tile_cache: Arc::new(VectorTileCache::new(16)),
+            base_url: String::new(),
+        }));
+        let app = api_tiles::router(state);
+        let req = Request::builder()
+            .uri("/collections/jit")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        let body = resp.into_body().collect().await.unwrap().to_bytes();
+        let json: Value = serde_json::from_slice(&body).unwrap();
+        let grid = &json["extent"]["temporal"]["grid"];
+        assert_eq!(grid["cellsCount"], 4);
+        assert_eq!(grid["resolution"], "PT1H");
+        assert!(grid.get("coordinates").is_none());
+    }
+}

--- a/crates/api-tiles/tests/integration.rs
+++ b/crates/api-tiles/tests/integration.rs
@@ -387,6 +387,15 @@ mod collections {
     }
 
     #[tokio::test]
+    async fn raster_collection_advertises_storage_crs() {
+        let (_, json) = get("/collections/radar").await;
+        assert_eq!(
+            json["storageCrs"],
+            "http://www.opengis.net/def/crs/EPSG/0/4326"
+        );
+    }
+
+    #[tokio::test]
     async fn temporal_extent_has_regular_grid_resolution() {
         let (_, json) = get("/collections/radar").await;
         let grid = &json["extent"]["temporal"]["grid"];

--- a/crates/api-tiles/tests/integration.rs
+++ b/crates/api-tiles/tests/integration.rs
@@ -372,7 +372,10 @@ mod collections {
     #[tokio::test]
     async fn collection_omits_nonstandard_apis_field() {
         let (_, json) = get("/collections/radar").await;
-        assert!(json.get("apis").is_none() || json["apis"].is_null());
+        assert!(
+            json.get("apis").is_none(),
+            "apis must not be present in the standard collection JSON"
+        );
     }
 
     #[tokio::test]

--- a/crates/api-wms/tests/integration.rs
+++ b/crates/api-wms/tests/integration.rs
@@ -57,6 +57,7 @@ impl MapEngine for EmptyMockMapEngine {
             unit: "dBZ".into(),
             parameters: vec![],
             vertical: None,
+            grid_size: None,
         }
     }
 }
@@ -206,6 +207,7 @@ impl MapEngine for FailingMockMapEngine {
             unit: "dBZ".into(),
             parameters: vec![],
             vertical: None,
+            grid_size: None,
         }
     }
 }
@@ -346,6 +348,7 @@ impl MapEngine for PopulatedMockMapEngine {
             unit: "dBZ".into(),
             parameters: vec![],
             vertical: None,
+            grid_size: None,
         }
     }
 }
@@ -689,6 +692,7 @@ impl MapEngine for CountingMockMapEngine {
             unit: "dBZ".into(),
             parameters: vec![],
             vertical: None,
+            grid_size: None,
         }
     }
 }

--- a/crates/core/src/datetime.rs
+++ b/crates/core/src/datetime.rs
@@ -148,12 +148,64 @@ pub fn format_iso8601_duration(seconds: i64) -> Option<String> {
     Some(out)
 }
 
+/// OGC API Common Part 2 `extent.temporal.grid` descriptor.
+///
+/// Serialises (via `serde`, the only serialization dependency ds-core carries)
+/// to `{ "cellsCount": N, "resolution": "<ISO 8601>" }` for a regular series or
+/// `{ "cellsCount": N, "coordinates": [<rfc3339>, …] }` for an irregular one.
+/// Defined here — not in the API crates — so the Maps and Tiles
+/// `extent.temporal.grid` builders share one definition and the JSON shape
+/// can't drift between `/maps/...` and `/tiles/...`. The API crates turn it
+/// into JSON with `serde_json::to_value` (ds-core never builds `serde_json::Value`).
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+#[serde(untagged)]
+pub enum TemporalGrid {
+    Regular {
+        #[serde(rename = "cellsCount")]
+        cells_count: usize,
+        resolution: String,
+    },
+    Irregular {
+        #[serde(rename = "cellsCount")]
+        cells_count: usize,
+        coordinates: Vec<String>,
+    },
+}
+
+/// Build the [`TemporalGrid`] descriptor for an ascending timestamp series: a
+/// single resolution when the step is regular (see [`regular_step_duration`]),
+/// else the full coordinates list. Returns `None` for fewer than two
+/// timestamps.
+pub fn temporal_grid(times: &[DateTime<Utc>]) -> Option<TemporalGrid> {
+    if times.len() < 2 {
+        return None;
+    }
+    let cells_count = times.len();
+    if let Some(resolution) = regular_step_duration(times) {
+        return Some(TemporalGrid::Regular {
+            cells_count,
+            resolution,
+        });
+    }
+    let coordinates = times.iter().map(|t| t.to_rfc3339()).collect();
+    Some(TemporalGrid::Irregular {
+        cells_count,
+        coordinates,
+    })
+}
+
 /// Detect a regular sampling step across `times` (assumed ascending) and
 /// return it as a canonical ISO 8601 duration. Returns `None` when there are
 /// fewer than two timestamps or the gaps vary by more than 2 seconds (an
 /// irregular series). The reported step is the rounded mean gap, so ±1 s
 /// jitter on any single interval doesn't shift it or flip a regular series to
 /// irregular. Shared by the Maps and Tiles `extent.temporal.grid` builders.
+///
+/// Caveat: the 2-second spread tolerance is absolute, sized for ±1 s clock
+/// jitter on the minute-and-coarser cadences every current engine produces.
+/// A truly alternating sub-minute series (e.g. gaps `[1, 3, 1, 3]`, spread 2)
+/// would be reported as "regular PT2S". If a sub-minute engine is ever added,
+/// revisit this threshold (e.g. make it relative to the mean step).
 pub fn regular_step_duration(times: &[DateTime<Utc>]) -> Option<String> {
     if times.len() < 2 {
         return None;
@@ -329,6 +381,36 @@ mod tests {
             t("2024-01-01T03:00:00Z"),
         ];
         assert_eq!(regular_step_duration(&jittered).as_deref(), Some("PT1H"));
+    }
+
+    #[test]
+    fn temporal_grid_picks_regular_or_irregular_variant() {
+        let t = |s: &str| s.parse::<DateTime<Utc>>().unwrap();
+        assert_eq!(temporal_grid(&[]), None);
+        let regular = [t("2024-01-01T00:00:00Z"), t("2024-01-01T00:05:00Z")];
+        assert_eq!(
+            temporal_grid(&regular),
+            Some(TemporalGrid::Regular {
+                cells_count: 2,
+                resolution: "PT5M".to_string()
+            })
+        );
+        let irregular = [
+            t("2024-01-01T00:00:00Z"),
+            t("2024-01-01T01:00:00Z"),
+            t("2024-01-01T03:00:00Z"),
+        ];
+        assert_eq!(
+            temporal_grid(&irregular),
+            Some(TemporalGrid::Irregular {
+                cells_count: 3,
+                coordinates: vec![
+                    "2024-01-01T00:00:00+00:00".to_string(),
+                    "2024-01-01T01:00:00+00:00".to_string(),
+                    "2024-01-01T03:00:00+00:00".to_string(),
+                ]
+            })
+        );
     }
 
     #[test]

--- a/crates/core/src/datetime.rs
+++ b/crates/core/src/datetime.rs
@@ -112,6 +112,42 @@ pub fn parse_iso8601_duration(s: &str) -> Result<Duration, DataServerError> {
     Ok(Duration::seconds(total_seconds))
 }
 
+/// Format a strictly-positive whole-second duration as a canonical ISO 8601
+/// string (`300` → `"PT5M"`, `3600` → `"PT1H"`, `86400` → `"P1D"`,
+/// `5400` → `"PT1H30M"`, `90000` → `"P1DT1H"`). Returns `None` for zero or
+/// negative input. Used to advertise the temporal grid resolution in OGC API
+/// Common Part 2 `extent.temporal.grid.resolution`.
+pub fn format_iso8601_duration(seconds: i64) -> Option<String> {
+    if seconds <= 0 {
+        return None;
+    }
+
+    let days = seconds / 86_400;
+    let mut rem = seconds % 86_400;
+    let hours = rem / 3600;
+    rem %= 3600;
+    let minutes = rem / 60;
+    let secs = rem % 60;
+
+    let mut out = String::from("P");
+    if days > 0 {
+        out.push_str(&format!("{days}D"));
+    }
+    if hours > 0 || minutes > 0 || secs > 0 {
+        out.push('T');
+        if hours > 0 {
+            out.push_str(&format!("{hours}H"));
+        }
+        if minutes > 0 {
+            out.push_str(&format!("{minutes}M"));
+        }
+        if secs > 0 {
+            out.push_str(&format!("{secs}S"));
+        }
+    }
+    Some(out)
+}
+
 /// Parses an OGC datetime interval string like "2024-01-01T00:00:00Z/2024-01-01T06:00:00Z"
 /// or a single instant "2024-01-01T00:00:00Z" (treated as a zero-width interval).
 /// Also supports open intervals with ".." (e.g., "../2024-01-01T06:00:00Z").
@@ -232,6 +268,35 @@ mod tests {
             err.contains("cannot mix 'W'"),
             "Expected 'cannot mix W' message, got: {err}"
         );
+    }
+
+    #[test]
+    fn format_iso8601_duration_canonical_forms() {
+        assert_eq!(format_iso8601_duration(300).as_deref(), Some("PT5M"));
+        assert_eq!(format_iso8601_duration(3600).as_deref(), Some("PT1H"));
+        assert_eq!(format_iso8601_duration(86_400).as_deref(), Some("P1D"));
+        assert_eq!(format_iso8601_duration(5400).as_deref(), Some("PT1H30M"));
+        assert_eq!(format_iso8601_duration(90).as_deref(), Some("PT1M30S"));
+        assert_eq!(format_iso8601_duration(90_000).as_deref(), Some("P1DT1H"));
+        assert_eq!(format_iso8601_duration(45).as_deref(), Some("PT45S"));
+    }
+
+    #[test]
+    fn format_iso8601_duration_rejects_non_positive() {
+        assert_eq!(format_iso8601_duration(0), None);
+        assert_eq!(format_iso8601_duration(-300), None);
+    }
+
+    #[test]
+    fn format_iso8601_duration_roundtrips_through_parser() {
+        for secs in [60_i64, 300, 900, 3600, 10_800, 86_400, 90_000] {
+            let formatted = format_iso8601_duration(secs).unwrap();
+            assert_eq!(
+                parse_iso8601_duration(&formatted).unwrap(),
+                Duration::seconds(secs),
+                "roundtrip failed for {secs}s -> {formatted}"
+            );
+        }
     }
 
     #[test]

--- a/crates/core/src/datetime.rs
+++ b/crates/core/src/datetime.rs
@@ -148,6 +148,30 @@ pub fn format_iso8601_duration(seconds: i64) -> Option<String> {
     Some(out)
 }
 
+/// Detect a regular sampling step across `times` (assumed ascending) and
+/// return it as a canonical ISO 8601 duration. Returns `None` when there are
+/// fewer than two timestamps or the gaps vary by more than 2 seconds (an
+/// irregular series). The reported step is the rounded mean gap, so ±1 s
+/// jitter on any single interval doesn't shift it or flip a regular series to
+/// irregular. Shared by the Maps and Tiles `extent.temporal.grid` builders.
+pub fn regular_step_duration(times: &[DateTime<Utc>]) -> Option<String> {
+    if times.len() < 2 {
+        return None;
+    }
+    let gaps: Vec<i64> = times
+        .windows(2)
+        .map(|w| (w[1] - w[0]).num_seconds())
+        .collect();
+    let min = *gaps.iter().min()?;
+    let max = *gaps.iter().max()?;
+    if min <= 0 || max - min > 2 {
+        return None;
+    }
+    let count = gaps.len() as i64;
+    let avg = (gaps.iter().sum::<i64>() + count / 2) / count;
+    format_iso8601_duration(avg)
+}
+
 /// Parses an OGC datetime interval string like "2024-01-01T00:00:00Z/2024-01-01T06:00:00Z"
 /// or a single instant "2024-01-01T00:00:00Z" (treated as a zero-width interval).
 /// Also supports open intervals with ".." (e.g., "../2024-01-01T06:00:00Z").
@@ -285,6 +309,40 @@ mod tests {
     fn format_iso8601_duration_rejects_non_positive() {
         assert_eq!(format_iso8601_duration(0), None);
         assert_eq!(format_iso8601_duration(-300), None);
+    }
+
+    #[test]
+    fn regular_step_duration_detects_regular_series() {
+        let t = |s: &str| s.parse::<DateTime<Utc>>().unwrap();
+        // Exactly regular.
+        let times = [
+            t("2024-01-01T00:00:00Z"),
+            t("2024-01-01T00:05:00Z"),
+            t("2024-01-01T00:10:00Z"),
+        ];
+        assert_eq!(regular_step_duration(&times).as_deref(), Some("PT5M"));
+        // ±1 s jitter on the first interval is still regular -> mean PT1H.
+        let jittered = [
+            t("2024-01-01T00:00:00Z"),
+            t("2024-01-01T00:59:59Z"),
+            t("2024-01-01T02:00:00Z"),
+            t("2024-01-01T03:00:00Z"),
+        ];
+        assert_eq!(regular_step_duration(&jittered).as_deref(), Some("PT1H"));
+    }
+
+    #[test]
+    fn regular_step_duration_rejects_irregular_and_short() {
+        let t = |s: &str| s.parse::<DateTime<Utc>>().unwrap();
+        assert_eq!(regular_step_duration(&[]), None);
+        assert_eq!(regular_step_duration(&[t("2024-01-01T00:00:00Z")]), None);
+        // 1 h then 2 h -> irregular.
+        let irregular = [
+            t("2024-01-01T00:00:00Z"),
+            t("2024-01-01T01:00:00Z"),
+            t("2024-01-01T03:00:00Z"),
+        ];
+        assert_eq!(regular_step_duration(&irregular), None);
     }
 
     #[test]

--- a/crates/core/src/geo.rs
+++ b/crates/core/src/geo.rs
@@ -80,6 +80,17 @@ pub fn native_crs_uri(label: &str) -> Option<&'static str> {
     }
 }
 
+/// Positive longitude and latitude spans (degrees) of a CRS84 bbox
+/// `[west, south, east, north]`. Handles an anti-meridian crossing where
+/// `east < west` (e.g. a STAC bbox like `[170.0, …, -170.0, …]`, a 20°-wide
+/// box, not a 340°-wide one). Used to derive spatial grid resolution, which
+/// must be positive per the OGC API Common Part 2 schema.
+pub fn crs84_bbox_spans(bbox: [f64; 4]) -> (f64, f64) {
+    let [w, s, e, n] = bbox;
+    let lon_span = if e >= w { e - w } else { e - w + 360.0 };
+    (lon_span, (n - s).abs())
+}
+
 impl Crs {
     /// Forward-transform WGS84 (lon_deg, lat_deg) to projected (easting, northing).
     /// For Wgs84, returns (lon, lat) unchanged.
@@ -1073,6 +1084,46 @@ fn rotlatlon_inverse(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn native_crs_uri_maps_known_labels_and_omits_the_rest() {
+        assert_eq!(
+            native_crs_uri("CRS:84"),
+            Some("http://www.opengis.net/def/crs/OGC/1.3/CRS84")
+        );
+        // EPSG:4326 (lat-first) maps to its own distinct URI, never CRS84.
+        assert_eq!(
+            native_crs_uri("EPSG:4326"),
+            Some("http://www.opengis.net/def/crs/EPSG/0/4326")
+        );
+        assert_eq!(
+            native_crs_uri("EPSG:3067"),
+            Some("http://www.opengis.net/def/crs/EPSG/0/3067")
+        );
+        assert_eq!(
+            native_crs_uri("EPSG:3035"),
+            Some("http://www.opengis.net/def/crs/EPSG/0/3035")
+        );
+        // Generic engine labels for projections without a stable code: omitted.
+        for label in ["TM", "LAEA", "LCC", "stere", "rotated_ll", "projected", ""] {
+            assert_eq!(native_crs_uri(label), None, "label {label:?} must not map");
+        }
+    }
+
+    #[test]
+    fn crs84_bbox_spans_handles_normal_and_antimeridian() {
+        // Normal bbox.
+        let (lon, lat) = crs84_bbox_spans([10.0, 55.0, 30.0, 70.0]);
+        assert!((lon - 20.0).abs() < 1e-9);
+        assert!((lat - 15.0).abs() < 1e-9);
+        // Anti-meridian crossing: east < west is a 20°-wide box, not 340°.
+        let (lon, _) = crs84_bbox_spans([170.0, 60.0, -170.0, 70.0]);
+        assert!(
+            (lon - 20.0).abs() < 1e-9,
+            "anti-meridian span should be 20, got {lon}"
+        );
+        assert!(lon > 0.0, "resolution span must be positive");
+    }
 
     fn wgs84_transform() -> GeoTransform {
         GeoTransform {

--- a/crates/core/src/geo.rs
+++ b/crates/core/src/geo.rs
@@ -80,6 +80,16 @@ pub fn native_crs_uri(label: &str) -> Option<&'static str> {
     }
 }
 
+/// True when `label` denotes a geographic lon/lat CRS whose cells are regular
+/// in degrees (`CRS:84` / `EPSG:4326`). For projected grids (EPSG:3067/3035/
+/// 3857, TM/LAEA/LCC/stere) and rotated lat/lon, a CRS84-degree
+/// `extent.spatial.grid` resolution would only approximate a grid that isn't
+/// degree-regular, so callers omit the grid for those rather than imply a
+/// regularity that doesn't hold.
+pub fn is_geographic_crs(label: &str) -> bool {
+    matches!(label, "CRS:84" | "EPSG:4326")
+}
+
 /// Positive longitude and latitude spans (degrees) of a CRS84 bbox
 /// `[west, south, east, north]`. Handles an anti-meridian crossing where
 /// `east < west` (e.g. a STAC bbox like `[170.0, …, -170.0, …]`, a 20°-wide
@@ -1107,6 +1117,24 @@ mod tests {
         // Generic engine labels for projections without a stable code: omitted.
         for label in ["TM", "LAEA", "LCC", "stere", "rotated_ll", "projected", ""] {
             assert_eq!(native_crs_uri(label), None, "label {label:?} must not map");
+        }
+    }
+
+    #[test]
+    fn is_geographic_crs_only_for_lonlat() {
+        assert!(is_geographic_crs("CRS:84"));
+        assert!(is_geographic_crs("EPSG:4326"));
+        // Projected / rotated grids are not degree-regular.
+        for label in [
+            "EPSG:3857",
+            "EPSG:3067",
+            "EPSG:3035",
+            "TM",
+            "LAEA",
+            "stere",
+            "rotated_ll",
+        ] {
+            assert!(!is_geographic_crs(label), "{label} must not be geographic");
         }
     }
 

--- a/crates/core/src/geo.rs
+++ b/crates/core/src/geo.rs
@@ -69,6 +69,13 @@ pub enum Crs {
 /// `"EPSG:4326"` (lat-first) and `"CRS:84"` (lon-first) map to their distinct
 /// URIs: emitting one for the other would invite a conformant client to swap
 /// axes and transpose the image.
+///
+/// This is keyed on the engine's `native_crs` *label*: a CRS only gets a
+/// `storageCrs` if some engine's `crs_label` emits the matching string. The
+/// `"EPSG:4326"` and `"EPSG:3857"` arms are forward-looking — no current engine
+/// emits those labels (WGS84 grids are tagged `"CRS:84"`, and there is no Web
+/// Mercator `Crs` variant) — so a new engine for one of those must emit the
+/// label here for the URI to apply.
 pub fn native_crs_uri(label: &str) -> Option<&'static str> {
     match label {
         "CRS:84" => Some("http://www.opengis.net/def/crs/OGC/1.3/CRS84"),

--- a/crates/core/src/geo.rs
+++ b/crates/core/src/geo.rs
@@ -87,14 +87,19 @@ pub fn native_crs_uri(label: &str) -> Option<&'static str> {
     }
 }
 
-/// True when `label` denotes a geographic lon/lat CRS whose cells are regular
-/// in degrees (`CRS:84` / `EPSG:4326`). For projected grids (EPSG:3067/3035/
-/// 3857, TM/LAEA/LCC/stere) and rotated lat/lon, a CRS84-degree
-/// `extent.spatial.grid` resolution would only approximate a grid that isn't
-/// degree-regular, so callers omit the grid for those rather than imply a
-/// regularity that doesn't hold.
-pub fn is_geographic_crs(label: &str) -> bool {
-    matches!(label, "CRS:84" | "EPSG:4326")
+/// True when `label` denotes a CRS:84 lon/lat degree grid — the case where a
+/// lon-first `extent.spatial.grid` (axis 0 = longitude, axis 1 = latitude) is
+/// an exact description of the source.
+///
+/// Deliberately matches **only** `"CRS:84"`, not `"EPSG:4326"`: we always emit
+/// the grid axes lon-first to match the CRS84 spatial extent, whereas EPSG:4326
+/// is lat-first, so emitting our lon-first grid for an EPSG:4326-labelled source
+/// would violate the OGC API Common Part 2 axis-order rule. Projected grids
+/// (EPSG:3067/3035/3857, TM/LAEA/LCC/stere) and rotated lat/lon are excluded
+/// too — their cells aren't degree-regular — so callers omit the grid rather
+/// than imply a regularity (or axis order) that doesn't hold.
+pub fn is_crs84_grid(label: &str) -> bool {
+    label == "CRS:84"
 }
 
 /// Positive longitude and latitude spans (degrees) of a CRS84 bbox
@@ -1128,9 +1133,10 @@ mod tests {
     }
 
     #[test]
-    fn is_geographic_crs_only_for_lonlat() {
-        assert!(is_geographic_crs("CRS:84"));
-        assert!(is_geographic_crs("EPSG:4326"));
+    fn is_crs84_grid_only_for_lonfirst_crs84() {
+        assert!(is_crs84_grid("CRS:84"));
+        // EPSG:4326 is lat-first: our lon-first grid axes wouldn't match it.
+        assert!(!is_crs84_grid("EPSG:4326"));
         // Projected / rotated grids are not degree-regular.
         for label in [
             "EPSG:3857",
@@ -1141,7 +1147,7 @@ mod tests {
             "stere",
             "rotated_ll",
         ] {
-            assert!(!is_geographic_crs(label), "{label} must not be geographic");
+            assert!(!is_crs84_grid(label), "{label} must not emit a CRS84 grid");
         }
     }
 

--- a/crates/core/src/geo.rs
+++ b/crates/core/src/geo.rs
@@ -59,6 +59,27 @@ pub enum Crs {
     },
 }
 
+/// Map an engine's internal native-CRS label (as stored in
+/// `RasterInfo.native_crs`) to a canonical OGC CRS URI, or `None` when the
+/// label has no stable URI — engines tag projected grids they can't pin to a
+/// specific EPSG code with generic names ("TM", "LAEA", "projected",
+/// "rotated_ll"). Used for the OGC API `storageCrs` field, where a wrong URI is
+/// worse than an absent one, so this deliberately never falls back to CRS84.
+///
+/// `"EPSG:4326"` (lat-first) and `"CRS:84"` (lon-first) map to their distinct
+/// URIs: emitting one for the other would invite a conformant client to swap
+/// axes and transpose the image.
+pub fn native_crs_uri(label: &str) -> Option<&'static str> {
+    match label {
+        "CRS:84" => Some("http://www.opengis.net/def/crs/OGC/1.3/CRS84"),
+        "EPSG:4326" => Some("http://www.opengis.net/def/crs/EPSG/0/4326"),
+        "EPSG:3857" => Some("http://www.opengis.net/def/crs/EPSG/0/3857"),
+        "EPSG:3067" => Some("http://www.opengis.net/def/crs/EPSG/0/3067"),
+        "EPSG:3035" => Some("http://www.opengis.net/def/crs/EPSG/0/3035"),
+        _ => None,
+    }
+}
+
 impl Crs {
     /// Forward-transform WGS84 (lon_deg, lat_deg) to projected (easting, northing).
     /// For Wgs84, returns (lon, lat) unchanged.

--- a/crates/core/src/map_engine.rs
+++ b/crates/core/src/map_engine.rs
@@ -47,6 +47,12 @@ pub struct RasterInfo {
     /// sweeps, pressure levels). `None` for collections with no vertical
     /// dimension.
     pub vertical: Option<VerticalDimension>,
+    /// Native grid cell counts `[x_cells, y_cells]` (columns, rows), used to
+    /// advertise spatial resolution via OGC API Common Part 2
+    /// `extent.spatial.grid`. `None` when the source has no regular geographic
+    /// grid (e.g. polar radar volumes) or when the cell counts are not cheaply
+    /// available without decoding data.
+    pub grid_size: Option<[u32; 2]>,
 }
 
 /// Trait for serving raster data as map images.

--- a/crates/engine-geotiff/src/lib.rs
+++ b/crates/engine-geotiff/src/lib.rs
@@ -1482,7 +1482,10 @@ impl ds_core::map_engine::MapEngine for GeoTiffEngine {
                     ds_core::geo::Crs::LambertAzimuthalEqualArea { .. } => "EPSG:3035".to_string(),
                     ds_core::geo::Crs::LambertConformalConic { .. } => "projected".to_string(),
                     ds_core::geo::Crs::Stereographic { .. } => "projected".to_string(),
-                    ds_core::geo::Crs::RotatedLatLon { .. } => "EPSG:4326".to_string(),
+                    // Rotated lat/lon is NOT EPSG:4326 — it has no standard
+                    // EPSG code. Use the same internal label as engine-querydata
+                    // so `storageCrs` is omitted rather than mislabelled.
+                    ds_core::geo::Crs::RotatedLatLon { .. } => "rotated_ll".to_string(),
                 })
             })
             .unwrap_or_else(|| "EPSG:4326".to_string());

--- a/crates/engine-geotiff/src/lib.rs
+++ b/crates/engine-geotiff/src/lib.rs
@@ -1200,6 +1200,63 @@ fn filter_by_datetime(
     }
 }
 
+/// Map a parsed [`Crs`](ds_core::geo::Crs) to the engine's native-CRS label
+/// (stored in `RasterInfo.native_crs`, surfaced as OGC `storageCrs`).
+///
+/// Projected variants only claim a specific EPSG code when their parameters
+/// match a grid with a stable code (TM35FIN → EPSG:3067, ETRS89-LAEA Europe →
+/// EPSG:3035); any other zone gets a generic label so the API layer omits
+/// `storageCrs` rather than asserting a wrong code. WGS84 maps to `"CRS:84"`
+/// (lon-first), not `"EPSG:4326"` (lat-first), to match the engine's internal
+/// axis order. Rotated lat/lon has no standard EPSG code.
+fn crs_label(crs: &ds_core::geo::Crs) -> String {
+    // Parameter tolerances: angles compared in radians, offsets in metres.
+    const ANG: f64 = 1e-9;
+    const OFF: f64 = 1e-3;
+    match crs {
+        ds_core::geo::Crs::Wgs84 => "CRS:84".to_string(),
+        ds_core::geo::Crs::TransverseMercator {
+            lat0,
+            lon0,
+            k0,
+            false_e,
+            false_n,
+        } => {
+            let is_tm35fin = lat0.abs() < ANG
+                && (lon0 - 27.0_f64.to_radians()).abs() < ANG
+                && (k0 - 0.9996).abs() < 1e-9
+                && (false_e - 500_000.0).abs() < OFF
+                && false_n.abs() < OFF;
+            if is_tm35fin {
+                "EPSG:3067".to_string()
+            } else {
+                "TM".to_string()
+            }
+        }
+        ds_core::geo::Crs::LambertAzimuthalEqualArea {
+            lat0,
+            lon0,
+            false_e,
+            false_n,
+        } => {
+            let is_etrs89_laea = (lat0 - 52.0_f64.to_radians()).abs() < ANG
+                && (lon0 - 10.0_f64.to_radians()).abs() < ANG
+                && (false_e - 4_321_000.0).abs() < OFF
+                && (false_n - 3_210_000.0).abs() < OFF;
+            if is_etrs89_laea {
+                "EPSG:3035".to_string()
+            } else {
+                "LAEA".to_string()
+            }
+        }
+        ds_core::geo::Crs::LambertConformalConic { .. } => "projected".to_string(),
+        ds_core::geo::Crs::Stereographic { .. } => "projected".to_string(),
+        // Rotated lat/lon is NOT EPSG:4326 — it has no standard EPSG code.
+        // Match engine-querydata so `storageCrs` is omitted, not mislabelled.
+        ds_core::geo::Crs::RotatedLatLon { .. } => "rotated_ll".to_string(),
+    }
+}
+
 impl ds_core::map_engine::MapEngine for GeoTiffEngine {
     fn get_raster_tile(
         &self,
@@ -1475,20 +1532,10 @@ impl ds_core::map_engine::MapEngine for GeoTiffEngine {
         let crs_name = catalog
             .entries
             .values()
-            .find_map(|entry| {
-                entry.metadata().map(|m| match &m.geo_transform.crs {
-                    ds_core::geo::Crs::Wgs84 => "EPSG:4326".to_string(),
-                    ds_core::geo::Crs::TransverseMercator { .. } => "EPSG:3067".to_string(),
-                    ds_core::geo::Crs::LambertAzimuthalEqualArea { .. } => "EPSG:3035".to_string(),
-                    ds_core::geo::Crs::LambertConformalConic { .. } => "projected".to_string(),
-                    ds_core::geo::Crs::Stereographic { .. } => "projected".to_string(),
-                    // Rotated lat/lon is NOT EPSG:4326 — it has no standard
-                    // EPSG code. Use the same internal label as engine-querydata
-                    // so `storageCrs` is omitted rather than mislabelled.
-                    ds_core::geo::Crs::RotatedLatLon { .. } => "rotated_ll".to_string(),
-                })
-            })
-            .unwrap_or_else(|| "EPSG:4326".to_string());
+            .find_map(|entry| entry.metadata().map(|m| crs_label(&m.geo_transform.crs)))
+            // No metadata could be read; the engine works internally in
+            // lon-first geographic coordinates, so default to CRS:84.
+            .unwrap_or_else(|| "CRS:84".to_string());
 
         let times: Vec<DateTime<Utc>> = catalog.entries.keys().cloned().collect();
 
@@ -1942,6 +1989,67 @@ mod tests {
     fn expand_prefix_static() {
         let result = expand_prefix_pattern("some/fixed/prefix", 2);
         assert_eq!(result, vec!["some/fixed/prefix"]);
+    }
+
+    #[test]
+    fn crs_label_wgs84_is_crs84_not_epsg4326() {
+        // Internal data is lon-first; EPSG:4326 would imply lat-first.
+        assert_eq!(crs_label(&ds_core::geo::Crs::Wgs84), "CRS:84");
+    }
+
+    #[test]
+    fn crs_label_tm_only_claims_3067_for_tm35fin() {
+        let tm35fin = ds_core::geo::Crs::TransverseMercator {
+            lat0: 0.0,
+            lon0: 27.0_f64.to_radians(),
+            k0: 0.9996,
+            false_e: 500_000.0,
+            false_n: 0.0,
+        };
+        assert_eq!(crs_label(&tm35fin), "EPSG:3067");
+        // A different TM zone (e.g. UTM 33N central meridian 15°E) is not 3067.
+        let utm33n = ds_core::geo::Crs::TransverseMercator {
+            lat0: 0.0,
+            lon0: 15.0_f64.to_radians(),
+            k0: 0.9996,
+            false_e: 500_000.0,
+            false_n: 0.0,
+        };
+        assert_eq!(crs_label(&utm33n), "TM");
+    }
+
+    #[test]
+    fn crs_label_laea_only_claims_3035_for_etrs89() {
+        let etrs89 = ds_core::geo::Crs::LambertAzimuthalEqualArea {
+            lat0: 52.0_f64.to_radians(),
+            lon0: 10.0_f64.to_radians(),
+            false_e: 4_321_000.0,
+            false_n: 3_210_000.0,
+        };
+        assert_eq!(crs_label(&etrs89), "EPSG:3035");
+        let other = ds_core::geo::Crs::LambertAzimuthalEqualArea {
+            lat0: 0.0,
+            lon0: 0.0,
+            false_e: 0.0,
+            false_n: 0.0,
+        };
+        assert_eq!(crs_label(&other), "LAEA");
+    }
+
+    #[test]
+    fn crs_label_rotated_has_no_epsg() {
+        let rot = ds_core::geo::Crs::RotatedLatLon {
+            south_pole_lat: (-30.0_f64).to_radians(),
+            south_pole_lon: 0.0,
+        };
+        assert_eq!(crs_label(&rot), "rotated_ll");
+        // And the generic labels have no storageCrs URI.
+        assert!(ds_core::geo::native_crs_uri("rotated_ll").is_none());
+        assert!(ds_core::geo::native_crs_uri("TM").is_none());
+        assert_eq!(
+            ds_core::geo::native_crs_uri("CRS:84"),
+            Some("http://www.opengis.net/def/crs/OGC/1.3/CRS84")
+        );
     }
 
     #[test]

--- a/crates/engine-geotiff/src/lib.rs
+++ b/crates/engine-geotiff/src/lib.rs
@@ -1249,10 +1249,12 @@ fn crs_label(crs: &ds_core::geo::Crs) -> String {
                 "LAEA".to_string()
             }
         }
-        ds_core::geo::Crs::LambertConformalConic { .. } => "projected".to_string(),
-        ds_core::geo::Crs::Stereographic { .. } => "projected".to_string(),
+        // No stable EPSG code for arbitrary LCC/Stereographic params; use the
+        // same descriptive labels as engine-odim so native_crs_uri (the single
+        // storageCrs source of truth) treats both engines identically.
+        ds_core::geo::Crs::LambertConformalConic { .. } => "LCC".to_string(),
+        ds_core::geo::Crs::Stereographic { .. } => "stere".to_string(),
         // Rotated lat/lon is NOT EPSG:4326 — it has no standard EPSG code.
-        // Match engine-querydata so `storageCrs` is omitted, not mislabelled.
         ds_core::geo::Crs::RotatedLatLon { .. } => "rotated_ll".to_string(),
     }
 }
@@ -2050,6 +2052,30 @@ mod tests {
             ds_core::geo::native_crs_uri("CRS:84"),
             Some("http://www.opengis.net/def/crs/OGC/1.3/CRS84")
         );
+    }
+
+    #[test]
+    fn crs_label_lcc_and_stereographic_match_odim_vocabulary() {
+        let lcc = ds_core::geo::Crs::LambertConformalConic {
+            lat1: 0.0,
+            lat2: 0.0,
+            lat0: 0.0,
+            lon0: 0.0,
+            false_e: 0.0,
+            false_n: 0.0,
+        };
+        let stere = ds_core::geo::Crs::Stereographic {
+            lat0: 0.0,
+            lon0: 0.0,
+            k0: 1.0,
+            false_e: 0.0,
+            false_n: 0.0,
+        };
+        assert_eq!(crs_label(&lcc), "LCC");
+        assert_eq!(crs_label(&stere), "stere");
+        // Neither resolves to a storageCrs URI (no stable EPSG code).
+        assert!(ds_core::geo::native_crs_uri("LCC").is_none());
+        assert!(ds_core::geo::native_crs_uri("stere").is_none());
     }
 
     #[test]

--- a/crates/engine-geotiff/src/lib.rs
+++ b/crates/engine-geotiff/src/lib.rs
@@ -1489,6 +1489,13 @@ impl ds_core::map_engine::MapEngine for GeoTiffEngine {
 
         let times: Vec<DateTime<Utc>> = catalog.entries.keys().cloned().collect();
 
+        // Native full-resolution grid dimensions, taken from the first loaded
+        // entry (all entries in a collection share the same grid).
+        let grid_size = catalog
+            .entries
+            .values()
+            .find_map(|entry| entry.metadata().map(|m| [m.width, m.height]));
+
         ds_core::map_engine::RasterInfo {
             native_crs: crs_name,
             spatial_extent: catalog.spatial_extent,
@@ -1497,6 +1504,7 @@ impl ds_core::map_engine::MapEngine for GeoTiffEngine {
             unit: self.unit.clone(),
             parameters: vec![], // single-parameter engine
             vertical: None,     // single-layer raster, no vertical dimension
+            grid_size,
         }
     }
 }

--- a/crates/engine-grib/src/lib.rs
+++ b/crates/engine-grib/src/lib.rs
@@ -1223,7 +1223,10 @@ impl MapEngine for GribEngine {
             .to_string();
 
         RasterInfo {
-            native_crs: "EPSG:4326".to_string(),
+            // Regular lat/lon grids served lon-first -> CRS:84, not the
+            // lat-first EPSG:4326 (which would make a conformant client swap
+            // axes). Matches engine-geotiff/odim/querydata for `storageCrs`.
+            native_crs: "CRS:84".to_string(),
             spatial_extent: Some([-180.0, -90.0, 180.0, 90.0]),
             times,
             parameter: default_param,

--- a/crates/engine-grib/src/lib.rs
+++ b/crates/engine-grib/src/lib.rs
@@ -1230,6 +1230,10 @@ impl MapEngine for GribEngine {
             unit: default_unit,
             parameters: params,
             vertical: None,
+            // Grid ni/nj are only known after a message is decoded; the
+            // catalog metadata doesn't carry them, so leave the spatial grid
+            // unadvertised for now (tracked as a follow-up).
+            grid_size: None,
         }
     }
 }

--- a/crates/engine-odim/src/engine.rs
+++ b/crates/engine-odim/src/engine.rs
@@ -755,6 +755,7 @@ impl MapEngine for OdimEngine {
             unit: self.unit.clone(),
             parameters: vec![],
             vertical: None, // 2-D composite, no vertical dimension
+            grid_size: Some([self.seed_xsize, self.seed_ysize]),
         }
     }
 }

--- a/crates/engine-odim/src/engine.rs
+++ b/crates/engine-odim/src/engine.rs
@@ -761,9 +761,14 @@ impl MapEngine for OdimEngine {
 }
 
 /// Human-readable identifier for a `Crs`. Used by `raster_info()` —
-/// approximate, not an authoritative EPSG mapping. ODIM composites
-/// in the wild use spheres so EPSG codes don't strictly apply
-/// anyway.
+/// approximate, not an authoritative EPSG mapping. ODIM composites in the wild
+/// use spheres, so EPSG codes don't strictly apply; this engine deliberately
+/// never claims one (unlike engine-geotiff, which upgrades TM35FIN/ETRS89-LAEA
+/// ellipsoidal grids to their EPSG codes).
+///
+/// The generic (non-EPSG) labels must match engine-geotiff's vocabulary so
+/// that `ds_core::geo::native_crs_uri` — the single source of truth for
+/// `storageCrs` — maps both engines' output consistently.
 fn crs_label(crs: &Crs) -> String {
     match crs {
         Crs::Wgs84 => "CRS:84".into(),
@@ -771,7 +776,7 @@ fn crs_label(crs: &Crs) -> String {
         Crs::LambertAzimuthalEqualArea { .. } => "LAEA".into(),
         Crs::LambertConformalConic { .. } => "LCC".into(),
         Crs::Stereographic { .. } => "stere".into(),
-        Crs::RotatedLatLon { .. } => "rotated_latlon".into(),
+        Crs::RotatedLatLon { .. } => "rotated_ll".into(),
     }
 }
 
@@ -804,7 +809,17 @@ mod tests {
             false_e: 0.0,
             false_n: 0.0,
         };
+        // Generic labels must match engine-geotiff's vocabulary (no EPSG claim
+        // for spherical composites) so native_crs_uri maps both consistently.
         assert_eq!(crs_label(&stere), "stere");
+        let rot = Crs::RotatedLatLon {
+            south_pole_lat: 0.0,
+            south_pole_lon: 0.0,
+        };
+        assert_eq!(crs_label(&rot), "rotated_ll");
+        // None of the generic projected labels resolve to a storageCrs URI.
+        assert!(ds_core::geo::native_crs_uri("stere").is_none());
+        assert!(ds_core::geo::native_crs_uri("rotated_ll").is_none());
     }
 
     /// `shutdown()` called before `poll_loop()` ever starts must

--- a/crates/engine-odim/src/volume_engine.rs
+++ b/crates/engine-odim/src/volume_engine.rs
@@ -1155,6 +1155,9 @@ impl MapEngine for PolarVolumeEngine {
             unit: String::new(),
             parameters,
             vertical: catalog.vertical.clone(),
+            // Polar volume — no regular CRS84 cell grid, so the spatial grid
+            // resolution is not meaningful here.
+            grid_size: None,
         }
     }
 }

--- a/crates/engine-querydata/src/engine.rs
+++ b/crates/engine-querydata/src/engine.rs
@@ -368,7 +368,9 @@ impl MapEngine for QueryDataEngine {
         let bbox = gt.bbox();
 
         let native_crs = match data.grid.area.crs {
-            ds_core::geo::Crs::Wgs84 => "EPSG:4326".to_string(),
+            // Internal grids are lon-first, so CRS:84 (not EPSG:4326, which is
+            // lat-first) — this is the value surfaced as OGC `storageCrs`.
+            ds_core::geo::Crs::Wgs84 => "CRS:84".to_string(),
             ds_core::geo::Crs::RotatedLatLon { .. } => "rotated_ll".to_string(),
             _ => "projected".to_string(),
         };
@@ -727,7 +729,8 @@ mod tests {
         let info = engine.raster_info();
 
         assert_eq!(info.parameter, "2 Metre Temperature (2t)");
-        assert_eq!(info.native_crs, "EPSG:4326");
+        // Lon-first geographic grid -> CRS:84 (not lat-first EPSG:4326).
+        assert_eq!(info.native_crs, "CRS:84");
         assert_eq!(info.times.len(), 49);
         assert!(info.spatial_extent.is_some());
     }

--- a/crates/engine-querydata/src/engine.rs
+++ b/crates/engine-querydata/src/engine.rs
@@ -397,6 +397,7 @@ impl MapEngine for QueryDataEngine {
             unit: String::new(),
             parameters,
             vertical: None,
+            grid_size: Some([gt.width, gt.height]),
         }
     }
 }

--- a/crates/engine-querydata/src/engine.rs
+++ b/crates/engine-querydata/src/engine.rs
@@ -370,7 +370,10 @@ impl MapEngine for QueryDataEngine {
         let native_crs = match data.grid.area.crs {
             // Internal grids are lon-first, so CRS:84 (not EPSG:4326, which is
             // lat-first) — this is the value surfaced as OGC `storageCrs`.
+            // Generic labels match engine-geotiff/engine-odim so
+            // ds_core::geo::native_crs_uri treats every engine consistently.
             ds_core::geo::Crs::Wgs84 => "CRS:84".to_string(),
+            ds_core::geo::Crs::Stereographic { .. } => "stere".to_string(),
             ds_core::geo::Crs::RotatedLatLon { .. } => "rotated_ll".to_string(),
             _ => "projected".to_string(),
         };

--- a/crates/server/src/preview.rs
+++ b/crates/server/src/preview.rs
@@ -852,6 +852,7 @@ mod tests {
                 unit: self.unit.clone(),
                 parameters: self.parameters.clone(),
                 vertical: None,
+                grid_size: None,
             }
         }
     }
@@ -1874,6 +1875,7 @@ mod tests {
                         ("msl".into(), "Mean SLP".into()),
                     ],
                     vertical: None,
+                    grid_size: None,
                 }
             }
         }

--- a/crates/server/tests/middleware.rs
+++ b/crates/server/tests/middleware.rs
@@ -55,6 +55,7 @@ impl MapEngine for MockMapEngine {
             unit: "dBZ".to_string(),
             parameters: vec![],
             vertical: None,
+            grid_size: None,
         }
     }
 }


### PR DESCRIPTION
## What & why

Brings the OGC API – Maps (and the related Tiles) collection metadata into line with [OGC API – Maps Part 1 (20-058)](https://docs.ogc.org/is/20-058/20-058.html) and the OGC API Common Part 2 extent model. All changes are **additive** except removing the non-standard `apis` field.

## Changes

- **Drop `apis` from collection JSON** (maps, tiles, edr, features) — it has no OGC schema; discovery is via typed `links`. The `apis` config field, admin routing, and the internal `/preview` SPA manifest are unchanged. (#255)
- **`extent.spatial.grid`** — per-axis `cellsCount` + CRS84-degree `resolution`, from a new `RasterInfo.grid_size` populated by geotiff/querydata/odim-composite (`None` for grib and polar odim-PVOL). (#256)
- **`extent.temporal.grid`** — regular `{cellsCount, resolution}` (ISO 8601 duration) or `{cellsCount, coordinates}` fallback, computed from the `times` vector via a new `ds_core::datetime::format_iso8601_duration`. (#257)
- **Vertical extent → Common Part 2** — adds `unit` + `grid.coordinates` alongside the retained `interval`/`values`. `vrs` deferred (radar elevation angle has no standard OGC vertical-CRS URI). (#258)
- **Map tilesets** — `tilesets-map` link (gated on the `tiles` API) + `conf/tilesets` conformance class. `/tiles` stays a standalone router. (#259)
- **`storageCrs`** on maps collection metadata. (#260)

## Verification

- `cargo fmt`, `cargo clippy --workspace --all-targets` clean; full `cargo test --workspace` green (48 suites, 0 failures).
- New unit/integration tests: spatial/temporal grid, vertical Common Part 2 form (new mock with elevation axis), `storageCrs`, `tilesets-map` present/absent, conformance class, `apis` absent across all four APIs.
- **Live smoke test** against real local fixtures:
  - EU OPERA composite → `has("apis")=false`, real `spatial.grid` (3800×4400), `temporal.grid` auto-detected `PT5M`, `tilesets-map` link, `storageCrs`.
  - FMI PVOL volume → vertical extent with real elevation angles (`unit: "deg"`, `grid.coordinates`), `spatial.grid` correctly `null` (no fabricated polar grid).

## Out of scope / follow-ups

- GRIB `grid_size` (needs ni/nj cached pre-decode).
- `vrs` on vertical extent (until a pressure/height axis is exposed).
- Porting the grid descriptors to the EDR extent.

Closes #255
Closes #256
Closes #257
Closes #258
Closes #259
Closes #260

🤖 Generated with [Claude Code](https://claude.com/claude-code)