### PR TITLE
fix(engine-odim): dedup PVOL VerticalProfile z-axis elevation angles

### DIFF
--- a/crates/engine-odim/src/volume_engine.rs
+++ b/crates/engine-odim/src/volume_engine.rs
@@ -1268,7 +1268,10 @@ fn volume_profile(entry: &VolumeEntry, lon: f64, lat: f64, quantities: &[String]
                     .volume
                     .sweeps
                     .iter()
-                    .filter(|s| round_elevation(s.elangle) == level)
+                    // `total_cmp` (not `==`) to stay consistent with the
+                    // `dedup_by` that built `levels`: a NaN level matches the
+                    // NaN-angle sweep instead of matching nothing.
+                    .filter(|s| round_elevation(s.elangle).total_cmp(&level).is_eq())
                     // First non-null sample among the cuts at this angle that
                     // carry the quantity: a cut missing the quantity, or one
                     // returning nodata at this point, falls through to its

--- a/crates/engine-odim/src/volume_engine.rs
+++ b/crates/engine-odim/src/volume_engine.rs
@@ -269,7 +269,14 @@ struct Catalog {
 /// Round an elevation angle to 0.1° so near-identical sweep angles from
 /// different sites or volumes collapse to one catalogue level.
 fn round_elevation(deg: f64) -> f64 {
-    (deg * 10.0).round() / 10.0
+    let r = (deg * 10.0).round() / 10.0;
+    // Normalise -0.0 → +0.0 so downstream dedup/equality treats slightly-
+    // negative grazing angles as a single zero level.
+    if r == 0.0 {
+        0.0
+    } else {
+        r
+    }
 }
 
 /// WGS84 bounding box `[w, s, e, n]` of the circular coverage area of
@@ -684,10 +691,11 @@ fn derive_catalog(
         .flat_map(|e| e.volume.sweeps.iter().map(|s| round_elevation(s.elangle)))
         .collect();
     // Drop non-finite angles before the extent — see the matching filter in
-    // `volume_profile`. `total_cmp` keeps a total order for sort + dedup.
+    // `volume_profile`. `round_elevation` normalises -0.0 → +0.0, so plain
+    // `dedup` after `sort_by(total_cmp)` collapses every duplicate.
     levels.retain(|v| v.is_finite());
     levels.sort_by(f64::total_cmp);
-    levels.dedup_by(|a, b| a.total_cmp(b).is_eq());
+    levels.dedup();
     let vertical =
         (!levels.is_empty()).then(|| VerticalDimension::new(VerticalKind::ElevationAngle, levels));
 
@@ -1255,11 +1263,11 @@ fn volume_profile(entry: &VolumeEntry, lon: f64, lat: f64, quantities: &[String]
         .collect();
     // Drop non-finite angles (a malformed file with a NaN elangle) before
     // they reach the z axis — a NaN there serialises to JSON `null` and
-    // breaks the numeric axis. `total_cmp` (not `==`) keeps a total order for
-    // the sort + dedup over the remaining finite f64s.
+    // breaks the numeric axis. `round_elevation` normalises -0.0 to +0.0,
+    // so plain `dedup` after `sort_by(total_cmp)` collapses every duplicate.
     levels.retain(|v| v.is_finite());
     levels.sort_by(f64::total_cmp);
-    levels.dedup_by(|a, b| a.total_cmp(b).is_eq());
+    levels.dedup();
     let (site_lon, site_lat) = (entry.volume.site.lon, entry.volume.site.lat);
 
     let mut ranges = HashMap::new();
@@ -1268,21 +1276,21 @@ fn volume_profile(entry: &VolumeEntry, lon: f64, lat: f64, quantities: &[String]
         let values: Vec<Option<f64>> = levels
             .iter()
             .map(|&level| {
+                // For a split cut (two sweeps at the same nominal angle, e.g.
+                // a surveillance and a Doppler cut), the *first* sweep that
+                // carries the quantity is authoritative — its sample stands
+                // even when nodata, so a genuine no-echo is not silently
+                // replaced by the sibling's measurement.
                 entry
                     .volume
                     .sweeps
                     .iter()
-                    // `total_cmp` (not `==`) to stay consistent with the
-                    // `dedup_by` that built `levels`: a NaN level matches the
-                    // NaN-angle sweep instead of matching nothing.
-                    .filter(|s| round_elevation(s.elangle).total_cmp(&level).is_eq())
-                    // First non-null sample among the cuts at this angle that
-                    // carry the quantity: a cut missing the quantity, or one
-                    // returning nodata at this point, falls through to its
-                    // split-cut sibling. With a single sweep this is just that
-                    // sweep's sample (None when absent or nodata).
-                    .find_map(|sweep| {
-                        let moment = sweep.moments.iter().find(|m| &m.quantity == quantity)?;
+                    .find(|s| {
+                        round_elevation(s.elangle) == level
+                            && s.moments.iter().any(|m| m.quantity == *quantity)
+                    })
+                    .and_then(|sweep| {
+                        let moment = sweep.moments.iter().find(|m| m.quantity == *quantity)?;
                         sample_sweep_moment(sweep, moment, site_lon, site_lat, lon, lat)
                     })
             })
@@ -1640,6 +1648,21 @@ mod tests {
     use crate::pvol::RadarSite;
     use crate::reader::RawPixels;
     use ndarray::Array2;
+
+    /// `round_elevation` collapses a slightly-negative grazing angle to a
+    /// canonical `+0.0` — otherwise `-0.0` and `+0.0` would survive dedup and
+    /// the z axis would carry both as separate "0" levels.
+    #[test]
+    fn round_elevation_normalises_negative_zero() {
+        let r = round_elevation(-0.04);
+        assert_eq!(r, 0.0);
+        assert!(
+            r.is_sign_positive(),
+            "expected +0.0 after normalisation, got {r}"
+        );
+        // NaN propagates (caller is responsible for filtering with retain).
+        assert!(round_elevation(f64::NAN).is_nan());
+    }
 
     /// A pixel due north of the site has bearing ≈ 0°.
     #[test]

--- a/crates/engine-odim/src/volume_engine.rs
+++ b/crates/engine-odim/src/volume_engine.rs
@@ -684,7 +684,9 @@ fn derive_catalog(
         .flat_map(|e| e.volume.sweeps.iter().map(|s| round_elevation(s.elangle)))
         .collect();
     levels.sort_by(f64::total_cmp);
-    levels.dedup();
+    // `total_cmp` (not `==`) so a NaN elevation still deduplicates — see
+    // the matching dedup in `volume_profile`.
+    levels.dedup_by(|a, b| a.total_cmp(b).is_eq());
     let vertical =
         (!levels.is_empty()).then(|| VerticalDimension::new(VerticalKind::ElevationAngle, levels));
 
@@ -1251,7 +1253,9 @@ fn volume_profile(entry: &VolumeEntry, lon: f64, lat: f64, quantities: &[String]
         .map(|s| round_elevation(s.elangle))
         .collect();
     levels.sort_by(f64::total_cmp);
-    levels.dedup();
+    // `total_cmp` (not `==`) so a NaN elevation — which `Vec::dedup`'s
+    // `PartialEq` would never collapse — still deduplicates.
+    levels.dedup_by(|a, b| a.total_cmp(b).is_eq());
     let (site_lon, site_lat) = (entry.volume.site.lon, entry.volume.site.lat);
 
     let mut ranges = HashMap::new();
@@ -1265,6 +1269,11 @@ fn volume_profile(entry: &VolumeEntry, lon: f64, lat: f64, quantities: &[String]
                     .sweeps
                     .iter()
                     .filter(|s| round_elevation(s.elangle) == level)
+                    // First non-null sample among the cuts at this angle that
+                    // carry the quantity: a cut missing the quantity, or one
+                    // returning nodata at this point, falls through to its
+                    // split-cut sibling. With a single sweep this is just that
+                    // sweep's sample (None when absent or nodata).
                     .find_map(|sweep| {
                         let moment = sweep.moments.iter().find(|m| &m.quantity == quantity)?;
                         sample_sweep_moment(sweep, moment, site_lon, site_lat, lon, lat)
@@ -2011,11 +2020,13 @@ mod tests {
             make_sweep(5.0, "DBZH"),
         ];
 
+        // Sample a point ~2.8 km from the site, well within every sweep's
+        // range, querying both quantities at once.
         let profile = volume_profile(
             &entry(vol, "v0"),
             site_lon + 0.05,
             site_lat,
-            &["DBZH".to_string()],
+            &["DBZH".to_string(), "VRADH".to_string()],
         );
         match &profile.domain {
             DomainDescription::VerticalProfile { z, .. } => {
@@ -2023,13 +2034,32 @@ mod tests {
             }
             _ => panic!("expected VerticalProfile"),
         }
+
+        // DBZH lives on a cut at every angle → a sample at each z level.
         let dbzh = profile.ranges.get("DBZH").expect("DBZH range");
         assert_eq!(
             dbzh.shape,
             vec![3],
             "range shape follows the deduped z axis"
         );
-        assert_eq!(dbzh.values.len(), 3);
+        assert!(
+            dbzh.values.iter().all(Option::is_some),
+            "DBZH sampled at every level, got {:?}",
+            dbzh.values
+        );
+
+        // VRADH lives only on the Doppler cut at 2.0°. Even though a DBZH cut
+        // shares that angle, the per-angle search must pick the VRADH-carrying
+        // sibling — so only the z=2.0 entry is populated, proving split-cut
+        // selection is per-quantity (not "first sweep at the angle wins").
+        let vradh = profile.ranges.get("VRADH").expect("VRADH range");
+        assert_eq!(vradh.shape, vec![3]);
+        assert!(vradh.values[0].is_none(), "no VRADH cut at 0.5°");
+        assert!(
+            vradh.values[1].is_some(),
+            "VRADH cut at 2.0° must be sampled"
+        );
+        assert!(vradh.values[2].is_none(), "no VRADH cut at 5.0°");
     }
 
     /// An out-of-window `datetime` range yields `LocationNotFound`.

--- a/crates/engine-odim/src/volume_engine.rs
+++ b/crates/engine-odim/src/volume_engine.rs
@@ -683,9 +683,10 @@ fn derive_catalog(
         .filter_map(|list| list.last())
         .flat_map(|e| e.volume.sweeps.iter().map(|s| round_elevation(s.elangle)))
         .collect();
+    // Drop non-finite angles before the extent — see the matching filter in
+    // `volume_profile`. `total_cmp` keeps a total order for sort + dedup.
+    levels.retain(|v| v.is_finite());
     levels.sort_by(f64::total_cmp);
-    // `total_cmp` (not `==`) so a NaN elevation still deduplicates — see
-    // the matching dedup in `volume_profile`.
     levels.dedup_by(|a, b| a.total_cmp(b).is_eq());
     let vertical =
         (!levels.is_empty()).then(|| VerticalDimension::new(VerticalKind::ElevationAngle, levels));
@@ -1252,9 +1253,12 @@ fn volume_profile(entry: &VolumeEntry, lon: f64, lat: f64, quantities: &[String]
         .iter()
         .map(|s| round_elevation(s.elangle))
         .collect();
+    // Drop non-finite angles (a malformed file with a NaN elangle) before
+    // they reach the z axis — a NaN there serialises to JSON `null` and
+    // breaks the numeric axis. `total_cmp` (not `==`) keeps a total order for
+    // the sort + dedup over the remaining finite f64s.
+    levels.retain(|v| v.is_finite());
     levels.sort_by(f64::total_cmp);
-    // `total_cmp` (not `==`) so a NaN elevation — which `Vec::dedup`'s
-    // `PartialEq` would never collapse — still deduplicates.
     levels.dedup_by(|a, b| a.total_cmp(b).is_eq());
     let (site_lon, site_lat) = (entry.volume.site.lon, entry.volume.site.lat);
 
@@ -2063,6 +2067,31 @@ mod tests {
             "VRADH cut at 2.0° must be sampled"
         );
         assert!(vradh.values[2].is_none(), "no VRADH cut at 5.0°");
+    }
+
+    /// A malformed sweep with a NaN elevation must be dropped from the z
+    /// axis — a NaN there serialises to JSON `null` and breaks CoverageJSON's
+    /// numeric axis.
+    #[test]
+    fn volume_profile_drops_nan_elevation() {
+        let (site_lon, site_lat) = (25.0, 60.0);
+        let mut vol = synthetic_volume(site_lon, site_lat);
+        let mut nan_sweep = vol.sweeps[0].clone();
+        nan_sweep.elangle = f64::NAN;
+        vol.sweeps.push(nan_sweep);
+
+        let profile = volume_profile(&entry(vol, "v0"), site_lon, site_lat, &["DBZH".to_string()]);
+        match &profile.domain {
+            DomainDescription::VerticalProfile { z, .. } => {
+                assert!(
+                    z.values.iter().all(|v| v.is_finite()),
+                    "z axis must contain no NaN, got {:?}",
+                    z.values
+                );
+                assert_eq!(z.values, vec![0.5], "only the finite sweep survives");
+            }
+            _ => panic!("expected VerticalProfile"),
+        }
     }
 
     /// An out-of-window `datetime` range yields `LocationNotFound`.

--- a/crates/engine-odim/src/volume_engine.rs
+++ b/crates/engine-odim/src/volume_engine.rs
@@ -1247,7 +1247,12 @@ fn snap_levels(requested: &[f64], canonical: &[f64]) -> Vec<f64> {
 /// One `VerticalProfile` coverage: every elevation sweep of `entry`'s
 /// volume sampled at WGS84 `(lon, lat)`, with the sweep angles as the
 /// `z` axis.
-fn volume_profile(entry: &VolumeEntry, lon: f64, lat: f64, quantities: &[String]) -> QueryResult {
+fn volume_profile(
+    entry: &VolumeEntry,
+    lon: f64,
+    lat: f64,
+    quantities: &[String],
+) -> Option<QueryResult> {
     // A radar may run split cuts — two sweeps at the same nominal
     // elevation angle (e.g. separate surveillance and Doppler scans),
     // so the raw per-sweep angles can repeat (FMI volumes carry two
@@ -1268,6 +1273,13 @@ fn volume_profile(entry: &VolumeEntry, lon: f64, lat: f64, quantities: &[String]
     levels.retain(|v| v.is_finite());
     levels.sort_by(f64::total_cmp);
     levels.dedup();
+    // No usable sweep (a severely malformed volume where every elangle was
+    // non-finite) — skip this coverage rather than emit a `VerticalProfile`
+    // with an empty z axis, which the CoverageJSON schema rejects
+    // (`numericValuesAxis.values` has `minItems: 1`).
+    if levels.is_empty() {
+        return None;
+    }
     let (site_lon, site_lat) = (entry.volume.site.lon, entry.volume.site.lat);
 
     let mut ranges = HashMap::new();
@@ -1306,7 +1318,7 @@ fn volume_profile(entry: &VolumeEntry, lon: f64, lat: f64, quantities: &[String]
         param_descs.insert(quantity.clone(), quantity_description(quantity));
     }
 
-    QueryResult {
+    Some(QueryResult {
         domain: DomainDescription::VerticalProfile {
             x: lon,
             y: lat,
@@ -1318,7 +1330,7 @@ fn volume_profile(entry: &VolumeEntry, lon: f64, lat: f64, quantities: &[String]
         },
         parameters: param_descs,
         ranges,
-    }
+    })
 }
 
 /// One `PointSeries` coverage pinned to elevation angle `level`: the
@@ -1410,7 +1422,9 @@ fn site_coverages(
     match levels {
         None => Ok(selected
             .iter()
-            .map(|e| volume_profile(e, lon, lat, &quantities))
+            // `filter_map` drops volumes that produced no plottable profile
+            // (every elangle non-finite — `volume_profile` returns `None`).
+            .filter_map(|e| volume_profile(e, lon, lat, &quantities))
             .collect()),
         Some(lvls) => {
             let times: Vec<DateTime<Utc>> = selected.iter().map(|e| e.volume.time).collect();
@@ -2057,7 +2071,8 @@ mod tests {
             site_lon + 0.05,
             site_lat,
             &["DBZH".to_string(), "VRADH".to_string()],
-        );
+        )
+        .expect("finite sweeps must produce a coverage");
         match &profile.domain {
             DomainDescription::VerticalProfile { z, .. } => {
                 assert_eq!(z.values, vec![0.5, 2.0, 5.0], "z axis must be deduped");
@@ -2103,7 +2118,8 @@ mod tests {
         nan_sweep.elangle = f64::NAN;
         vol.sweeps.push(nan_sweep);
 
-        let profile = volume_profile(&entry(vol, "v0"), site_lon, site_lat, &["DBZH".to_string()]);
+        let profile = volume_profile(&entry(vol, "v0"), site_lon, site_lat, &["DBZH".to_string()])
+            .expect("one finite sweep remains, so a coverage is produced");
         match &profile.domain {
             DomainDescription::VerticalProfile { z, .. } => {
                 assert!(
@@ -2115,6 +2131,21 @@ mod tests {
             }
             _ => panic!("expected VerticalProfile"),
         }
+    }
+
+    /// A volume where *every* sweep has a non-finite elevation angle
+    /// (severely malformed) returns no coverage rather than emitting a
+    /// `VerticalProfile` with an empty z axis (`numericValuesAxis.values`
+    /// has `minItems: 1`).
+    #[test]
+    fn volume_profile_all_nan_returns_none() {
+        let (site_lon, site_lat) = (25.0, 60.0);
+        let mut vol = synthetic_volume(site_lon, site_lat);
+        for s in &mut vol.sweeps {
+            s.elangle = f64::NAN;
+        }
+        let result = volume_profile(&entry(vol, "v0"), site_lon, site_lat, &["DBZH".to_string()]);
+        assert!(result.is_none(), "expected None, got {result:?}");
     }
 
     /// An out-of-window `datetime` range yields `LocationNotFound`.

--- a/crates/engine-odim/src/volume_engine.rs
+++ b/crates/engine-odim/src/volume_engine.rs
@@ -1237,24 +1237,38 @@ fn snap_levels(requested: &[f64], canonical: &[f64]) -> Vec<f64> {
 /// volume sampled at WGS84 `(lon, lat)`, with the sweep angles as the
 /// `z` axis.
 fn volume_profile(entry: &VolumeEntry, lon: f64, lat: f64, quantities: &[String]) -> QueryResult {
-    let levels: Vec<f64> = entry
+    // A radar may run split cuts — two sweeps at the same nominal
+    // elevation angle (e.g. separate surveillance and Doppler scans),
+    // so the raw per-sweep angles can repeat (FMI volumes carry two
+    // sweeps at 2.0°). CoverageJSON axis values must be unique
+    // (`uniqueItems`), so collapse to distinct angles — matching the
+    // catalog's deduped vertical extent — and sample each quantity from
+    // whichever sweep at that angle carries it.
+    let mut levels: Vec<f64> = entry
         .volume
         .sweeps
         .iter()
         .map(|s| round_elevation(s.elangle))
         .collect();
+    levels.sort_by(f64::total_cmp);
+    levels.dedup();
     let (site_lon, site_lat) = (entry.volume.site.lon, entry.volume.site.lat);
 
     let mut ranges = HashMap::new();
     let mut param_descs = HashMap::new();
     for quantity in quantities {
-        let values: Vec<Option<f64>> = entry
-            .volume
-            .sweeps
+        let values: Vec<Option<f64>> = levels
             .iter()
-            .map(|sweep| {
-                let moment = sweep.moments.iter().find(|m| &m.quantity == quantity)?;
-                sample_sweep_moment(sweep, moment, site_lon, site_lat, lon, lat)
+            .map(|&level| {
+                entry
+                    .volume
+                    .sweeps
+                    .iter()
+                    .filter(|s| round_elevation(s.elangle) == level)
+                    .find_map(|sweep| {
+                        let moment = sweep.moments.iter().find(|m| &m.quantity == quantity)?;
+                        sample_sweep_moment(sweep, moment, site_lon, site_lat, lon, lat)
+                    })
             })
             .collect();
         ranges.insert(
@@ -1971,6 +1985,51 @@ mod tests {
             covs[0].ranges.get("DBZH").expect("DBZH range").shape,
             vec![1]
         );
+    }
+
+    /// A radar running split cuts has two sweeps at the same nominal
+    /// elevation angle. The `VerticalProfile` `z` axis must collapse
+    /// them to distinct values — CoverageJSON axis values are
+    /// `uniqueItems` — and the per-quantity range must shrink to match,
+    /// sampling each angle from whichever sweep carries the quantity.
+    #[test]
+    fn volume_profile_dedups_split_cut_elevation_angles() {
+        let (site_lon, site_lat) = (25.0, 60.0);
+        // A real FMI scan strategy: two sweeps at 2.0° (a surveillance
+        // cut carrying DBZH, a Doppler cut carrying VRADH).
+        let mut vol = synthetic_volume(site_lon, site_lat);
+        let make_sweep = |elangle: f64, quantity: &str| {
+            let mut s = vol.sweeps[0].clone();
+            s.elangle = elangle;
+            s.moments[0].quantity = quantity.to_string();
+            s
+        };
+        vol.sweeps = vec![
+            make_sweep(0.5, "DBZH"),
+            make_sweep(2.0, "DBZH"),
+            make_sweep(2.0, "VRADH"),
+            make_sweep(5.0, "DBZH"),
+        ];
+
+        let profile = volume_profile(
+            &entry(vol, "v0"),
+            site_lon + 0.05,
+            site_lat,
+            &["DBZH".to_string()],
+        );
+        match &profile.domain {
+            DomainDescription::VerticalProfile { z, .. } => {
+                assert_eq!(z.values, vec![0.5, 2.0, 5.0], "z axis must be deduped");
+            }
+            _ => panic!("expected VerticalProfile"),
+        }
+        let dbzh = profile.ranges.get("DBZH").expect("DBZH range");
+        assert_eq!(
+            dbzh.shape,
+            vec![3],
+            "range shape follows the deduped z axis"
+        );
+        assert_eq!(dbzh.values.len(), 3);
     }
 
     /// An out-of-window `datetime` range yields `LocationNotFound`.


### PR DESCRIPTION
## Summary

- Fixes #269 — a PVOL EDR `position`/`locations`/`area` query with no `z` returned CoverageJSON whose `VerticalProfile` `z` axis had a duplicate elevation angle, violating the schema's `uniqueItems` constraint on axis values.
- Root cause: FMI radars run split cuts (two sweeps at the same nominal angle, e.g. a surveillance cut with `DBZH` and a Doppler cut with `VRADH`). `volume_profile()` built the `z` axis straight from every sweep with no dedup, while the catalog's collection-level vertical extent already deduped.
- Fix: collapse per-sweep angles to distinct values (sort + dedup, matching the catalog) and sample each quantity per unique angle from whichever sweep at that angle carries it — so split cuts resolve correctly.

## Test plan

- [x] New regression test `volume_profile_dedups_split_cut_elevation_angles` (4 sweeps, two at 2.0° carrying different moments) asserts a deduped `z` axis and matching range shape.
- [x] `cargo test -p engine-odim` green (74 + 19 tests); `cargo fmt` + `cargo clippy -D warnings` clean.
- [x] Live re-query of the reported URL on a fresh build: 12 unique `z` values, range shape `[12]`, all 16 PVOL parameters pass dup-axis + shape-product checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)