### PR TITLE
feat(api-edr): default_output_format=CoverageJSON; drop unsupported GeoJSON from locations

### DIFF
--- a/crates/api-edr/src/handlers.rs
+++ b/crates/api-edr/src/handlers.rs
@@ -833,7 +833,8 @@ fn build_collection_metadata(
                     "rel": "data",
                     "variables": {
                         "query_type": qt,
-                        "output_formats": output_formats
+                        "output_formats": output_formats,
+                        "default_output_format": "CoverageJSON"
                     }
                 }
             }),

--- a/crates/api-edr/src/handlers.rs
+++ b/crates/api-edr/src/handlers.rs
@@ -436,7 +436,6 @@ pub async fn conformance() -> impl IntoResponse {
             "http://www.opengis.net/spec/ogcapi-edr-1/1.1/conf/core",
             "http://www.opengis.net/spec/ogcapi-edr-1/1.1/conf/collections",
             "http://www.opengis.net/spec/ogcapi-edr-1/1.1/conf/json",
-            "http://www.opengis.net/spec/ogcapi-edr-1/1.1/conf/edr-geojson",
             "http://www.opengis.net/spec/ogcapi-edr-1/1.1/conf/covjson"
         ]
     }))

--- a/crates/api-edr/src/handlers.rs
+++ b/crates/api-edr/src/handlers.rs
@@ -813,7 +813,7 @@ fn build_collection_metadata(
         let (endpoint, output_formats) = match qt.as_str() {
             "locations" => (
                 format!("{base_url}/edr/collections/{}/locations", config.id),
-                json!(["CoverageJSON", "GeoJSON", "PNG"]),
+                json!(["CoverageJSON", "PNG"]),
             ),
             "position" => (
                 format!("{base_url}/edr/collections/{}/position", config.id),
@@ -857,6 +857,6 @@ fn build_collection_metadata(
         "data_queries": data_queries,
         "crs": ["http://www.opengis.net/def/crs/OGC/1.3/CRS84"],
         "parameter_names": parameter_names,
-        "output_formats": ["CoverageJSON", "GeoJSON", "PNG"]
+        "output_formats": ["CoverageJSON", "PNG"]
     })
 }

--- a/crates/api-edr/tests/spec_compliance_tests.rs
+++ b/crates/api-edr/tests/spec_compliance_tests.rs
@@ -603,6 +603,14 @@ async fn finding_16_data_queries_link_structure() {
         "GeoJSON must not appear in locations output_formats — f=GeoJSON returns HTTP 400"
     );
     assert_eq!(vars["default_output_format"], "CoverageJSON");
+
+    // Prove the comment above: f=GeoJSON on the data endpoint returns 400.
+    let (status, _) = get_json("/collections/weather/locations/station1?f=GeoJSON").await;
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "f=GeoJSON must be rejected on the locations data endpoint"
+    );
 }
 
 #[tokio::test]
@@ -864,6 +872,12 @@ async fn finding_27_conformance_valid() {
     for item in conforms_to {
         assert!(item.is_string(), "each conformsTo entry must be a string");
     }
+    assert!(
+        !conforms_to.iter().any(|v| v
+            .as_str()
+            .is_some_and(|s| s.ends_with("/conf/edr-geojson"))),
+        "edr-geojson conformance class must not be advertised — data queries return HTTP 400 for f=GeoJSON"
+    );
 }
 
 // ===========================================================================

--- a/crates/api-edr/tests/spec_compliance_tests.rs
+++ b/crates/api-edr/tests/spec_compliance_tests.rs
@@ -601,6 +601,59 @@ async fn finding_16_data_queries_link_structure() {
     assert_eq!(vars["default_output_format"], "CoverageJSON");
 }
 
+#[tokio::test]
+async fn data_queries_default_output_format_set_for_all_query_types() {
+    struct AllQueriesEngine;
+    impl EdrEngine for AllQueriesEngine {
+        fn get_locations(&self) -> Result<Vec<Location>, DataServerError> {
+            Ok(vec![])
+        }
+        fn query_location(
+            &self,
+            location_id: &str,
+            _: Option<(DateTime<Utc>, DateTime<Utc>)>,
+            _: Option<&[String]>,
+            _: Option<&[f64]>,
+        ) -> Result<ds_core::model::CoverageResponse, DataServerError> {
+            Err(DataServerError::LocationNotFound(location_id.into()))
+        }
+        fn get_parameters(&self) -> Vec<String> {
+            vec!["t".to_string()]
+        }
+        fn get_temporal_extent(&self) -> Option<(DateTime<Utc>, DateTime<Utc>)> {
+            None
+        }
+        fn get_spatial_extent(&self) -> Option<[f64; 4]> {
+            Some([0.0, 0.0, 1.0, 1.0])
+        }
+        fn supported_query_types(&self) -> Vec<String> {
+            vec!["locations".into(), "position".into(), "area".into()]
+        }
+    }
+
+    let state = make_edr_state(Arc::new(AllQueriesEngine));
+    let app = api_edr::router(state);
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/collections/weather")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    let json: Value = serde_json::from_slice(&bytes).unwrap();
+
+    for qt in ["locations", "position", "area"] {
+        let vars = &json["data_queries"][qt]["link"]["variables"];
+        assert_eq!(
+            vars["default_output_format"], "CoverageJSON",
+            "data_queries[{qt}].link.variables.default_output_format must be \"CoverageJSON\""
+        );
+    }
+}
+
 // ===========================================================================
 // FINDING 17: Collections list missing numberMatched / numberReturned
 // ===========================================================================

--- a/crates/api-edr/tests/spec_compliance_tests.rs
+++ b/crates/api-edr/tests/spec_compliance_tests.rs
@@ -598,6 +598,7 @@ async fn finding_16_data_queries_link_structure() {
     let vars = &link["variables"];
     assert_eq!(vars["query_type"], "locations");
     assert!(vars["output_formats"].is_array());
+    assert_eq!(vars["default_output_format"], "CoverageJSON");
 }
 
 // ===========================================================================

--- a/crates/api-edr/tests/spec_compliance_tests.rs
+++ b/crates/api-edr/tests/spec_compliance_tests.rs
@@ -597,7 +597,11 @@ async fn finding_16_data_queries_link_structure() {
     // Verify variables structure
     let vars = &link["variables"];
     assert_eq!(vars["query_type"], "locations");
-    assert!(vars["output_formats"].is_array());
+    let formats = vars["output_formats"].as_array().expect("output_formats");
+    assert!(
+        !formats.iter().any(|v| v == "GeoJSON"),
+        "GeoJSON must not appear in locations output_formats — f=GeoJSON returns HTTP 400"
+    );
     assert_eq!(vars["default_output_format"], "CoverageJSON");
 }
 
@@ -642,6 +646,7 @@ async fn data_queries_default_output_format_set_for_all_query_types() {
         )
         .await
         .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK, "/collections/weather");
     let bytes = resp.into_body().collect().await.unwrap().to_bytes();
     let json: Value = serde_json::from_slice(&bytes).unwrap();
 


### PR DESCRIPTION
## Summary
- Add `default_output_format: "CoverageJSON"` to each data_queries entry's `variables` block in the collection detail JSON (locations / position / area). Matches `parse_edr_format` behavior when `f` is absent (`crates/api-edr/src/params.rs:42`). Conforms to OGC EDR 1.1 schema (`schemas/ogcapi-edr-1.1-bundled.json:809`).
- Drop `GeoJSON` from the locations data-query `output_formats` (and the collection-level `output_formats`) — `/locations/{locationId}?f=GeoJSON` was returning HTTP 400 because `parse_edr_format` only accepts CoverageJSON/PNG. The locations *list* endpoint still emits GeoJSON natively (it doesn't consume `f=`).
- Drop the `edr-geojson` conformance class — it signals that EDR data queries can return EDR-GeoJSON; ours can't. The locations list endpoint is a navigation resource, not a data-query response.
- Tests: extend `finding_16_data_queries_link_structure` with a `default_output_format` assertion, plus a focused test that exercises all three query types via an inline mock.

## Test plan
- [x] `cargo test -p api-edr` — all suites pass (35 spec-compliance, 14 ogc, 22 covjson, 7 png_plot, 28 security, 72 performance, 14 unit)
- [x] `cargo clippy -p api-edr --all-targets -- -D warnings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)