### PR TITLE
feat(api-edr): PNG plot output for EDR profile/time-series queries (f=png)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,7 @@ When completing work, close the relevant issue: `gh issue close <number>`.
 - **ds-core has no framework dependencies.** Only chrono, serde, thiserror, toml. Keep it that way. Use `PropertyValue` enum instead of `serde_json::Value` for feature properties.
 - **CRS and GeoTransform live in ds-core** (`ds_core::geo`), shared by all engines.
 - **ds-render has no framework dependencies.** Only ds-core and `png`.
-- **API crates depend only on ds-core** (and ds-render for api-wms/api-maps), not on any engine crate. API state is a registry of engines keyed by collection ID.
+- **API crates depend only on ds-core** (and ds-render for api-wms/api-maps, plus api-edr for its `f=png` profile/time-series plots), not on any engine crate. API state is a registry of engines keyed by collection ID.
 - **EDR, Features, Maps, Tiles, and WMS are separate services** with separate base routes (`/edr/...`, `/features/...`, `/maps/...`, `/tiles/...`, `/wms/...`).
 - **WMS uses XML, not JSON.** All XML output in api-wms uses `quick-xml::Writer` for proper escaping. Never build XML with `format!()` or string concatenation (XML injection risk).
 - **CORS is applied at the server level**, not in individual API crates. The `CorsLayer` lives in `server/src/main.rs`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,6 +72,7 @@ dependencies = [
  "axum",
  "chrono",
  "ds-core",
+ "ds-render",
  "http-body-util",
  "jsonschema",
  "serde",

--- a/crates/api-edr/Cargo.toml
+++ b/crates/api-edr/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 ds-core = { path = "../core" }
+ds-render = { path = "../render" }
 arc-swap = "1"
 axum = "0.8"
 serde = { version = "1", features = ["derive"] }

--- a/crates/api-edr/src/handlers.rs
+++ b/crates/api-edr/src/handlers.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use arc_swap::ArcSwap;
 use axum::extract::{Path, Query, State};
 use axum::http::{header, StatusCode};
-use axum::response::IntoResponse;
+use axum::response::{IntoResponse, Response};
 use axum::Json;
 use serde_json::json;
 
@@ -12,12 +12,64 @@ use ds_core::config::CollectionConfig;
 use ds_core::datetime::parse_datetime_interval;
 use ds_core::edr_engine::EdrEngine;
 
+use ds_core::error::DataServerError;
 use ds_core::model::CoverageResponse;
+use ds_render::render_chart;
 
 use crate::params::{
-    parse_z, split_position_coords, AreaQueryParams, LocationQueryParams, PositionQueryParams,
+    parse_edr_format, parse_z, plot_dimensions, split_position_coords, AreaQueryParams, EdrFormat,
+    LocationQueryParams, PositionQueryParams,
 };
+use crate::plot_convert::coverage_response_to_panels;
 use crate::response::{coverage_response_to_json, locations_to_geojson, LocationsContext};
+
+type HandlerError = (StatusCode, Json<serde_json::Value>);
+
+/// Serialise an EDR coverage response in the requested output format.
+///
+/// `CoverageJSON` is the default; `PNG` renders a vertical-profile or
+/// time-series plot (one stacked panel per parameter). A response that can't
+/// be plotted (a gridded/area result) maps to 400.
+fn render_coverage_response(
+    result: CoverageResponse,
+    format: EdrFormat,
+    width: Option<u32>,
+    height: Option<u32>,
+) -> Result<Response, HandlerError> {
+    match format {
+        EdrFormat::CoverageJson => {
+            let body = serde_json::to_string(&coverage_response_to_json(&result)).unwrap();
+            Ok((
+                [(header::CONTENT_TYPE, "application/prs.coverage+json")],
+                body,
+            )
+                .into_response())
+        }
+        EdrFormat::Png => {
+            let panels = coverage_response_to_panels(&result).map_err(|e| bad_request(&e))?;
+            let (w, h) = plot_dimensions(width, height);
+            let png = render_chart(&panels, w, h).map_err(|e| {
+                tracing::error!("EDR plot render error: {e}");
+                server_error()
+            })?;
+            Ok(([(header::CONTENT_TYPE, "image/png")], png).into_response())
+        }
+    }
+}
+
+fn bad_request(e: &DataServerError) -> HandlerError {
+    (
+        StatusCode::BAD_REQUEST,
+        Json(json!({ "code": "BadRequest", "description": e.to_string() })),
+    )
+}
+
+fn server_error() -> HandlerError {
+    (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        Json(json!({ "code": "ServerError", "description": "Internal server error" })),
+    )
+}
 
 /// Shared state for the EDR API: a registry of collection engines + metadata.
 #[derive(Clone)]
@@ -163,7 +215,14 @@ pub async fn api_definition(State(state): State<AppState>) -> impl IntoResponse 
                     },
                     {"$ref": "#/components/parameters/datetime"},
                     {"$ref": "#/components/parameters/parameter-name"},
-                    {"$ref": "#/components/parameters/z"}
+                    {"$ref": "#/components/parameters/z"},
+                    {
+                        "name": "f",
+                        "in": "query",
+                        "description": "Output format: CoverageJSON (default) or PNG (a vertical-profile / time-series plot).",
+                        "required": false,
+                        "schema": {"type": "string", "enum": ["CoverageJSON", "PNG"]}
+                    }
                 ],
                 "responses": {
                     "200": {
@@ -171,6 +230,9 @@ pub async fn api_definition(State(state): State<AppState>) -> impl IntoResponse 
                         "content": {
                             "application/prs.coverage+json": {
                                 "schema": {"$ref": "#/components/schemas/coverageJSON"}
+                            },
+                            "image/png": {
+                                "schema": {"type": "string", "format": "binary"}
                             }
                         }
                     },
@@ -192,7 +254,14 @@ pub async fn api_definition(State(state): State<AppState>) -> impl IntoResponse 
                     {"$ref": "#/components/parameters/coords-point"},
                     {"$ref": "#/components/parameters/datetime"},
                     {"$ref": "#/components/parameters/parameter-name"},
-                    {"$ref": "#/components/parameters/z"}
+                    {"$ref": "#/components/parameters/z"},
+                    {
+                        "name": "f",
+                        "in": "query",
+                        "description": "Output format: CoverageJSON (default) or PNG (a vertical-profile / time-series plot).",
+                        "required": false,
+                        "schema": {"type": "string", "enum": ["CoverageJSON", "PNG"]}
+                    }
                 ],
                 "responses": {
                     "200": {
@@ -200,6 +269,9 @@ pub async fn api_definition(State(state): State<AppState>) -> impl IntoResponse 
                         "content": {
                             "application/prs.coverage+json": {
                                 "schema": {"$ref": "#/components/schemas/coverageJSON"}
+                            },
+                            "image/png": {
+                                "schema": {"type": "string", "format": "binary"}
                             }
                         }
                     },
@@ -487,11 +559,8 @@ pub async fn location_query(
             }
         })?;
 
-    let body = serde_json::to_string(&coverage_response_to_json(&result)).unwrap();
-    Ok((
-        [(header::CONTENT_TYPE, "application/prs.coverage+json")],
-        body,
-    ))
+    let format = parse_edr_format(params.f.as_deref()).map_err(|e| bad_request(&e))?;
+    render_coverage_response(result, format, params.width, params.height)
 }
 
 pub async fn position_query(
@@ -559,15 +628,13 @@ pub async fn position_query(
         }
     };
 
+    let format = parse_edr_format(params.f.as_deref()).map_err(|e| bad_request(&e))?;
+
     if points.len() == 1 {
         let result = engine
             .query_position(&points[0], datetime, param_names.as_deref(), z.as_deref())
             .map_err(|e| map_engine_error(&e))?;
-        let body = serde_json::to_string(&coverage_response_to_json(&result)).unwrap();
-        return Ok((
-            [(header::CONTENT_TYPE, "application/prs.coverage+json")],
-            body,
-        ));
+        return render_coverage_response(result, format, params.width, params.height);
     }
 
     // MULTIPOINT — fan out one query per point and flatten every point's
@@ -583,14 +650,12 @@ pub async fn position_query(
         }
     }
 
-    let body = serde_json::to_string(&coverage_response_to_json(&CoverageResponse::Collection(
-        coverages,
-    )))
-    .unwrap();
-    Ok((
-        [(header::CONTENT_TYPE, "application/prs.coverage+json")],
-        body,
-    ))
+    render_coverage_response(
+        CoverageResponse::Collection(coverages),
+        format,
+        params.width,
+        params.height,
+    )
 }
 
 pub async fn area_query(
@@ -600,6 +665,13 @@ pub async fn area_query(
 ) -> Result<impl IntoResponse, (StatusCode, Json<serde_json::Value>)> {
     let state = state.load_full();
     let (engine, _config) = lookup_collection(&state, &id)?;
+
+    // An area result is gridded / multi-coverage, not a single line plot.
+    if parse_edr_format(params.f.as_deref()).map_err(|e| bad_request(&e))? == EdrFormat::Png {
+        return Err(bad_request(&DataServerError::InvalidParameter(
+            "PNG output is not available for area queries".into(),
+        )));
+    }
 
     let datetime = params
         .datetime
@@ -738,11 +810,11 @@ fn build_collection_metadata(
         let (endpoint, output_formats) = match qt.as_str() {
             "locations" => (
                 format!("{base_url}/edr/collections/{}/locations", config.id),
-                json!(["CoverageJSON", "GeoJSON"]),
+                json!(["CoverageJSON", "GeoJSON", "PNG"]),
             ),
             "position" => (
                 format!("{base_url}/edr/collections/{}/position", config.id),
-                json!(["CoverageJSON"]),
+                json!(["CoverageJSON", "PNG"]),
             ),
             "area" => (
                 format!("{base_url}/edr/collections/{}/area", config.id),
@@ -781,6 +853,6 @@ fn build_collection_metadata(
         "data_queries": data_queries,
         "crs": ["http://www.opengis.net/def/crs/OGC/1.3/CRS84"],
         "parameter_names": parameter_names,
-        "output_formats": ["CoverageJSON", "GeoJSON"]
+        "output_formats": ["CoverageJSON", "GeoJSON", "PNG"]
     })
 }

--- a/crates/api-edr/src/handlers.rs
+++ b/crates/api-edr/src/handlers.rs
@@ -38,7 +38,10 @@ fn render_coverage_response(
 ) -> Result<Response, HandlerError> {
     match format {
         EdrFormat::CoverageJson => {
-            let body = serde_json::to_string(&coverage_response_to_json(&result)).unwrap();
+            let body = serde_json::to_string(&coverage_response_to_json(&result)).map_err(|e| {
+                tracing::error!("EDR CoverageJSON serialise error: {e}");
+                server_error()
+            })?;
             Ok((
                 [(header::CONTENT_TYPE, "application/prs.coverage+json")],
                 body,

--- a/crates/api-edr/src/lib.rs
+++ b/crates/api-edr/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod handlers;
 pub mod params;
+pub mod plot_convert;
 pub mod response;
 
 use axum::routing::get;

--- a/crates/api-edr/src/lib.rs
+++ b/crates/api-edr/src/lib.rs
@@ -1,6 +1,6 @@
 pub mod handlers;
 pub mod params;
-pub mod plot_convert;
+pub(crate) mod plot_convert;
 pub mod response;
 
 use axum::routing::get;

--- a/crates/api-edr/src/params.rs
+++ b/crates/api-edr/src/params.rs
@@ -7,6 +7,11 @@ pub struct LocationQueryParams {
     #[serde(rename = "parameter-name")]
     pub parameter_name: Option<String>,
     pub z: Option<String>,
+    /// Output format: `CoverageJSON` (default) or `PNG` (plot).
+    pub f: Option<String>,
+    /// PNG plot dimensions (ignored for CoverageJSON).
+    pub width: Option<u32>,
+    pub height: Option<u32>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -16,6 +21,41 @@ pub struct PositionQueryParams {
     #[serde(rename = "parameter-name")]
     pub parameter_name: Option<String>,
     pub z: Option<String>,
+    /// Output format: `CoverageJSON` (default) or `PNG` (plot).
+    pub f: Option<String>,
+    /// PNG plot dimensions (ignored for CoverageJSON).
+    pub width: Option<u32>,
+    pub height: Option<u32>,
+}
+
+/// EDR response output format selected by the `f` query parameter.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EdrFormat {
+    /// OGC CoverageJSON (the default).
+    CoverageJson,
+    /// A rendered PNG plot (vertical profile or time series).
+    Png,
+}
+
+/// Parse the `f` query parameter. Absent/blank → CoverageJSON. `coveragejson`
+/// and `png` are accepted case-insensitively; anything else is a 400.
+pub fn parse_edr_format(f: Option<&str>) -> Result<EdrFormat, DataServerError> {
+    match f.map(str::trim).filter(|s| !s.is_empty()) {
+        None => Ok(EdrFormat::CoverageJson),
+        Some(s) if s.eq_ignore_ascii_case("coveragejson") => Ok(EdrFormat::CoverageJson),
+        Some(s) if s.eq_ignore_ascii_case("png") => Ok(EdrFormat::Png),
+        Some(other) => Err(DataServerError::InvalidParameter(format!(
+            "Unsupported output format '{other}' — expected 'CoverageJSON' or 'PNG'"
+        ))),
+    }
+}
+
+/// Clamp the requested plot dimensions to a sane range, defaulting to 800×600.
+pub fn plot_dimensions(width: Option<u32>, height: Option<u32>) -> (u32, u32) {
+    (
+        width.unwrap_or(800).clamp(160, 4096),
+        height.unwrap_or(600).clamp(120, 4096),
+    )
 }
 
 #[derive(Debug, Deserialize)]
@@ -25,6 +65,9 @@ pub struct AreaQueryParams {
     #[serde(rename = "parameter-name")]
     pub parameter_name: Option<String>,
     pub z: Option<String>,
+    /// Output format. Area queries only support `CoverageJSON`; `PNG` is
+    /// rejected (an area result is gridded / multi-coverage, not a single plot).
+    pub f: Option<String>,
 }
 
 /// Parse the EDR `z` query parameter — a comma-separated list of numeric

--- a/crates/api-edr/src/params.rs
+++ b/crates/api-edr/src/params.rs
@@ -51,10 +51,12 @@ pub fn parse_edr_format(f: Option<&str>) -> Result<EdrFormat, DataServerError> {
 }
 
 /// Clamp the requested plot dimensions to a sane range, defaulting to 800×600.
+/// The upper bound is intentionally modest — the plot renders synchronously on
+/// the request worker, so the worst-case buffer stays small.
 pub fn plot_dimensions(width: Option<u32>, height: Option<u32>) -> (u32, u32) {
     (
-        width.unwrap_or(800).clamp(160, 4096),
-        height.unwrap_or(600).clamp(120, 4096),
+        width.unwrap_or(800).clamp(160, 2000),
+        height.unwrap_or(600).clamp(120, 2000),
     )
 }
 

--- a/crates/api-edr/src/params.rs
+++ b/crates/api-edr/src/params.rs
@@ -50,14 +50,11 @@ pub fn parse_edr_format(f: Option<&str>) -> Result<EdrFormat, DataServerError> {
     }
 }
 
-/// Clamp the requested plot dimensions to a sane range, defaulting to 800×600.
-/// The upper bound is intentionally modest — the plot renders synchronously on
-/// the request worker, so the worst-case buffer stays small.
+/// Default plot dimensions when `width`/`height` aren't supplied. The actual
+/// safe range is enforced inside `ds_render::render_chart`, so user input
+/// passes through unclamped here — one source of truth for the bounds.
 pub fn plot_dimensions(width: Option<u32>, height: Option<u32>) -> (u32, u32) {
-    (
-        width.unwrap_or(800).clamp(160, 2000),
-        height.unwrap_or(600).clamp(120, 2000),
-    )
+    (width.unwrap_or(800), height.unwrap_or(600))
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/api-edr/src/plot_convert.rs
+++ b/crates/api-edr/src/plot_convert.rs
@@ -26,6 +26,21 @@ pub fn coverage_response_to_panels(resp: &CoverageResponse) -> Result<Vec<Panel>
         return Err(DataServerError::InvalidParameter("no data to plot".into()));
     }
 
+    // Reject heterogeneous-domain collections explicitly: `build_panel`
+    // dispatches on the first coverage's domain, so a mixed-kind collection
+    // would silently drop the non-matching coverages instead of producing
+    // partial output. Engines emit homogeneous responses today; this guard
+    // is a defensive contract check.
+    let first_kind = domain_kind(&coverages[0].domain);
+    if coverages
+        .iter()
+        .any(|q| domain_kind(&q.domain) != first_kind)
+    {
+        return Err(DataServerError::InvalidParameter(
+            "PNG output requires every coverage to share a domain type".into(),
+        ));
+    }
+
     // Stable, de-duplicated parameter order across every coverage.
     let mut params: Vec<String> = Vec::new();
     for q in coverages {
@@ -117,6 +132,15 @@ fn build_panel(param: &str, coverages: &[QueryResult]) -> Result<Panel, DataServ
         DomainDescription::Grid { .. } => Err(DataServerError::InvalidParameter(
             "PNG output is not available for gridded (area) responses".into(),
         )),
+    }
+}
+
+/// Classify a domain so a heterogeneous-domain collection can be rejected.
+fn domain_kind(d: &DomainDescription) -> &'static str {
+    match d {
+        DomainDescription::VerticalProfile { .. } => "VerticalProfile",
+        DomainDescription::PointSeries { .. } => "PointSeries",
+        DomainDescription::Grid { .. } => "Grid",
     }
 }
 
@@ -330,5 +354,35 @@ mod tests {
             },
         };
         assert!(coverage_response_to_panels(&CoverageResponse::Single(q)).is_err());
+    }
+
+    /// A collection that mixes domain types is rejected explicitly — the
+    /// per-panel dispatch would otherwise silently drop the non-matching
+    /// coverages and produce partial output.
+    #[test]
+    fn heterogeneous_collection_is_rejected() {
+        let p = profile(VerticalKind::ElevationAngle, vec![0.5], vec![Some(1.0)]);
+        let mut parameters = HashMap::new();
+        parameters.insert("t2m".to_string(), pdesc("Temperature", "K"));
+        let mut ranges = HashMap::new();
+        ranges.insert(
+            "t2m".to_string(),
+            NdArray {
+                shape: vec![1],
+                axis_names: vec!["t".into()],
+                values: vec![Some(280.0)],
+            },
+        );
+        let ts = QueryResult {
+            domain: DomainDescription::PointSeries {
+                x: 25.0,
+                y: 60.0,
+                t: vec![DateTime::from_timestamp(1_778_889_600, 0).unwrap()],
+                z: None,
+            },
+            parameters,
+            ranges,
+        };
+        assert!(coverage_response_to_panels(&CoverageResponse::Collection(vec![p, ts])).is_err());
     }
 }

--- a/crates/api-edr/src/plot_convert.rs
+++ b/crates/api-edr/src/plot_convert.rs
@@ -1,0 +1,334 @@
+//! Map an EDR [`CoverageResponse`] onto stacked plot [`Panel`]s for PNG output.
+//!
+//! - A `VerticalProfile` domain plots the parameter value on x against the
+//!   vertical coordinate on y (oriented per [`VerticalKind::direction`]).
+//! - A `PointSeries` domain plots time on x against the value on y.
+//! - A `Grid` domain (area queries) is not plottable and is rejected.
+//!
+//! One panel is produced per parameter; each coverage in a collection becomes
+//! one overlaid series (timestep for profiles, level/station for time series).
+
+use chrono::{DateTime, Utc};
+
+use ds_core::error::DataServerError;
+use ds_core::model::{
+    CoverageResponse, DomainDescription, ParameterDescription, QueryResult, VerticalCoord,
+};
+use ds_render::{Panel, Series};
+
+/// Build one panel per parameter from an EDR coverage response.
+pub fn coverage_response_to_panels(resp: &CoverageResponse) -> Result<Vec<Panel>, DataServerError> {
+    let coverages: &[QueryResult] = match resp {
+        CoverageResponse::Single(q) => std::slice::from_ref(q),
+        CoverageResponse::Collection(v) => v.as_slice(),
+    };
+    if coverages.is_empty() {
+        return Err(DataServerError::InvalidParameter("no data to plot".into()));
+    }
+
+    // Stable, de-duplicated parameter order across every coverage.
+    let mut params: Vec<String> = Vec::new();
+    for q in coverages {
+        let mut keys: Vec<&String> = q.ranges.keys().collect();
+        keys.sort();
+        for k in keys {
+            if !params.iter().any(|p| p == k) {
+                params.push(k.clone());
+            }
+        }
+    }
+    if params.is_empty() {
+        return Err(DataServerError::InvalidParameter(
+            "no parameters to plot".into(),
+        ));
+    }
+
+    params.iter().map(|p| build_panel(p, coverages)).collect()
+}
+
+fn build_panel(param: &str, coverages: &[QueryResult]) -> Result<Panel, DataServerError> {
+    let title = param_desc(param, coverages)
+        .map(|d| d.label.clone())
+        .unwrap_or_else(|| param.to_string());
+    let value_caption = value_caption(param, coverages);
+
+    match &coverages[0].domain {
+        DomainDescription::VerticalProfile { z, .. } => {
+            let y_label = axis_caption(z.kind.default_label(), z.kind.default_unit());
+            let y_invert = z.kind.direction() == "down";
+            let mut series = Vec::new();
+            for q in coverages {
+                let DomainDescription::VerticalProfile { z, t, .. } = &q.domain else {
+                    continue;
+                };
+                let Some(nd) = q.ranges.get(param) else {
+                    continue;
+                };
+                // Profile: x = value (nullable), y = level (always present).
+                let points = z
+                    .values
+                    .iter()
+                    .zip(nd.values.iter())
+                    .map(|(&level, &value)| (value, Some(level)))
+                    .collect();
+                series.push(Series {
+                    label: t.map(fmt_time).unwrap_or_default(),
+                    points,
+                });
+            }
+            Ok(Panel {
+                title,
+                x_label: value_caption,
+                y_label,
+                y_invert,
+                x_is_time: false,
+                series,
+            })
+        }
+        DomainDescription::PointSeries { .. } => {
+            let mut series = Vec::new();
+            for (idx, q) in coverages.iter().enumerate() {
+                let DomainDescription::PointSeries { t, z, .. } = &q.domain else {
+                    continue;
+                };
+                let Some(nd) = q.ranges.get(param) else {
+                    continue;
+                };
+                // Time series: x = time (always present), y = value (nullable).
+                let points = t
+                    .iter()
+                    .zip(nd.values.iter())
+                    .map(|(dt, &value)| (Some(dt.timestamp() as f64), value))
+                    .collect();
+                series.push(Series {
+                    label: pointseries_label(z.as_ref(), idx, coverages.len()),
+                    points,
+                });
+            }
+            Ok(Panel {
+                title,
+                x_label: "Time (UTC)".to_string(),
+                y_label: value_caption,
+                y_invert: false,
+                x_is_time: true,
+                series,
+            })
+        }
+        DomainDescription::Grid { .. } => Err(DataServerError::InvalidParameter(
+            "PNG output is not available for gridded (area) responses".into(),
+        )),
+    }
+}
+
+/// First parameter descriptor for `param` across the coverages.
+fn param_desc<'a>(param: &str, coverages: &'a [QueryResult]) -> Option<&'a ParameterDescription> {
+    coverages.iter().find_map(|q| q.parameters.get(param))
+}
+
+/// `"Label (unit)"`, or just `"Label"` when the unit is blank.
+fn value_caption(param: &str, coverages: &[QueryResult]) -> String {
+    match param_desc(param, coverages) {
+        Some(d) => axis_caption(&d.label, &d.unit),
+        None => param.to_string(),
+    }
+}
+
+fn axis_caption(label: &str, unit: &str) -> String {
+    if unit.trim().is_empty() {
+        label.to_string()
+    } else {
+        format!("{label} ({unit})")
+    }
+}
+
+/// Legend label for a time-series coverage: the vertical level if pinned,
+/// otherwise a 1-based index when overlaying several, else blank.
+fn pointseries_label(z: Option<&VerticalCoord>, idx: usize, total: usize) -> String {
+    if let Some(z) = z {
+        if let Some(&level) = z.values.first() {
+            let unit = z.kind.default_unit();
+            return if unit == "1" {
+                format!("{level}")
+            } else {
+                format!("{level} {unit}")
+            };
+        }
+    }
+    if total > 1 {
+        format!("#{}", idx + 1)
+    } else {
+        String::new()
+    }
+}
+
+fn fmt_time(t: DateTime<Utc>) -> String {
+    t.format("%H:%M").to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use ds_core::model::NdArray;
+    use ds_core::vertical::VerticalKind;
+
+    use super::*;
+
+    fn pdesc(label: &str, unit: &str) -> ParameterDescription {
+        ParameterDescription {
+            label: label.into(),
+            unit: unit.into(),
+            observed_property: label.into(),
+        }
+    }
+
+    fn profile(kind: VerticalKind, levels: Vec<f64>, vals: Vec<Option<f64>>) -> QueryResult {
+        let mut parameters = HashMap::new();
+        parameters.insert("DBZH".to_string(), pdesc("Reflectivity", "dBZ"));
+        let mut ranges = HashMap::new();
+        ranges.insert(
+            "DBZH".to_string(),
+            NdArray {
+                shape: vec![levels.len()],
+                axis_names: vec!["z".into()],
+                values: vals,
+            },
+        );
+        QueryResult {
+            domain: DomainDescription::VerticalProfile {
+                x: 25.0,
+                y: 60.0,
+                t: Some(DateTime::from_timestamp(1_778_889_600, 0).unwrap()),
+                z: VerticalCoord {
+                    kind,
+                    values: levels,
+                },
+            },
+            parameters,
+            ranges,
+        }
+    }
+
+    #[test]
+    fn vertical_profile_maps_value_x_level_y() {
+        let q = profile(
+            VerticalKind::ElevationAngle,
+            vec![0.5, 2.0, 5.0],
+            vec![Some(10.0), Some(20.0), None],
+        );
+        let panels = coverage_response_to_panels(&CoverageResponse::Single(q)).unwrap();
+        assert_eq!(panels.len(), 1);
+        let p = &panels[0];
+        assert_eq!(p.title, "Reflectivity");
+        assert_eq!(p.x_label, "Reflectivity (dBZ)");
+        assert_eq!(p.y_label, "Elevation angle (deg)");
+        assert!(!p.y_invert, "elevation angle grows up");
+        assert_eq!(p.series.len(), 1);
+        // x = value (None for the third), y = level.
+        assert_eq!(
+            p.series[0].points,
+            vec![
+                (Some(10.0), Some(0.5)),
+                (Some(20.0), Some(2.0)),
+                (None, Some(5.0)),
+            ]
+        );
+    }
+
+    #[test]
+    fn pressure_profile_inverts_y() {
+        let q = profile(
+            VerticalKind::Pressure,
+            vec![1000.0, 500.0],
+            vec![Some(1.0), Some(2.0)],
+        );
+        let panels = coverage_response_to_panels(&CoverageResponse::Single(q)).unwrap();
+        assert!(panels[0].y_invert, "pressure grows down");
+        assert_eq!(panels[0].y_label, "Pressure (hPa)");
+    }
+
+    #[test]
+    fn collection_overlays_one_series_per_coverage() {
+        let a = profile(
+            VerticalKind::ElevationAngle,
+            vec![0.5, 2.0],
+            vec![Some(1.0), Some(2.0)],
+        );
+        let b = profile(
+            VerticalKind::ElevationAngle,
+            vec![0.5, 2.0],
+            vec![Some(3.0), Some(4.0)],
+        );
+        let panels =
+            coverage_response_to_panels(&CoverageResponse::Collection(vec![a, b])).unwrap();
+        assert_eq!(panels.len(), 1);
+        assert_eq!(panels[0].series.len(), 2);
+    }
+
+    #[test]
+    fn point_series_is_time_axis() {
+        let mut parameters = HashMap::new();
+        parameters.insert("t2m".to_string(), pdesc("Temperature", "K"));
+        let mut ranges = HashMap::new();
+        ranges.insert(
+            "t2m".to_string(),
+            NdArray {
+                shape: vec![2],
+                axis_names: vec!["t".into()],
+                values: vec![Some(280.0), None],
+            },
+        );
+        let q = QueryResult {
+            domain: DomainDescription::PointSeries {
+                x: 25.0,
+                y: 60.0,
+                t: vec![
+                    DateTime::from_timestamp(1_778_889_600, 0).unwrap(),
+                    DateTime::from_timestamp(1_778_893_200, 0).unwrap(),
+                ],
+                z: None,
+            },
+            parameters,
+            ranges,
+        };
+        let panels = coverage_response_to_panels(&CoverageResponse::Single(q)).unwrap();
+        let p = &panels[0];
+        assert!(p.x_is_time);
+        assert_eq!(p.x_label, "Time (UTC)");
+        assert_eq!(p.y_label, "Temperature (K)");
+        assert_eq!(p.series.len(), 1);
+        assert_eq!(
+            p.series[0].points,
+            vec![
+                (Some(1_778_889_600.0), Some(280.0)),
+                (Some(1_778_893_200.0), None)
+            ]
+        );
+    }
+
+    #[test]
+    fn grid_domain_is_rejected() {
+        let q = QueryResult {
+            domain: DomainDescription::Grid {
+                x: vec![1.0],
+                y: vec![1.0],
+                t: None,
+                z: None,
+            },
+            parameters: HashMap::new(),
+            ranges: {
+                let mut m = HashMap::new();
+                m.insert(
+                    "p".to_string(),
+                    NdArray {
+                        shape: vec![1, 1],
+                        axis_names: vec!["y".into(), "x".into()],
+                        values: vec![Some(1.0)],
+                    },
+                );
+                m
+            },
+        };
+        assert!(coverage_response_to_panels(&CoverageResponse::Single(q)).is_err());
+    }
+}

--- a/crates/api-edr/tests/png_plot_tests.rs
+++ b/crates/api-edr/tests/png_plot_tests.rs
@@ -1,0 +1,280 @@
+//! Integration tests for EDR `f=png` plot output.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use arc_swap::ArcSwap;
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use chrono::{DateTime, Utc};
+use http_body_util::BodyExt;
+use tower::ServiceExt;
+
+use api_edr::handlers::EdrState;
+use ds_core::config::CollectionConfig;
+use ds_core::edr_engine::EdrEngine;
+use ds_core::error::DataServerError;
+use ds_core::model::*;
+use ds_core::vertical::VerticalKind;
+
+const PNG_SIGNATURE: [u8; 8] = [0x89, b'P', b'N', b'G', 0x0d, 0x0a, 0x1a, 0x0a];
+
+/// Engine whose position query returns a VerticalProfile (radar-style).
+struct ProfileEngine;
+/// Engine whose position query returns a PointSeries (time series).
+struct SeriesEngine;
+
+fn profile_result() -> QueryResult {
+    let mut parameters = HashMap::new();
+    parameters.insert(
+        "DBZH".into(),
+        ParameterDescription {
+            label: "Reflectivity".into(),
+            unit: "dBZ".into(),
+            observed_property: "DBZH".into(),
+        },
+    );
+    let mut ranges = HashMap::new();
+    ranges.insert(
+        "DBZH".into(),
+        NdArray {
+            shape: vec![3],
+            axis_names: vec!["z".into()],
+            values: vec![Some(10.0), Some(20.0), None],
+        },
+    );
+    QueryResult {
+        domain: DomainDescription::VerticalProfile {
+            x: 25.0,
+            y: 60.0,
+            t: Some("2026-05-15T00:00:00Z".parse().unwrap()),
+            z: VerticalCoord {
+                kind: VerticalKind::ElevationAngle,
+                values: vec![0.5, 2.0, 5.0],
+            },
+        },
+        parameters,
+        ranges,
+    }
+}
+
+fn series_result() -> QueryResult {
+    let times: Vec<DateTime<Utc>> = (0..3)
+        .map(|h| format!("2024-01-01T{h:02}:00:00Z").parse().unwrap())
+        .collect();
+    let mut parameters = HashMap::new();
+    parameters.insert(
+        "temperature".into(),
+        ParameterDescription {
+            label: "Temperature".into(),
+            unit: "degC".into(),
+            observed_property: "temperature".into(),
+        },
+    );
+    let mut ranges = HashMap::new();
+    ranges.insert(
+        "temperature".into(),
+        NdArray {
+            shape: vec![3],
+            axis_names: vec!["t".into()],
+            values: vec![Some(-2.5), Some(-2.8), None],
+        },
+    );
+    QueryResult {
+        domain: DomainDescription::PointSeries {
+            x: 24.9,
+            y: 60.1,
+            t: times,
+            z: None,
+        },
+        parameters,
+        ranges,
+    }
+}
+
+macro_rules! impl_common {
+    ($t:ty, $result:expr) => {
+        impl EdrEngine for $t {
+            fn get_locations(&self) -> Result<Vec<Location>, DataServerError> {
+                Ok(vec![])
+            }
+            fn query_location(
+                &self,
+                _id: &str,
+                _dt: Option<(DateTime<Utc>, DateTime<Utc>)>,
+                _p: Option<&[String]>,
+                _z: Option<&[f64]>,
+            ) -> Result<CoverageResponse, DataServerError> {
+                Ok(CoverageResponse::Single($result))
+            }
+            fn get_parameters(&self) -> Vec<String> {
+                vec![]
+            }
+            fn get_temporal_extent(&self) -> Option<(DateTime<Utc>, DateTime<Utc>)> {
+                None
+            }
+            fn get_spatial_extent(&self) -> Option<[f64; 4]> {
+                None
+            }
+            fn supported_query_types(&self) -> Vec<String> {
+                vec!["position".into(), "area".into()]
+            }
+            fn query_position(
+                &self,
+                _coords: &str,
+                _dt: Option<(DateTime<Utc>, DateTime<Utc>)>,
+                _p: Option<&[String]>,
+                _z: Option<&[f64]>,
+            ) -> Result<CoverageResponse, DataServerError> {
+                Ok(CoverageResponse::Single($result))
+            }
+            fn query_area(
+                &self,
+                _coords: &str,
+                _dt: Option<(DateTime<Utc>, DateTime<Utc>)>,
+                _p: Option<&[String]>,
+                _z: Option<&[f64]>,
+            ) -> Result<CoverageResponse, DataServerError> {
+                Ok(CoverageResponse::Single($result))
+            }
+        }
+    };
+}
+
+impl_common!(ProfileEngine, profile_result());
+impl_common!(SeriesEngine, series_result());
+
+fn router_with(engine: Arc<dyn EdrEngine>) -> axum::Router {
+    let mut engines = HashMap::new();
+    let mut collections = HashMap::new();
+    engines.insert("c".to_string(), engine);
+    collections.insert(
+        "c".to_string(),
+        CollectionConfig {
+            id: "c".to_string(),
+            title: "Test".to_string(),
+            description: "Test".to_string(),
+            data_path: None,
+            apis: vec!["edr".to_string()],
+            engine_type: "csv".to_string(),
+            geotiff: None,
+            querydata: None,
+            wms: None,
+            grib: None,
+            odim: None,
+            postgis: None,
+            preview: None,
+        },
+    );
+    api_edr::router(Arc::new(ArcSwap::from_pointee(EdrState {
+        engines,
+        collections,
+        base_url: String::new(),
+    })))
+}
+
+async fn request(engine: Arc<dyn EdrEngine>, uri: &str) -> (StatusCode, String, Vec<u8>) {
+    let app = router_with(engine);
+    let req = Request::builder().uri(uri).body(Body::empty()).unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    let status = resp.status();
+    let ct = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("")
+        .to_string();
+    let body = resp
+        .into_body()
+        .collect()
+        .await
+        .unwrap()
+        .to_bytes()
+        .to_vec();
+    (status, ct, body)
+}
+
+#[tokio::test]
+async fn position_profile_png_returns_valid_image() {
+    let (status, ct, body) = request(
+        Arc::new(ProfileEngine),
+        "/collections/c/position?coords=POINT(25%2060)&f=png",
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(ct.contains("image/png"), "content-type was {ct}");
+    assert_eq!(&body[0..8], &PNG_SIGNATURE, "PNG signature");
+    assert!(
+        body.len() > 200,
+        "non-trivial PNG, got {} bytes",
+        body.len()
+    );
+}
+
+#[tokio::test]
+async fn position_series_png_returns_valid_image() {
+    let (status, ct, body) = request(
+        Arc::new(SeriesEngine),
+        "/collections/c/position?coords=POINT(25%2060)&f=png",
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(ct.contains("image/png"), "content-type was {ct}");
+    assert_eq!(&body[0..8], &PNG_SIGNATURE);
+}
+
+#[tokio::test]
+async fn format_token_is_case_insensitive() {
+    let (status, ct, _) = request(
+        Arc::new(ProfileEngine),
+        "/collections/c/position?coords=POINT(25%2060)&f=PNG",
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(ct.contains("image/png"));
+}
+
+#[tokio::test]
+async fn default_format_is_still_coveragejson() {
+    let (status, ct, _) = request(
+        Arc::new(ProfileEngine),
+        "/collections/c/position?coords=POINT(25%2060)",
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(ct.contains("coverage+json"), "content-type was {ct}");
+}
+
+#[tokio::test]
+async fn unknown_format_is_400() {
+    let (status, _, _) = request(
+        Arc::new(ProfileEngine),
+        "/collections/c/position?coords=POINT(25%2060)&f=bogus",
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn png_on_area_is_400() {
+    let (status, _, _) = request(
+        Arc::new(SeriesEngine),
+        "/collections/c/area?coords=POLYGON((0%200,1%200,1%201,0%201,0%200))&f=png",
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn custom_dimensions_are_honored() {
+    let (status, _, body) = request(
+        Arc::new(ProfileEngine),
+        "/collections/c/position?coords=POINT(25%2060)&f=png&width=400&height=300",
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    // IHDR width/height live at bytes 16..24, big-endian.
+    let w = u32::from_be_bytes([body[16], body[17], body[18], body[19]]);
+    let h = u32::from_be_bytes([body[20], body[21], body[22], body[23]]);
+    assert_eq!((w, h), (400, 300));
+}

--- a/crates/render/src/lib.rs
+++ b/crates/render/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod colormap;
 mod encode;
 pub mod metatile;
+pub mod plot;
 
 pub use colormap::{
     parse_hex_color, BuiltinColormap, ColorMap, ColorStop, IntegerLutColorMap, LinearColorMap,
@@ -8,6 +9,7 @@ pub use colormap::{
 };
 pub use encode::{encode_jpeg, encode_png, encode_webp};
 pub use metatile::{render_metatiled, MetaTile, MetaTileStats, TileKeyPrefix, TilePixelCache};
+pub use plot::{render_chart, Panel, Series};
 
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;

--- a/crates/render/src/plot.rs
+++ b/crates/render/src/plot.rs
@@ -176,8 +176,10 @@ pub fn render_chart(panels: &[Panel], width: u32, height: u32) -> Result<Vec<u8>
     if panels.is_empty() {
         return Err(DataServerError::Render("no panels to plot".into()));
     }
-    let width = width.clamp(160, 4096);
-    let height = height.clamp(120, 4096);
+    // Bound the worst-case canvas: this runs synchronously on the request
+    // worker, so cap the buffer well below the WMS raster sizes.
+    let width = width.clamp(160, 2000);
+    let height = height.clamp(120, 2000);
     let mut cv = Canvas::new(width, height);
 
     let n = panels.len() as i32;
@@ -269,7 +271,9 @@ fn draw_panel(cv: &mut Canvas, panel: &Panel, top: i32, panel_h: i32) {
         cv.text(x0 - 6 - lw, yy - 3, &label, BLACK, 1);
     }
 
-    // X ticks + gridlines + labels.
+    // X ticks + gridlines + labels. A time axis spanning more than a day
+    // needs the date too, else both ends can read "00:00".
+    let multiday = panel.x_is_time && (xmax - xmin) > 86_400.0;
     for t in x_ticks(panel, xmin, xmax, 5) {
         if t < xmin || t > xmax {
             continue;
@@ -278,7 +282,7 @@ fn draw_panel(cv: &mut Canvas, panel: &Panel, top: i32, panel_h: i32) {
         cv.vline(xx, y0 + 1, y1 - 1, GRID);
         cv.vline(xx, y1, y1 + 3, FRAME);
         let label = if panel.x_is_time {
-            format_time(t)
+            format_time(t, multiday)
         } else {
             format_value(t)
         };
@@ -408,9 +412,11 @@ fn format_value(v: f64) -> String {
     }
 }
 
-/// Format epoch seconds as `HH:MM` (UTC).
-fn format_time(epoch_secs: f64) -> String {
+/// Format epoch seconds as `HH:MM` (UTC), or `MM-DD HH:MM` when the axis
+/// spans more than a day and bare times would be ambiguous.
+fn format_time(epoch_secs: f64, with_date: bool) -> String {
     match DateTime::from_timestamp(epoch_secs.round() as i64, 0) {
+        Some(dt) if with_date => dt.format("%m-%d %H:%M").to_string(),
         Some(dt) => dt.format("%H:%M").to_string(),
         None => String::new(),
     }
@@ -675,8 +681,11 @@ mod tests {
 
     #[test]
     fn format_time_is_hh_mm() {
-        // 2026-05-15T00:00:00Z = 1_778_889_600
-        assert_eq!(format_time(1_778_889_600.0), "00:00");
+        let ts = chrono::DateTime::parse_from_rfc3339("2026-05-15T13:45:00Z")
+            .unwrap()
+            .timestamp() as f64;
+        assert_eq!(format_time(ts, false), "13:45");
+        assert_eq!(format_time(ts, true), "05-15 13:45");
     }
 
     #[test]

--- a/crates/render/src/plot.rs
+++ b/crates/render/src/plot.rs
@@ -1,0 +1,695 @@
+//! Minimal dependency-free line-chart rasteriser.
+//!
+//! Renders EDR vertical-profile and time-series responses to PNG without a
+//! charting or font crate — it draws into an RGBA buffer with a small
+//! embedded 5×7 bitmap font and hands the buffer to [`crate::encode_png`].
+//! All label text is upper-cased before drawing so the font only needs
+//! `A–Z`, `0–9`, space and a handful of symbols.
+//!
+//! One [`Panel`] is drawn per parameter (stacked vertically); within a panel
+//! every [`Series`] is overlaid in a cycling colour with a legend.
+
+use chrono::DateTime;
+
+use ds_core::error::DataServerError;
+
+use crate::encode_png;
+
+/// One labelled line within a panel. `points` are `(x, y)` in data
+/// coordinates; a `None` in *either* coordinate breaks the line (a gap, not a
+/// zero). Both ends are optional because the nullable coordinate differs by
+/// plot kind: a time series has a null *value* (y), a vertical profile has a
+/// null *value* on x with the level always present on y.
+#[derive(Debug, Clone)]
+pub struct Series {
+    pub label: String,
+    pub points: Vec<(Option<f64>, Option<f64>)>,
+}
+
+/// One stacked sub-plot (one parameter). The vertical axis carries the
+/// domain coordinate (profile) or the value (time series); see the api-edr
+/// `plot_convert` module for how domains map onto these fields.
+#[derive(Debug, Clone)]
+pub struct Panel {
+    /// Centred title (the parameter label).
+    pub title: String,
+    /// Horizontal-axis caption.
+    pub x_label: String,
+    /// Vertical-axis caption.
+    pub y_label: String,
+    /// When true the y axis grows downward (pressure / model level): the
+    /// largest value sits at the bottom.
+    pub y_invert: bool,
+    /// When true x values are epoch seconds and ticks are formatted as time.
+    pub x_is_time: bool,
+    pub series: Vec<Series>,
+}
+
+const BLACK: [u8; 3] = [0x20, 0x20, 0x20];
+const FRAME: [u8; 3] = [0x55, 0x55, 0x55];
+const GRID: [u8; 3] = [0xe2, 0xe2, 0xe2];
+
+/// Distinct, colour-blind-friendly series colours (cycled).
+const SERIES_COLORS: [[u8; 3]; 8] = [
+    [0x1f, 0x77, 0xb4],
+    [0xd6, 0x27, 0x28],
+    [0x2c, 0xa0, 0x2c],
+    [0xff, 0x7f, 0x0e],
+    [0x94, 0x67, 0xbd],
+    [0x8c, 0x56, 0x4b],
+    [0x17, 0xbe, 0xcf],
+    [0xe3, 0x77, 0xc2],
+];
+
+/// A mutable RGBA canvas with primitive drawing ops.
+struct Canvas {
+    w: i32,
+    h: i32,
+    buf: Vec<u8>,
+}
+
+impl Canvas {
+    fn new(w: u32, h: u32) -> Self {
+        Canvas {
+            w: w as i32,
+            h: h as i32,
+            buf: vec![0xff; (w as usize) * (h as usize) * 4],
+        }
+    }
+
+    #[inline]
+    fn put(&mut self, x: i32, y: i32, c: [u8; 3]) {
+        if x < 0 || y < 0 || x >= self.w || y >= self.h {
+            return;
+        }
+        let i = ((y * self.w + x) as usize) * 4;
+        self.buf[i] = c[0];
+        self.buf[i + 1] = c[1];
+        self.buf[i + 2] = c[2];
+        self.buf[i + 3] = 0xff;
+    }
+
+    fn fill_rect(&mut self, x: i32, y: i32, w: i32, h: i32, c: [u8; 3]) {
+        for yy in y..y + h {
+            for xx in x..x + w {
+                self.put(xx, yy, c);
+            }
+        }
+    }
+
+    fn hline(&mut self, x0: i32, x1: i32, y: i32, c: [u8; 3]) {
+        for x in x0.min(x1)..=x0.max(x1) {
+            self.put(x, y, c);
+        }
+    }
+
+    fn vline(&mut self, x: i32, y0: i32, y1: i32, c: [u8; 3]) {
+        for y in y0.min(y1)..=y0.max(y1) {
+            self.put(x, y, c);
+        }
+    }
+
+    /// Bresenham line.
+    fn line(&mut self, x0: i32, y0: i32, x1: i32, y1: i32, c: [u8; 3]) {
+        let dx = (x1 - x0).abs();
+        let dy = -(y1 - y0).abs();
+        let sx = if x0 < x1 { 1 } else { -1 };
+        let sy = if y0 < y1 { 1 } else { -1 };
+        let mut err = dx + dy;
+        let (mut x, mut y) = (x0, y0);
+        loop {
+            self.put(x, y, c);
+            if x == x1 && y == y1 {
+                break;
+            }
+            let e2 = 2 * err;
+            if e2 >= dy {
+                err += dy;
+                x += sx;
+            }
+            if e2 <= dx {
+                err += dx;
+                y += sy;
+            }
+        }
+    }
+
+    fn rect(&mut self, x0: i32, y0: i32, x1: i32, y1: i32, c: [u8; 3]) {
+        self.hline(x0, x1, y0, c);
+        self.hline(x0, x1, y1, c);
+        self.vline(x0, y0, y1, c);
+        self.vline(x1, y0, y1, c);
+    }
+
+    /// Draw upper-cased `text` with the top-left of the first glyph at
+    /// `(x, y)`. Returns the x just past the text.
+    fn text(&mut self, x: i32, y: i32, text: &str, c: [u8; 3], scale: i32) -> i32 {
+        let mut cx = x;
+        for ch in text.chars() {
+            let glyph = glyph(ch.to_ascii_uppercase());
+            for (row, bits) in glyph.iter().enumerate() {
+                for col in 0..GLYPH_W {
+                    if bits & (1 << (GLYPH_W - 1 - col)) != 0 {
+                        self.fill_rect(
+                            cx + col as i32 * scale,
+                            y + row as i32 * scale,
+                            scale,
+                            scale,
+                            c,
+                        );
+                    }
+                }
+            }
+            cx += (GLYPH_W as i32 + 1) * scale;
+        }
+        cx
+    }
+}
+
+/// Rendered width of `text` at `scale`, in pixels.
+fn text_width(text: &str, scale: i32) -> i32 {
+    text.chars().count() as i32 * (GLYPH_W as i32 + 1) * scale
+}
+
+/// Render `panels` (stacked vertically) to PNG bytes.
+pub fn render_chart(panels: &[Panel], width: u32, height: u32) -> Result<Vec<u8>, DataServerError> {
+    if panels.is_empty() {
+        return Err(DataServerError::Render("no panels to plot".into()));
+    }
+    let width = width.clamp(160, 4096);
+    let height = height.clamp(120, 4096);
+    let mut cv = Canvas::new(width, height);
+
+    let n = panels.len() as i32;
+    let panel_h = cv.h / n;
+    for (i, panel) in panels.iter().enumerate() {
+        let top = i as i32 * panel_h;
+        draw_panel(&mut cv, panel, top, panel_h);
+    }
+
+    encode_png(&cv.buf, width, height)
+}
+
+fn draw_panel(cv: &mut Canvas, panel: &Panel, top: i32, panel_h: i32) {
+    // Margins carve the plot frame out of the panel's slice.
+    let m_left = 58;
+    let m_right = 12;
+    let m_top = 26;
+    let m_bottom = 30;
+
+    let x0 = m_left;
+    let x1 = cv.w - m_right;
+    let y0 = top + m_top;
+    let y1 = top + panel_h - m_bottom;
+    if x1 <= x0 + 4 || y1 <= y0 + 4 {
+        return; // panel too small to draw anything meaningful
+    }
+
+    // Centred panel title.
+    let title = panel.title.to_ascii_uppercase();
+    let tw = text_width(&title, 2);
+    cv.text((cv.w - tw) / 2, top + 6, &title, BLACK, 2);
+
+    // Collect finite data bounds across every series.
+    let mut xmin = f64::INFINITY;
+    let mut xmax = f64::NEG_INFINITY;
+    let mut ymin = f64::INFINITY;
+    let mut ymax = f64::NEG_INFINITY;
+    for s in &panel.series {
+        for &(x, y) in &s.points {
+            let (Some(x), Some(y)) = (x, y) else { continue };
+            if !x.is_finite() || !y.is_finite() {
+                continue;
+            }
+            xmin = xmin.min(x);
+            xmax = xmax.max(x);
+            ymin = ymin.min(y);
+            ymax = ymax.max(y);
+        }
+    }
+
+    cv.rect(x0, y0, x1, y1, FRAME);
+
+    if !xmin.is_finite() || !ymin.is_finite() {
+        let msg = "NO DATA";
+        let w = text_width(msg, 2);
+        cv.text((x0 + x1) / 2 - w / 2, (y0 + y1) / 2 - 7, msg, FRAME, 2);
+        // Still label the axes so the empty plot is self-describing.
+        draw_axis_captions(cv, panel, x0, x1, y1, top);
+        return;
+    }
+
+    // Pad ranges; expand a degenerate (single-value) range so it maps.
+    let (xmin, xmax) = pad_range(xmin, xmax);
+    let (ymin, ymax) = pad_range(ymin, ymax);
+
+    let px =
+        |x: f64| -> i32 { x0 + (((x - xmin) / (xmax - xmin)) * (x1 - x0) as f64).round() as i32 };
+    let py = |y: f64| -> i32 {
+        let frac = (y - ymin) / (ymax - ymin);
+        // Screen y grows downward: an "up" axis puts ymax at the top (y0);
+        // an inverted ("down") axis puts ymax at the bottom (y1).
+        if panel.y_invert {
+            y0 + (frac * (y1 - y0) as f64).round() as i32
+        } else {
+            y1 - (frac * (y1 - y0) as f64).round() as i32
+        }
+    };
+
+    // Y ticks + gridlines + labels.
+    for t in nice_ticks(ymin, ymax, 5) {
+        if t < ymin || t > ymax {
+            continue;
+        }
+        let yy = py(t);
+        cv.hline(x0 + 1, x1 - 1, yy, GRID);
+        cv.hline(x0 - 3, x0, yy, FRAME);
+        let label = format_value(t);
+        let lw = text_width(&label, 1);
+        cv.text(x0 - 6 - lw, yy - 3, &label, BLACK, 1);
+    }
+
+    // X ticks + gridlines + labels.
+    for t in x_ticks(panel, xmin, xmax, 5) {
+        if t < xmin || t > xmax {
+            continue;
+        }
+        let xx = px(t);
+        cv.vline(xx, y0 + 1, y1 - 1, GRID);
+        cv.vline(xx, y1, y1 + 3, FRAME);
+        let label = if panel.x_is_time {
+            format_time(t)
+        } else {
+            format_value(t)
+        };
+        let lw = text_width(&label, 1);
+        cv.text(xx - lw / 2, y1 + 6, &label, BLACK, 1);
+    }
+
+    // Series polylines + point markers.
+    for (i, s) in panel.series.iter().enumerate() {
+        let color = SERIES_COLORS[i % SERIES_COLORS.len()];
+        let mut prev: Option<(i32, i32)> = None;
+        for &(x, y) in &s.points {
+            match (x, y) {
+                (Some(x), Some(y)) if x.is_finite() && y.is_finite() => {
+                    let p = (px(x), py(y));
+                    if let Some(q) = prev {
+                        cv.line(q.0, q.1, p.0, p.1, color);
+                    }
+                    cv.fill_rect(p.0 - 1, p.1 - 1, 3, 3, color);
+                    prev = Some(p);
+                }
+                _ => prev = None, // gap
+            }
+        }
+    }
+
+    draw_legend(cv, panel, x0, y0);
+    draw_axis_captions(cv, panel, x0, x1, y1, top);
+}
+
+/// Y-axis caption (horizontal, top-left above the frame) and centred X-axis
+/// caption (below the frame).
+fn draw_axis_captions(cv: &mut Canvas, panel: &Panel, x0: i32, x1: i32, y1: i32, top: i32) {
+    let y_cap = panel.y_label.to_ascii_uppercase();
+    cv.text(4, top + 16, &y_cap, BLACK, 1);
+
+    let x_cap = panel.x_label.to_ascii_uppercase();
+    let w = text_width(&x_cap, 1);
+    cv.text((x0 + x1) / 2 - w / 2, y1 + 16, &x_cap, BLACK, 1);
+}
+
+/// Top-right legend: a colour swatch + label per series.
+fn draw_legend(cv: &mut Canvas, panel: &Panel, x0: i32, y0: i32) {
+    let any_labeled = panel.series.iter().any(|s| !s.label.is_empty());
+    if panel.series.len() < 2 && !any_labeled {
+        return; // a single unlabelled series needs no legend
+    }
+    let mut ly = y0 + 4;
+    for (i, s) in panel.series.iter().enumerate() {
+        let color = SERIES_COLORS[i % SERIES_COLORS.len()];
+        let label = s.label.to_ascii_uppercase();
+        let lw = text_width(&label, 1);
+        let lx = x0 + 8;
+        // Right-aligned block: swatch (8px) + gap (3px) + text.
+        let block_w = 8 + 3 + lw;
+        let bx = (cv.w - 14 - block_w).max(lx);
+        cv.fill_rect(bx, ly + 1, 8, 5, color);
+        cv.text(bx + 11, ly, &label, BLACK, 1);
+        ly += 9;
+    }
+}
+
+/// Expand a data range by 5%, widening a degenerate range to ±1 (or ±|v|).
+fn pad_range(min: f64, max: f64) -> (f64, f64) {
+    if (max - min).abs() < f64::EPSILON {
+        let d = if min.abs() > 1.0 {
+            min.abs() * 0.1
+        } else {
+            1.0
+        };
+        return (min - d, max + d);
+    }
+    let pad = (max - min) * 0.05;
+    (min - pad, max + pad)
+}
+
+/// ~`n` round tick values spanning `[min, max]` (1/2/5 × 10^k steps).
+fn nice_ticks(min: f64, max: f64, n: usize) -> Vec<f64> {
+    if !(min.is_finite() && max.is_finite()) || max <= min || n == 0 {
+        return vec![];
+    }
+    let range = max - min;
+    let raw = range / n as f64;
+    let mag = 10f64.powf(raw.log10().floor());
+    let norm = raw / mag;
+    let step = if norm < 1.5 {
+        mag
+    } else if norm < 3.0 {
+        2.0 * mag
+    } else if norm < 7.0 {
+        5.0 * mag
+    } else {
+        10.0 * mag
+    };
+    let mut t = (min / step).ceil() * step;
+    let mut out = Vec::new();
+    while t <= max + step * 0.5 && out.len() < 64 {
+        // Snap values that are integers-in-disguise (e.g. 1.9999999).
+        out.push((t / step).round() * step);
+        t += step;
+    }
+    out
+}
+
+/// Tick values for the x axis — nice numbers for values, evenly spaced for time.
+fn x_ticks(panel: &Panel, min: f64, max: f64, n: usize) -> Vec<f64> {
+    if panel.x_is_time {
+        if max <= min {
+            return vec![min];
+        }
+        (0..=n)
+            .map(|i| min + (max - min) * i as f64 / n as f64)
+            .collect()
+    } else {
+        nice_ticks(min, max, n)
+    }
+}
+
+/// Format a numeric tick: integer when whole, else one decimal, dropping a
+/// trailing `.0`.
+fn format_value(v: f64) -> String {
+    let r = (v * 10.0).round() / 10.0;
+    if (r - r.round()).abs() < 0.05 && r.abs() < 1e7 {
+        format!("{}", r.round() as i64)
+    } else {
+        format!("{r:.1}")
+    }
+}
+
+/// Format epoch seconds as `HH:MM` (UTC).
+fn format_time(epoch_secs: f64) -> String {
+    match DateTime::from_timestamp(epoch_secs.round() as i64, 0) {
+        Some(dt) => dt.format("%H:%M").to_string(),
+        None => String::new(),
+    }
+}
+
+const GLYPH_W: usize = 5;
+
+/// 5×7 glyph (7 rows, low 5 bits each, MSB = leftmost column). Covers the
+/// upper-cased label charset; unknown glyphs render as a hollow box.
+fn glyph(c: char) -> [u8; 7] {
+    match c {
+        ' ' => [0; 7],
+        '0' => [
+            0b01110, 0b10001, 0b10011, 0b10101, 0b11001, 0b10001, 0b01110,
+        ],
+        '1' => [
+            0b00100, 0b01100, 0b00100, 0b00100, 0b00100, 0b00100, 0b01110,
+        ],
+        '2' => [
+            0b01110, 0b10001, 0b00001, 0b00010, 0b00100, 0b01000, 0b11111,
+        ],
+        '3' => [
+            0b11111, 0b00010, 0b00100, 0b00010, 0b00001, 0b10001, 0b01110,
+        ],
+        '4' => [
+            0b00010, 0b00110, 0b01010, 0b10010, 0b11111, 0b00010, 0b00010,
+        ],
+        '5' => [
+            0b11111, 0b10000, 0b11110, 0b00001, 0b00001, 0b10001, 0b01110,
+        ],
+        '6' => [
+            0b00110, 0b01000, 0b10000, 0b11110, 0b10001, 0b10001, 0b01110,
+        ],
+        '7' => [
+            0b11111, 0b00001, 0b00010, 0b00100, 0b01000, 0b01000, 0b01000,
+        ],
+        '8' => [
+            0b01110, 0b10001, 0b10001, 0b01110, 0b10001, 0b10001, 0b01110,
+        ],
+        '9' => [
+            0b01110, 0b10001, 0b10001, 0b01111, 0b00001, 0b00010, 0b01100,
+        ],
+        'A' => [
+            0b01110, 0b10001, 0b10001, 0b11111, 0b10001, 0b10001, 0b10001,
+        ],
+        'B' => [
+            0b11110, 0b10001, 0b10001, 0b11110, 0b10001, 0b10001, 0b11110,
+        ],
+        'C' => [
+            0b01110, 0b10001, 0b10000, 0b10000, 0b10000, 0b10001, 0b01110,
+        ],
+        'D' => [
+            0b11110, 0b10001, 0b10001, 0b10001, 0b10001, 0b10001, 0b11110,
+        ],
+        'E' => [
+            0b11111, 0b10000, 0b10000, 0b11110, 0b10000, 0b10000, 0b11111,
+        ],
+        'F' => [
+            0b11111, 0b10000, 0b10000, 0b11110, 0b10000, 0b10000, 0b10000,
+        ],
+        'G' => [
+            0b01110, 0b10001, 0b10000, 0b10111, 0b10001, 0b10001, 0b01111,
+        ],
+        'H' => [
+            0b10001, 0b10001, 0b10001, 0b11111, 0b10001, 0b10001, 0b10001,
+        ],
+        'I' => [
+            0b01110, 0b00100, 0b00100, 0b00100, 0b00100, 0b00100, 0b01110,
+        ],
+        'J' => [
+            0b00111, 0b00010, 0b00010, 0b00010, 0b00010, 0b10010, 0b01100,
+        ],
+        'K' => [
+            0b10001, 0b10010, 0b10100, 0b11000, 0b10100, 0b10010, 0b10001,
+        ],
+        'L' => [
+            0b10000, 0b10000, 0b10000, 0b10000, 0b10000, 0b10000, 0b11111,
+        ],
+        'M' => [
+            0b10001, 0b11011, 0b10101, 0b10101, 0b10001, 0b10001, 0b10001,
+        ],
+        'N' => [
+            0b10001, 0b11001, 0b10101, 0b10011, 0b10001, 0b10001, 0b10001,
+        ],
+        'O' => [
+            0b01110, 0b10001, 0b10001, 0b10001, 0b10001, 0b10001, 0b01110,
+        ],
+        'P' => [
+            0b11110, 0b10001, 0b10001, 0b11110, 0b10000, 0b10000, 0b10000,
+        ],
+        'Q' => [
+            0b01110, 0b10001, 0b10001, 0b10001, 0b10101, 0b10010, 0b01101,
+        ],
+        'R' => [
+            0b11110, 0b10001, 0b10001, 0b11110, 0b10100, 0b10010, 0b10001,
+        ],
+        'S' => [
+            0b01111, 0b10000, 0b10000, 0b01110, 0b00001, 0b00001, 0b11110,
+        ],
+        'T' => [
+            0b11111, 0b00100, 0b00100, 0b00100, 0b00100, 0b00100, 0b00100,
+        ],
+        'U' => [
+            0b10001, 0b10001, 0b10001, 0b10001, 0b10001, 0b10001, 0b01110,
+        ],
+        'V' => [
+            0b10001, 0b10001, 0b10001, 0b10001, 0b10001, 0b01010, 0b00100,
+        ],
+        'W' => [
+            0b10001, 0b10001, 0b10001, 0b10101, 0b10101, 0b10101, 0b01010,
+        ],
+        'X' => [
+            0b10001, 0b10001, 0b01010, 0b00100, 0b01010, 0b10001, 0b10001,
+        ],
+        'Y' => [
+            0b10001, 0b10001, 0b01010, 0b00100, 0b00100, 0b00100, 0b00100,
+        ],
+        'Z' => [
+            0b11111, 0b00001, 0b00010, 0b00100, 0b01000, 0b10000, 0b11111,
+        ],
+        '.' => [
+            0b00000, 0b00000, 0b00000, 0b00000, 0b00000, 0b00110, 0b00110,
+        ],
+        ',' => [
+            0b00000, 0b00000, 0b00000, 0b00000, 0b00110, 0b00110, 0b01100,
+        ],
+        '-' => [
+            0b00000, 0b00000, 0b00000, 0b11111, 0b00000, 0b00000, 0b00000,
+        ],
+        '+' => [
+            0b00000, 0b00100, 0b00100, 0b11111, 0b00100, 0b00100, 0b00000,
+        ],
+        ':' => [
+            0b00000, 0b00110, 0b00110, 0b00000, 0b00110, 0b00110, 0b00000,
+        ],
+        '/' => [
+            0b00001, 0b00010, 0b00010, 0b00100, 0b01000, 0b01000, 0b10000,
+        ],
+        '(' => [
+            0b00010, 0b00100, 0b01000, 0b01000, 0b01000, 0b00100, 0b00010,
+        ],
+        ')' => [
+            0b01000, 0b00100, 0b00010, 0b00010, 0b00010, 0b00100, 0b01000,
+        ],
+        '%' => [
+            0b11001, 0b11010, 0b00100, 0b01000, 0b10011, 0b00011, 0b00000,
+        ],
+        _ => [
+            0b11111, 0b10001, 0b10001, 0b10001, 0b10001, 0b10001, 0b11111,
+        ],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn decode_dims(png: &[u8]) -> (u32, u32) {
+        // PNG IHDR width/height are big-endian u32 at bytes 16..24.
+        assert_eq!(&png[0..8], b"\x89PNG\r\n\x1a\n", "PNG signature");
+        let w = u32::from_be_bytes([png[16], png[17], png[18], png[19]]);
+        let h = u32::from_be_bytes([png[20], png[21], png[22], png[23]]);
+        (w, h)
+    }
+
+    fn sample_panel() -> Panel {
+        Panel {
+            title: "DBZH".into(),
+            x_label: "Reflectivity (dBZ)".into(),
+            y_label: "Elevation angle (deg)".into(),
+            y_invert: false,
+            x_is_time: false,
+            series: vec![Series {
+                label: "00:00".into(),
+                points: vec![
+                    (Some(5.0), Some(0.5)),
+                    (Some(12.0), Some(2.0)),
+                    (Some(8.0), Some(5.0)),
+                    (Some(3.0), Some(9.0)),
+                ],
+            }],
+        }
+    }
+
+    #[test]
+    fn renders_valid_png_of_requested_size() {
+        let png = render_chart(&[sample_panel()], 800, 600).unwrap();
+        assert_eq!(decode_dims(&png), (800, 600));
+    }
+
+    #[test]
+    fn render_is_deterministic() {
+        let a = render_chart(&[sample_panel()], 640, 480).unwrap();
+        let b = render_chart(&[sample_panel()], 640, 480).unwrap();
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn all_null_series_still_renders() {
+        let panel = Panel {
+            title: "VRADH".into(),
+            x_label: "x".into(),
+            y_label: "y".into(),
+            y_invert: false,
+            x_is_time: false,
+            series: vec![Series {
+                label: "s".into(),
+                points: vec![(Some(1.0), None), (Some(2.0), None)],
+            }],
+        };
+        let png = render_chart(&[panel], 400, 300).unwrap();
+        assert_eq!(decode_dims(&png), (400, 300));
+    }
+
+    #[test]
+    fn multi_panel_stacks() {
+        let png = render_chart(&[sample_panel(), sample_panel()], 500, 600).unwrap();
+        assert_eq!(decode_dims(&png), (500, 600));
+    }
+
+    #[test]
+    fn dimensions_are_clamped() {
+        let png = render_chart(&[sample_panel()], 10, 10).unwrap();
+        // Clamped up to the 160×120 floor.
+        assert_eq!(decode_dims(&png), (160, 120));
+    }
+
+    #[test]
+    fn empty_panels_is_error() {
+        assert!(render_chart(&[], 100, 100).is_err());
+    }
+
+    #[test]
+    fn nice_ticks_are_round() {
+        let t = nice_ticks(0.0, 10.0, 5);
+        assert!(t.contains(&0.0) || t.contains(&2.0));
+        assert!(t.iter().all(|v| v.is_finite()));
+    }
+
+    #[test]
+    fn time_axis_ticks_are_evenly_spaced() {
+        let p = Panel {
+            title: "T".into(),
+            x_label: "TIME".into(),
+            y_label: "V".into(),
+            y_invert: false,
+            x_is_time: true,
+            series: vec![],
+        };
+        let t = x_ticks(&p, 0.0, 3600.0, 4);
+        assert_eq!(t.len(), 5);
+        assert_eq!(t[0], 0.0);
+        assert_eq!(t[4], 3600.0);
+    }
+
+    #[test]
+    fn format_value_drops_trailing_zero() {
+        assert_eq!(format_value(2.0), "2");
+        assert_eq!(format_value(2.5), "2.5");
+        assert_eq!(format_value(-12.34), "-12.3");
+    }
+
+    #[test]
+    fn format_time_is_hh_mm() {
+        // 2026-05-15T00:00:00Z = 1_778_889_600
+        assert_eq!(format_time(1_778_889_600.0), "00:00");
+    }
+
+    #[test]
+    fn font_draws_known_pixels() {
+        // 'I' (0x0E top row 01110) should set the middle columns of a glyph.
+        let mut cv = Canvas::new(20, 20);
+        cv.text(2, 2, "I", BLACK, 1);
+        // top row of 'I' spans cols 1..4 (bits 01110) at y=2.
+        let lit = |x: i32, y: i32| -> bool {
+            let i = ((y * cv.w + x) as usize) * 4;
+            cv.buf[i] != 0xff
+        };
+        assert!(lit(3, 2), "I top bar pixel set");
+        assert!(!lit(2, 2), "I top-left corner clear");
+    }
+}


### PR DESCRIPTION
## Summary

- EDR `position` / `locations` queries can now return an `image/png` plot via `f=png`, alongside the default CoverageJSON.
  - A **VerticalProfile** plots the parameter value (x) against the vertical coordinate (y), oriented per `VerticalKind::direction` (elevation/height up, pressure down).
  - A **PointSeries** plots a time-series line (time x, value y).
- Rendering is **hand-rolled in `ds-render`** (new `plot` module + embedded 5×7 bitmap font) reusing the existing `encode_png` — **no new dependencies**; ds-render keeps its `ds-core` + `png`-only rule.
- **One stacked panel per parameter**; a `CoverageCollection` (e.g. PVOL one-profile-per-timestep, or one-series-per-level) **overlays each coverage as a labelled series with a legend**. Null samples break the line; an all-null panel draws "NO DATA".
- `area` rejects `f=png` (gridded / multi-coverage, not a single line plot). `api-edr` now depends on `ds-render`; collection `output_formats` and the OpenAPI definition advertise PNG.

## Test plan

- [x] `ds-render` unit tests: valid PNG signature + dimensions, deterministic bytes, all-null panel, multi-panel stacking, dimension clamping, nice-ticks, time-axis ticks, value/time formatting, a font-glyph pixel check.
- [x] `api-edr` unit tests (`plot_convert`): VerticalProfile → value-x/level-y mapping incl. null gap; pressure → `y_invert`; collection → one series per coverage; PointSeries → `x_is_time`; Grid → 400.
- [x] `api-edr` integration tests (`png_plot_tests`): position profile & series `f=png` → valid `image/png`; `f=PNG` case-insensitive; default → CoverageJSON; `f=bogus` → 400; `f=png` on area → 400; `width`/`height` honoured.
- [x] `cargo fmt` + `cargo clippy --all-targets -D warnings` clean on both crates; existing `covjson_validation` suite still green.
- [x] **End-to-end**: built the server, ran a throwaway instance, and rendered a real FMI PVOL profile — `TH` value vs elevation angle (0.5°→45°, ticks, gridlines, point markers, timestamp legend) renders correctly; a point with no echo shows "NO DATA".

### Notes / follow-ups
- With many parameters (e.g. a full PVOL volume's ~16 quantities) the stacked panels get very short at the default 600 px height; select a `parameter-name` or request a taller `height`. Multi-parameter layout polish, `area`/`Grid` rendering, and SVG output are out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)