### PR TITLE
fix(wms,maps): render projected output CRS (EPSG:3067/3035) instead of blank tiles

### DIFF
--- a/crates/api-maps/src/handlers.rs
+++ b/crates/api-maps/src/handlers.rs
@@ -848,7 +848,16 @@ async fn render_map(
             ds_render::ImageFormat::Webp => 2,
         },
         crs: validated.crs.clone(),
-        bbox: ds_render::quantize_bbox(&validated.bbox),
+        // Projected output renders over the projected-metres bbox carried in
+        // `output_crs`, not the WGS84 envelope in `validated.bbox`; key on the
+        // metres so two projected requests sharing an envelope don't collide
+        // (#267 review).
+        bbox: match &validated.output_crs {
+            ds_core::map_engine::OutputCrs::Projected { bbox, .. } => {
+                ds_render::quantize_bbox(bbox)
+            }
+            _ => ds_render::quantize_bbox(&validated.bbox),
+        },
         width: validated.width,
         height: validated.height,
         time,

--- a/crates/api-maps/src/params.rs
+++ b/crates/api-maps/src/params.rs
@@ -148,7 +148,14 @@ impl MapQueryParams {
                     MapsError::BadRequest(format!("CRS '{crs}' has no projection definition"))
                 })?;
                 let proj_bbox = ds_core::geo::projected_envelope(&proj_crs, bbox);
-                let wgs84 = ds_core::geo::wgs84_envelope(&proj_crs, proj_bbox);
+                // None means the projected frame is entirely outside the CRS's
+                // valid domain — reject (400) rather than reading a global window.
+                let wgs84 =
+                    ds_core::geo::wgs84_envelope(&proj_crs, proj_bbox).ok_or_else(|| {
+                        MapsError::BadRequest(
+                            "bbox is outside the valid area of the requested crs".to_string(),
+                        )
+                    })?;
                 (
                     wgs84,
                     ds_core::map_engine::OutputCrs::Projected {

--- a/crates/api-maps/src/params.rs
+++ b/crates/api-maps/src/params.rs
@@ -134,9 +134,30 @@ impl MapQueryParams {
         // DATETIME / TIME
         let time = self.datetime.as_deref().map(parse_time).transpose()?;
 
-        let output_crs = match crs.as_str() {
-            "EPSG:3857" => ds_core::map_engine::OutputCrs::WebMercator,
-            _ => ds_core::map_engine::OutputCrs::Wgs84,
+        // OGC API Maps fixes `bbox-crs` to CRS:84 (checked above), so `bbox` is
+        // always WGS84 degrees; the `crs` parameter selects the *output* CRS.
+        // For a projected output CRS the map frame must cover the requested
+        // geographic box, so forward-project it to a projected envelope, render
+        // the projection over that, and widen the WGS84 read window to the
+        // envelope's inverse so the engine reads the right source pixels
+        // (#160 — previously these codes silently rendered as WGS84).
+        let (bbox, output_crs) = match crs.as_str() {
+            "EPSG:3857" => (bbox, ds_core::map_engine::OutputCrs::WebMercator),
+            "EPSG:3067" | "EPSG:3035" => {
+                let proj_crs = ds_core::geo::projected_output_crs(&crs).ok_or_else(|| {
+                    MapsError::BadRequest(format!("CRS '{crs}' has no projection definition"))
+                })?;
+                let proj_bbox = ds_core::geo::projected_envelope(&proj_crs, bbox);
+                let wgs84 = ds_core::geo::wgs84_envelope(&proj_crs, proj_bbox);
+                (
+                    wgs84,
+                    ds_core::map_engine::OutputCrs::Projected {
+                        crs: proj_crs,
+                        bbox: proj_bbox,
+                    },
+                )
+            }
+            _ => (bbox, ds_core::map_engine::OutputCrs::Wgs84),
         };
 
         // parameter-name — validation that the name is in the engine's list
@@ -275,5 +296,57 @@ mod tests {
     #[test]
     fn test_parse_time_invalid() {
         assert!(parse_time("not-a-time").is_err());
+    }
+
+    fn query_with_crs(crs: &str) -> MapQueryParams {
+        MapQueryParams {
+            // CRS:84 bbox over Finland (bbox-crs is always CRS:84 in OGC Maps).
+            bbox: Some("19,59,32,70".to_string()),
+            width: Some(256),
+            height: Some(256),
+            crs: Some(crs.to_string()),
+            datetime: None,
+            transparent: None,
+            format: None,
+            bbox_crs: None,
+            parameter_name: None,
+            elevation: None,
+        }
+    }
+
+    #[test]
+    fn validate_projected_output_crs_3067() {
+        // #160: a projected output CRS must produce OutputCrs::Projected, not a
+        // silent Wgs84 fallback. The bbox stays CRS:84 (bbox-crs), but the
+        // engine read window widens to the projected frame's WGS84 envelope.
+        let validated = query_with_crs("EPSG:3067").validate().unwrap();
+        match validated.output_crs {
+            ds_core::map_engine::OutputCrs::Projected { ref crs, bbox } => {
+                assert!(matches!(crs, ds_core::geo::Crs::TransverseMercator { .. }));
+                // Projected envelope of the CRS:84 box: easting near the 500 km
+                // false-easting band, northing in the millions of metres.
+                assert!(bbox[1] > 5_000_000.0 && bbox[3] > 6_000_000.0, "{bbox:?}");
+            }
+            other => panic!("expected Projected, got {other:?}"),
+        }
+        // The read window stays in plausible WGS84 degrees.
+        let [w, s, e, n] = validated.bbox;
+        assert!(
+            w > 10.0 && e < 40.0 && s > 55.0 && n < 75.0,
+            "{:?}",
+            validated.bbox
+        );
+    }
+
+    #[test]
+    fn validate_wgs84_and_webmercator_unchanged() {
+        assert_eq!(
+            query_with_crs("CRS:84").validate().unwrap().output_crs,
+            ds_core::map_engine::OutputCrs::Wgs84
+        );
+        assert_eq!(
+            query_with_crs("EPSG:3857").validate().unwrap().output_crs,
+            ds_core::map_engine::OutputCrs::WebMercator
+        );
     }
 }

--- a/crates/api-wms/src/handlers.rs
+++ b/crates/api-wms/src/handlers.rs
@@ -177,7 +177,15 @@ pub async fn wms_handler(
                     ds_render::ImageFormat::Webp => 2,
                 },
                 crs: params.crs.clone(),
-                bbox: ds_render::quantize_bbox(&params.bbox),
+                // For a projected output CRS the rendered pixels are laid out
+                // over the projected-metres bbox (carried in `output_crs`), not
+                // the WGS84 envelope in `params.bbox` — two requests with
+                // different projected bboxes can share an envelope, so key on the
+                // metres to avoid serving one's tile for the other (#267 review).
+                bbox: match &params.output_crs {
+                    OutputCrs::Projected { bbox, .. } => ds_render::quantize_bbox(bbox),
+                    _ => ds_render::quantize_bbox(&params.bbox),
+                },
                 width: params.width,
                 height: params.height,
                 time: params.time,

--- a/crates/api-wms/src/params.rs
+++ b/crates/api-wms/src/params.rs
@@ -342,7 +342,11 @@ fn parse_bbox(bbox_str: &str, crs: &str) -> Result<([f64; 4], OutputCrs), WmsErr
                 WmsError::invalid_parameter(&format!("CRS '{crs}' has no projection definition"))
             })?;
             let proj_bbox = [x1, y1, x2, y2];
-            let wgs84 = ds_core::geo::wgs84_envelope(&proj_crs, proj_bbox);
+            // None means the whole bbox is outside the projection's valid domain
+            // — reject (400) rather than letting the engine read a global window.
+            let wgs84 = ds_core::geo::wgs84_envelope(&proj_crs, proj_bbox).ok_or_else(|| {
+                WmsError::invalid_parameter("BBOX is outside the valid area of the requested CRS")
+            })?;
             Ok((
                 wgs84,
                 OutputCrs::Projected {

--- a/crates/api-wms/src/params.rs
+++ b/crates/api-wms/src/params.rs
@@ -149,12 +149,13 @@ impl WmsQuery {
         }
         let crs = crs.to_string();
 
-        // BBOX
+        // BBOX — also resolves the output CRS (axis order + reprojection both
+        // depend on the CRS, so they're determined together).
         let bbox_str = self
             .bbox
             .as_deref()
             .ok_or(WmsError::missing_parameter("BBOX"))?;
-        let bbox = parse_bbox(bbox_str, &crs)?;
+        let (bbox, output_crs) = parse_bbox(bbox_str, &crs)?;
 
         // WIDTH
         let width: u32 = self
@@ -230,11 +231,6 @@ impl WmsQuery {
             None => None,
         };
 
-        let output_crs = match crs.as_str() {
-            "EPSG:3857" => OutputCrs::WebMercator,
-            _ => OutputCrs::Wgs84,
-        };
-
         // STYLES — empty string or missing = "default"
         let style = self
             .styles
@@ -269,15 +265,25 @@ pub enum WmsRequestType {
     GetLegendGraphic,
 }
 
-/// Parse BBOX string, handling WMS 1.3.0 axis order.
+/// Parse a BBOX string and resolve the output CRS, handling WMS 1.3.0 axis
+/// order and reprojection.
 ///
 /// WMS 1.3.0 axis order depends on CRS:
-/// - EPSG:4326 → lat,lon order: BBOX=south,west,north,east
 /// - CRS:84    → lon,lat order: BBOX=west,south,east,north
-/// - EPSG:3857 → easting,northing: not yet supported for direct passthrough
+/// - EPSG:4326 → lat,lon order: BBOX=south,west,north,east (swapped)
+/// - EPSG:3857/3067/3035 → easting,northing: BBOX=minx,miny,maxx,maxy
 ///
-/// Returns [west, south, east, north] in WGS84.
-fn parse_bbox(bbox_str: &str, crs: &str) -> Result<[f64; 4], WmsError> {
+/// Returns the WGS84 bounding box `[west, south, east, north]` the engine reads
+/// against, paired with the [`OutputCrs`] that tells the engine how output
+/// pixels map to coordinates:
+/// - CRS:84 / EPSG:4326 → bbox is already WGS84 degrees; [`OutputCrs::Wgs84`].
+/// - EPSG:3857 → bbox metres reprojected to a WGS84 box; [`OutputCrs::WebMercator`].
+/// - EPSG:3067 / EPSG:3035 → bbox is projected metres; [`OutputCrs::Projected`]
+///   carries it, and the returned WGS84 box is its inverse-projected envelope so
+///   the engine reads the right source window (#160/#251). Previously these two
+///   codes fell through to `Wgs84` and the engine read projected metres as
+///   degrees → fully-transparent tiles.
+fn parse_bbox(bbox_str: &str, crs: &str) -> Result<([f64; 4], OutputCrs), WmsError> {
     let parts: Vec<f64> = bbox_str
         .split(',')
         .map(|s| {
@@ -302,7 +308,7 @@ fn parse_bbox(bbox_str: &str, crs: &str) -> Result<[f64; 4], WmsError> {
         }
     }
 
-    // WMS 1.3.0 axis order: EPSG:4326 uses lat/lon, CRS:84 uses lon/lat
+    // WMS 1.3.0 axis order: EPSG:4326 uses lat/lon, everything else x/y.
     let [x1, y1, x2, y2] = match crs {
         "EPSG:4326" => {
             // BBOX = south, west, north, east (lat/lon order) → normalize to x/y
@@ -321,23 +327,35 @@ fn parse_bbox(bbox_str: &str, crs: &str) -> Result<[f64; 4], WmsError> {
         ));
     }
 
-    // Reproject to WGS84 [west, south, east, north] if needed
-    let [west, south, east, north] = match crs {
+    match crs {
         "EPSG:3857" => {
-            // Web Mercator meters → WGS84 degrees
+            // Web Mercator metres → WGS84 degrees; pixel Y stays Mercator-spaced.
             let (lon1, lat1) = epsg3857_to_wgs84(x1, y1);
             let (lon2, lat2) = epsg3857_to_wgs84(x2, y2);
-            [lon1, lat1, lon2, lat2]
+            Ok(([lon1, lat1, lon2, lat2], OutputCrs::WebMercator))
+        }
+        "EPSG:3067" | "EPSG:3035" => {
+            // Projected metres: keep them in the OutputCrs so the engine lays
+            // output pixels out in the projection, and pass its inverse-
+            // projected WGS84 envelope as the read window.
+            let proj_crs = ds_core::geo::projected_output_crs(crs).ok_or_else(|| {
+                WmsError::invalid_parameter(&format!("CRS '{crs}' has no projection definition"))
+            })?;
+            let proj_bbox = [x1, y1, x2, y2];
+            let wgs84 = ds_core::geo::wgs84_envelope(&proj_crs, proj_bbox);
+            Ok((
+                wgs84,
+                OutputCrs::Projected {
+                    crs: proj_crs,
+                    bbox: proj_bbox,
+                },
+            ))
         }
         _ => {
-            // CRS:84 and EPSG:4326 are already in WGS84 degrees
-            // EPSG:3067 and EPSG:3035 — the engine handles reprojection internally
-            // via GeoTransform::world_to_pixel which calls Crs::forward
-            [x1, y1, x2, y2]
+            // CRS:84 and EPSG:4326 are already in WGS84 degrees.
+            Ok(([x1, y1, x2, y2], OutputCrs::Wgs84))
         }
-    };
-
-    Ok([west, south, east, north])
+    }
 }
 
 /// Convert EPSG:3857 (Web Mercator) coordinates to WGS84 (lon/lat degrees).
@@ -380,15 +398,17 @@ mod tests {
 
     #[test]
     fn test_bbox_crs84() {
-        let bbox = parse_bbox("10,55,30,70", "CRS:84").unwrap();
+        let (bbox, crs) = parse_bbox("10,55,30,70", "CRS:84").unwrap();
         assert_eq!(bbox, [10.0, 55.0, 30.0, 70.0]);
+        assert_eq!(crs, OutputCrs::Wgs84);
     }
 
     #[test]
     fn test_bbox_epsg4326_axis_swap() {
         // EPSG:4326 uses lat/lon order: south,west,north,east
-        let bbox = parse_bbox("55,10,70,30", "EPSG:4326").unwrap();
+        let (bbox, crs) = parse_bbox("55,10,70,30", "EPSG:4326").unwrap();
         assert_eq!(bbox, [10.0, 55.0, 30.0, 70.0]);
+        assert_eq!(crs, OutputCrs::Wgs84);
     }
 
     #[test]
@@ -400,12 +420,70 @@ mod tests {
     #[test]
     fn test_bbox_epsg3857_reprojection() {
         // Web Mercator bbox covering roughly lon 1.5-14.3, lat 53.0-63.0
-        let bbox = parse_bbox("171318.93,6897641.62,2528475.00,9153471.98", "EPSG:3857").unwrap();
+        let (bbox, crs) =
+            parse_bbox("171318.93,6897641.62,2528475.00,9153471.98", "EPSG:3857").unwrap();
         // Should be reprojected to WGS84 degrees
         assert!((bbox[0] - 1.539).abs() < 0.01); // west ≈ 1.54°
         assert!((bbox[1] - 52.536).abs() < 0.01); // south ≈ 52.54°
         assert!((bbox[2] - 22.714).abs() < 0.01); // east ≈ 22.71°
         assert!((bbox[3] - 63.216).abs() < 0.01); // north ≈ 63.22°
+        assert_eq!(crs, OutputCrs::WebMercator);
+    }
+
+    #[test]
+    fn test_bbox_epsg3067_projected() {
+        // Regression for #251/#160: FMI's native TM35FIN extent. The bbox is in
+        // EPSG:3067 metres and must NOT be passed through as WGS84 degrees.
+        let (bbox, crs) = parse_bbox(
+            "-118331.366408,6335621.167014,875567.731907,7907751.537264",
+            "EPSG:3067",
+        )
+        .unwrap();
+
+        // OutputCrs carries the projected request rectangle verbatim.
+        match &crs {
+            OutputCrs::Projected {
+                bbox: proj,
+                crs: proj_crs,
+            } => {
+                assert_eq!(
+                    *proj,
+                    [
+                        -118331.366408,
+                        6335621.167014,
+                        875567.731907,
+                        7907751.537264
+                    ]
+                );
+                // EPSG:3067 is Transverse Mercator (TM35FIN).
+                assert!(matches!(
+                    proj_crs,
+                    ds_core::geo::Crs::TransverseMercator { .. }
+                ));
+            }
+            other => panic!("expected Projected, got {other:?}"),
+        }
+
+        // The returned WGS84 envelope must be plausible Nordic degrees, NOT the
+        // metres treated as degrees (a metres-as-degrees bug puts these in the
+        // millions). FMI's composite is wide, so the lon span reaches ~10–37°E.
+        let [west, south, east, north] = bbox;
+        assert!(
+            (-30.0..60.0).contains(&west) && (-30.0..60.0).contains(&east),
+            "envelope lon {west}..{east} should be degrees"
+        );
+        assert!(
+            (45.0..75.0).contains(&south) && (45.0..75.0).contains(&north),
+            "envelope lat {south}..{north} should be degrees"
+        );
+        assert!(west < east && south < north);
+    }
+
+    #[test]
+    fn test_bbox_epsg3035_projected() {
+        // EPSG:3035 (ETRS89-LAEA) is also projected metres → Projected, not Wgs84.
+        let (_bbox, crs) = parse_bbox("4200000,3200000,5300000,5000000", "EPSG:3035").unwrap();
+        assert!(matches!(crs, OutputCrs::Projected { .. }));
     }
 
     #[test]

--- a/crates/core/src/geo.rs
+++ b/crates/core/src/geo.rs
@@ -203,9 +203,20 @@ fn edge_envelope(bbox: [f64; 4], map: impl Fn(f64, f64) -> Option<(f64, f64)>) -
 ///
 /// Falls back to the conservative global extent `[-180, -90, 180, 90]` if every
 /// reprojection fails — over-broad but dimensionally valid (returning the
-/// metres `bbox` would be a unit-confusion bug). Unreachable for any real grid.
+/// metres `bbox` would be a unit-confusion bug). Unreachable for any real grid,
+/// but a mis-configured / out-of-domain bbox would otherwise silently widen the
+/// caller's read window to the whole globe, so the fallback warns. ds-core is
+/// framework-free (no `tracing`), so this goes to stderr — same convention as
+/// `resample.rs`'s MAX_CELLS warning.
 pub fn wgs84_envelope(crs: &Crs, bbox: [f64; 4]) -> [f64; 4] {
-    edge_envelope(bbox, |x, y| crs.inverse(x, y)).unwrap_or([-180.0, -90.0, 180.0, 90.0])
+    edge_envelope(bbox, |x, y| crs.inverse(x, y)).unwrap_or_else(|| {
+        eprintln!(
+            "WARN ds_core::geo::wgs84_envelope: every edge sample of bbox \
+             {bbox:?} failed inverse projection; falling back to global extent \
+             [-180, -90, 180, 90] (likely a bbox outside the projection's valid area)"
+        );
+        [-180.0, -90.0, 180.0, 90.0]
+    })
 }
 
 /// Projected envelope `[min_e, min_n, max_e, max_n]` (in `crs`'s metres) of a

--- a/crates/core/src/geo.rs
+++ b/crates/core/src/geo.rs
@@ -9,7 +9,7 @@ const WGS84_E2: f64 = 2.0 * WGS84_F - WGS84_F * WGS84_F; // eccentricity squared
 ///
 /// Stores projection parameters and provides forward/inverse transforms
 /// between WGS84 geographic coordinates and projected coordinates.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum Crs {
     /// WGS84 geographic (EPSG:4326 / CRS84). Coordinates are (lon, lat) in degrees.
     Wgs84,
@@ -111,6 +111,113 @@ pub fn crs84_bbox_spans(bbox: [f64; 4]) -> (f64, f64) {
     let [w, s, e, n] = bbox;
     let lon_span = if e >= w { e - w } else { e - w + 360.0 };
     (lon_span, (n - s).abs())
+}
+
+/// Projection definition for a projected CRS the server accepts as a WMS / OGC
+/// API Maps **output** CRS, keyed by its EPSG identifier.
+///
+/// Returns `None` for the geographic codes (`CRS:84` / `EPSG:4326`, which need
+/// no projection) and for `EPSG:3857` (Web Mercator has its own dedicated
+/// output path, [`crate::map_engine::OutputCrs::WebMercator`]). The parameters
+/// match the authoritative EPSG definitions and the ones engine-geotiff already
+/// derives from GeoTIFF GeoKeys:
+/// - **EPSG:3067** (ETRS89 / TM35FIN) — Transverse Mercator, central meridian
+///   27°E, k₀=0.9996, false easting 500 km.
+/// - **EPSG:3035** (ETRS89-extended / LAEA Europe) — Lambert Azimuthal Equal
+///   Area centred at 52°N 10°E, false easting 4 321 km, northing 3 210 km.
+///
+/// This is the single source of truth so api-wms and api-maps build identical
+/// output projections (#160).
+pub fn projected_output_crs(epsg: &str) -> Option<Crs> {
+    match epsg {
+        "EPSG:3067" => Some(Crs::TransverseMercator {
+            lat0: 0.0,
+            lon0: 27.0_f64.to_radians(),
+            k0: 0.9996,
+            false_e: 500_000.0,
+            false_n: 0.0,
+        }),
+        "EPSG:3035" => Some(Crs::LambertAzimuthalEqualArea {
+            lat0: 52.0_f64.to_radians(),
+            lon0: 10.0_f64.to_radians(),
+            false_e: 4_321_000.0,
+            false_n: 3_210_000.0,
+        }),
+        _ => None,
+    }
+}
+
+/// Edge samples per side used by [`wgs84_envelope`] / [`projected_envelope`].
+/// 20 matches `GeoTransform::bbox`'s sampling — enough to pin the bow of a
+/// continental TM/LAEA box to well under a pixel.
+const ENVELOPE_EDGE_SAMPLES: usize = 20;
+
+/// Accumulate the axis-aligned min/max of points produced by `map` along the
+/// four edges of `bbox` (`[min_a, min_b, max_a, max_b]`). `map` returns `None`
+/// for points that don't transform (e.g. outside a projection's valid domain);
+/// those are skipped. Returns `None` if every sampled point failed.
+fn edge_envelope(bbox: [f64; 4], map: impl Fn(f64, f64) -> Option<(f64, f64)>) -> Option<[f64; 4]> {
+    let [min_a, min_b, max_a, max_b] = bbox;
+    let mut min_x = f64::MAX;
+    let mut max_x = f64::MIN;
+    let mut min_y = f64::MAX;
+    let mut max_y = f64::MIN;
+    for i in 0..=ENVELOPE_EDGE_SAMPLES {
+        let frac = i as f64 / ENVELOPE_EDGE_SAMPLES as f64;
+        // Top + bottom edges (a varies, b pinned to each end).
+        let a = min_a + frac * (max_a - min_a);
+        for &b in &[min_b, max_b] {
+            if let Some((x, y)) = map(a, b) {
+                min_x = min_x.min(x);
+                max_x = max_x.max(x);
+                min_y = min_y.min(y);
+                max_y = max_y.max(y);
+            }
+        }
+        // Left + right edges (b varies, a pinned to each end).
+        let b = min_b + frac * (max_b - min_b);
+        for &a in &[min_a, max_a] {
+            if let Some((x, y)) = map(a, b) {
+                min_x = min_x.min(x);
+                max_x = max_x.max(x);
+                min_y = min_y.min(y);
+                max_y = max_y.max(y);
+            }
+        }
+    }
+    if min_x > max_x {
+        None
+    } else {
+        Some([min_x, min_y, max_x, max_y])
+    }
+}
+
+/// WGS84 lon/lat envelope `[west, south, east, north]` of a projected bbox
+/// `[min_e, min_n, max_e, max_n]` (in `crs`'s metres), found by inverse-
+/// projecting points sampled along the four edges.
+///
+/// Projection curvature means the extreme lon/lat can fall in the middle of an
+/// edge, not only at a corner, so this samples the edges rather than just the
+/// corners. Used to derive the WGS84 read window for a projected-output render
+/// (the engine still reads source pixels by lon/lat).
+///
+/// Falls back to the conservative global extent `[-180, -90, 180, 90]` if every
+/// reprojection fails — over-broad but dimensionally valid (returning the
+/// metres `bbox` would be a unit-confusion bug). Unreachable for any real grid.
+pub fn wgs84_envelope(crs: &Crs, bbox: [f64; 4]) -> [f64; 4] {
+    edge_envelope(bbox, |x, y| crs.inverse(x, y)).unwrap_or([-180.0, -90.0, 180.0, 90.0])
+}
+
+/// Projected envelope `[min_e, min_n, max_e, max_n]` (in `crs`'s metres) of a
+/// WGS84 bbox `[west, south, east, north]`, found by forward-projecting points
+/// sampled along the four edges.
+///
+/// The inverse of [`wgs84_envelope`]: used by OGC API Maps, where the request
+/// `bbox` is in CRS:84 but the output `crs` is projected — the projected map
+/// frame must cover the requested geographic box. `Crs::forward` is total, so
+/// this always returns `Some`; the `unwrap_or` is a defensive identity fallback.
+pub fn projected_envelope(crs: &Crs, bbox: [f64; 4]) -> [f64; 4] {
+    edge_envelope(bbox, |lon, lat| Some(crs.forward(lon, lat))).unwrap_or(bbox)
 }
 
 impl Crs {
@@ -1106,6 +1213,71 @@ fn rotlatlon_inverse(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn projected_output_crs_pins_epsg_parameters() {
+        // EPSG:3067 (TM35FIN): on the central meridian (27°E) easting is exactly
+        // the false easting (500 km), independent of latitude — this pins the
+        // central meridian + false easting against the authoritative definition.
+        let tm = projected_output_crs("EPSG:3067").expect("3067 defined");
+        let (e, _n) = tm.forward(27.0, 60.0);
+        assert!((e - 500_000.0).abs() < 1e-3, "3067 easting at λ0 = {e}");
+        // EPSG:3035 (ETRS89-LAEA): at the projection centre (10°E, 52°N) the
+        // result is exactly the false easting/northing (4321 km, 3210 km).
+        let laea = projected_output_crs("EPSG:3035").expect("3035 defined");
+        let (e, n) = laea.forward(10.0, 52.0);
+        assert!((e - 4_321_000.0).abs() < 1e-3, "3035 FE = {e}");
+        assert!((n - 3_210_000.0).abs() < 1e-3, "3035 FN = {n}");
+        // Geographic and Web Mercator codes have no projected definition here.
+        for code in ["CRS:84", "EPSG:4326", "EPSG:3857", "EPSG:9999", ""] {
+            assert!(projected_output_crs(code).is_none(), "{code} must be None");
+        }
+    }
+
+    #[test]
+    fn envelope_roundtrip_contains_original_box() {
+        // Forward a CRS:84 Finland box into EPSG:3067, then inverse-envelope
+        // back: the WGS84 envelope must *contain* the original box (projection
+        // bow can only widen it). This mirrors the api-maps read-window logic.
+        let crs = projected_output_crs("EPSG:3067").unwrap();
+        let original = [19.0, 59.0, 32.0, 70.0];
+        let proj = projected_envelope(&crs, original);
+        assert!(proj[0] < proj[2] && proj[1] < proj[3], "proj {proj:?}");
+        let back = wgs84_envelope(&crs, proj);
+        assert!(
+            back[0] <= original[0] + 1e-6
+                && back[1] <= original[1] + 1e-6
+                && back[2] >= original[2] - 1e-6
+                && back[3] >= original[3] - 1e-6,
+            "envelope {back:?} must contain {original:?}"
+        );
+    }
+
+    #[test]
+    fn wgs84_envelope_of_projected_metres_is_degrees_not_metres() {
+        // Regression for #251: a projected-metres bbox must come back as
+        // plausible degrees, never the metres passed through unchanged.
+        let crs = projected_output_crs("EPSG:3067").unwrap();
+        // FMI's native TM35FIN extent.
+        let env = wgs84_envelope(
+            &crs,
+            [
+                -118331.366408,
+                6335621.167014,
+                875567.731907,
+                7907751.537264,
+            ],
+        );
+        let [w, s, e, n] = env;
+        assert!(
+            (10.0..30.0).contains(&w) && (20.0..40.0).contains(&e),
+            "lon {w}..{e}"
+        );
+        assert!(
+            (55.0..72.0).contains(&s) && (60.0..72.0).contains(&n),
+            "lat {s}..{n}"
+        );
+    }
 
     #[test]
     fn native_crs_uri_maps_known_labels_and_omits_the_rest() {

--- a/crates/core/src/geo.rs
+++ b/crates/core/src/geo.rs
@@ -201,22 +201,14 @@ fn edge_envelope(bbox: [f64; 4], map: impl Fn(f64, f64) -> Option<(f64, f64)>) -
 /// corners. Used to derive the WGS84 read window for a projected-output render
 /// (the engine still reads source pixels by lon/lat).
 ///
-/// Falls back to the conservative global extent `[-180, -90, 180, 90]` if every
-/// reprojection fails — over-broad but dimensionally valid (returning the
-/// metres `bbox` would be a unit-confusion bug). Unreachable for any real grid,
-/// but a mis-configured / out-of-domain bbox would otherwise silently widen the
-/// caller's read window to the whole globe, so the fallback warns. ds-core is
-/// framework-free (no `tracing`), so this goes to stderr — same convention as
-/// `resample.rs`'s MAX_CELLS warning.
-pub fn wgs84_envelope(crs: &Crs, bbox: [f64; 4]) -> [f64; 4] {
-    edge_envelope(bbox, |x, y| crs.inverse(x, y)).unwrap_or_else(|| {
-        eprintln!(
-            "WARN ds_core::geo::wgs84_envelope: every edge sample of bbox \
-             {bbox:?} failed inverse projection; falling back to global extent \
-             [-180, -90, 180, 90] (likely a bbox outside the projection's valid area)"
-        );
-        [-180.0, -90.0, 180.0, 90.0]
-    })
+/// Returns `None` when **every** sampled point fails to inverse-project — i.e.
+/// the projected bbox lies entirely outside the projection's valid domain. The
+/// caller must surface that as a client error (HTTP 400), *not* fall back to a
+/// global extent: a global read window on a planet-scale GRIB/COG source would
+/// decode the whole dataset for one bogus request (a DoS vector). Unreachable
+/// for any valid EPSG:3067/3035 bbox.
+pub fn wgs84_envelope(crs: &Crs, bbox: [f64; 4]) -> Option<[f64; 4]> {
+    edge_envelope(bbox, |x, y| crs.inverse(x, y))
 }
 
 /// Projected envelope `[min_e, min_n, max_e, max_n]` (in `crs`'s metres) of a
@@ -1254,7 +1246,7 @@ mod tests {
         let original = [19.0, 59.0, 32.0, 70.0];
         let proj = projected_envelope(&crs, original);
         assert!(proj[0] < proj[2] && proj[1] < proj[3], "proj {proj:?}");
-        let back = wgs84_envelope(&crs, proj);
+        let back = wgs84_envelope(&crs, proj).expect("in-domain bbox has an envelope");
         assert!(
             back[0] <= original[0] + 1e-6
                 && back[1] <= original[1] + 1e-6
@@ -1278,7 +1270,8 @@ mod tests {
                 875567.731907,
                 7907751.537264,
             ],
-        );
+        )
+        .expect("in-domain bbox has an envelope");
         let [w, s, e, n] = env;
         assert!(
             (10.0..30.0).contains(&w) && (20.0..40.0).contains(&e),
@@ -1288,6 +1281,29 @@ mod tests {
             (55.0..72.0).contains(&s) && (60.0..72.0).contains(&n),
             "lat {s}..{n}"
         );
+    }
+
+    #[test]
+    fn edge_envelope_is_none_when_every_sample_fails() {
+        // Backs the wgs84_envelope DoS guard (#267 review): if no sampled point
+        // transforms, the envelope is None so the caller returns HTTP 400 —
+        // never a fabricated or global-extent box that would trigger a
+        // whole-dataset read. (The projection inverses are Newton-based and
+        // return finite values almost everywhere, so this contract is exercised
+        // at the edge-sampling level rather than via a specific CRS.)
+        assert_eq!(edge_envelope([0.0, 0.0, 1.0, 1.0], |_, _| None), None);
+        // And Some, with correct min/max, when points do transform.
+        assert_eq!(
+            edge_envelope([0.0, 0.0, 2.0, 4.0], |a, b| Some((a, b))),
+            Some([0.0, 0.0, 2.0, 4.0])
+        );
+    }
+
+    #[test]
+    fn wgs84_envelope_some_for_valid_projected_bbox() {
+        let crs = projected_output_crs("EPSG:3035").unwrap();
+        let proj = projected_envelope(&crs, [5.0, 48.0, 15.0, 55.0]);
+        assert!(wgs84_envelope(&crs, proj).is_some());
     }
 
     #[test]

--- a/crates/core/src/geo.rs
+++ b/crates/core/src/geo.rs
@@ -185,7 +185,10 @@ fn edge_envelope(bbox: [f64; 4], map: impl Fn(f64, f64) -> Option<(f64, f64)>) -
             }
         }
     }
-    if min_x > max_x {
+    // Both axes update together from the same `Some((x, y))`, so either bound
+    // being un-touched means *no* point transformed — check both for symmetry /
+    // defence rather than relying on x alone.
+    if min_x > max_x || min_y > max_y {
         None
     } else {
         Some([min_x, min_y, max_x, max_y])

--- a/crates/core/src/map_engine.rs
+++ b/crates/core/src/map_engine.rs
@@ -1,6 +1,7 @@
 use chrono::{DateTime, Utc};
 
 use crate::error::DataServerError;
+use crate::geo::Crs;
 use crate::vertical::VerticalDimension;
 
 /// The output CRS for map rendering, determining how pixels map to coordinates.
@@ -11,6 +12,85 @@ pub enum OutputCrs {
     /// Web Mercator (EPSG:3857). Bbox is in WGS84 degrees but pixel Y spacing
     /// follows the Mercator projection (non-linear in latitude).
     WebMercator,
+    /// A projected output CRS (e.g. EPSG:3067 TM35FIN, EPSG:3035 ETRS89-LAEA).
+    ///
+    /// The output pixel grid is laid out **linearly in the projected metres** of
+    /// `crs` over `bbox`, then each grid node is inverse-projected to WGS84
+    /// lon/lat before the engine samples its source. This is what makes a
+    /// Finland-native client's `CRS=EPSG:3067&BBOX=<metres>` request render
+    /// correctly instead of treating the metres as degrees (#160/#251).
+    ///
+    /// `bbox` is the request rectangle in `crs`'s metres,
+    /// `[min_e, min_n, max_e, max_n]`. The WGS84 bounding box the engine uses to
+    /// pick its read window / overview is passed separately as the
+    /// `get_raster_tile` `bbox` argument (see [`wgs84_envelope`]).
+    ///
+    /// [`wgs84_envelope`]: crate::geo::wgs84_envelope
+    Projected {
+        /// Projection definition (from [`crate::geo::projected_output_crs`]).
+        crs: Crs,
+        /// Request rectangle in projected metres `[min_e, min_n, max_e, max_n]`.
+        bbox: [f64; 4],
+    },
+}
+
+/// Convert WGS84 latitude (degrees) to Web Mercator Y (metres). Shared by every
+/// map engine's output-axis mapping so the equal-Y-metres spacing of
+/// `OutputCrs::WebMercator` is computed identically everywhere.
+fn lat_to_merc_y(lat_deg: f64) -> f64 {
+    const R: f64 = 6_378_137.0;
+    R * ((std::f64::consts::FRAC_PI_4 + lat_deg.to_radians() / 2.0).tan()).ln()
+}
+
+/// Inverse of [`lat_to_merc_y`].
+///
+/// `π/2 - 2·atan(exp(-y/R))` is algebraically equal to the standard EPSG:3857
+/// inverse `2·atan(exp(y/R)) - π/2` but negates the exponent so `exp()` decays
+/// toward zero as |y| grows rather than overflowing — numerically stable across
+/// the full ±π/2 range under f64.
+fn merc_y_to_lat(y: f64) -> f64 {
+    const R: f64 = 6_378_137.0;
+    (std::f64::consts::FRAC_PI_2 - 2.0 * (-y / R).exp().atan()).to_degrees()
+}
+
+impl OutputCrs {
+    /// Map a fractional output position `(fx, fy)` in `[0, 1]²` to WGS84
+    /// `(lon, lat)` degrees, where `fx = 0` is the west/left edge and `fy = 0`
+    /// the north/top edge.
+    ///
+    /// `wgs84_bbox` is the request's WGS84 bounding box `[west, south, east,
+    /// north]`, used by the `Wgs84` and `WebMercator` variants. The `Projected`
+    /// variant ignores it and instead interpolates linearly in its own carried
+    /// projected metres before inverse-projecting, so output pixels are square
+    /// in the requested projection (the inverse may be non-finite outside the
+    /// projection's valid domain — callers finite-check, exactly as they do for
+    /// `GeoTransform::world_to_pixel`).
+    ///
+    /// This is the single shared output→world mapping for every `MapEngine`
+    /// (#160/#251): engines feed it to [`crate::resample::ProjectionGrid`] (or
+    /// call it per pixel for non-gridded sources) instead of re-deriving the
+    /// per-CRS axis math.
+    pub fn project_node(&self, wgs84_bbox: [f64; 4], fx: f64, fy: f64) -> (f64, f64) {
+        let [west, south, east, north] = wgs84_bbox;
+        match self {
+            OutputCrs::Wgs84 => (west + fx * (east - west), north - fy * (north - south)),
+            OutputCrs::WebMercator => {
+                // Pixels are equally spaced in Mercator Y metres: interpolate in
+                // Mercator Y, then convert back to latitude.
+                let (my_n, my_s) = (lat_to_merc_y(north), lat_to_merc_y(south));
+                (
+                    west + fx * (east - west),
+                    merc_y_to_lat(my_n - fy * (my_n - my_s)),
+                )
+            }
+            OutputCrs::Projected { crs, bbox } => {
+                let [min_e, min_n, max_e, max_n] = bbox;
+                let e = min_e + fx * (max_e - min_e);
+                let n = max_n - fy * (max_n - min_n);
+                crs.inverse(e, n).unwrap_or((f64::NAN, f64::NAN))
+            }
+        }
+    }
 }
 
 /// A raster tile that can be colorized and served as a map image.
@@ -99,4 +179,65 @@ pub trait MapEngine: Send + Sync {
     /// every call. If your engine genuinely needs to derive metadata
     /// per-request, cache it.
     fn raster_info(&self) -> RasterInfo;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::geo::projected_output_crs;
+
+    const FINLAND_WGS84: [f64; 4] = [19.0, 59.0, 32.0, 70.0]; // [w, s, e, n]
+
+    #[test]
+    fn project_node_wgs84_is_linear_corners() {
+        let crs = OutputCrs::Wgs84;
+        // fx=0,fy=0 is the NW corner (west, north); fx=1,fy=1 is SE (east, south).
+        assert_eq!(crs.project_node(FINLAND_WGS84, 0.0, 0.0), (19.0, 70.0));
+        assert_eq!(crs.project_node(FINLAND_WGS84, 1.0, 1.0), (32.0, 59.0));
+        // The centre is the arithmetic midpoint (linear in both axes).
+        let (lon, lat) = crs.project_node(FINLAND_WGS84, 0.5, 0.5);
+        assert!((lon - 25.5).abs() < 1e-9 && (lat - 64.5).abs() < 1e-9);
+    }
+
+    #[test]
+    fn project_node_web_mercator_pins_corners_and_bows_centre() {
+        let crs = OutputCrs::WebMercator;
+        // Longitude is still linear; the corner latitudes are exact.
+        let (lon0, lat0) = crs.project_node(FINLAND_WGS84, 0.0, 0.0);
+        assert!((lon0 - 19.0).abs() < 1e-9 && (lat0 - 70.0).abs() < 1e-9);
+        let (_, lat1) = crs.project_node(FINLAND_WGS84, 1.0, 1.0);
+        assert!((lat1 - 59.0).abs() < 1e-9);
+        // The mid-row latitude sits north of the linear midpoint (Mercator rows
+        // are equally spaced in metres, which compress toward the pole).
+        let (_, latm) = crs.project_node(FINLAND_WGS84, 0.5, 0.5);
+        assert!(
+            latm > 64.5,
+            "Mercator mid-row {latm} should exceed linear 64.5"
+        );
+    }
+
+    #[test]
+    fn project_node_projected_inverts_projected_metres() {
+        // Build a projected bbox by forward-projecting a known lon/lat, then
+        // confirm project_node inverts the correct corner — proving the bbox is
+        // read as metres and inverse-projected, not treated as degrees (#251).
+        let proj = projected_output_crs("EPSG:3067").unwrap();
+        let (e_w, n_s) = proj.forward(20.0, 60.0); // SW-ish in projected space
+        let (e_e, n_n) = proj.forward(30.0, 68.0); // NE-ish
+        let bbox = [e_w.min(e_e), n_s.min(n_n), e_w.max(e_e), n_s.max(n_n)];
+        let out = OutputCrs::Projected {
+            crs: proj.clone(),
+            bbox,
+        };
+        // NW corner (fx=0,fy=0) → (min_e, max_n) inverse.
+        let expect = proj.inverse(bbox[0], bbox[3]).unwrap();
+        let got = out.project_node([0.0; 4], 0.0, 0.0); // wgs84_bbox is ignored
+        assert!((got.0 - expect.0).abs() < 1e-9 && (got.1 - expect.1).abs() < 1e-9);
+        // A degrees-as-metres bug would land lon/lat in the millions; assert sane.
+        let (lon, lat) = out.project_node([0.0; 4], 0.5, 0.5);
+        assert!(
+            (15.0..35.0).contains(&lon) && (55.0..72.0).contains(&lat),
+            "{lon},{lat}"
+        );
+    }
 }

--- a/crates/core/src/resample.rs
+++ b/crates/core/src/resample.rs
@@ -260,9 +260,21 @@ impl ProjectionGrid {
     /// `(ox, oy)`. Coordinates are fractional and unclamped — the caller floors
     /// and bounds-checks them, exactly as `GeoTransform::world_to_pixel` does.
     ///
-    /// If a grid node is non-finite (only reachable via a degenerate source
-    /// mapping, e.g. a zero pixel size) the result is non-finite; the caller
-    /// must finite-check before use.
+    /// If any of a cell's four nodes is non-finite the bilinear blend is
+    /// non-finite for *every* pixel in that cell; the caller must finite-check
+    /// before use (and a non-finite result resolves to nodata/transparent).
+    /// Non-finite nodes arise when `out_to_world` or `world_to_src_px` returns
+    /// NaN — i.e. a degenerate source mapping (zero pixel size) **or** a
+    /// projected output CRS whose inverse is undefined for an out-of-domain
+    /// node (`OutputCrs::Projected` past the projection's valid area). The
+    /// consequence is that the on-raster region can be under-filled by up to one
+    /// coarse cell (≤ `GRID_STEP_PX`, more at low zoom) right at that domain
+    /// boundary. This is accepted: it only bites thousands of km outside the
+    /// useful extent of EPSG:3067/3035 (whose Newton inverses return finite
+    /// values across all of Europe, so nodes there are finite), and resolving a
+    /// boundary that cuts through a cell exactly would defeat the coarse-grid
+    /// optimisation. Engines that must be pixel-exact at such a boundary should
+    /// fall back to per-pixel projection for cells `sample` reports as nodata.
     pub fn sample(&self, ox: u32, oy: u32) -> (f64, f64) {
         // Position of the pixel centre in grid-cell units.
         let gx = (ox as f64 + 0.5) / self.cell_w;

--- a/crates/core/src/resample.rs
+++ b/crates/core/src/resample.rs
@@ -108,6 +108,35 @@ impl ProjectionGrid {
         lat_at: impl Fn(f64) -> f64,
         world_to_src_px: impl Fn(f64, f64) -> (f64, f64),
     ) -> Self {
+        // Separable axes (linear lon / linear-or-Mercator lat) are the common
+        // case; express them through the general 2-D mapping.
+        Self::build_2d(
+            out_width,
+            out_height,
+            src_cols,
+            src_rows,
+            |fx, fy| (lon_at(fx), lat_at(fy)),
+            world_to_src_px,
+        )
+    }
+
+    /// Like [`build`](Self::build) but with a fully 2-D output→world
+    /// parameterisation: `out_to_world(fx, fy)` maps a fractional output
+    /// position `(fx, fy)` in `[0, 1]²` to geographic `(lon, lat)` degrees.
+    ///
+    /// Required for a **projected output CRS** (e.g. EPSG:3067), where lon and
+    /// lat each depend on *both* output axes because the inverse projection
+    /// mixes easting and northing — so the separable `lon_at(fx)` / `lat_at(fy)`
+    /// decomposition of [`build`](Self::build) does not hold (#160). Engines
+    /// pass `|fx, fy| output_crs.project_node(bbox, fx, fy)`.
+    pub fn build_2d(
+        out_width: u32,
+        out_height: u32,
+        src_cols: u32,
+        src_rows: u32,
+        out_to_world: impl Fn(f64, f64) -> (f64, f64),
+        world_to_src_px: impl Fn(f64, f64) -> (f64, f64),
+    ) -> Self {
         let mut cells_x = out_width.div_ceil(GRID_STEP_PX).clamp(MIN_CELLS, MAX_CELLS);
         let mut cells_y = out_height
             .div_ceil(GRID_STEP_PX)
@@ -118,11 +147,10 @@ impl ProjectionGrid {
                 out_height,
                 cells_x,
                 cells_y,
-                &lon_at,
-                &lat_at,
+                &out_to_world,
                 &world_to_src_px,
             );
-            let error = grid.estimate_error(src_cols, src_rows, &lon_at, &lat_at, &world_to_src_px);
+            let error = grid.estimate_error(src_cols, src_rows, &out_to_world, &world_to_src_px);
             if error <= MAX_INTERP_ERROR_PX {
                 return grid;
             }
@@ -149,14 +177,13 @@ impl ProjectionGrid {
     }
 
     /// Build a grid with an explicit cell count (no refinement).
-    #[allow(clippy::too_many_arguments)] // output dims + cell counts + 3 mapping closures are all genuine inputs
+    #[allow(clippy::too_many_arguments)] // output dims + cell counts + 2 mapping closures are all genuine inputs
     fn with_cells(
         out_width: u32,
         out_height: u32,
         cells_x: u32,
         cells_y: u32,
-        lon_at: impl Fn(f64) -> f64,
-        lat_at: impl Fn(f64) -> f64,
+        out_to_world: impl Fn(f64, f64) -> (f64, f64),
         world_to_src_px: impl Fn(f64, f64) -> (f64, f64),
     ) -> Self {
         let cells_x = cells_x as usize;
@@ -165,9 +192,9 @@ impl ProjectionGrid {
 
         let mut nodes = Vec::with_capacity(stride * (cells_y + 1));
         for j in 0..=cells_y {
-            let lat = lat_at(j as f64 / cells_y as f64);
+            let fy = j as f64 / cells_y as f64;
             for i in 0..=cells_x {
-                let lon = lon_at(i as f64 / cells_x as f64);
+                let (lon, lat) = out_to_world(i as f64 / cells_x as f64, fy);
                 nodes.push(world_to_src_px(lon, lat));
             }
         }
@@ -198,8 +225,7 @@ impl ProjectionGrid {
         &self,
         src_cols: u32,
         src_rows: u32,
-        lon_at: impl Fn(f64) -> f64,
-        lat_at: impl Fn(f64) -> f64,
+        out_to_world: impl Fn(f64, f64) -> (f64, f64),
         world_to_src_px: impl Fn(f64, f64) -> (f64, f64),
     ) -> f64 {
         // Generous on-raster window: within one raster-size of the data.
@@ -213,8 +239,10 @@ impl ProjectionGrid {
                 let (c00, c10) = (self.nodes[n], self.nodes[n + 1]);
                 let (c01, c11) = (self.nodes[n + self.stride], self.nodes[n + self.stride + 1]);
                 for (tx, ty) in ERROR_PROBES {
-                    let lon = lon_at((i as f64 + tx) / self.cells_x as f64);
-                    let lat = lat_at((j as f64 + ty) / self.cells_y as f64);
+                    let (lon, lat) = out_to_world(
+                        (i as f64 + tx) / self.cells_x as f64,
+                        (j as f64 + ty) / self.cells_y as f64,
+                    );
                     let (ec, er) = world_to_src_px(lon, lat);
                     if !in_window(ec, er) {
                         continue;

--- a/crates/engine-geotiff/src/lib.rs
+++ b/crates/engine-geotiff/src/lib.rs
@@ -1449,31 +1449,16 @@ impl ds_core::map_engine::MapEngine for GeoTiffEngine {
 
             // Map output pixels to source pixels through a coarse projection
             // grid instead of projecting every pixel: the CRS forward transform
-            // dominates render CPU for projected sources.
-            let to_web_mercator = *output_crs == ds_core::map_engine::OutputCrs::WebMercator;
-            let (merc_y_north, merc_y_south) = if to_web_mercator {
-                (lat_to_merc_y(north), lat_to_merc_y(south))
-            } else {
-                (0.0, 0.0) // unused
-            };
-            let lon_at = |frac_x: f64| west + frac_x * (east - west);
-            let lat_at = |frac_y: f64| {
-                if to_web_mercator {
-                    // In Mercator, pixels have equal spacing in Y meters:
-                    // interpolate in Mercator Y, then convert back to latitude.
-                    merc_y_to_lat(merc_y_north - frac_y * (merc_y_north - merc_y_south))
-                } else {
-                    // Linear interpolation in latitude.
-                    north - frac_y * (north - south)
-                }
-            };
-            let grid = ds_core::resample::ProjectionGrid::build(
+            // dominates render CPU for projected sources. The output→world axis
+            // mapping (linear lon/lat, Mercator Y, or a projected output CRS) is
+            // the shared `OutputCrs::project_node`, so EPSG:3067/3035 output is
+            // handled here without per-engine axis math (#160).
+            let grid = ds_core::resample::ProjectionGrid::build_2d(
                 width,
                 height,
                 gt.width,
                 gt.height,
-                lon_at,
-                lat_at,
+                |fx, fy| output_crs.project_node(bbox, fx, fy),
                 |lon, lat| gt.world_to_pixel_f64(lon, lat),
             );
 
@@ -1717,19 +1702,6 @@ impl EdrEngine for GeoTiffEngine {
 
 /// Validate GeoTIFF config for common mistakes that would otherwise cause
 /// confusing runtime behavior.
-/// Convert latitude (degrees) to Web Mercator Y (meters).
-fn lat_to_merc_y(lat_deg: f64) -> f64 {
-    const R: f64 = 6_378_137.0;
-    let lat_rad = lat_deg.to_radians();
-    R * ((std::f64::consts::FRAC_PI_4 + lat_rad / 2.0).tan()).ln()
-}
-
-/// Convert Web Mercator Y (meters) to latitude (degrees).
-fn merc_y_to_lat(y: f64) -> f64 {
-    const R: f64 = 6_378_137.0;
-    (std::f64::consts::FRAC_PI_2 - 2.0 * (-y / R).exp().atan()).to_degrees()
-}
-
 fn validate_config(
     collection_id: &str,
     data_path: Option<&str>,

--- a/crates/engine-geotiff/tests/render_projection.rs
+++ b/crates/engine-geotiff/tests/render_projection.rs
@@ -113,6 +113,49 @@ fn web_mercator_and_wgs84_render_consistently() {
 }
 
 #[test]
+fn renders_projected_geotiff_to_epsg3067() {
+    // Regression for #251/#160: rendering with a *projected* output CRS
+    // (EPSG:3067) must place real data, not a fully-transparent tile. The
+    // source raster is itself TM35FIN, so output crs=3067 is a near-identity
+    // resample and should be at least as well-covered as the WGS84 render.
+    let engine = tm35fin_engine();
+    let crs = ds_core::geo::projected_output_crs("EPSG:3067").expect("3067 defined");
+    // Project COVERED_BBOX into EPSG:3067 metres (the request rectangle a
+    // Finland-native client sends), and derive the WGS84 read window the API
+    // layer would pass alongside it.
+    let proj_bbox = ds_core::geo::projected_envelope(&crs, COVERED_BBOX);
+    let wgs84 = ds_core::geo::wgs84_envelope(&crs, proj_bbox);
+    let output_crs = OutputCrs::Projected {
+        crs,
+        bbox: proj_bbox,
+    };
+    let (w, h) = (256, 256);
+    let tile = engine
+        .get_raster_tile(wgs84, w, h, None, &output_crs, None, None)
+        .expect("projected render should succeed");
+
+    assert_eq!(tile.values.len() as u32, w * h);
+    let data = count_data(&tile);
+    assert!(
+        data > (w * h) as usize / MIN_DATA_FRACTION_DENOM,
+        "EPSG:3067 render must place a broad swath of data, got {data}/{} \
+         (the #251 bug returned 0)",
+        w * h
+    );
+
+    // Sanity: the projected render covers a comparable amount of data to the
+    // WGS84 render over the same geographic region.
+    let wgs = engine
+        .get_raster_tile(COVERED_BBOX, w, h, None, &OutputCrs::Wgs84, None, None)
+        .expect("wgs84 render should succeed");
+    let (dp, dw) = (data as f64, count_data(&wgs) as f64);
+    assert!(
+        (dp - dw).abs() / dw < 0.25,
+        "EPSG:3067 ({dp}) and WGS84 ({dw}) data counts diverge too far"
+    );
+}
+
+#[test]
 fn bbox_outside_coverage_is_empty() {
     let engine = tm35fin_engine();
     // Mid-Atlantic — nowhere near the TM35FIN raster.

--- a/crates/engine-geotiff/tests/render_projection.rs
+++ b/crates/engine-geotiff/tests/render_projection.rs
@@ -124,7 +124,7 @@ fn renders_projected_geotiff_to_epsg3067() {
     // Finland-native client sends), and derive the WGS84 read window the API
     // layer would pass alongside it.
     let proj_bbox = ds_core::geo::projected_envelope(&crs, COVERED_BBOX);
-    let wgs84 = ds_core::geo::wgs84_envelope(&crs, proj_bbox);
+    let wgs84 = ds_core::geo::wgs84_envelope(&crs, proj_bbox).expect("in-domain bbox has envelope");
     let output_crs = OutputCrs::Projected {
         crs,
         bbox: proj_bbox,

--- a/crates/engine-grib/src/cache.rs
+++ b/crates/engine-grib/src/cache.rs
@@ -107,6 +107,14 @@ impl DecodedGrid {
     /// Convert (lon, lat) to (col, row) grid indices plus fractional offsets (dx, dy).
     /// dx/dy are in [0, 1) representing the position within the grid cell.
     fn lonlat_to_fractional(&self, lon: f64, lat: f64) -> Option<(usize, usize, f64, f64)> {
+        // An out-of-domain projected output pixel arrives as NaN (OutputCrs::
+        // Projected inverse failure). NaN must be rejected up front: every
+        // comparison below is false for NaN and `NaN as isize` saturates to 0,
+        // so the bounds guard would pass and this would return grid-origin
+        // data (rendered as a colour) instead of None (transparent).
+        if !lon.is_finite() || !lat.is_finite() {
+            return None;
+        }
         // Normalize longitude to grid range
         let mut lon = lon;
         if lon < self.lon_first {
@@ -312,5 +320,64 @@ impl GridCache {
     /// Whether the cache is currently empty.
     pub fn is_empty(&self) -> bool {
         self.cache.len() == 0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// 2×2 regular lat/lon grid (10–11°E, 59–60°N) for sampling tests.
+    fn grid_2x2() -> DecodedGrid {
+        DecodedGrid {
+            ni: 2,
+            nj: 2,
+            lon_first: 10.0,
+            lat_first: 60.0,
+            lon_inc: 1.0,
+            lat_inc: -1.0,
+            values: Arc::new(vec![1.0, 2.0, 3.0, 4.0]),
+            triple: (0, 0, 0),
+            centre: 0,
+            first_surface_type: 1,
+            first_surface_value: None,
+        }
+    }
+
+    #[test]
+    fn bilinear_value_rejects_nan_lonlat() {
+        // Regression for the OutputCrs::Projected NaN path: an out-of-domain
+        // pixel arrives as NaN and must resolve to None (transparent), not
+        // grid-origin data — NaN bypasses the bounds guard otherwise.
+        let g = grid_2x2();
+        assert_eq!(g.bilinear_value(f64::NAN, 59.5), None);
+        assert_eq!(g.bilinear_value(10.5, f64::NAN), None);
+        assert_eq!(g.bilinear_value(f64::NAN, f64::NAN), None);
+        assert_eq!(g.bilinear_value(f64::INFINITY, 59.5), None);
+        // A normal in-grid sample still returns a value.
+        assert!(g.bilinear_value(10.5, 59.5).is_some());
+    }
+
+    #[test]
+    fn resample_projected_out_of_domain_is_all_none() {
+        // EPSG:3035 (LAEA) inverse is undefined near the antipode of its
+        // centre; a bbox far outside the grid must render fully transparent,
+        // never a NaN/grid-origin colour.
+        let g = grid_2x2();
+        let crs = ds_core::geo::projected_output_crs("EPSG:3035").unwrap();
+        // Projected metres nowhere near the 10–11°E / 59–60°N grid.
+        let out = g.resample(
+            [-5_000_000.0, -5_000_000.0, -4_900_000.0, -4_900_000.0],
+            8,
+            8,
+            &OutputCrs::Projected {
+                crs,
+                bbox: [-5_000_000.0, -5_000_000.0, -4_900_000.0, -4_900_000.0],
+            },
+        );
+        assert!(
+            out.iter().all(|v| v.is_none()),
+            "out-of-domain projected render must be all-None, got {out:?}"
+        );
     }
 }

--- a/crates/engine-grib/src/cache.rs
+++ b/crates/engine-grib/src/cache.rs
@@ -76,12 +76,30 @@ impl DecodedGrid {
         if !col_f.is_finite() || !row_f.is_finite() {
             return None;
         }
-        let col = col_f.floor() as isize;
+        let col = self.wrap_col(col_f).floor() as isize;
         let row = row_f.floor() as isize;
         if col < 0 || col >= self.ni as isize || row < 0 || row >= self.nj as isize {
             return None;
         }
         Some(self.values[row as usize * self.ni + col as usize])
+    }
+
+    /// Wrap a fractional column into `[0, ni)` for (near-)global grids — a
+    /// column outside the grid on a 360°-spanning grid names the same meridian
+    /// one wrap away. Regional grids (span < 360°) don't wrap, so an
+    /// out-of-range column stays out of range (genuine nodata).
+    ///
+    /// The wrap lives here (and is idempotent via `rem_euclid`) rather than in
+    /// [`Self::lonlat_to_src_px`], so the lon→col mapping stays continuous for
+    /// [`ProjectionGrid::build_2d`]'s node interpolation while [`Self::nearest_value`]
+    /// and [`Self::bilinear_at`] still resolve wrapped meridians.
+    fn wrap_col(&self, col_f: f64) -> f64 {
+        let cols_per_360 = 360.0 / self.lon_inc;
+        if (self.ni as f64) >= cols_per_360 - 0.5 {
+            col_f.rem_euclid(cols_per_360)
+        } else {
+            col_f
+        }
     }
 
     /// Bilinear interpolation at (lon, lat).
@@ -93,18 +111,17 @@ impl DecodedGrid {
     }
 
     /// Map (lon, lat) to fractional source-grid pixel `(col_f, row_f)` — the
-    /// cheap affine inverse of the grid's regular lat/lon spacing, plus the
-    /// ±360° longitude normalisation. No bounds or finiteness check: this is the
-    /// per-node mapping fed to [`ProjectionGrid::build_2d`] and the front half of
-    /// [`Self::bilinear_value`]; [`Self::bilinear_at`] does the checking.
+    /// cheap affine inverse of the grid's regular lat/lon spacing.
+    ///
+    /// **No longitude wrap here.** The wrap is applied in [`Self::bilinear_at`]
+    /// instead, so this mapping stays *continuous* in longitude. That matters
+    /// because [`ProjectionGrid::build_2d`] bilinearly interpolates the `col_f`
+    /// values between coarse nodes: if this wrapped, two adjacent nodes
+    /// straddling `lon_first` (e.g. a projected viewport crossing Greenwich on a
+    /// 0–360° global grid) would get `col_f` like 1428 and 12, and the midpoint
+    /// would interpolate to ~720 — sampling ~180° away. No bounds/finiteness
+    /// check: that is [`Self::bilinear_at`]'s job.
     fn lonlat_to_src_px(&self, lon: f64, lat: f64) -> (f64, f64) {
-        let mut lon = lon;
-        if lon < self.lon_first {
-            lon += 360.0;
-        }
-        if lon >= self.lon_first + (self.ni as f64) * self.lon_inc {
-            lon -= 360.0;
-        }
         (
             (lon - self.lon_first) / self.lon_inc,
             (lat - self.lat_first) / self.lat_inc,
@@ -122,6 +139,9 @@ impl DecodedGrid {
         if !col_f.is_finite() || !row_f.is_finite() {
             return None;
         }
+        // Apply the deferred ±360° longitude wrap here (once, idempotently —
+        // replacing the old sequential-`if` that could double-adjust).
+        let col_f = self.wrap_col(col_f);
         let col = col_f.floor() as isize;
         let row = row_f.floor() as isize;
         if col < 0 || col >= self.ni as isize || row < 0 || row >= self.nj as isize {
@@ -142,8 +162,10 @@ impl DecodedGrid {
 
         // Skip interpolation if any neighbor is NaN
         if v00.is_nan() || v10.is_nan() || v01.is_nan() || v11.is_nan() {
-            // Fall back to nearest non-NaN
-            return if !v00.is_nan() { Some(v00) } else { None };
+            // Fall back to the nearest non-NaN of the four neighbours (not just
+            // v00 — otherwise a NaN at v00 with valid v10/v01/v11 would widen the
+            // nodata hole by one source pixel).
+            return [v00, v10, v01, v11].into_iter().find(|v| !v.is_nan());
         }
 
         let val = v00 * (1.0 - dx) * (1.0 - dy)
@@ -412,6 +434,53 @@ mod tests {
         );
         // Every produced value is finite (no NaN leaked through build_2d).
         assert!(out.iter().flatten().all(|v| v.is_finite()));
+    }
+
+    #[test]
+    fn build_2d_projected_handles_lon_first_seam() {
+        // Regression for the #267 round-4 finding: a projected viewport
+        // straddling the grid's lon_first (Greenwich, on a 0–360° global grid)
+        // must not let build_2d interpolate col_f across the wrap seam. The grid
+        // value is cos(lon): ~1 near lon 0, but ~ -1 at lon 180. A seam bug
+        // interpolates adjacent nodes (col ~359 and ~1) to col ~180 and samples
+        // ~ -1; the fix (raw affine in lonlat_to_src_px, wrap in bilinear_at)
+        // keeps col_f continuous so every sample stays near the true meridian.
+        let (ni, nj) = (360usize, 21usize);
+        let mut values = vec![0.0f64; ni * nj];
+        for r in 0..nj {
+            for c in 0..ni {
+                values[r * ni + c] = (c as f64).to_radians().cos(); // c == lon°
+            }
+        }
+        let g = DecodedGrid {
+            ni,
+            nj,
+            lon_first: 0.0,
+            lat_first: 60.0,
+            lon_inc: 1.0,
+            lat_inc: -1.0,
+            values: Arc::new(values),
+            triple: (0, 0, 0),
+            centre: 0,
+            first_surface_type: 1,
+            first_surface_value: None,
+        };
+        let crs = ds_core::geo::projected_output_crs("EPSG:3035").unwrap();
+        // Western Europe, straddling the Greenwich meridian.
+        let proj = ds_core::geo::projected_envelope(&crs, [-5.0, 45.0, 10.0, 55.0]);
+        let read = ds_core::geo::wgs84_envelope(&crs, proj).unwrap();
+        let out = g.resample(read, 64, 64, &OutputCrs::Projected { crs, bbox: proj });
+
+        assert!(
+            out.iter().all(|v| v.is_some()),
+            "the whole viewport is inside the grid; no holes expected"
+        );
+        for v in out.iter().flatten() {
+            assert!(
+                *v > 0.5,
+                "lon_first seam mis-sample: cos={v} (≈ -1 means it sampled ~180° away)"
+            );
+        }
     }
 
     #[test]

--- a/crates/engine-grib/src/cache.rs
+++ b/crates/engine-grib/src/cache.rs
@@ -6,6 +6,8 @@
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
+use ds_core::map_engine::OutputCrs;
+
 /// Cache key: identifies a specific GRIB message.
 /// Uses `Arc<str>` instead of `String` for a smaller allocation (no capacity field).
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
@@ -196,33 +198,31 @@ impl DecodedGrid {
     }
 
     /// Resample grid to output dimensions for map rendering.
-    /// bbox is [west, south, east, north] in WGS84.
+    ///
+    /// `bbox` is the WGS84 bounding box `[west, south, east, north]`. Each output
+    /// pixel's lon/lat comes from the shared [`OutputCrs::project_node`], so the
+    /// output axes follow the requested CRS — linear lon/lat (`Wgs84`),
+    /// equal-Mercator-Y rows (`WebMercator`), or a projected output CRS such as
+    /// EPSG:3067/3035 (`Projected`, inverse-projected per pixel; #160). The
+    /// source is a regular lat/lon grid, so [`Self::bilinear_value`] samples it
+    /// directly from lon/lat — only the projected case adds a per-pixel inverse,
+    /// and the common `Wgs84`/`WebMercator` paths keep their previous arithmetic.
     pub fn resample(
         &self,
         bbox: [f64; 4],
         width: u32,
         height: u32,
-        web_mercator: bool,
+        output_crs: &OutputCrs,
     ) -> Vec<Option<f64>> {
-        let [west, south, east, north] = bbox;
         let w = width as usize;
         let h = height as usize;
         let mut out = Vec::with_capacity(w * h);
 
         for row in 0..h {
-            // For WebMercator, compute latitude using Mercator inverse
-            let lat = if web_mercator {
-                let y_frac = 1.0 - (row as f64 + 0.5) / h as f64;
-                let y_merc_south = south.to_radians().sin().atanh();
-                let y_merc_north = north.to_radians().sin().atanh();
-                let y_merc = y_merc_south + y_frac * (y_merc_north - y_merc_south);
-                y_merc.sinh().atan().to_degrees()
-            } else {
-                north - (row as f64 + 0.5) * (north - south) / h as f64
-            };
-
+            let fy = (row as f64 + 0.5) / h as f64;
             for col in 0..w {
-                let lon = west + (col as f64 + 0.5) * (east - west) / w as f64;
+                let fx = (col as f64 + 0.5) / w as f64;
+                let (lon, lat) = output_crs.project_node(bbox, fx, fy);
                 out.push(self.bilinear_value(lon, lat));
             }
         }

--- a/crates/engine-grib/src/cache.rs
+++ b/crates/engine-grib/src/cache.rs
@@ -70,17 +70,66 @@ impl DecodedGrid {
     }
 
     /// Get the value at the grid point nearest to (lon, lat).
-    /// Returns None if the point is outside the grid.
+    /// Returns None if the point is outside the grid (or non-finite).
     pub fn nearest_value(&self, lon: f64, lat: f64) -> Option<f64> {
-        let (col, row, _, _) = self.lonlat_to_fractional(lon, lat)?;
-        Some(self.values[row * self.ni + col])
+        let (col_f, row_f) = self.lonlat_to_src_px(lon, lat);
+        if !col_f.is_finite() || !row_f.is_finite() {
+            return None;
+        }
+        let col = col_f.floor() as isize;
+        let row = row_f.floor() as isize;
+        if col < 0 || col >= self.ni as isize || row < 0 || row >= self.nj as isize {
+            return None;
+        }
+        Some(self.values[row as usize * self.ni + col as usize])
     }
 
     /// Bilinear interpolation at (lon, lat).
     /// Interpolates between the 4 surrounding grid points.
     /// Returns None if the point is outside the grid.
     pub fn bilinear_value(&self, lon: f64, lat: f64) -> Option<f64> {
-        let (col, row, dx, dy) = self.lonlat_to_fractional(lon, lat)?;
+        let (col_f, row_f) = self.lonlat_to_src_px(lon, lat);
+        self.bilinear_at(col_f, row_f)
+    }
+
+    /// Map (lon, lat) to fractional source-grid pixel `(col_f, row_f)` — the
+    /// cheap affine inverse of the grid's regular lat/lon spacing, plus the
+    /// ±360° longitude normalisation. No bounds or finiteness check: this is the
+    /// per-node mapping fed to [`ProjectionGrid::build_2d`] and the front half of
+    /// [`Self::bilinear_value`]; [`Self::bilinear_at`] does the checking.
+    fn lonlat_to_src_px(&self, lon: f64, lat: f64) -> (f64, f64) {
+        let mut lon = lon;
+        if lon < self.lon_first {
+            lon += 360.0;
+        }
+        if lon >= self.lon_first + (self.ni as f64) * self.lon_inc {
+            lon -= 360.0;
+        }
+        (
+            (lon - self.lon_first) / self.lon_inc,
+            (lat - self.lat_first) / self.lat_inc,
+        )
+    }
+
+    /// Bilinearly sample the grid at fractional source pixel `(col_f, row_f)`.
+    ///
+    /// Returns `None` (transparent) for non-finite inputs or points outside the
+    /// grid. Non-finite is the out-of-domain projected pixel case (`project_node`
+    /// → NaN): it must be rejected up front because `NaN` comparisons are false
+    /// and `NaN as isize` saturates to 0, so the bounds guard would otherwise
+    /// pass and return grid-origin data rendered as a colour.
+    fn bilinear_at(&self, col_f: f64, row_f: f64) -> Option<f64> {
+        if !col_f.is_finite() || !row_f.is_finite() {
+            return None;
+        }
+        let col = col_f.floor() as isize;
+        let row = row_f.floor() as isize;
+        if col < 0 || col >= self.ni as isize || row < 0 || row >= self.nj as isize {
+            return None;
+        }
+        let (col, row) = (col as usize, row as usize);
+        let dx = col_f - col as f64;
+        let dy = row_f - row as f64;
 
         // Right and bottom neighbors (clamp to grid edge)
         let col1 = (col + 1).min(self.ni - 1);
@@ -102,42 +151,6 @@ impl DecodedGrid {
             + v01 * (1.0 - dx) * dy
             + v11 * dx * dy;
         Some(val)
-    }
-
-    /// Convert (lon, lat) to (col, row) grid indices plus fractional offsets (dx, dy).
-    /// dx/dy are in [0, 1) representing the position within the grid cell.
-    fn lonlat_to_fractional(&self, lon: f64, lat: f64) -> Option<(usize, usize, f64, f64)> {
-        // An out-of-domain projected output pixel arrives as NaN (OutputCrs::
-        // Projected inverse failure). NaN must be rejected up front: every
-        // comparison below is false for NaN and `NaN as isize` saturates to 0,
-        // so the bounds guard would pass and this would return grid-origin
-        // data (rendered as a colour) instead of None (transparent).
-        if !lon.is_finite() || !lat.is_finite() {
-            return None;
-        }
-        // Normalize longitude to grid range
-        let mut lon = lon;
-        if lon < self.lon_first {
-            lon += 360.0;
-        }
-        if lon >= self.lon_first + (self.ni as f64) * self.lon_inc {
-            lon -= 360.0;
-        }
-
-        let col_f = (lon - self.lon_first) / self.lon_inc;
-        let row_f = (lat - self.lat_first) / self.lat_inc;
-
-        let col = col_f.floor() as isize;
-        let row = row_f.floor() as isize;
-
-        if col < 0 || col >= self.ni as isize || row < 0 || row >= self.nj as isize {
-            return None;
-        }
-
-        let dx = col_f - col as f64;
-        let dy = row_f - row as f64;
-
-        Some((col as usize, row as usize, dx, dy))
     }
 
     /// Extract a grid subset for the given bbox [west, south, east, north].
@@ -209,16 +222,16 @@ impl DecodedGrid {
     ///
     /// `bbox` is the WGS84 bounding box `[west, south, east, north]`. Each output
     /// pixel's lon/lat comes from the shared [`OutputCrs::project_node`], so the
-    /// output axes follow the requested CRS — linear lon/lat (`Wgs84`),
-    /// equal-Mercator-Y rows (`WebMercator`), or a projected output CRS such as
-    /// EPSG:3067/3035 (`Projected`, inverse-projected per pixel; #160). The
-    /// source is a regular lat/lon grid, so [`Self::bilinear_value`] samples it
-    /// directly from lon/lat — only the projected case adds a per-pixel inverse,
-    /// and the common `Wgs84`/`WebMercator` paths keep their previous arithmetic.
+    /// output axes follow the requested CRS.
     ///
-    /// TODO(#268): the projected path runs `Crs::inverse` per output pixel,
-    /// against the CLAUDE.md "never project per output pixel" rule. Route it
-    /// through `ProjectionGrid::build_2d` like engine-geotiff/odim-COMP do.
+    /// - `Wgs84` / `WebMercator`: `project_node` is cheap (no projection), so we
+    ///   sample per pixel. This path also keeps the ±360° longitude wrap that a
+    ///   global grid needs for viewports crossing the antimeridian.
+    /// - `Projected` (EPSG:3067/3035): `project_node` runs `Crs::inverse` per
+    ///   node — so map output→source through [`ProjectionGrid::build_2d`] (coarse
+    ///   grid + bilinear) rather than per pixel, per the CLAUDE.md "never project
+    ///   per output pixel" rule (matches engine-geotiff/odim-COMP). Projected
+    ///   output is regional, so no cell crosses the antimeridian wrap.
     pub fn resample(
         &self,
         bbox: [f64; 4],
@@ -230,12 +243,32 @@ impl DecodedGrid {
         let h = height as usize;
         let mut out = Vec::with_capacity(w * h);
 
-        for row in 0..h {
-            let fy = (row as f64 + 0.5) / h as f64;
-            for col in 0..w {
-                let fx = (col as f64 + 0.5) / w as f64;
-                let (lon, lat) = output_crs.project_node(bbox, fx, fy);
-                out.push(self.bilinear_value(lon, lat));
+        match output_crs {
+            OutputCrs::Projected { .. } => {
+                let grid = ds_core::resample::ProjectionGrid::build_2d(
+                    width,
+                    height,
+                    self.ni as u32,
+                    self.nj as u32,
+                    |fx, fy| output_crs.project_node(bbox, fx, fy),
+                    |lon, lat| self.lonlat_to_src_px(lon, lat),
+                );
+                for oy in 0..height {
+                    for ox in 0..width {
+                        let (col_f, row_f) = grid.sample(ox, oy);
+                        out.push(self.bilinear_at(col_f, row_f));
+                    }
+                }
+            }
+            OutputCrs::Wgs84 | OutputCrs::WebMercator => {
+                for row in 0..h {
+                    let fy = (row as f64 + 0.5) / h as f64;
+                    for col in 0..w {
+                        let fx = (col as f64 + 0.5) / w as f64;
+                        let (lon, lat) = output_crs.project_node(bbox, fx, fy);
+                        out.push(self.bilinear_value(lon, lat));
+                    }
+                }
             }
         }
 
@@ -359,10 +392,33 @@ mod tests {
     }
 
     #[test]
+    fn resample_projected_in_domain_has_data_via_build_2d() {
+        // The OutputCrs::Projected path goes through ProjectionGrid::build_2d
+        // (no per-pixel inverse). A projected bbox covering the 10–11°E/59–60°N
+        // grid must resample to real values, not all-None.
+        let g = grid_2x2();
+        let crs = ds_core::geo::projected_output_crs("EPSG:3035").unwrap();
+        // Forward the grid's WGS84 footprint into EPSG:3035 metres.
+        let proj = ds_core::geo::projected_envelope(&crs, [10.0, 59.0, 11.0, 60.0]);
+        let out = g.resample(
+            ds_core::geo::wgs84_envelope(&crs, proj).unwrap(),
+            16,
+            16,
+            &OutputCrs::Projected { crs, bbox: proj },
+        );
+        assert!(
+            out.iter().any(|v| v.is_some()),
+            "projected render over the grid footprint must place data"
+        );
+        // Every produced value is finite (no NaN leaked through build_2d).
+        assert!(out.iter().flatten().all(|v| v.is_finite()));
+    }
+
+    #[test]
     fn resample_projected_out_of_domain_is_all_none() {
-        // EPSG:3035 (LAEA) inverse is undefined near the antipode of its
-        // centre; a bbox far outside the grid must render fully transparent,
-        // never a NaN/grid-origin colour.
+        // A projected bbox whose inverse-projected lon/lat fall far outside the
+        // 10–11°E / 59–60°N grid must render fully transparent — every sample
+        // resolves off-grid (or NaN) → None, never a grid-origin colour.
         let g = grid_2x2();
         let crs = ds_core::geo::projected_output_crs("EPSG:3035").unwrap();
         // Projected metres nowhere near the 10–11°E / 59–60°N grid.

--- a/crates/engine-grib/src/cache.rs
+++ b/crates/engine-grib/src/cache.rs
@@ -207,6 +207,10 @@ impl DecodedGrid {
     /// source is a regular lat/lon grid, so [`Self::bilinear_value`] samples it
     /// directly from lon/lat — only the projected case adds a per-pixel inverse,
     /// and the common `Wgs84`/`WebMercator` paths keep their previous arithmetic.
+    ///
+    /// TODO(#268): the projected path runs `Crs::inverse` per output pixel,
+    /// against the CLAUDE.md "never project per output pixel" rule. Route it
+    /// through `ProjectionGrid::build_2d` like engine-geotiff/odim-COMP do.
     pub fn resample(
         &self,
         bbox: [f64; 4],

--- a/crates/engine-grib/src/lib.rs
+++ b/crates/engine-grib/src/lib.rs
@@ -1172,8 +1172,7 @@ impl MapEngine for GribEngine {
 
         let grid = self.fetch_grid(&step_file, param_name, level)?;
 
-        let web_mercator = matches!(output_crs, OutputCrs::WebMercator);
-        let values = grid.resample(bbox, width, height, web_mercator);
+        let values = grid.resample(bbox, width, height, output_crs);
 
         // Apply unit conversion so colormap ranges use display units.
         // fetch_grid populates the metadata cache from the decoded message's

--- a/crates/engine-odim/src/engine.rs
+++ b/crates/engine-odim/src/engine.rs
@@ -635,29 +635,6 @@ fn source_label(source: &Source) -> String {
     }
 }
 
-/// Convert WGS84 latitude (degrees) to Web Mercator Y (metres).
-/// Used to interpolate output-row latitudes in equal-Mercator-Y
-/// steps when `OutputCrs::WebMercator` is requested.
-fn lat_to_merc_y(lat_deg: f64) -> f64 {
-    const R: f64 = 6_378_137.0;
-    let lat_rad = lat_deg.to_radians();
-    R * ((std::f64::consts::FRAC_PI_4 + lat_rad / 2.0).tan()).ln()
-}
-
-/// Inverse of [`lat_to_merc_y`].
-///
-/// The formula `π/2 - 2·atan(exp(-y/R))` is algebraically
-/// equivalent to the standard EPSG:3857 inverse
-/// `2·atan(exp(y/R)) - π/2`, but uses the negated exponent so the
-/// `exp()` term decays toward zero as |y| grows rather than growing
-/// without bound — that keeps the math numerically stable across the
-/// full ±π/2 latitude range under f64 arithmetic. EPSG:3857 dataset:
-/// https://epsg.io/3857.
-fn merc_y_to_lat(y: f64) -> f64 {
-    const R: f64 = 6_378_137.0;
-    (std::f64::consts::FRAC_PI_2 - 2.0 * (-y / R).exp().atan()).to_degrees()
-}
-
 impl MapEngine for OdimEngine {
     fn get_raster_tile(
         &self,
@@ -677,17 +654,10 @@ impl MapEngine for OdimEngine {
         })?;
         let composite = self.load_composite(&entry.location)?;
 
-        let [west, south, east, north] = bbox;
         let gain = self.gain_override.unwrap_or(composite.gain);
         let offset = self.offset_override.unwrap_or(composite.offset);
         let nodata = self.nodata_override.unwrap_or(composite.nodata);
         let undetect = composite.undetect;
-
-        let (merc_y_north, merc_y_south) = if *output_crs == OutputCrs::WebMercator {
-            (lat_to_merc_y(north), lat_to_merc_y(south))
-        } else {
-            (0.0, 0.0)
-        };
 
         let [src_w, src_s, src_e, src_n] = composite.bbox;
         let src_dx = (src_e - src_w) / composite.xsize as f64;
@@ -698,18 +668,10 @@ impl MapEngine for OdimEngine {
         // instead of forward-projecting every pixel: `crs.forward` is a full
         // CRS transform (≈ a dozen transcendental ops for TM/LAEA/LCC/Stereo)
         // and per-pixel it dominates render CPU on large viewports (#236/#203).
-        let to_web_mercator = *output_crs == OutputCrs::WebMercator;
-        let lon_at = |frac_x: f64| west + frac_x * (east - west);
-        let lat_at = |frac_y: f64| {
-            if to_web_mercator {
-                // In Mercator, pixels have equal spacing in Y meters:
-                // interpolate in Mercator Y, then convert back to latitude.
-                merc_y_to_lat(merc_y_north - frac_y * (merc_y_north - merc_y_south))
-            } else {
-                // Linear interpolation in latitude.
-                north - frac_y * (north - south)
-            }
-        };
+        // The output→world axis mapping (linear lon/lat, Mercator Y, or a
+        // projected output CRS such as EPSG:3067/3035) is the shared
+        // `OutputCrs::project_node` (#160).
+        //
         // World (lon/lat) → fractional source pixel. ODIM rows go north→south,
         // so the row index counts from the north edge — that orientation lives
         // here, not in the sampling loop.
@@ -717,13 +679,12 @@ impl MapEngine for OdimEngine {
             let (x, y) = composite.crs.forward(lon, lat);
             ((x - src_w) / src_dx, (src_n - y) / src_dy)
         };
-        let grid = ProjectionGrid::build(
+        let grid = ProjectionGrid::build_2d(
             width,
             height,
             cols as u32,
             rows as u32,
-            lon_at,
-            lat_at,
+            |fx, fy| output_crs.project_node(bbox, fx, fy),
             world_to_src_px,
         );
 
@@ -807,18 +768,6 @@ fn crs_label(crs: &Crs) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn lat_merc_round_trip_is_identity() {
-        for lat in [-60.0, -30.0, 0.0, 30.0, 60.0] {
-            let y = lat_to_merc_y(lat);
-            let lat_back = merc_y_to_lat(y);
-            assert!(
-                (lat - lat_back).abs() < 1e-9,
-                "lat={lat} y={y} back={lat_back}"
-            );
-        }
-    }
 
     #[test]
     fn crs_label_covers_every_variant() {

--- a/crates/engine-odim/src/volume_engine.rs
+++ b/crates/engine-odim/src/volume_engine.rs
@@ -1025,6 +1025,11 @@ fn polar_sample(
     // this loop maps each pixel's WGS84 lon/lat with the shared
     // `OutputCrs::project_node` directly — covering linear lon/lat, Mercator Y,
     // and projected output CRSs (EPSG:3067/3035) in one place (#160).
+    //
+    // For `OutputCrs::Projected` this adds one `Crs::inverse` per pixel on top of
+    // the inherent per-pixel polar geometry. A coarse-grid map (as the gridded
+    // engines use) doesn't drop in cleanly here because the polar sampler is not
+    // a smooth source-pixel function; tracked in #268 if it proves to matter.
     let mut values: Vec<Option<f64>> = Vec::with_capacity((width as usize) * (height as usize));
     for oy in 0..height {
         let frac_y = (oy as f64 + 0.5) / height as f64;

--- a/crates/engine-odim/src/volume_engine.rs
+++ b/crates/engine-odim/src/volume_engine.rs
@@ -87,9 +87,6 @@ pub const SITE_QUANTITY_SEP: char = ':';
 /// ranges (≤ ~250 km) is far below one output pixel.
 const EARTH_RADIUS_M: f64 = 6_371_000.0;
 
-/// Web-Mercator sphere radius (metres) — EPSG:3857 uses 6378137.
-const MERC_RADIUS_M: f64 = 6_378_137.0;
-
 // ---------------------------------------------------------------------------
 // Geodesic helper
 // ---------------------------------------------------------------------------
@@ -123,21 +120,6 @@ pub fn ground_distance_bearing(lon0: f64, lat0: f64, lon1: f64, lat1: f64) -> (f
     let bearing = y.atan2(x).to_degrees().rem_euclid(360.0);
 
     (distance, bearing)
-}
-
-// ---------------------------------------------------------------------------
-// Web-Mercator row interpolation (mirrors engine.rs)
-// ---------------------------------------------------------------------------
-
-/// WGS84 latitude (degrees) → Web-Mercator Y (metres).
-fn lat_to_merc_y(lat_deg: f64) -> f64 {
-    let lat_rad = lat_deg.to_radians();
-    MERC_RADIUS_M * ((std::f64::consts::FRAC_PI_4 + lat_rad / 2.0).tan()).ln()
-}
-
-/// Inverse of [`lat_to_merc_y`].
-fn merc_y_to_lat(y: f64) -> f64 {
-    (std::f64::consts::FRAC_PI_2 - 2.0 * (-y / MERC_RADIUS_M).exp().atan()).to_degrees()
 }
 
 // ---------------------------------------------------------------------------
@@ -978,11 +960,11 @@ fn nearest_sweep(volume: &PolarVolume, target: f64) -> Option<&Sweep> {
 
 /// Resample one polar moment of a sweep into a Cartesian output grid.
 ///
-/// `bbox` is `[west, south, east, north]` in WGS84 degrees. For
-/// [`OutputCrs::WebMercator`], output row latitudes are interpolated in
-/// Mercator-Y so pixels are square in the projection; for
-/// [`OutputCrs::Wgs84`] they are linear in latitude. For each output
-/// pixel centre the algorithm:
+/// `bbox` is `[west, south, east, north]` in WGS84 degrees. Each output pixel's
+/// WGS84 lon/lat comes from [`OutputCrs::project_node`], so the output axes
+/// follow the requested CRS: linear lon/lat for `Wgs84`, equal-Mercator-Y rows
+/// for `WebMercator`, or linear-in-projected-metres for a `Projected` CRS
+/// (EPSG:3067/3035). For each output pixel centre the algorithm:
 ///
 /// 1. computes ground distance + azimuth from the site via
 ///    [`ground_distance_bearing`];
@@ -1031,7 +1013,6 @@ fn polar_sample(
             ))
         })?;
 
-    let [west, south, east, north] = bbox;
     let (site_lon, site_lat) = (volume.site.lon, volume.site.lat);
     if sweep.nrays == 0 || sweep.nbins == 0 {
         return Err(DataServerError::Engine(
@@ -1039,24 +1020,17 @@ fn polar_sample(
         ));
     }
 
-    let (merc_y_north, merc_y_south) = if *output_crs == OutputCrs::WebMercator {
-        (lat_to_merc_y(north), lat_to_merc_y(south))
-    } else {
-        (0.0, 0.0)
-    };
-
+    // Polar sampling is inherently per-pixel (each output pixel resolves to a
+    // ground distance + bearing from the site), so unlike the gridded engines
+    // this loop maps each pixel's WGS84 lon/lat with the shared
+    // `OutputCrs::project_node` directly — covering linear lon/lat, Mercator Y,
+    // and projected output CRSs (EPSG:3067/3035) in one place (#160).
     let mut values: Vec<Option<f64>> = Vec::with_capacity((width as usize) * (height as usize));
     for oy in 0..height {
         let frac_y = (oy as f64 + 0.5) / height as f64;
-        let lat = if *output_crs == OutputCrs::WebMercator {
-            let merc_y = merc_y_north - frac_y * (merc_y_north - merc_y_south);
-            merc_y_to_lat(merc_y)
-        } else {
-            north - frac_y * (north - south)
-        };
         for ox in 0..width {
             let frac_x = (ox as f64 + 0.5) / width as f64;
-            let lon = west + frac_x * (east - west);
+            let (lon, lat) = output_crs.project_node(bbox, frac_x, frac_y);
 
             values.push(sample_sweep_moment(
                 sweep, moment, site_lon, site_lat, lon, lat,

--- a/crates/engine-odim/src/volume_engine.rs
+++ b/crates/engine-odim/src/volume_engine.rs
@@ -1031,6 +1031,14 @@ fn polar_sample(
         for ox in 0..width {
             let frac_x = (ox as f64 + 0.5) / width as f64;
             let (lon, lat) = output_crs.project_node(bbox, frac_x, frac_y);
+            // An out-of-domain projected output pixel arrives as NaN (OutputCrs::
+            // Projected inverse failure). NaN would propagate through
+            // ground_distance_bearing and saturate to (ray=0, bin=0), returning
+            // real radar data at the sweep origin instead of None (transparent).
+            if !lon.is_finite() || !lat.is_finite() {
+                values.push(None);
+                continue;
+            }
 
             values.push(sample_sweep_moment(
                 sweep, moment, site_lon, site_lat, lon, lat,

--- a/crates/engine-querydata/src/engine.rs
+++ b/crates/engine-querydata/src/engine.rs
@@ -329,21 +329,47 @@ impl MapEngine for QueryDataEngine {
         let mut values = Vec::with_capacity((width * height) as usize);
 
         // Each output pixel's WGS84 lon/lat comes from the shared
-        // `OutputCrs::project_node`: linear lon/lat (`Wgs84`), equal-Mercator-Y
-        // rows (`WebMercator`), or a projected output CRS such as EPSG:3067/3035
-        // (`Projected`, inverse-projected per pixel; #160). `interpolate` then
-        // bilinearly samples the source grid (which may itself be projected) at
-        // that lon/lat.
-        //
-        // TODO(#268): the projected path runs `Crs::inverse` per output pixel,
-        // against the CLAUDE.md "never project per output pixel" rule. Route it
-        // through `ProjectionGrid::build_2d` like engine-geotiff/odim-COMP do.
-        for row in 0..height {
-            let fy = (row as f64 + 0.5) / height as f64;
-            for col in 0..width {
-                let fx = (col as f64 + 0.5) / width as f64;
-                let (lon, lat) = output_crs.project_node(bbox, fx, fy);
-                values.push(interpolate(&data, lon, lat, param_idx, 0, time_idx));
+        // `OutputCrs::project_node` (linear lon/lat, Mercator-Y, or a projected
+        // output CRS; #160), and the source grid — itself possibly projected
+        // (stereographic / rotated lat-lon) — is sampled by `world_to_grid_px`
+        // (`Crs::forward` + affine) then bilinear.
+        match output_crs {
+            OutputCrs::Projected { .. } => {
+                // Projected output runs `Crs::inverse` per node, and the source
+                // mapping runs `Crs::forward` per node; compose both into a
+                // coarse `ProjectionGrid` and bilinearly interpolate the
+                // output→source pixel map, rather than projecting per output
+                // pixel (CLAUDE.md "never project per output pixel"; #268). This
+                // also removes the per-pixel *source* forward projection on this
+                // path. Projected output is regional, so the grid stays accurate.
+                let gt = data.grid.geo_transform();
+                let grid = ds_core::resample::ProjectionGrid::build_2d(
+                    width,
+                    height,
+                    data.grid.nx,
+                    data.grid.ny,
+                    |fx, fy| output_crs.project_node(bbox, fx, fy),
+                    |lon, lat| world_to_grid_px(&gt, lon, lat),
+                );
+                for oy in 0..height {
+                    for ox in 0..width {
+                        let (col_f, row_f) = grid.sample(ox, oy);
+                        values.push(sample_grid_bilinear(
+                            &data, col_f, row_f, param_idx, 0, time_idx,
+                        ));
+                    }
+                }
+            }
+            OutputCrs::Wgs84 | OutputCrs::WebMercator => {
+                // `project_node` is cheap here (no projection); sample per pixel.
+                for row in 0..height {
+                    let fy = (row as f64 + 0.5) / height as f64;
+                    for col in 0..width {
+                        let fx = (col as f64 + 0.5) / width as f64;
+                        let (lon, lat) = output_crs.project_node(bbox, fx, fy);
+                        values.push(interpolate(&data, lon, lat, param_idx, 0, time_idx));
+                    }
+                }
             }
         }
 
@@ -450,6 +476,10 @@ fn log_loaded(collection_id: &str, path: &Path, data: &QueryData) {
 }
 
 /// Bilinear interpolation at (lon, lat) for a given parameter and time.
+///
+/// Used by EDR position queries and the `Wgs84`/`WebMercator` map path. The
+/// projected map path instead drives [`sample_grid_bilinear`] through a coarse
+/// [`ProjectionGrid`] to avoid per-pixel projection (#268).
 fn interpolate(
     data: &QueryData,
     lon: f64,
@@ -458,20 +488,47 @@ fn interpolate(
     level_idx: usize,
     time_idx: usize,
 ) -> Option<f64> {
-    // An out-of-domain projected output pixel arrives as NaN (OutputCrs::
-    // Projected inverse failure). Reject before the forward transform: NaN
-    // comparisons are false and `NaN as i64/usize` saturates to 0, so the
-    // bounds guards below would pass and return grid-origin data instead of
-    // None (transparent).
+    // An out-of-domain projected output pixel arrives as NaN; reject before the
+    // forward transform (see `sample_grid_bilinear` for why NaN is dangerous).
     if !lon.is_finite() || !lat.is_finite() {
         return None;
     }
-
     let gt = data.grid.geo_transform();
-    let (x, y) = gt.crs.forward(lon, lat);
+    let (col_f, row_f) = world_to_grid_px(&gt, lon, lat);
+    sample_grid_bilinear(data, col_f, row_f, param_idx, level_idx, time_idx)
+}
 
-    let col_f = (x - gt.origin_x) / gt.pixel_width - 0.5;
-    let row_f = (gt.origin_y - y) / gt.pixel_height - 0.5;
+/// Map WGS84 (lon, lat) to fractional source-grid pixel `(col_f, row_f)` — the
+/// source `Crs::forward` plus the grid's affine, with the half-pixel centre
+/// offset. This is the (possibly projected) per-node mapping fed to
+/// [`ProjectionGrid::build_2d`] and the front half of [`interpolate`].
+fn world_to_grid_px(gt: &ds_core::geo::GeoTransform, lon: f64, lat: f64) -> (f64, f64) {
+    let (x, y) = gt.crs.forward(lon, lat);
+    (
+        (x - gt.origin_x) / gt.pixel_width - 0.5,
+        (gt.origin_y - y) / gt.pixel_height - 0.5,
+    )
+}
+
+/// Bilinearly sample the grid at fractional source pixel `(col_f, row_f)`,
+/// falling back to nearest when a bilinear neighbour is nodata.
+///
+/// Returns `None` (transparent) for non-finite inputs or points off the grid.
+/// Non-finite is the out-of-domain projected pixel case (`project_node` → NaN):
+/// rejected up front because NaN comparisons are false and `NaN as i64/usize`
+/// saturates to 0, so the bounds guards would otherwise pass and return
+/// grid-origin data.
+fn sample_grid_bilinear(
+    data: &QueryData,
+    col_f: f64,
+    row_f: f64,
+    param_idx: usize,
+    level_idx: usize,
+    time_idx: usize,
+) -> Option<f64> {
+    if !col_f.is_finite() || !row_f.is_finite() {
+        return None;
+    }
 
     let col0 = col_f.floor() as i64;
     let row0 = row_f.floor() as i64;
@@ -717,6 +774,44 @@ mod tests {
         assert_eq!(tile.values.len(), 256);
         let non_none = tile.values.iter().filter(|v| v.is_some()).count();
         assert!(non_none > 0, "Tile should have some data values");
+    }
+
+    #[test]
+    fn map_engine_raster_tile_projected_via_build_2d() {
+        // Exercises the OutputCrs::Projected coarse-grid path (#268). TM math is
+        // globally valid, so projecting the fixture's own region into EPSG:3067
+        // metres and back must still place data and never leak NaN — even though
+        // the fixture is nowhere near the TM35FIN zone.
+        if !test_file_exists() {
+            return;
+        }
+        let engine =
+            QueryDataEngine::new(&test_dir(), "test", Some("2 Metre Temperature (2t)"), 30)
+                .unwrap();
+        let crs = ds_core::geo::projected_output_crs("EPSG:3067").unwrap();
+        let proj = ds_core::geo::projected_envelope(&crs, [33.0, -5.0, 42.0, 5.0]);
+        let read = ds_core::geo::wgs84_envelope(&crs, proj).expect("in-domain envelope");
+        let tile = engine
+            .get_raster_tile(
+                read,
+                16,
+                16,
+                None,
+                &OutputCrs::Projected { crs, bbox: proj },
+                None,
+                None,
+            )
+            .unwrap();
+
+        assert_eq!(tile.values.len(), 256);
+        assert!(
+            tile.values.iter().filter(|v| v.is_some()).count() > 0,
+            "projected build_2d tile should have data"
+        );
+        assert!(
+            tile.values.iter().flatten().all(|v| v.is_finite()),
+            "no NaN may leak through the build_2d path"
+        );
     }
 
     #[test]

--- a/crates/engine-querydata/src/engine.rs
+++ b/crates/engine-querydata/src/engine.rs
@@ -458,6 +458,15 @@ fn interpolate(
     level_idx: usize,
     time_idx: usize,
 ) -> Option<f64> {
+    // An out-of-domain projected output pixel arrives as NaN (OutputCrs::
+    // Projected inverse failure). Reject before the forward transform: NaN
+    // comparisons are false and `NaN as i64/usize` saturates to 0, so the
+    // bounds guards below would pass and return grid-origin data instead of
+    // None (transparent).
+    if !lon.is_finite() || !lat.is_finite() {
+        return None;
+    }
+
     let gt = data.grid.geo_transform();
     let (x, y) = gt.crs.forward(lon, lat);
 

--- a/crates/engine-querydata/src/engine.rs
+++ b/crates/engine-querydata/src/engine.rs
@@ -326,23 +326,19 @@ impl MapEngine for QueryDataEngine {
             DataServerError::Engine("No data available for the requested time".into())
         })?;
 
-        let [west, south, east, north] = bbox;
         let mut values = Vec::with_capacity((width * height) as usize);
 
+        // Each output pixel's WGS84 lon/lat comes from the shared
+        // `OutputCrs::project_node`: linear lon/lat (`Wgs84`), equal-Mercator-Y
+        // rows (`WebMercator`), or a projected output CRS such as EPSG:3067/3035
+        // (`Projected`, inverse-projected per pixel; #160). `interpolate` then
+        // bilinearly samples the source grid (which may itself be projected) at
+        // that lon/lat.
         for row in 0..height {
-            let lat = match output_crs {
-                OutputCrs::Wgs84 => north - (row as f64 + 0.5) * (north - south) / height as f64,
-                OutputCrs::WebMercator => {
-                    let merc_north = lat_to_merc_y(north);
-                    let merc_south = lat_to_merc_y(south);
-                    let merc_y =
-                        merc_north - (row as f64 + 0.5) * (merc_north - merc_south) / height as f64;
-                    merc_y_to_lat(merc_y)
-                }
-            };
-
+            let fy = (row as f64 + 0.5) / height as f64;
             for col in 0..width {
-                let lon = west + (col as f64 + 0.5) * (east - west) / width as f64;
+                let fx = (col as f64 + 0.5) / width as f64;
+                let (lon, lat) = output_crs.project_node(bbox, fx, fy);
                 values.push(interpolate(&data, lon, lat, param_idx, 0, time_idx));
             }
         }
@@ -586,17 +582,6 @@ fn parse_coords(coords: &str) -> Result<(f64, f64), DataServerError> {
     Err(DataServerError::InvalidParameter(
         "Expected POINT(lon lat) or lon,lat format".into(),
     ))
-}
-
-fn lat_to_merc_y(lat_deg: f64) -> f64 {
-    const R: f64 = 6_378_137.0;
-    let lat_rad = lat_deg.to_radians();
-    R * ((std::f64::consts::FRAC_PI_4 + lat_rad / 2.0).tan()).ln()
-}
-
-fn merc_y_to_lat(y: f64) -> f64 {
-    const R: f64 = 6_378_137.0;
-    (std::f64::consts::FRAC_PI_2 - 2.0 * (-y / R).exp().atan()).to_degrees()
 }
 
 #[cfg(test)]

--- a/crates/engine-querydata/src/engine.rs
+++ b/crates/engine-querydata/src/engine.rs
@@ -334,6 +334,10 @@ impl MapEngine for QueryDataEngine {
         // (`Projected`, inverse-projected per pixel; #160). `interpolate` then
         // bilinearly samples the source grid (which may itself be projected) at
         // that lon/lat.
+        //
+        // TODO(#268): the projected path runs `Crs::inverse` per output pixel,
+        // against the CLAUDE.md "never project per output pixel" rule. Route it
+        // through `ProjectionGrid::build_2d` like engine-geotiff/odim-COMP do.
         for row in 0..height {
             let fy = (row as f64 + 0.5) / height as f64;
             for col in 0..width {


### PR DESCRIPTION
## Problem

WMS/Maps `GetMap` with `CRS=EPSG:3067` (or `EPSG:3035`) returned a **fully-transparent PNG** for every Finland-bbox radar layer (#251). The projected-metre `BBOX` was handed to the engine as if it were WGS84 degrees, so every output pixel sampled far outside the raster.

Root cause (#160): each map engine independently mapped output pixels → lon/lat and only handled `Wgs84`/`WebMercator`, so the same gap reproduced across **all five engines** (geotiff composites, odim COMP + PVOL, grib, querydata). FMI GeoServer renders the same 3067 bbox fine, so this was silently advertised-but-broken.

## Fix (option 3 from #160 — consolidate, don't patch five copies)

The projection *math* (`Crs::forward`/`inverse`) was already shared in `ds-core`; the per-engine **output-axis glue** was not. This PR moves that glue into `ds-core` too:

- **ds-core**: `OutputCrs::Projected { crs, bbox }` (bbox = projected metres) + `OutputCrs::project_node(wgs84_bbox, fx, fy)` — the single shared output→world mapping. Canonical `lat_to_merc_y`/`merc_y_to_lat` now live here.
- **ds-core/resample**: `ProjectionGrid::build_2d` for the non-separable projected axes (`build()` kept as a separable wrapper).
- **ds-core/geo**: `projected_output_crs` (3067=TM35FIN, 3035=ETRS89-LAEA), `wgs84_envelope` (inverse, promoted from engine-odim), `projected_envelope` (forward, for api-maps); `Crs` derives `PartialEq`.
- **Engines**: geotiff + odim COMP use `build_2d` + `project_node`; odim PVOL, grib, querydata call `project_node` per pixel. Per-engine Mercator copies deleted — **no behaviour change for Wgs84/WebMercator** (project_node reproduces the existing arithmetic).
- **api-wms**: `parse_bbox` → `(bbox, OutputCrs)`; projected metres become `Projected` + an inverse-projected WGS84 read window.
- **api-maps**: `bbox-crs` is CRS:84, so it forward-projects the geographic bbox to the projected frame.
- **api-tiles**: unaffected (only WebMercatorQuad/WorldCRS84Quad TMS — no projected CRS, contrary to #160's note).

## Tests

- `engine-geotiff/tests/render_projection.rs::renders_projected_geotiff_to_epsg3067` — asserts a 3067 render places a broad swath of data (the bug returned 0 pixels) and tracks the WGS84 render.
- ds-core `project_node_*` / `envelope_*` (incl. an absolute EPSG pin: 3035 centre → false E/N exactly).
- api-wms `test_bbox_epsg3067_projected` (+ 3035), api-maps `validate_projected_output_crs_3067`.

Full `cargo test --workspace`: **1115 passed, 0 failed**. `cargo fmt` + `clippy --all-targets` clean.

Closes #251
Closes #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)