### PR TITLE
style(engine-postgis): fix clippy 1.96 manual_option_zip (unblocks CI)

### DIFF
--- a/crates/engine-postgis/src/metadata.rs
+++ b/crates/engine-postgis/src/metadata.rs
@@ -382,7 +382,7 @@ async fn fetch_temporal_extent(
     let hi: Option<DateTime<Utc>> = row
         .try_get("hi")
         .map_err(|e| MetadataError::Decode(e.to_string()))?;
-    Ok(lo.and_then(|lo_v| hi.map(|hi_v| (lo_v, hi_v))))
+    Ok(lo.zip(hi))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## What

`clippy 1.96` (stable, released 2026-05-25) flags `manual_option_zip`, and CI runs `cargo clippy --all-targets -- -D warnings`, so it's a hard error. The temporal-extent decode in `engine-postgis` built its `(lo, hi)` tuple by hand:

```rust
Ok(lo.and_then(|lo_v| hi.map(|hi_v| (lo_v, hi_v))))   // → Ok(lo.zip(hi))
```

This code is 5 weeks old and passed CI when it landed (#105) — the runner's floating `@stable` toolchain has since rolled forward to 1.96, which newly rejects the pattern. **It blocks every open PR**, not just any one branch.

## Why separate

Pure CI-unblocker, unrelated to any feature work — shipped on its own so it doesn't bundle into an in-flight PR. `Option::zip` is exactly equivalent; **no behaviour change**.

## Testing

Updated local toolchain to 1.96.0 to match CI; `cargo clippy --workspace --all-targets -- -D warnings` now clean across the whole workspace (this was the only drift error).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
