### PR TITLE
feat(api-edr,engine-odim): PVOL trajectory cross-sections (Section domain) (#198)

### DIFF
--- a/crates/api-edr/Cargo.toml
+++ b/crates/api-edr/Cargo.toml
@@ -12,6 +12,8 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 chrono = { version = "0.4", features = ["serde"] }
 tracing = "0.1"
+# `rt` provides `task::spawn_blocking` for the heavy trajectory query path.
+tokio = { version = "1", features = ["rt"] }
 
 [dev-dependencies]
 jsonschema = "0.28"

--- a/crates/api-edr/src/handlers.rs
+++ b/crates/api-edr/src/handlers.rs
@@ -807,6 +807,28 @@ pub async fn trajectory_query(
     let state = state.load_full();
     let (engine, _config) = lookup_collection(&state, &id)?;
 
+    // An engine that doesn't advertise `trajectory` has no cross-section
+    // capability. Return 404 (the resource doesn't exist for this
+    // collection) rather than letting the default trait method answer
+    // 400 (which wrongly implies the *request* was malformed). Keeps the
+    // live route consistent with the `api_definition` OpenAPI gating and
+    // the `data_queries` collection metadata. Flagged by claude-review.
+    if !engine
+        .supported_query_types()
+        .iter()
+        .any(|q| q == "trajectory")
+    {
+        return Err((
+            StatusCode::NOT_FOUND,
+            Json(json!({
+                "code": "NotFound",
+                "description": format!(
+                    "Collection '{id}' does not support trajectory (cross-section) queries"
+                )
+            })),
+        ));
+    }
+
     // A Section is a 2-D cross-section — not a single plot.
     if parse_edr_format(params.f.as_deref()).map_err(|e| bad_request(&e))? == EdrFormat::Png {
         return Err(bad_request(&DataServerError::InvalidParameter(

--- a/crates/api-edr/src/handlers.rs
+++ b/crates/api-edr/src/handlers.rs
@@ -17,8 +17,8 @@ use ds_core::model::CoverageResponse;
 use ds_render::{render_chart, render_heatmap};
 
 use crate::params::{
-    parse_edr_format, parse_z, plot_dimensions, split_position_coords, AreaQueryParams, EdrFormat,
-    LocationQueryParams, PositionQueryParams, TrajectoryQueryParams,
+    parse_edr_format, parse_z, plot_dimensions, resolve_z_levels, split_position_coords,
+    AreaQueryParams, EdrFormat, LocationQueryParams, PositionQueryParams, TrajectoryQueryParams,
 };
 use crate::plot_convert::{coverage_response_to_panels, section_response_to_heatmaps};
 use crate::response::{coverage_response_to_json, locations_to_geojson, LocationsContext};
@@ -100,14 +100,23 @@ fn lookup_collection<'a>(
     Ok((engine, config))
 }
 
-/// Reject a `z` selector against a collection with no vertical dimension.
-/// Collections that have one let the engine resolve `z`; collections that
-/// don't return HTTP 400 rather than silently ignoring the parameter.
-fn reject_z_without_vertical(
+/// Parse and resolve the request `z` parameter into the concrete level
+/// list an engine samples.
+///
+/// - Absent / blank → `None` (whole vertical extent).
+/// - A `z` against a collection with no vertical dimension → 400 (rather
+///   than silently ignored).
+/// - An interval (`z=min/max`) is expanded against the collection's
+///   advertised levels; a list passes through for the engine to snap.
+fn resolve_request_z(
     engine: &Arc<dyn EdrEngine>,
-    z: &Option<Vec<f64>>,
-) -> Result<(), (StatusCode, Json<serde_json::Value>)> {
-    if z.is_some() && engine.get_vertical_extent().is_none() {
+    z: Option<&str>,
+) -> Result<Option<Vec<f64>>, (StatusCode, Json<serde_json::Value>)> {
+    let Some(sel) = parse_z(z).map_err(|e| bad_request(&e))? else {
+        return Ok(None);
+    };
+    let extent = engine.get_vertical_extent();
+    if extent.is_none() {
         return Err((
             StatusCode::BAD_REQUEST,
             Json(json!({
@@ -117,7 +126,8 @@ fn reject_z_without_vertical(
             })),
         ));
     }
-    Ok(())
+    let levels = resolve_z_levels(&sel, extent.as_ref()).map_err(|e| bad_request(&e))?;
+    Ok(Some(levels))
 }
 
 pub async fn landing_page(State(state): State<AppState>) -> impl IntoResponse {
@@ -470,7 +480,7 @@ pub async fn api_definition(State(state): State<AppState>) -> impl IntoResponse 
                     "in": "query",
                     "required": false,
                     "schema": {"type": "string"},
-                    "description": "Height range for the cross-section z axis, in metres above the radar antenna. Forms: z=H (single-height slice), z=Hmin,Hmax (range bracketed by the default vertical step), z=H1,H2,H3,… (explicit levels). Absent → 0..coverage-top derived from the radar's highest sweep."
+                    "description": "Elevation-angle selection for the cross-section, matching the collection's advertised vertical extent (sweep angles in degrees). Forms: z=5 (one sweep), z=0.5,1.5,5 (a list), or z=0.3/15 (a min/max interval → every advertised angle in range). The selected angle window bounds which sweeps build the RHI; the rendered z axis is derived height above the antenna (metres). Absent → all sweeps."
                 }
             },
             "schemas": {
@@ -607,13 +617,7 @@ pub async fn location_query(
         .as_deref()
         .map(|s| s.split(',').map(|p| p.trim().to_string()).collect());
 
-    let z = parse_z(params.z.as_deref()).map_err(|e| {
-        (
-            StatusCode::BAD_REQUEST,
-            Json(json!({ "code": "BadRequest", "description": e.to_string() })),
-        )
-    })?;
-    reject_z_without_vertical(engine, &z)?;
+    let z = resolve_request_z(engine, params.z.as_deref())?;
 
     let result = engine
         .query_location(&loc_id, datetime, param_names.as_deref(), z.as_deref())
@@ -664,13 +668,7 @@ pub async fn position_query(
         .as_deref()
         .map(|s| s.split(',').map(|p| p.trim().to_string()).collect());
 
-    let z = parse_z(params.z.as_deref()).map_err(|e| {
-        (
-            StatusCode::BAD_REQUEST,
-            Json(json!({ "code": "BadRequest", "description": e.to_string() })),
-        )
-    })?;
-    reject_z_without_vertical(engine, &z)?;
+    let z = resolve_request_z(engine, params.z.as_deref())?;
 
     // Split coords into one or more POINT(lon lat) strings. A single POINT is
     // passed through to the engine as-is; MULTIPOINT is fanned out into one
@@ -766,13 +764,7 @@ pub async fn area_query(
         .as_deref()
         .map(|s| s.split(',').map(|p| p.trim().to_string()).collect());
 
-    let z = parse_z(params.z.as_deref()).map_err(|e| {
-        (
-            StatusCode::BAD_REQUEST,
-            Json(json!({ "code": "BadRequest", "description": e.to_string() })),
-        )
-    })?;
-    reject_z_without_vertical(engine, &z)?;
+    let z = resolve_request_z(engine, params.z.as_deref())?;
 
     let result = engine
         .query_area(
@@ -858,16 +850,10 @@ pub async fn trajectory_query(
         .as_deref()
         .map(|s| s.split(',').map(|p| p.trim().to_string()).collect());
 
-    let z = parse_z(params.z.as_deref()).map_err(|e| {
-        (
-            StatusCode::BAD_REQUEST,
-            Json(json!({ "code": "BadRequest", "description": e.to_string() })),
-        )
-    })?;
-    // Trajectory `z` is a height range in metres, not a vertical-extent
-    // pin against the collection's elevation-angle axis, so the standard
-    // `reject_z_without_vertical` gate doesn't apply — the engine accepts
-    // it whenever it can produce a Section.
+    // Trajectory `z` selects elevation angles from the collection's
+    // advertised vertical extent (the cross-section is built from those
+    // sweeps); an interval `z=0.3/15` expands to the angles in range.
+    let z = resolve_request_z(engine, params.z.as_deref())?;
 
     let result = engine
         .query_trajectory(

--- a/crates/api-edr/src/handlers.rs
+++ b/crates/api-edr/src/handlers.rs
@@ -341,9 +341,10 @@ pub async fn api_definition(State(state): State<AppState>) -> impl IntoResponse 
         // Trajectory query (vertical cross-section). Only advertised
         // for engines that report `trajectory` in
         // `supported_query_types` — keeps the OpenAPI spec consistent
-        // with `data_queries` in the collection metadata. Engines
-        // without the capability return `InvalidParameter → 400` from
-        // the default trait method if a client still calls the path.
+        // with `data_queries` in the collection metadata. A client that
+        // calls the path on a non-trajectory engine gets a 404 from the
+        // handler's capability guard (the resource doesn't exist for
+        // that collection).
         if supported.contains("trajectory") {
             let trajectory_path = format!("/edr/collections/{id}/trajectory");
             collection_paths[&trajectory_path] = json!({

--- a/crates/api-edr/src/handlers.rs
+++ b/crates/api-edr/src/handlers.rs
@@ -795,7 +795,10 @@ pub async fn area_query(
             }
         })?;
 
-    let body = serde_json::to_string(&coverage_response_to_json(&result)).unwrap();
+    let body = serde_json::to_string(&coverage_response_to_json(&result)).map_err(|e| {
+        tracing::error!("Area CoverageJSON serialise error: {e}");
+        server_error()
+    })?;
     Ok((
         [(header::CONTENT_TYPE, "application/prs.coverage+json")],
         body,
@@ -856,37 +859,51 @@ pub async fn trajectory_query(
     // sweeps); an interval `z=0.3/15` expands to the angles in range.
     let z = resolve_request_z(engine, params.z.as_deref())?;
 
-    let result = engine
-        .query_trajectory(
-            &params.coords,
-            datetime,
-            param_names.as_deref(),
-            z.as_deref(),
-        )
-        .map_err(|e| match &e {
-            ds_core::error::DataServerError::InvalidParameter(_)
-            | ds_core::error::DataServerError::InvalidBbox(_)
-            | ds_core::error::DataServerError::InvalidDatetime(_) => (
-                StatusCode::BAD_REQUEST,
-                Json(json!({ "code": "BadRequest", "description": e.to_string() })),
-            ),
-            ds_core::error::DataServerError::LocationNotFound(_)
-            | ds_core::error::DataServerError::CollectionNotFound(_) => (
-                StatusCode::NOT_FOUND,
-                Json(json!({ "code": "NotFound", "description": e.to_string() })),
-            ),
-            _ => {
-                tracing::error!("Trajectory query error: {e}");
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(json!({ "code": "ServerError", "description": "Internal server error" })),
-                )
-            }
-        })?;
+    // The cross-section sampler is the heaviest EDR path — up to
+    // nodes × z-levels × quantities × timesteps `sample_polar_slant`
+    // iterations (millions, seconds of CPU). Run it on the blocking pool
+    // so it doesn't park a request-serving worker and head-of-line-block
+    // other requests. Safe here: the trajectory path reads an in-memory
+    // `ArcSwap` catalog snapshot and never touches `DataStore` (whose
+    // `block_in_place` would panic on a `spawn_blocking` thread). The
+    // general "wrap every EdrEngine query" work is tracked in #178.
+    let engine = engine.clone();
+    let coords = params.coords.clone();
+    let result = tokio::task::spawn_blocking(move || {
+        engine.query_trajectory(&coords, datetime, param_names.as_deref(), z.as_deref())
+    })
+    .await
+    .map_err(|e| {
+        tracing::error!("Trajectory query task join error: {e}");
+        server_error()
+    })?
+    .map_err(|e| match &e {
+        ds_core::error::DataServerError::InvalidParameter(_)
+        | ds_core::error::DataServerError::InvalidBbox(_)
+        | ds_core::error::DataServerError::InvalidDatetime(_) => (
+            StatusCode::BAD_REQUEST,
+            Json(json!({ "code": "BadRequest", "description": e.to_string() })),
+        ),
+        ds_core::error::DataServerError::LocationNotFound(_)
+        | ds_core::error::DataServerError::CollectionNotFound(_) => (
+            StatusCode::NOT_FOUND,
+            Json(json!({ "code": "NotFound", "description": e.to_string() })),
+        ),
+        _ => {
+            tracing::error!("Trajectory query error: {e}");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({ "code": "ServerError", "description": "Internal server error" })),
+            )
+        }
+    })?;
 
     match format {
         EdrFormat::CoverageJson => {
-            let body = serde_json::to_string(&coverage_response_to_json(&result)).unwrap();
+            let body = serde_json::to_string(&coverage_response_to_json(&result)).map_err(|e| {
+                tracing::error!("Trajectory CoverageJSON serialise error: {e}");
+                server_error()
+            })?;
             Ok((
                 [(header::CONTENT_TYPE, "application/prs.coverage+json")],
                 body,

--- a/crates/api-edr/src/handlers.rs
+++ b/crates/api-edr/src/handlers.rs
@@ -166,6 +166,20 @@ pub async fn api_definition(State(state): State<AppState>) -> impl IntoResponse 
     let mut collection_paths = json!({});
     for config in state.collections.values() {
         let id = &config.id;
+        // Per-collection supported-query-types so the OpenAPI spec only
+        // advertises endpoints the engine actually implements. The
+        // `data_queries` block in `build_collection_metadata` already
+        // gates on this; without the same gate here the two discovery
+        // surfaces disagree (an OGC CITE crawl following /api would hit
+        // the default `InvalidParameter → 400` arm on an unsupported
+        // engine, while /collections/{id} omits the link entirely).
+        // The legacy /position and /area entries below stay unconditional
+        // for back-compat; trajectory ships gated from day one.
+        let supported: std::collections::HashSet<String> = state
+            .engines
+            .get(id)
+            .map(|e| e.supported_query_types().into_iter().collect())
+            .unwrap_or_default();
 
         // Collection detail
         let detail_path = format!("/edr/collections/{id}");
@@ -314,36 +328,41 @@ pub async fn api_definition(State(state): State<AppState>) -> impl IntoResponse 
             }
         });
 
-        // Trajectory query (vertical cross-section). Engines that don't
-        // support it return an `InvalidParameter` 400 — same precedent
-        // as the unconditional `/area` and `/position` entries above.
-        let trajectory_path = format!("/edr/collections/{id}/trajectory");
-        collection_paths[&trajectory_path] = json!({
-            "get": {
-                "summary": format!("Trajectory cross-section for {}", config.title),
-                "operationId": format!("getTrajectory_{id}"),
-                "tags": [id],
-                "parameters": [
-                    {"$ref": "#/components/parameters/coords-linestring"},
-                    {"$ref": "#/components/parameters/datetime"},
-                    {"$ref": "#/components/parameters/parameter-name"},
-                    {"$ref": "#/components/parameters/z-trajectory"}
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Coverage data — CoverageJSON Section domain",
-                        "content": {
-                            "application/prs.coverage+json": {
-                                "schema": {"$ref": "#/components/schemas/coverageJSON"}
+        // Trajectory query (vertical cross-section). Only advertised
+        // for engines that report `trajectory` in
+        // `supported_query_types` — keeps the OpenAPI spec consistent
+        // with `data_queries` in the collection metadata. Engines
+        // without the capability return `InvalidParameter → 400` from
+        // the default trait method if a client still calls the path.
+        if supported.contains("trajectory") {
+            let trajectory_path = format!("/edr/collections/{id}/trajectory");
+            collection_paths[&trajectory_path] = json!({
+                "get": {
+                    "summary": format!("Trajectory cross-section for {}", config.title),
+                    "operationId": format!("getTrajectory_{id}"),
+                    "tags": [id],
+                    "parameters": [
+                        {"$ref": "#/components/parameters/coords-linestring"},
+                        {"$ref": "#/components/parameters/datetime"},
+                        {"$ref": "#/components/parameters/parameter-name"},
+                        {"$ref": "#/components/parameters/z-trajectory"}
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Coverage data — CoverageJSON Section domain",
+                            "content": {
+                                "application/prs.coverage+json": {
+                                    "schema": {"$ref": "#/components/schemas/coverageJSON"}
+                                }
                             }
-                        }
-                    },
-                    "400": {"description": "Bad request"},
-                    "404": {"description": "Not found"},
-                    "500": {"description": "Server error"}
+                        },
+                        "400": {"description": "Bad request"},
+                        "404": {"description": "Not found"},
+                        "500": {"description": "Server error"}
+                    }
                 }
-            }
-        });
+            });
+        }
     }
 
     let mut paths = json!({

--- a/crates/api-edr/src/handlers.rs
+++ b/crates/api-edr/src/handlers.rs
@@ -14,13 +14,13 @@ use ds_core::edr_engine::EdrEngine;
 
 use ds_core::error::DataServerError;
 use ds_core::model::CoverageResponse;
-use ds_render::render_chart;
+use ds_render::{render_chart, render_heatmap};
 
 use crate::params::{
     parse_edr_format, parse_z, plot_dimensions, split_position_coords, AreaQueryParams, EdrFormat,
     LocationQueryParams, PositionQueryParams, TrajectoryQueryParams,
 };
-use crate::plot_convert::coverage_response_to_panels;
+use crate::plot_convert::{coverage_response_to_panels, section_response_to_heatmaps};
 use crate::response::{coverage_response_to_json, locations_to_geojson, LocationsContext};
 
 type HandlerError = (StatusCode, Json<serde_json::Value>);
@@ -345,14 +345,24 @@ pub async fn api_definition(State(state): State<AppState>) -> impl IntoResponse 
                         {"$ref": "#/components/parameters/coords-linestring"},
                         {"$ref": "#/components/parameters/datetime"},
                         {"$ref": "#/components/parameters/parameter-name"},
-                        {"$ref": "#/components/parameters/z-trajectory"}
+                        {"$ref": "#/components/parameters/z-trajectory"},
+                        {
+                            "name": "f",
+                            "in": "query",
+                            "description": "Output format: CoverageJSON (default) or PNG (a colour-mapped distance×height cross-section heatmap).",
+                            "required": false,
+                            "schema": {"type": "string", "enum": ["CoverageJSON", "PNG"]}
+                        }
                     ],
                     "responses": {
                         "200": {
-                            "description": "Coverage data — CoverageJSON Section domain",
+                            "description": "Coverage data — CoverageJSON Section domain or PNG heatmap",
                             "content": {
                                 "application/prs.coverage+json": {
                                     "schema": {"$ref": "#/components/schemas/coverageJSON"}
+                                },
+                                "image/png": {
+                                    "schema": {"type": "string", "format": "binary"}
                                 }
                             }
                         },
@@ -805,7 +815,7 @@ pub async fn trajectory_query(
     State(state): State<AppState>,
 ) -> Result<impl IntoResponse, (StatusCode, Json<serde_json::Value>)> {
     let state = state.load_full();
-    let (engine, _config) = lookup_collection(&state, &id)?;
+    let (engine, config) = lookup_collection(&state, &id)?;
 
     // An engine that doesn't advertise `trajectory` has no cross-section
     // capability. Return 404 (the resource doesn't exist for this
@@ -829,12 +839,7 @@ pub async fn trajectory_query(
         ));
     }
 
-    // A Section is a 2-D cross-section — not a single plot.
-    if parse_edr_format(params.f.as_deref()).map_err(|e| bad_request(&e))? == EdrFormat::Png {
-        return Err(bad_request(&DataServerError::InvalidParameter(
-            "PNG output is not available for trajectory queries".into(),
-        )));
-    }
+    let format = parse_edr_format(params.f.as_deref()).map_err(|e| bad_request(&e))?;
 
     let datetime = params
         .datetime
@@ -892,11 +897,29 @@ pub async fn trajectory_query(
             }
         })?;
 
-    let body = serde_json::to_string(&coverage_response_to_json(&result)).unwrap();
-    Ok((
-        [(header::CONTENT_TYPE, "application/prs.coverage+json")],
-        body,
-    ))
+    match format {
+        EdrFormat::CoverageJson => {
+            let body = serde_json::to_string(&coverage_response_to_json(&result)).unwrap();
+            Ok((
+                [(header::CONTENT_TYPE, "application/prs.coverage+json")],
+                body,
+            )
+                .into_response())
+        }
+        EdrFormat::Png => {
+            // Render the cross-section as a colour-mapped heatmap using
+            // the collection's WMS colormap (or a data-scaled viridis
+            // fallback).
+            let (heatmaps, colormap) = section_response_to_heatmaps(&result, config.wms.as_ref())
+                .map_err(|e| bad_request(&e))?;
+            let (w, h) = plot_dimensions(params.width, params.height);
+            let png = render_heatmap(&heatmaps, colormap.as_ref(), w, h).map_err(|e| {
+                tracing::error!("Trajectory PNG render error: {e}");
+                server_error()
+            })?;
+            Ok(([(header::CONTENT_TYPE, "image/png")], png).into_response())
+        }
+    }
 }
 
 fn build_collection_metadata(
@@ -999,7 +1022,7 @@ fn build_collection_metadata(
             ),
             "trajectory" => (
                 format!("{base_url}/edr/collections/{}/trajectory", config.id),
-                json!(["CoverageJSON"]),
+                json!(["CoverageJSON", "PNG"]),
             ),
             _ => continue,
         };

--- a/crates/api-edr/src/handlers.rs
+++ b/crates/api-edr/src/handlers.rs
@@ -18,7 +18,7 @@ use ds_render::render_chart;
 
 use crate::params::{
     parse_edr_format, parse_z, plot_dimensions, split_position_coords, AreaQueryParams, EdrFormat,
-    LocationQueryParams, PositionQueryParams,
+    LocationQueryParams, PositionQueryParams, TrajectoryQueryParams,
 };
 use crate::plot_convert::coverage_response_to_panels;
 use crate::response::{coverage_response_to_json, locations_to_geojson, LocationsContext};
@@ -313,6 +313,37 @@ pub async fn api_definition(State(state): State<AppState>) -> impl IntoResponse 
                 }
             }
         });
+
+        // Trajectory query (vertical cross-section). Engines that don't
+        // support it return an `InvalidParameter` 400 — same precedent
+        // as the unconditional `/area` and `/position` entries above.
+        let trajectory_path = format!("/edr/collections/{id}/trajectory");
+        collection_paths[&trajectory_path] = json!({
+            "get": {
+                "summary": format!("Trajectory cross-section for {}", config.title),
+                "operationId": format!("getTrajectory_{id}"),
+                "tags": [id],
+                "parameters": [
+                    {"$ref": "#/components/parameters/coords-linestring"},
+                    {"$ref": "#/components/parameters/datetime"},
+                    {"$ref": "#/components/parameters/parameter-name"},
+                    {"$ref": "#/components/parameters/z-trajectory"}
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Coverage data — CoverageJSON Section domain",
+                        "content": {
+                            "application/prs.coverage+json": {
+                                "schema": {"$ref": "#/components/schemas/coverageJSON"}
+                            }
+                        }
+                    },
+                    "400": {"description": "Bad request"},
+                    "404": {"description": "Not found"},
+                    "500": {"description": "Server error"}
+                }
+            }
+        });
     }
 
     let mut paths = json!({
@@ -397,6 +428,20 @@ pub async fn api_definition(State(state): State<AppState>) -> impl IntoResponse 
                     "required": true,
                     "schema": {"type": "string"},
                     "description": "WKT POLYGON geometry, e.g. POLYGON((24 60, 26 60, 26 61, 24 61, 24 60))"
+                },
+                "coords-linestring": {
+                    "name": "coords",
+                    "in": "query",
+                    "required": true,
+                    "schema": {"type": "string"},
+                    "description": "WKT LINESTRING geometry (lon lat, lon lat, …). LINESTRINGZ/M variants are not accepted — per-node z and time will arrive in a follow-up."
+                },
+                "z-trajectory": {
+                    "name": "z",
+                    "in": "query",
+                    "required": false,
+                    "schema": {"type": "string"},
+                    "description": "Height range for the cross-section z axis, in metres above the radar antenna. Forms: z=H (single-height slice), z=Hmin,Hmax (range bracketed by the default vertical step), z=H1,H2,H3,… (explicit levels). Absent → 0..coverage-top derived from the radar's highest sweep."
                 }
             },
             "schemas": {
@@ -735,6 +780,84 @@ pub async fn area_query(
     ))
 }
 
+pub async fn trajectory_query(
+    Path(id): Path<String>,
+    Query(params): Query<TrajectoryQueryParams>,
+    State(state): State<AppState>,
+) -> Result<impl IntoResponse, (StatusCode, Json<serde_json::Value>)> {
+    let state = state.load_full();
+    let (engine, _config) = lookup_collection(&state, &id)?;
+
+    // A Section is a 2-D cross-section — not a single plot.
+    if parse_edr_format(params.f.as_deref()).map_err(|e| bad_request(&e))? == EdrFormat::Png {
+        return Err(bad_request(&DataServerError::InvalidParameter(
+            "PNG output is not available for trajectory queries".into(),
+        )));
+    }
+
+    let datetime = params
+        .datetime
+        .as_deref()
+        .map(parse_datetime_interval)
+        .transpose()
+        .map_err(|e| {
+            (
+                StatusCode::BAD_REQUEST,
+                Json(json!({ "code": "BadRequest", "description": e.to_string() })),
+            )
+        })?;
+
+    let param_names: Option<Vec<String>> = params
+        .parameter_name
+        .as_deref()
+        .map(|s| s.split(',').map(|p| p.trim().to_string()).collect());
+
+    let z = parse_z(params.z.as_deref()).map_err(|e| {
+        (
+            StatusCode::BAD_REQUEST,
+            Json(json!({ "code": "BadRequest", "description": e.to_string() })),
+        )
+    })?;
+    // Trajectory `z` is a height range in metres, not a vertical-extent
+    // pin against the collection's elevation-angle axis, so the standard
+    // `reject_z_without_vertical` gate doesn't apply — the engine accepts
+    // it whenever it can produce a Section.
+
+    let result = engine
+        .query_trajectory(
+            &params.coords,
+            datetime,
+            param_names.as_deref(),
+            z.as_deref(),
+        )
+        .map_err(|e| match &e {
+            ds_core::error::DataServerError::InvalidParameter(_)
+            | ds_core::error::DataServerError::InvalidBbox(_)
+            | ds_core::error::DataServerError::InvalidDatetime(_) => (
+                StatusCode::BAD_REQUEST,
+                Json(json!({ "code": "BadRequest", "description": e.to_string() })),
+            ),
+            ds_core::error::DataServerError::LocationNotFound(_)
+            | ds_core::error::DataServerError::CollectionNotFound(_) => (
+                StatusCode::NOT_FOUND,
+                Json(json!({ "code": "NotFound", "description": e.to_string() })),
+            ),
+            _ => {
+                tracing::error!("Trajectory query error: {e}");
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(json!({ "code": "ServerError", "description": "Internal server error" })),
+                )
+            }
+        })?;
+
+    let body = serde_json::to_string(&coverage_response_to_json(&result)).unwrap();
+    Ok((
+        [(header::CONTENT_TYPE, "application/prs.coverage+json")],
+        body,
+    ))
+}
+
 fn build_collection_metadata(
     engine: &dyn EdrEngine,
     config: &CollectionConfig,
@@ -820,6 +943,10 @@ fn build_collection_metadata(
             ),
             "area" => (
                 format!("{base_url}/edr/collections/{}/area", config.id),
+                json!(["CoverageJSON"]),
+            ),
+            "trajectory" => (
+                format!("{base_url}/edr/collections/{}/trajectory", config.id),
                 json!(["CoverageJSON"]),
             ),
             _ => continue,

--- a/crates/api-edr/src/handlers.rs
+++ b/crates/api-edr/src/handlers.rs
@@ -895,15 +895,26 @@ fn build_collection_metadata(
     }
 
     // Vertical extent — advertise the available levels so a client knows
-    // what `z` values it may request. `vrs` is intentionally omitted:
-    // vertical coordinate kinds like radar elevation angle have no
-    // standard OGC vertical-CRS URI, and `vrs` is optional in OGC EDR.
+    // what `z` values it may request.
+    //
+    // OGC EDR 1.1 requires `interval` items, `values` items, and `vrs`
+    // — and `interval`/`values` are typed as STRINGS in the schema
+    // (lines 670–676 of `schemas/ogcapi-edr-1.1-bundled.json`), not
+    // numbers. Floats round-trip through `Display` so a client can
+    // parse them back when needed. `vrs` is taken from the kind's
+    // built-in WKT/URI so a radar collection still validates against
+    // the EDR schema.
     if let Some(vertical) = engine.get_vertical_extent() {
         let mut vertical_obj = serde_json::Map::new();
         if let Some((lo, hi)) = vertical.extent() {
-            vertical_obj.insert("interval".to_string(), json!([[lo, hi]]));
+            vertical_obj.insert(
+                "interval".to_string(),
+                json!([[lo.to_string(), hi.to_string()]]),
+            );
         }
-        vertical_obj.insert("values".to_string(), json!(vertical.levels));
+        let values: Vec<String> = vertical.levels.iter().map(|v| v.to_string()).collect();
+        vertical_obj.insert("values".to_string(), json!(values));
+        vertical_obj.insert("vrs".to_string(), json!(vertical.kind.vrs()));
         extent.insert("vertical".to_string(), json!(vertical_obj));
     }
 

--- a/crates/api-edr/src/handlers.rs
+++ b/crates/api-edr/src/handlers.rs
@@ -897,8 +897,15 @@ pub async fn trajectory_query(
             // Render the cross-section as a colour-mapped heatmap using
             // the collection's WMS colormap (or a data-scaled viridis
             // fallback).
+            // A failure here is an internal inconsistency (the engine
+            // already returned a Section for this trajectory query), not
+            // a client mistake — log it and return a generic 500 rather
+            // than leaking the internal message in a 400.
             let (heatmaps, colormap) = section_response_to_heatmaps(&result, config.wms.as_ref())
-                .map_err(|e| bad_request(&e))?;
+                .map_err(|e| {
+                tracing::error!("Trajectory PNG section conversion error: {e}");
+                server_error()
+            })?;
             let (w, h) = plot_dimensions(params.width, params.height);
             let png = render_heatmap(&heatmaps, colormap.as_ref(), w, h).map_err(|e| {
                 tracing::error!("Trajectory PNG render error: {e}");

--- a/crates/api-edr/src/lib.rs
+++ b/crates/api-edr/src/lib.rs
@@ -23,5 +23,9 @@ pub fn router(state: AppState) -> Router {
         )
         .route("/collections/{id}/position", get(handlers::position_query))
         .route("/collections/{id}/area", get(handlers::area_query))
+        .route(
+            "/collections/{id}/trajectory",
+            get(handlers::trajectory_query),
+        )
         .with_state(state)
 }

--- a/crates/api-edr/src/params.rs
+++ b/crates/api-edr/src/params.rs
@@ -69,6 +69,25 @@ pub struct AreaQueryParams {
     pub f: Option<String>,
 }
 
+/// Trajectory (vertical cross-section) query parameters. Accepts a WKT
+/// `LINESTRING(lon lat, lon lat, …)` and the standard EDR filters; `z`
+/// here selects the *height* axis (metres above antenna), with the same
+/// "single height pins a slice, two values bracket a range" semantics
+/// used elsewhere. The corridor variant (`corridor-width` /
+/// `corridor-height`) ships in a follow-up.
+#[derive(Debug, Deserialize)]
+pub struct TrajectoryQueryParams {
+    pub coords: String,
+    pub datetime: Option<String>,
+    #[serde(rename = "parameter-name")]
+    pub parameter_name: Option<String>,
+    pub z: Option<String>,
+    /// Output format. Trajectory queries return a `Section` domain —
+    /// a 2-D cross-section, not a single plot — so `f=PNG` is rejected
+    /// (same precedent as `area_query`).
+    pub f: Option<String>,
+}
+
 /// Parse the EDR `z` query parameter — a comma-separated list of numeric
 /// vertical levels (e.g. `z=850,700,500` or a single `z=0.5`). An absent
 /// or blank value yields `None` (the whole vertical extent / a profile).

--- a/crates/api-edr/src/params.rs
+++ b/crates/api-edr/src/params.rs
@@ -71,10 +71,10 @@ pub struct AreaQueryParams {
 
 /// Trajectory (vertical cross-section) query parameters. Accepts a WKT
 /// `LINESTRING(lon lat, lon lat, …)` and the standard EDR filters; `z`
-/// here selects the *height* axis (metres above antenna), with the same
-/// "single height pins a slice, two values bracket a range" semantics
-/// used elsewhere. The corridor variant (`corridor-width` /
-/// `corridor-height`) ships in a follow-up.
+/// selects *elevation angles* from the collection's advertised vertical
+/// extent (a list or a `min/max` interval), bounding which sweeps build
+/// the cross-section — whose own axis is derived height. The corridor
+/// variant (`corridor-width` / `corridor-height`) ships in a follow-up.
 #[derive(Debug, Deserialize)]
 pub struct TrajectoryQueryParams {
     pub coords: String,
@@ -90,40 +90,109 @@ pub struct TrajectoryQueryParams {
     pub height: Option<u32>,
 }
 
-/// Parse the EDR `z` query parameter — a comma-separated list of numeric
-/// vertical levels (e.g. `z=850,700,500` or a single `z=0.5`). An absent
-/// or blank value yields `None` (the whole vertical extent / a profile).
-///
-/// The EDR `min/max` interval form is not supported — pass the discrete
-/// levels explicitly (the available set is advertised in the collection's
-/// vertical extent).
-pub fn parse_z(z: Option<&str>) -> Result<Option<Vec<f64>>, DataServerError> {
+/// A parsed EDR `z` selector: either an explicit list of levels or a
+/// closed `min/max` interval. The interval is resolved against the
+/// collection's advertised vertical levels at the handler boundary (see
+/// [`resolve_z_levels`]) so engines keep their `Option<&[f64]>` contract.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ZSelector {
+    /// Discrete levels (`z=0.5` or `z=850,700,500`).
+    Levels(Vec<f64>),
+    /// A closed interval `z=min/max` (OGC EDR interval form).
+    Interval { min: f64, max: f64 },
+}
+
+/// Parse one finite `f64` from a `z` token, rejecting `inf`/`nan` (a
+/// non-finite level would poison `quantize_z` cache keys and `nearest_sweep`
+/// comparisons downstream).
+fn parse_z_value(part: &str) -> Result<f64, DataServerError> {
+    part.trim()
+        .parse::<f64>()
+        .ok()
+        .filter(|v| v.is_finite())
+        .ok_or_else(|| {
+            DataServerError::InvalidParameter(format!(
+                "Invalid `z` value '{}' — expected a finite number",
+                part.trim()
+            ))
+        })
+}
+
+/// Parse the EDR `z` query parameter. Accepts a comma-separated list of
+/// numeric levels (`z=850,700,500` / a single `z=0.5`) **or** the OGC
+/// `min/max` interval form (`z=850/500`, order-independent). An absent or
+/// blank value yields `None` (the whole vertical extent / a profile).
+pub fn parse_z(z: Option<&str>) -> Result<Option<ZSelector>, DataServerError> {
     let Some(raw) = z.map(str::trim).filter(|s| !s.is_empty()) else {
         return Ok(None);
     };
+
+    // Interval form `min/max` — exactly one slash, two finite endpoints.
+    if raw.contains('/') {
+        let parts: Vec<&str> = raw.split('/').collect();
+        if parts.len() != 2 {
+            return Err(DataServerError::InvalidParameter(
+                "`z` interval must be `min/max` (one slash, two values)".into(),
+            ));
+        }
+        let a = parse_z_value(parts[0])?;
+        let b = parse_z_value(parts[1])?;
+        let (min, max) = if a <= b { (a, b) } else { (b, a) };
+        return Ok(Some(ZSelector::Interval { min, max }));
+    }
+
     let levels: Vec<f64> = raw
         .split(',')
         .map(|part| {
-            let part = part.trim();
-            if part.is_empty() {
+            if part.trim().is_empty() {
                 return Err(DataServerError::InvalidParameter(
                     "`z` has an empty element — check for a stray comma".into(),
                 ));
             }
-            // `parse::<f64>()` also accepts "inf"/"nan"; reject those so a
-            // non-finite level can't reach `quantize_z` (→ `i64::MAX`
-            // cache aliasing) or `nearest_sweep` (NaN distance comparisons).
-            part.parse::<f64>()
-                .ok()
-                .filter(|v| v.is_finite())
-                .ok_or_else(|| {
-                    DataServerError::InvalidParameter(format!(
-                        "Invalid `z` value '{part}' — expected a finite number"
-                    ))
-                })
+            parse_z_value(part)
         })
         .collect::<Result<_, _>>()?;
-    Ok((!levels.is_empty()).then_some(levels))
+    Ok((!levels.is_empty()).then_some(ZSelector::Levels(levels)))
+}
+
+/// Resolve a [`ZSelector`] into the concrete level list an engine samples.
+///
+/// - `Levels` pass through unchanged (the engine snaps each to its nearest
+///   available level).
+/// - `Interval { min, max }` expands to the collection's advertised levels
+///   that fall within `[min, max]` (inclusive). An interval that selects no
+///   advertised level is a 400 — the caller asked for a band the collection
+///   doesn't cover.
+///
+/// `extent` is the collection's advertised vertical levels; it must be
+/// present for an interval (callers gate `z` against a missing vertical
+/// dimension first).
+pub fn resolve_z_levels(
+    sel: &ZSelector,
+    extent: Option<&ds_core::vertical::VerticalDimension>,
+) -> Result<Vec<f64>, DataServerError> {
+    match sel {
+        ZSelector::Levels(v) => Ok(v.clone()),
+        ZSelector::Interval { min, max } => {
+            let levels = extent.map(|e| e.levels.as_slice()).ok_or_else(|| {
+                DataServerError::InvalidParameter(
+                    "a `z` interval needs a collection with a vertical extent".into(),
+                )
+            })?;
+            let selected: Vec<f64> = levels
+                .iter()
+                .copied()
+                .filter(|v| *v >= *min && *v <= *max)
+                .collect();
+            if selected.is_empty() {
+                return Err(DataServerError::InvalidParameter(format!(
+                    "`z` interval {min}/{max} selects none of the collection's \
+                     available levels"
+                )));
+            }
+            Ok(selected)
+        }
+    }
 }
 
 /// Split a position-query `coords` value into one or more `POINT(lon lat)` WKT
@@ -212,6 +281,89 @@ fn starts_with_ignore_ascii_case(s: &str, prefix: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ds_core::vertical::{VerticalDimension, VerticalKind};
+
+    #[test]
+    fn parse_z_none_and_blank() {
+        assert_eq!(parse_z(None).unwrap(), None);
+        assert_eq!(parse_z(Some("   ")).unwrap(), None);
+    }
+
+    #[test]
+    fn parse_z_single_and_list() {
+        assert_eq!(
+            parse_z(Some("0.5")).unwrap(),
+            Some(ZSelector::Levels(vec![0.5]))
+        );
+        assert_eq!(
+            parse_z(Some("850,700,500")).unwrap(),
+            Some(ZSelector::Levels(vec![850.0, 700.0, 500.0]))
+        );
+    }
+
+    #[test]
+    fn parse_z_interval_orders_endpoints() {
+        assert_eq!(
+            parse_z(Some("0.3/15")).unwrap(),
+            Some(ZSelector::Interval {
+                min: 0.3,
+                max: 15.0
+            })
+        );
+        // Reversed endpoints normalise to (min, max).
+        assert_eq!(
+            parse_z(Some("850/500")).unwrap(),
+            Some(ZSelector::Interval {
+                min: 500.0,
+                max: 850.0
+            })
+        );
+    }
+
+    #[test]
+    fn parse_z_rejects_bad_interval_and_values() {
+        assert!(parse_z(Some("1/2/3")).is_err());
+        assert!(parse_z(Some("a/2")).is_err());
+        assert!(parse_z(Some("nan")).is_err());
+        assert!(parse_z(Some("1,,3")).is_err());
+    }
+
+    #[test]
+    fn resolve_z_levels_passes_through_list() {
+        let sel = ZSelector::Levels(vec![1.5, 9.0]);
+        assert_eq!(resolve_z_levels(&sel, None).unwrap(), vec![1.5, 9.0]);
+    }
+
+    #[test]
+    fn resolve_z_levels_expands_interval_against_extent() {
+        let ext = VerticalDimension::new(
+            VerticalKind::ElevationAngle,
+            vec![
+                0.3, 0.7, 1.5, 2.0, 3.0, 5.0, 7.0, 9.0, 11.0, 15.0, 25.0, 45.0,
+            ],
+        );
+        let sel = ZSelector::Interval {
+            min: 0.3,
+            max: 15.0,
+        };
+        let got = resolve_z_levels(&sel, Some(&ext)).unwrap();
+        assert_eq!(
+            got,
+            vec![0.3, 0.7, 1.5, 2.0, 3.0, 5.0, 7.0, 9.0, 11.0, 15.0]
+        );
+    }
+
+    #[test]
+    fn resolve_z_levels_interval_outside_extent_is_error() {
+        let ext = VerticalDimension::new(VerticalKind::ElevationAngle, vec![0.3, 0.7, 1.5]);
+        let sel = ZSelector::Interval {
+            min: 20.0,
+            max: 30.0,
+        };
+        assert!(resolve_z_levels(&sel, Some(&ext)).is_err());
+        // An interval with no extent at all is also an error.
+        assert!(resolve_z_levels(&sel, None).is_err());
+    }
 
     #[test]
     fn single_point_passthrough() {

--- a/crates/api-edr/src/params.rs
+++ b/crates/api-edr/src/params.rs
@@ -82,10 +82,12 @@ pub struct TrajectoryQueryParams {
     #[serde(rename = "parameter-name")]
     pub parameter_name: Option<String>,
     pub z: Option<String>,
-    /// Output format. Trajectory queries return a `Section` domain —
-    /// a 2-D cross-section, not a single plot — so `f=PNG` is rejected
-    /// (same precedent as `area_query`).
+    /// Output format: `CoverageJSON` (default) or `PNG` — a colour-mapped
+    /// cross-section heatmap (distance × height).
     pub f: Option<String>,
+    /// PNG image dimensions (ignored for CoverageJSON).
+    pub width: Option<u32>,
+    pub height: Option<u32>,
 }
 
 /// Parse the EDR `z` query parameter — a comma-separated list of numeric

--- a/crates/api-edr/src/plot_convert.rs
+++ b/crates/api-edr/src/plot_convert.rs
@@ -132,6 +132,9 @@ fn build_panel(param: &str, coverages: &[QueryResult]) -> Result<Panel, DataServ
         DomainDescription::Grid { .. } => Err(DataServerError::InvalidParameter(
             "PNG output is not available for gridded (area) responses".into(),
         )),
+        DomainDescription::Section { .. } => Err(DataServerError::InvalidParameter(
+            "PNG output is not available for cross-section (trajectory) responses".into(),
+        )),
     }
 }
 
@@ -141,6 +144,7 @@ fn domain_kind(d: &DomainDescription) -> &'static str {
         DomainDescription::VerticalProfile { .. } => "VerticalProfile",
         DomainDescription::PointSeries { .. } => "PointSeries",
         DomainDescription::Grid { .. } => "Grid",
+        DomainDescription::Section { .. } => "Section",
     }
 }
 

--- a/crates/api-edr/src/plot_convert.rs
+++ b/crates/api-edr/src/plot_convert.rs
@@ -288,19 +288,22 @@ fn section_colormap(
 /// Convert a cross-section (`Section`) coverage response into stacked
 /// heatmaps plus the shared colormap, ready for [`ds_render::render_heatmap`].
 ///
-/// One heatmap is produced per quantity in the **first** coverage (a
-/// multi-timestep request renders its earliest section — a PNG is a
-/// single snapshot). The x axis is cumulative great-circle distance (km)
-/// along the path; the y axis is the vertical coordinate (height above
-/// antenna, m). All quantities share the collection colormap; for a
-/// correctly-scaled single panel, filter with `parameter-name`.
+/// One heatmap is produced per quantity in the **latest** coverage (a
+/// multi-timestep request renders its most recent section — a PNG is a
+/// single snapshot, and the newest scan is the right default for radar
+/// imagery). The x axis is cumulative great-circle distance (km) along
+/// the path; the y axis is the vertical coordinate (height above antenna,
+/// m). All quantities share the collection colormap; for a correctly-
+/// scaled single panel, filter with `parameter-name`.
 pub fn section_response_to_heatmaps(
     resp: &CoverageResponse,
     wms: Option<&WmsConfig>,
 ) -> Result<(Vec<Heatmap>, Box<dyn ColorMap>), DataServerError> {
     let qr = match resp {
         CoverageResponse::Single(q) => q,
-        CoverageResponse::Collection(v) => v.first().ok_or_else(|| {
+        // The engine returns the per-timestep sections oldest-first
+        // (`by_site` is time-ascending), so the newest is `last`.
+        CoverageResponse::Collection(v) => v.last().ok_or_else(|| {
             DataServerError::InvalidParameter("no cross-section data to plot".into())
         })?,
     };

--- a/crates/api-edr/src/plot_convert.rs
+++ b/crates/api-edr/src/plot_convert.rs
@@ -10,11 +10,12 @@
 
 use chrono::{DateTime, Utc};
 
+use ds_core::config::WmsConfig;
 use ds_core::error::DataServerError;
 use ds_core::model::{
     CoverageResponse, DomainDescription, ParameterDescription, QueryResult, VerticalCoord,
 };
-use ds_render::{Panel, Series};
+use ds_render::{ColorMap, Heatmap, Panel, Series};
 
 /// Build one panel per parameter from an EDR coverage response.
 pub fn coverage_response_to_panels(resp: &CoverageResponse) -> Result<Vec<Panel>, DataServerError> {
@@ -191,6 +192,192 @@ fn pointseries_label(z: Option<&VerticalCoord>, idx: usize, total: usize) -> Str
 
 fn fmt_time(t: DateTime<Utc>) -> String {
     t.format("%H:%M").to_string()
+}
+
+// ---------------------------------------------------------------------------
+// Section (cross-section) → heatmap, for PNG output
+// ---------------------------------------------------------------------------
+
+const EARTH_RADIUS_M: f64 = 6_371_000.0;
+
+/// Great-circle distance (km) between two WGS84 points — a local
+/// haversine so `plot_convert` needn't pull in an engine's geo helper.
+fn haversine_km(lon0: f64, lat0: f64, lon1: f64, lat1: f64) -> f64 {
+    let dlat = (lat1 - lat0).to_radians();
+    let dlon = (lon1 - lon0).to_radians();
+    let a = (dlat / 2.0).sin().powi(2)
+        + lat0.to_radians().cos() * lat1.to_radians().cos() * (dlon / 2.0).sin().powi(2);
+    let c = 2.0 * a.sqrt().clamp(0.0, 1.0).asin();
+    EARTH_RADIUS_M * c / 1000.0
+}
+
+/// Build the colormap (and its value range) for a cross-section PNG from
+/// the collection's optional `[wms]` style config. Mirrors the server's
+/// `build_colormap_from_wms_config` priority — inline `color_stops`, then
+/// a built-in `colormap` name, then a fallback — using only `ds_render`
+/// public APIs.
+///
+/// The fallback is viridis stretched to `data_range` (the finite min/max
+/// of the values being rendered) so a collection with no usable colormap
+/// config still produces a readable image rather than a flat one clamped
+/// to 0..1.
+fn section_colormap(
+    wms: Option<&WmsConfig>,
+    data_range: (f64, f64),
+) -> (Box<dyn ColorMap>, f64, f64) {
+    if let Some(w) = wms {
+        // Inline custom stops win.
+        if !w.color_stops.is_empty() {
+            let stops: Vec<ds_render::ColorStop> = w
+                .color_stops
+                .iter()
+                .filter_map(|s| {
+                    ds_render::parse_hex_color(&s.color)
+                        .ok()
+                        .map(|color| ds_render::ColorStop {
+                            value: s.value,
+                            color,
+                        })
+                })
+                .collect();
+            if !stops.is_empty() {
+                let min = w
+                    .min
+                    .unwrap_or_else(|| stops.first().map(|s| s.value).unwrap_or(0.0));
+                let max = w
+                    .max
+                    .unwrap_or_else(|| stops.last().map(|s| s.value).unwrap_or(1.0));
+                return (Box::new(ds_render::LinearColorMap::new(stops)), min, max);
+            }
+        }
+        // Then a named built-in.
+        if let Some(name) = w.colormap.as_deref() {
+            if let Some(builtin) = ds_render::colormap::resolve_builtin(name) {
+                let stops = ds_render::colormap::builtin_stops(&builtin);
+                let min = w
+                    .min
+                    .unwrap_or_else(|| stops.first().map(|s| s.value).unwrap_or(0.0));
+                let max = w
+                    .max
+                    .unwrap_or_else(|| stops.last().map(|s| s.value).unwrap_or(1.0));
+                return (
+                    Box::new(ds_render::LutColorMap::from_builtin(builtin, min, max)),
+                    min,
+                    max,
+                );
+            }
+        }
+    }
+    // Fallback: viridis stretched to the data's own finite range.
+    let (mut min, mut max) = data_range;
+    if !(min.is_finite() && max.is_finite()) || max <= min {
+        min = 0.0;
+        max = 1.0;
+    }
+    (
+        Box::new(ds_render::LutColorMap::from_builtin(
+            ds_render::BuiltinColormap::Viridis,
+            min,
+            max,
+        )),
+        min,
+        max,
+    )
+}
+
+/// Convert a cross-section (`Section`) coverage response into stacked
+/// heatmaps plus the shared colormap, ready for [`ds_render::render_heatmap`].
+///
+/// One heatmap is produced per quantity in the **first** coverage (a
+/// multi-timestep request renders its earliest section — a PNG is a
+/// single snapshot). The x axis is cumulative great-circle distance (km)
+/// along the path; the y axis is the vertical coordinate (height above
+/// antenna, m). All quantities share the collection colormap; for a
+/// correctly-scaled single panel, filter with `parameter-name`.
+pub fn section_response_to_heatmaps(
+    resp: &CoverageResponse,
+    wms: Option<&WmsConfig>,
+) -> Result<(Vec<Heatmap>, Box<dyn ColorMap>), DataServerError> {
+    let qr = match resp {
+        CoverageResponse::Single(q) => q,
+        CoverageResponse::Collection(v) => v.first().ok_or_else(|| {
+            DataServerError::InvalidParameter("no cross-section data to plot".into())
+        })?,
+    };
+    let DomainDescription::Section { nodes, z } = &qr.domain else {
+        return Err(DataServerError::InvalidParameter(
+            "PNG cross-section requires a Section domain".into(),
+        ));
+    };
+    if nodes.len() < 2 || z.values.is_empty() {
+        return Err(DataServerError::InvalidParameter(
+            "cross-section has too few nodes or levels to plot".into(),
+        ));
+    }
+
+    // Cumulative along-path distance (km) per node.
+    let mut x_values = Vec::with_capacity(nodes.len());
+    let mut acc = 0.0;
+    x_values.push(0.0);
+    for w in nodes.windows(2) {
+        let (_, lon0, lat0) = w[0];
+        let (_, lon1, lat1) = w[1];
+        acc += haversine_km(lon0, lat0, lon1, lat1);
+        x_values.push(acc);
+    }
+
+    // Quantities in stable order.
+    let mut params: Vec<&String> = qr.ranges.keys().collect();
+    params.sort();
+    if params.is_empty() {
+        return Err(DataServerError::InvalidParameter(
+            "cross-section carries no parameters to plot".into(),
+        ));
+    }
+
+    // Global finite data range across the rendered quantities — only used
+    // as the colormap fallback when the collection has no colormap config.
+    let mut dmin = f64::INFINITY;
+    let mut dmax = f64::NEG_INFINITY;
+    for p in &params {
+        if let Some(nd) = qr.ranges.get(*p) {
+            for v in nd.values.iter().flatten() {
+                if v.is_finite() {
+                    dmin = dmin.min(*v);
+                    dmax = dmax.max(*v);
+                }
+            }
+        }
+    }
+
+    let (colormap, vmin, vmax) = section_colormap(wms, (dmin, dmax));
+
+    let y_label = axis_caption(z.kind.default_label(), z.kind.default_unit());
+    let mut heatmaps = Vec::with_capacity(params.len());
+    for p in params {
+        let nd = match qr.ranges.get(p) {
+            Some(nd) => nd,
+            None => continue,
+        };
+        // Section ndarray is row-major [n_nodes, n_z] — exactly the
+        // order `render_heatmap` expects.
+        let desc = qr.parameters.get(p);
+        let unit = desc.map(|d| d.unit.clone()).unwrap_or_default();
+        let label = desc.map(|d| d.label.clone()).unwrap_or_else(|| p.clone());
+        heatmaps.push(Heatmap {
+            title: label,
+            x_label: "Distance along path (km)".to_string(),
+            y_label: y_label.clone(),
+            value_label: unit,
+            x_values: x_values.clone(),
+            y_values: z.values.clone(),
+            values: nd.values.clone(),
+            value_min: vmin,
+            value_max: vmax,
+        });
+    }
+
+    Ok((heatmaps, colormap))
 }
 
 #[cfg(test)]
@@ -388,5 +575,98 @@ mod tests {
             ranges,
         };
         assert!(coverage_response_to_panels(&CoverageResponse::Collection(vec![p, ts])).is_err());
+    }
+
+    // -- Section → heatmap --
+
+    fn section(quantity: &str, unit: &str) -> QueryResult {
+        // 3 nodes × 2 levels, row-major [node][level].
+        let t = DateTime::from_timestamp(1_778_889_600, 0).unwrap();
+        let nodes = vec![(t, 25.0, 60.0), (t, 25.2, 60.1), (t, 25.4, 60.2)];
+        let mut parameters = HashMap::new();
+        parameters.insert(quantity.to_string(), pdesc("Reflectivity", unit));
+        let mut ranges = HashMap::new();
+        ranges.insert(
+            quantity.to_string(),
+            NdArray {
+                shape: vec![3, 2],
+                axis_names: vec!["composite".into(), "z".into()],
+                values: vec![
+                    Some(10.0),
+                    Some(20.0),
+                    Some(15.0),
+                    None,
+                    Some(5.0),
+                    Some(25.0),
+                ],
+            },
+        );
+        QueryResult {
+            domain: DomainDescription::Section {
+                nodes,
+                z: VerticalCoord {
+                    kind: VerticalKind::HeightAboveAntenna,
+                    values: vec![0.0, 1000.0],
+                },
+            },
+            parameters,
+            ranges,
+        }
+    }
+
+    #[test]
+    fn section_to_heatmap_builds_distance_axis_and_shape() {
+        let qr = section("DBZH", "dBZ");
+        let (heatmaps, _cmap) =
+            section_response_to_heatmaps(&CoverageResponse::Single(qr), None).unwrap();
+        assert_eq!(heatmaps.len(), 1);
+        let hm = &heatmaps[0];
+        // x axis: 3 cumulative distances, monotonic ascending from 0.
+        assert_eq!(hm.x_values.len(), 3);
+        assert_eq!(hm.x_values[0], 0.0);
+        assert!(hm.x_values[1] > 0.0 && hm.x_values[2] > hm.x_values[1]);
+        // y axis: the two heights.
+        assert_eq!(hm.y_values, vec![0.0, 1000.0]);
+        // values are the row-major ndarray verbatim.
+        assert_eq!(hm.values.len(), 6);
+        assert_eq!(hm.value_label, "dBZ");
+    }
+
+    #[test]
+    fn section_colormap_uses_builtin_when_configured() {
+        use ds_core::config::WmsConfig;
+        let wms = WmsConfig {
+            style_bundle: None,
+            colormap: Some("radar_dbz".into()),
+            color_stops: vec![],
+            min: Some(-32.0),
+            max: Some(95.0),
+            styles: vec![],
+            parameters: vec![],
+            rendered_cache_mb: 0,
+        };
+        let qr = section("DBZH", "dBZ");
+        let (heatmaps, _cmap) =
+            section_response_to_heatmaps(&CoverageResponse::Single(qr), Some(&wms)).unwrap();
+        // Config min/max drive the colour-bar bounds.
+        assert_eq!(heatmaps[0].value_min, -32.0);
+        assert_eq!(heatmaps[0].value_max, 95.0);
+    }
+
+    #[test]
+    fn section_colormap_falls_back_to_data_range() {
+        // No WMS config → viridis stretched to the data's finite range
+        // (5..25 in the fixture).
+        let qr = section("DBZH", "dBZ");
+        let (heatmaps, _cmap) =
+            section_response_to_heatmaps(&CoverageResponse::Single(qr), None).unwrap();
+        assert_eq!(heatmaps[0].value_min, 5.0);
+        assert_eq!(heatmaps[0].value_max, 25.0);
+    }
+
+    #[test]
+    fn section_heatmap_rejects_non_section() {
+        let p = profile(VerticalKind::ElevationAngle, vec![0.5], vec![Some(1.0)]);
+        assert!(section_response_to_heatmaps(&CoverageResponse::Single(p), None).is_err());
     }
 }

--- a/crates/api-edr/src/plot_convert.rs
+++ b/crates/api-edr/src/plot_convert.rs
@@ -228,7 +228,7 @@ fn section_colormap(
     if let Some(w) = wms {
         // Inline custom stops win.
         if !w.color_stops.is_empty() {
-            let stops: Vec<ds_render::ColorStop> = w
+            let mut stops: Vec<ds_render::ColorStop> = w
                 .color_stops
                 .iter()
                 .filter_map(|s| {
@@ -240,6 +240,11 @@ fn section_colormap(
                         })
                 })
                 .collect();
+            // Sort ascending by value: config stops may be authored
+            // highest-first (a natural radar-dBZ legend order), which
+            // would otherwise give `min > max` (reversed colour-bar
+            // labels) and a broken `LinearColorMap` bracket lookup.
+            stops.sort_by(|a, b| a.value.total_cmp(&b.value));
             if !stops.is_empty() {
                 let min = w
                     .min
@@ -671,5 +676,42 @@ mod tests {
     fn section_heatmap_rejects_non_section() {
         let p = profile(VerticalKind::ElevationAngle, vec![0.5], vec![Some(1.0)]);
         assert!(section_response_to_heatmaps(&CoverageResponse::Single(p), None).is_err());
+    }
+
+    /// Descending-order `color_stops` (a natural radar-dBZ legend order)
+    /// must still yield `value_min < value_max` — the colour bar would
+    /// otherwise label max→min top-to-bottom against the gradient.
+    #[test]
+    fn section_colormap_sorts_descending_color_stops() {
+        use ds_core::config::{ColorStop, WmsConfig};
+        let wms = WmsConfig {
+            style_bundle: None,
+            colormap: None,
+            // Authored highest-value-first.
+            color_stops: vec![
+                ColorStop {
+                    value: 60.0,
+                    color: "#ff0000".into(),
+                },
+                ColorStop {
+                    value: 30.0,
+                    color: "#00ff00".into(),
+                },
+                ColorStop {
+                    value: 0.0,
+                    color: "#0000ff".into(),
+                },
+            ],
+            min: None,
+            max: None,
+            styles: vec![],
+            parameters: vec![],
+            rendered_cache_mb: 0,
+        };
+        let qr = section("DBZH", "dBZ");
+        let (heatmaps, _cmap) =
+            section_response_to_heatmaps(&CoverageResponse::Single(qr), Some(&wms)).unwrap();
+        assert_eq!(heatmaps[0].value_min, 0.0, "min from the lowest stop");
+        assert_eq!(heatmaps[0].value_max, 60.0, "max from the highest stop");
     }
 }

--- a/crates/api-edr/src/response.rs
+++ b/crates/api-edr/src/response.rs
@@ -152,6 +152,7 @@ fn domain_type_name(domain: &DomainDescription) -> &'static str {
         DomainDescription::PointSeries { .. } => "PointSeries",
         DomainDescription::Grid { .. } => "Grid",
         DomainDescription::VerticalProfile { .. } => "VerticalProfile",
+        DomainDescription::Section { .. } => "Section",
     }
 }
 
@@ -270,6 +271,32 @@ fn build_domain(desc: &DomainDescription) -> Value {
                 "domainType": "VerticalProfile",
                 "axes": axes,
                 "referencing": referencing
+            })
+        }
+        DomainDescription::Section { nodes, z } => {
+            // Each composite-axis entry is a 3-tuple `[t, x, y]`, exactly
+            // matching the CoverageJSON 1.0 `Section` schema (the only
+            // tuple shape it accepts).
+            let tuples: Vec<Value> = nodes
+                .iter()
+                .map(|(t, lon, lat)| json!([t.to_rfc3339(), lon, lat]))
+                .collect();
+            let mut axes = Map::new();
+            axes.insert(
+                "composite".into(),
+                json!({
+                    "dataType": "tuple",
+                    "coordinates": ["t", "x", "y"],
+                    "values": tuples,
+                }),
+            );
+            axes.insert("z".into(), json!({ "values": z.values }));
+            let referencing = vec![spatial_ref(), temporal_ref(), vertical_ref(z)];
+            json!({
+                "type": "Domain",
+                "domainType": "Section",
+                "axes": axes,
+                "referencing": referencing,
             })
         }
     }

--- a/crates/api-edr/src/response.rs
+++ b/crates/api-edr/src/response.rs
@@ -104,7 +104,13 @@ fn build_ndarray(ndarray: &ds_core::model::NdArray) -> Value {
         .values
         .iter()
         .map(|v| match v {
-            Some(f) => Value::Number(Number::from_f64(*f).unwrap_or(Number::from(0))),
+            // `Number::from_f64` returns `None` for NaN / ±inf (JSON has
+            // no representation), so a non-finite measurement must encode
+            // as `null` — not `0`, which would be indistinguishable from a
+            // genuine zero reading. Flagged by claude-review on PR #275.
+            Some(f) => Number::from_f64(*f)
+                .map(Value::Number)
+                .unwrap_or(Value::Null),
             None => Value::Null,
         })
         .collect();

--- a/crates/api-edr/tests/covjson_validation.rs
+++ b/crates/api-edr/tests/covjson_validation.rs
@@ -192,6 +192,39 @@ fn coverage_with_all_nulls_validates() {
     validate(&json, &schema);
 }
 
+/// A non-finite `Some(NaN)` / `Some(inf)` measurement must serialise to
+/// JSON `null`, not `0` — a fabricated zero would be indistinguishable
+/// from a genuine reading. Regression for the claude-review finding on
+/// PR #275.
+#[test]
+fn coverage_with_non_finite_values_encodes_null_not_zero() {
+    let schema = load_schema();
+    let times = vec![make_time(0), make_time(1), make_time(2)];
+    let result = make_query_result(
+        times,
+        vec![(
+            "temperature",
+            "°C",
+            vec![Some(f64::NAN), Some(f64::INFINITY), Some(-1.5)],
+        )],
+    );
+    let json = query_result_to_coverage_json(&result);
+    let values = &json["ranges"]["temperature"]["values"];
+    assert!(
+        values[0].is_null(),
+        "NaN must encode as null, got {}",
+        values[0]
+    );
+    assert!(
+        values[1].is_null(),
+        "inf must encode as null, got {}",
+        values[1]
+    );
+    assert_eq!(values[2], serde_json::json!(-1.5));
+    // Still schema-valid (CoverageJSON allows null in numeric ranges).
+    validate(&json, &schema);
+}
+
 #[test]
 fn coverage_required_fields_present() {
     let schema = load_schema();

--- a/crates/api-edr/tests/covjson_validation.rs
+++ b/crates/api-edr/tests/covjson_validation.rs
@@ -697,3 +697,63 @@ fn grid_with_z_validates() {
     assert!(json["domain"]["axes"]["z"]["values"].is_array());
     validate(&json, &schema);
 }
+
+// --- Section domain (#198 — radar cross-section / trajectory) ---
+
+#[test]
+fn section_coverage_validates_against_schema() {
+    let schema = load_schema();
+    let t = make_time(12);
+    let nodes = vec![
+        (t, 24.0, 60.0),
+        (t, 24.5, 60.25),
+        (t, 25.0, 60.5),
+        (t, 25.5, 60.75),
+    ];
+    let heights = vec![0.0, 500.0, 1000.0, 2000.0, 5000.0];
+    let mut parameters = HashMap::new();
+    parameters.insert(
+        "DBZH".to_string(),
+        ParameterDescription {
+            label: "Reflectivity".to_string(),
+            unit: "dBZ".to_string(),
+            observed_property: "DBZH".to_string(),
+        },
+    );
+    let mut ranges = HashMap::new();
+    let values: Vec<Option<f64>> = (0..nodes.len() * heights.len())
+        .map(|i| if i % 3 == 0 { None } else { Some(i as f64) })
+        .collect();
+    ranges.insert(
+        "DBZH".to_string(),
+        NdArray {
+            shape: vec![nodes.len(), heights.len()],
+            axis_names: vec!["composite".to_string(), "z".to_string()],
+            values,
+        },
+    );
+
+    let result = QueryResult {
+        domain: DomainDescription::Section {
+            nodes,
+            z: VerticalCoord {
+                kind: VerticalKind::HeightAboveAntenna,
+                values: heights,
+            },
+        },
+        parameters,
+        ranges,
+    };
+
+    let json = query_result_to_coverage_json(&result);
+    assert_eq!(json["domain"]["domainType"], "Section");
+    let composite = &json["domain"]["axes"]["composite"];
+    assert_eq!(composite["dataType"], "tuple");
+    assert_eq!(composite["coordinates"], serde_json::json!(["t", "x", "y"]));
+    assert!(composite["values"].is_array());
+    let first = &composite["values"][0];
+    assert_eq!(first.as_array().unwrap().len(), 3);
+    assert!(json["domain"]["axes"]["z"]["values"].is_array());
+
+    validate(&json, &schema);
+}

--- a/crates/api-edr/tests/ogc_edr_api_tests.rs
+++ b/crates/api-edr/tests/ogc_edr_api_tests.rs
@@ -1174,12 +1174,14 @@ mod unimplemented_queries {
     }
 
     #[tokio::test]
-    #[ignore = "trajectory query not yet implemented"]
-    async fn trajectory_query() {
-        // GET /collections/{id}/trajectory?coords=LINESTRING(24 60,25 61)
-        let (status, _) =
-            get("/collections/weather/trajectory?coords=LINESTRING(24 60,25 61)").await;
-        assert_eq!(status, StatusCode::OK);
+    async fn trajectory_query_unsupported_engine_returns_404() {
+        // `MockEngine` does not advertise `trajectory` in
+        // `supported_query_types`, so the route must answer 404 (the
+        // capability is absent for this collection) rather than 400.
+        let (status, json) =
+            get("/collections/weather/trajectory?coords=LINESTRING(24%2060,25%2061)").await;
+        assert_eq!(status, StatusCode::NOT_FOUND);
+        assert_eq!(json["code"], "NotFound");
     }
 
     #[tokio::test]

--- a/crates/api-edr/tests/ogc_edr_api_tests.rs
+++ b/crates/api-edr/tests/ogc_edr_api_tests.rs
@@ -1184,6 +1184,126 @@ mod unimplemented_queries {
         assert_eq!(json["code"], "NotFound");
     }
 
+    /// A trajectory-capable engine routes a real `Section` through the
+    /// Axum handler: 200 + CoverageJSON by default, 200 + `image/png` for
+    /// `f=PNG`. Guards the handler's content-type and PNG dispatch, which
+    /// the 404-only test above can't reach.
+    #[tokio::test]
+    async fn trajectory_query_returns_section_and_png() {
+        use ds_core::model::{NdArray, VerticalCoord};
+        use ds_core::vertical::VerticalKind;
+
+        struct TrajectoryMock;
+        impl EdrEngine for TrajectoryMock {
+            fn get_locations(&self) -> Result<Vec<Location>, DataServerError> {
+                Ok(vec![])
+            }
+            fn query_location(
+                &self,
+                _id: &str,
+                _dt: Option<(DateTime<Utc>, DateTime<Utc>)>,
+                _p: Option<&[String]>,
+                _z: Option<&[f64]>,
+            ) -> Result<CoverageResponse, DataServerError> {
+                Err(DataServerError::LocationNotFound("n/a".into()))
+            }
+            fn get_parameters(&self) -> Vec<String> {
+                vec!["DBZH".into()]
+            }
+            fn get_temporal_extent(&self) -> Option<(DateTime<Utc>, DateTime<Utc>)> {
+                None
+            }
+            fn get_spatial_extent(&self) -> Option<[f64; 4]> {
+                Some([24.0, 60.0, 25.0, 61.0])
+            }
+            fn supported_query_types(&self) -> Vec<String> {
+                vec!["trajectory".into()]
+            }
+            fn query_trajectory(
+                &self,
+                _coords: &str,
+                _dt: Option<(DateTime<Utc>, DateTime<Utc>)>,
+                _p: Option<&[String]>,
+                _z: Option<&[f64]>,
+            ) -> Result<CoverageResponse, DataServerError> {
+                let t = "2024-01-01T00:00:00Z".parse::<DateTime<Utc>>().unwrap();
+                let nodes = vec![(t, 24.0, 60.0), (t, 24.5, 60.5), (t, 25.0, 61.0)];
+                let mut parameters = HashMap::new();
+                parameters.insert(
+                    "DBZH".to_string(),
+                    ParameterDescription {
+                        label: "Reflectivity".into(),
+                        unit: "dBZ".into(),
+                        observed_property: "DBZH".into(),
+                    },
+                );
+                let mut ranges = HashMap::new();
+                ranges.insert(
+                    "DBZH".to_string(),
+                    NdArray {
+                        shape: vec![3, 2],
+                        axis_names: vec!["composite".into(), "z".into()],
+                        values: vec![
+                            Some(10.0),
+                            Some(20.0),
+                            None,
+                            Some(15.0),
+                            Some(5.0),
+                            Some(25.0),
+                        ],
+                    },
+                );
+                Ok(CoverageResponse::Single(QueryResult {
+                    domain: DomainDescription::Section {
+                        nodes,
+                        z: VerticalCoord {
+                            kind: VerticalKind::HeightAboveAntenna,
+                            values: vec![0.0, 1000.0],
+                        },
+                    },
+                    parameters,
+                    ranges,
+                }))
+            }
+        }
+
+        let engine: Arc<dyn EdrEngine> = Arc::new(TrajectoryMock);
+        let router = api_edr::router(make_edr_state(engine));
+
+        // Default → CoverageJSON Section.
+        let req = Request::builder()
+            .uri("/collections/weather/trajectory?coords=LINESTRING(24%2060,25%2061)")
+            .body(Body::empty())
+            .unwrap();
+        let resp = router.clone().oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(
+            resp.headers()
+                .get("content-type")
+                .and_then(|v| v.to_str().ok()),
+            Some("application/prs.coverage+json")
+        );
+        let body = resp.into_body().collect().await.unwrap().to_bytes();
+        let json: Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["domain"]["domainType"], "Section");
+
+        // f=PNG → image/png with a valid PNG signature.
+        let req = Request::builder()
+            .uri("/collections/weather/trajectory?coords=LINESTRING(24%2060,25%2061)&f=PNG")
+            .body(Body::empty())
+            .unwrap();
+        let resp = router.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(
+            resp.headers()
+                .get("content-type")
+                .and_then(|v| v.to_str().ok()),
+            Some("image/png")
+        );
+        let body = resp.into_body().collect().await.unwrap().to_bytes();
+        assert_eq!(&body[0..8], b"\x89PNG\r\n\x1a\n", "PNG signature");
+    }
+
     #[tokio::test]
     #[ignore = "corridor query not yet implemented"]
     async fn corridor_query() {

--- a/crates/api-edr/tests/ogc_edr_api_tests.rs
+++ b/crates/api-edr/tests/ogc_edr_api_tests.rs
@@ -412,6 +412,90 @@ mod collections {
         }
     }
 
+    /// `/collections` validates against the OGC EDR 1.1 bundled OpenAPI
+    /// schema for `GET /collections` 200 `application/json`. The
+    /// `extent.vertical` block in particular requires `vrs` and typed
+    /// strings for `interval` / `values` — this test guards against the
+    /// regressions that broke a real radar collection. A dedicated
+    /// vertical-aware mock fires that branch without disturbing the
+    /// `no-vertical` invariant the rest of the suite relies on.
+    #[tokio::test]
+    async fn listing_validates_against_ogc_edr_schema() {
+        // Reuse MockEngine for everything except `get_vertical_extent`
+        // by wrapping it — that way every other handler invariant
+        // (locations, parameters, etc.) is exercised identically.
+        struct VerticalMockEngine(MockEngine);
+        impl EdrEngine for VerticalMockEngine {
+            fn get_locations(&self) -> Result<Vec<Location>, DataServerError> {
+                self.0.get_locations()
+            }
+            fn query_location(
+                &self,
+                location_id: &str,
+                dt: Option<(DateTime<Utc>, DateTime<Utc>)>,
+                params: Option<&[String]>,
+                z: Option<&[f64]>,
+            ) -> Result<CoverageResponse, DataServerError> {
+                self.0.query_location(location_id, dt, params, z)
+            }
+            fn get_parameters(&self) -> Vec<String> {
+                self.0.get_parameters()
+            }
+            fn get_temporal_extent(&self) -> Option<(DateTime<Utc>, DateTime<Utc>)> {
+                self.0.get_temporal_extent()
+            }
+            fn get_spatial_extent(&self) -> Option<[f64; 4]> {
+                self.0.get_spatial_extent()
+            }
+            fn get_vertical_extent(&self) -> Option<ds_core::vertical::VerticalDimension> {
+                Some(ds_core::vertical::VerticalDimension::new(
+                    ds_core::vertical::VerticalKind::Pressure,
+                    vec![1000.0, 850.0, 700.0, 500.0, 250.0],
+                ))
+            }
+            fn supported_query_types(&self) -> Vec<String> {
+                self.0.supported_query_types()
+            }
+        }
+
+        let engine: Arc<dyn EdrEngine> = Arc::new(VerticalMockEngine(MockEngine));
+        let router = api_edr::router(make_edr_state(engine));
+        let req = Request::builder()
+            .uri("/collections")
+            .body(Body::empty())
+            .unwrap();
+        let resp = router.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = resp.into_body().collect().await.unwrap().to_bytes();
+        let json: Value = serde_json::from_slice(&body).unwrap();
+
+        let schema_str = std::fs::read_to_string(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../schemas/ogcapi-edr-1.1-bundled.json"
+        ))
+        .expect("read bundled OGC EDR schema");
+        let bundle: Value = serde_json::from_str(&schema_str).expect("parse schema");
+        let collections_schema = &bundle["paths"]["/collections"]["get"]["responses"]["200"]
+            ["content"]["application/json"]["schema"];
+        assert!(
+            !collections_schema.is_null(),
+            "Schema path /collections.get.responses.200 must resolve in the bundled spec"
+        );
+
+        let validator =
+            jsonschema::Validator::new(collections_schema).expect("compile collections schema");
+        let errors: Vec<String> = validator
+            .iter_errors(&json)
+            .map(|e| format!("- {} (at {})", e, e.instance_path))
+            .collect();
+        assert!(
+            errors.is_empty(),
+            "OGC EDR /collections schema violations:\n{}\n\nResponse:\n{}",
+            errors.join("\n"),
+            serde_json::to_string_pretty(&json).unwrap()
+        );
+    }
+
     // -- Single collection detail --
 
     #[tokio::test]

--- a/crates/core/src/edr_engine.rs
+++ b/crates/core/src/edr_engine.rs
@@ -94,4 +94,24 @@ pub trait EdrEngine: Send + Sync {
             "Position query not supported by this engine".into(),
         ))
     }
+
+    /// Execute a trajectory (vertical cross-section) query along a WKT
+    /// `LINESTRING`. The result is a CoverageJSON `Section` domain (or a
+    /// collection of them, one per timestep): a 2-D field over an
+    /// along-path composite axis and a vertical `z` axis. `z`, when set,
+    /// pins the height range — engines free to interpret as a discrete
+    /// list, a `[min, max]` interval, or both.
+    /// Default implementation returns an error.
+    fn query_trajectory(
+        &self,
+        coords: &str,
+        datetime: Option<(DateTime<Utc>, DateTime<Utc>)>,
+        parameters: Option<&[String]>,
+        z: Option<&[f64]>,
+    ) -> Result<CoverageResponse, DataServerError> {
+        let _ = (coords, datetime, parameters, z);
+        Err(DataServerError::InvalidParameter(
+            "Trajectory query not supported by this engine".into(),
+        ))
+    }
 }

--- a/crates/core/src/feature.rs
+++ b/crates/core/src/feature.rs
@@ -376,8 +376,15 @@ pub fn parse_linestring_coords(coords: &str) -> Result<Vec<(f64, f64)>, DataServ
 
     // Reject Z/M variants explicitly so the error message points at the
     // dimensional mismatch rather than failing as "not a number".
+    //
+    // Compare bytes (not `&str` slices) — axum percent-decodes query
+    // params into UTF-8, so a payload like `coords=LINESTRING%C3%A9(...)`
+    // would arrive with a multibyte char straddling byte index 11 and a
+    // `&str` slice at that index would panic (`byte index … is not a
+    // char boundary`), crashing the handler with an unhandled 500.
     for variant in ["LINESTRINGZM", "LINESTRINGZ", "LINESTRINGM"] {
-        if trimmed.len() >= variant.len() && trimmed[..variant.len()].eq_ignore_ascii_case(variant)
+        if trimmed.len() >= variant.len()
+            && trimmed.as_bytes()[..variant.len()].eq_ignore_ascii_case(variant.as_bytes())
         {
             return Err(DataServerError::InvalidParameter(format!(
                 "{variant} is not supported — pass a plain 2-D LINESTRING(lon lat, lon lat, …)"
@@ -424,6 +431,21 @@ pub fn parse_linestring_coords(coords: &str) -> Result<Vec<(f64, f64)>, DataServ
             "LINESTRING must have at least two nodes — use POINT(...) for a single location".into(),
         ));
     }
+    // A LINESTRING whose nodes are all the same point produces a
+    // zero-length path. Downstream `resample_path` would return two
+    // identical composite tuples, and the rendered CoverageJSON `Section`
+    // domain would carry duplicate `[t,x,y]` values — semantically
+    // meaningless and prone to surprise clients. Reject early so the
+    // caller can fix the request rather than receive a degenerate
+    // coverage. (A LINESTRING with *some* repeated vertices and a
+    // non-zero total length is still accepted.)
+    let (lon0, lat0) = nodes[0];
+    if nodes.iter().all(|&(lon, lat)| lon == lon0 && lat == lat0) {
+        return Err(DataServerError::InvalidParameter(
+            "LINESTRING nodes must not all be identical — use POINT(...) for a single location"
+                .into(),
+        ));
+    }
 
     Ok(nodes)
 }
@@ -435,9 +457,17 @@ fn strip_wkt_prefix<'a>(s: &'a str, keyword: &str) -> Option<&'a str> {
     if s.len() < keyword.len() + 2 {
         return None;
     }
-    if !s[..keyword.len()].eq_ignore_ascii_case(keyword) {
+    // Byte-level compare so a multibyte char straddling `keyword.len()`
+    // doesn't panic (see the matching note in `parse_linestring_coords`).
+    // `s.get(..keyword.len())` would also work; bytes are clearer here.
+    if !s.as_bytes()[..keyword.len()].eq_ignore_ascii_case(keyword.as_bytes()) {
         return None;
     }
+    // `keyword.len()` is the same byte count as
+    // `s.as_bytes()[..keyword.len()]`, and the case-insensitive ASCII
+    // match above proves those bytes are ASCII (a UTF-8 leading byte
+    // never matches an ASCII keyword byte), so this str slice is on a
+    // char boundary by construction.
     let after = s[keyword.len()..].trim_start();
     after
         .strip_prefix('(')
@@ -801,5 +831,33 @@ mod tests {
         assert!(parse_linestring_coords("POINT(10 50)").is_err());
         assert!(parse_linestring_coords("LINESTRING(200 50, 11 51)").is_err());
         assert!(parse_linestring_coords("LINESTRING(NaN 50, 11 51)").is_err());
+    }
+
+    /// A multibyte UTF-8 character straddling the prefix length byte must
+    /// not panic. Caught by claude-review on PR #275 — `&str[..N]` is
+    /// byte-indexed, so a `LINESTRINGé(...)` input would crash the
+    /// handler with `byte index … is not a char boundary`.
+    #[test]
+    fn parse_linestring_handles_multibyte_prefix_collision() {
+        // `é` is 2 bytes, landing at byte index 10 — exactly where the
+        // length check would slice a `LINESTRINGZ` prefix.
+        let res = parse_linestring_coords("LINESTRINGé(10 50, 11 51)");
+        assert!(res.is_err(), "non-LINESTRING prefix must error, not panic");
+        // And the prefix check itself must not crash on this input.
+        assert!(parse_linestring_coords("LINESTRING\u{1F600}(0 0, 1 1)").is_err());
+    }
+
+    /// `LINESTRING(24 60, 24 60)` is a zero-length path — every along-path
+    /// node maps to the same `(t, lon, lat)` tuple, producing a degenerate
+    /// `Section` coverage. Reject early so the caller knows.
+    #[test]
+    fn parse_linestring_rejects_all_identical_nodes() {
+        let err = parse_linestring_coords("LINESTRING(24 60, 24 60)").unwrap_err();
+        assert!(format!("{err:?}").contains("identical"));
+        // Three identical nodes — same outcome.
+        assert!(parse_linestring_coords("LINESTRING(1 2, 1 2, 1 2)").is_err());
+        // A LINESTRING with *some* duplicates but a non-zero length is
+        // accepted — the resample step handles the geometry fine.
+        assert!(parse_linestring_coords("LINESTRING(1 2, 1 2, 2 3)").is_ok());
     }
 }

--- a/crates/core/src/feature.rs
+++ b/crates/core/src/feature.rs
@@ -372,6 +372,15 @@ pub fn parse_point_coords(coords: &str) -> Result<(f64, f64), DataServerError> {
 /// follow-up. At least two distinct nodes are required (a single node is
 /// not a path; the position query covers that case).
 pub fn parse_linestring_coords(coords: &str) -> Result<Vec<(f64, f64)>, DataServerError> {
+    // Bound the input before any parsing so a 10 MB payload can't
+    // allocate one `(f64, f64)` per comma before `TRAJECTORY_MAX_NODES`
+    // (engine-odim) ever clamps the resampled path. Same limit as
+    // `parse_area_coords`. Flagged by claude-review on PR #275.
+    if coords.len() > MAX_WKT_LENGTH {
+        return Err(DataServerError::InvalidParameter(format!(
+            "LINESTRING geometry exceeds maximum length of {MAX_WKT_LENGTH} bytes"
+        )));
+    }
     let trimmed = coords.trim();
 
     // Reject Z/M variants explicitly so the error message points at the
@@ -850,6 +859,25 @@ mod tests {
     /// `LINESTRING(24 60, 24 60)` is a zero-length path — every along-path
     /// node maps to the same `(t, lon, lat)` tuple, producing a degenerate
     /// `Section` coverage. Reject early so the caller knows.
+    /// A LINESTRING payload longer than `MAX_WKT_LENGTH` is rejected
+    /// without allocating one `(f64, f64)` per comma. Mirrors
+    /// `parse_rejects_too_long` for polygons; caught by claude-review.
+    #[test]
+    fn parse_linestring_rejects_too_long_payload() {
+        // ~30 KB of valid LINESTRING content. Length-cap fires before
+        // any per-node parsing — i.e. this completes instantly.
+        let mut s = String::from("LINESTRING(");
+        for i in 0..5_000 {
+            if i > 0 {
+                s.push(',');
+            }
+            s.push_str("0 0");
+        }
+        s.push(')');
+        assert!(s.len() > MAX_WKT_LENGTH);
+        assert!(parse_linestring_coords(&s).is_err());
+    }
+
     #[test]
     fn parse_linestring_rejects_all_identical_nodes() {
         let err = parse_linestring_coords("LINESTRING(24 60, 24 60)").unwrap_err();

--- a/crates/core/src/feature.rs
+++ b/crates/core/src/feature.rs
@@ -363,6 +363,88 @@ pub fn parse_point_coords(coords: &str) -> Result<(f64, f64), DataServerError> {
     Ok((lat, lon))
 }
 
+/// Parse a WKT `LINESTRING(lon lat, lon lat, ...)` into a `Vec<(lon, lat)>`
+/// (engine-friendly order — note `parse_point_coords` returns `(lat, lon)`
+/// for legacy reasons; cross-section paths always carry `(lon, lat)` here).
+///
+/// A leading space before `(` is tolerated. `LINESTRINGZ` / `LINESTRINGM` /
+/// `LINESTRINGZM` are rejected — per-node z and time are deferred to a
+/// follow-up. At least two distinct nodes are required (a single node is
+/// not a path; the position query covers that case).
+pub fn parse_linestring_coords(coords: &str) -> Result<Vec<(f64, f64)>, DataServerError> {
+    let trimmed = coords.trim();
+
+    // Reject Z/M variants explicitly so the error message points at the
+    // dimensional mismatch rather than failing as "not a number".
+    for variant in ["LINESTRINGZM", "LINESTRINGZ", "LINESTRINGM"] {
+        if trimmed.len() >= variant.len() && trimmed[..variant.len()].eq_ignore_ascii_case(variant)
+        {
+            return Err(DataServerError::InvalidParameter(format!(
+                "{variant} is not supported — pass a plain 2-D LINESTRING(lon lat, lon lat, …)"
+            )));
+        }
+    }
+
+    let inner = strip_wkt_prefix(trimmed, "LINESTRING").ok_or_else(|| {
+        DataServerError::InvalidParameter(
+            "Expected WKT LINESTRING(lon lat, lon lat, …) geometry".into(),
+        )
+    })?;
+
+    let mut nodes = Vec::new();
+    for part in inner.split(',') {
+        let tokens: Vec<&str> = part.split_whitespace().collect();
+        if tokens.len() != 2 {
+            return Err(DataServerError::InvalidParameter(format!(
+                "LINESTRING node '{}' is not 'lon lat'",
+                part.trim()
+            )));
+        }
+        let lon: f64 = tokens[0].parse().map_err(|_| {
+            DataServerError::InvalidParameter(format!("Invalid longitude: {}", tokens[0]))
+        })?;
+        let lat: f64 = tokens[1].parse().map_err(|_| {
+            DataServerError::InvalidParameter(format!("Invalid latitude: {}", tokens[1]))
+        })?;
+        if !lon.is_finite() || !lat.is_finite() {
+            return Err(DataServerError::InvalidParameter(
+                "LINESTRING coordinates must be finite".into(),
+            ));
+        }
+        if !(-180.0..=180.0).contains(&lon) || !(-90.0..=90.0).contains(&lat) {
+            return Err(DataServerError::InvalidParameter(format!(
+                "LINESTRING node out of range: lon={lon}, lat={lat}"
+            )));
+        }
+        nodes.push((lon, lat));
+    }
+
+    if nodes.len() < 2 {
+        return Err(DataServerError::InvalidParameter(
+            "LINESTRING must have at least two nodes — use POINT(...) for a single location".into(),
+        ));
+    }
+
+    Ok(nodes)
+}
+
+/// Strip a leading `KEYWORD(` / `KEYWORD (` and the matching trailing `)`.
+/// Case-insensitive on the keyword. Returns `None` when the input does not
+/// match the wrapper shape.
+fn strip_wkt_prefix<'a>(s: &'a str, keyword: &str) -> Option<&'a str> {
+    if s.len() < keyword.len() + 2 {
+        return None;
+    }
+    if !s[..keyword.len()].eq_ignore_ascii_case(keyword) {
+        return None;
+    }
+    let after = s[keyword.len()..].trim_start();
+    after
+        .strip_prefix('(')
+        .and_then(|inner| inner.strip_suffix(')'))
+        .map(str::trim)
+}
+
 /// A typed property value. Keeps ds-core free of serde_json.
 #[derive(Debug, Clone, PartialEq)]
 pub enum PropertyValue {
@@ -684,5 +766,40 @@ mod tests {
         // Non-finite.
         assert!(parse_point_coords("NaN, 10.0").is_err());
         assert!(parse_point_coords("inf, 10.0").is_err());
+    }
+
+    #[test]
+    fn parse_linestring_accepts_two_or_more_nodes() {
+        let nodes = parse_linestring_coords("LINESTRING(10 50, 11 51)").unwrap();
+        assert_eq!(nodes, vec![(10.0, 50.0), (11.0, 51.0)]);
+
+        let nodes =
+            parse_linestring_coords("linestring ( 24.94 60.17 , 25.5 60.5 , 26.0 61.0 )").unwrap();
+        assert_eq!(nodes.len(), 3);
+        assert!((nodes[2].0 - 26.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn parse_linestring_rejects_z_and_m_variants() {
+        for s in [
+            "LINESTRINGZ(10 50 0, 11 51 100)",
+            "LINESTRINGM(10 50 0, 11 51 1)",
+            "LINESTRINGZM(10 50 0 1, 11 51 100 2)",
+        ] {
+            let err = parse_linestring_coords(s).unwrap_err();
+            assert!(
+                format!("{err:?}").contains("not supported"),
+                "expected Z/M-rejected error, got {err:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn parse_linestring_rejects_single_node_and_malformed() {
+        assert!(parse_linestring_coords("LINESTRING(10 50)").is_err());
+        assert!(parse_linestring_coords("LINESTRING(10, 50)").is_err());
+        assert!(parse_linestring_coords("POINT(10 50)").is_err());
+        assert!(parse_linestring_coords("LINESTRING(200 50, 11 51)").is_err());
+        assert!(parse_linestring_coords("LINESTRING(NaN 50, 11 51)").is_err());
     }
 }

--- a/crates/core/src/model.rs
+++ b/crates/core/src/model.rs
@@ -43,6 +43,15 @@ pub enum DomainDescription {
         t: Option<DateTime<Utc>>,
         z: VerticalCoord,
     },
+    /// A vertical cross-section along a path: the CoverageJSON `Section`
+    /// domain. `nodes` carries one `(time, longitude, latitude)` tuple
+    /// per along-path output column and is serialised as the mandatory
+    /// composite axis with `coordinates: ["t", "x", "y"]`; `z` carries
+    /// the vertical levels. The ndarray range shape is `[N_nodes, N_z]`.
+    Section {
+        nodes: Vec<(DateTime<Utc>, f64, f64)>,
+        z: VerticalCoord,
+    },
 }
 
 #[derive(Debug, Clone)]

--- a/crates/core/src/vertical.rs
+++ b/crates/core/src/vertical.rs
@@ -96,9 +96,14 @@ impl VerticalKind {
             // (an earlier draft of this code referenced EPSG:5798, which
             // is actually "EGM96 height" — wrong kind entirely; flagged
             // by claude-review on PR #275). Emit an inline WKT2 instead.
+            // VDATUM is "Atmosphere" rather than "Mean sea level" — MSL
+            // is an altimetric gravity-surface datum, semantically wrong
+            // for a pressure axis. "Atmosphere" matches how NWP vertical
+            // CRS definitions describe atmospheric levels (GRIB2 §3.0).
+            // Flagged by claude-review on PR #275.
             VerticalKind::Pressure => {
                 "VERTCRS[\"Atmospheric pressure\",\
-                 VDATUM[\"Mean sea level\"],\
+                 VDATUM[\"Atmosphere\"],\
                  CS[vertical,1],\
                  AXIS[\"Pressure (hPa)\",down],\
                  UNIT[\"hPa\",100]]"

--- a/crates/core/src/vertical.rs
+++ b/crates/core/src/vertical.rs
@@ -78,8 +78,17 @@ impl VerticalKind {
         match self {
             // EPSG:5714 = "MSL height", the closest match for altimetric height.
             VerticalKind::Height => "http://www.opengis.net/def/crs/EPSG/0/5714",
-            // EPSG:5798 = "WMO standard atmospheric pressure" — pressure altitude.
-            VerticalKind::Pressure => "http://www.opengis.net/def/crs/EPSG/0/5798",
+            // EPSG has no standard URI for an atmospheric pressure CRS
+            // (an earlier draft of this code referenced EPSG:5798, which
+            // is actually "EGM96 height" — wrong kind entirely; flagged
+            // by claude-review on PR #275). Emit an inline WKT2 instead.
+            VerticalKind::Pressure => {
+                "VERTCRS[\"Atmospheric pressure\",\
+                 VDATUM[\"Mean sea level\"],\
+                 CS[vertical,1],\
+                 AXIS[\"Pressure (hPa)\",down],\
+                 UNIT[\"hPa\",100]]"
+            }
             VerticalKind::ElevationAngle => {
                 "VERTCRS[\"Elevation angle\",\
                  VDATUM[\"Antenna horizon\"],\

--- a/crates/core/src/vertical.rs
+++ b/crates/core/src/vertical.rs
@@ -70,10 +70,24 @@ impl VerticalKind {
 
     /// Vertical reference system string for OGC EDR collection metadata
     /// (`extent.vertical.vrs`). The OGC EDR 1.1 schema marks `vrs` as a
-    /// required string with no standard URI for non-altimetric kinds
-    /// (radar elevation, model level, isentropic), so we emit a WKT2
-    /// `VERTCRS[...]` describing the axis. For `Height` an EPSG URI is
-    /// available and preferred; everything else uses an inline WKT.
+    /// required `string` with no `format` constraint, so any string
+    /// satisfies it; we prefer a resolvable EPSG URI when one exists
+    /// (`Height` → EPSG:5714) and fall back to an inline WKT2
+    /// `VERTCRS[...]` for kinds with no registered URI (radar elevation,
+    /// height-above-antenna, atmospheric pressure, model level,
+    /// isentropic).
+    ///
+    /// **Tradeoff (claude-review on PR #275)**: the JSON schema is
+    /// satisfied either way, but strict OGC CITE / EDR-spec clients
+    /// sometimes verify that `vrs` is a *resolvable* OGC or EPSG URI
+    /// rather than an inline WKT — so the inline-WKT kinds may fail
+    /// such conformance checks, trading "vrs absent" (the prior
+    /// behaviour) for "vrs unresolvable". An invented placeholder URI
+    /// would be worse (silently wrong, the way `EPSG:5798` was for
+    /// pressure before this rewrite), and there is no public OGC
+    /// namespace for these custom verticals, so WKT2 is the right
+    /// pragmatic choice. Override per-kind here if a future EPSG/OGC
+    /// registration covers one of these.
     pub fn vrs(self) -> &'static str {
         match self {
             // EPSG:5714 = "MSL height", the closest match for altimetric height.

--- a/crates/core/src/vertical.rs
+++ b/crates/core/src/vertical.rs
@@ -19,6 +19,12 @@ pub enum VerticalKind {
     Height,
     /// Radar beam elevation angle (degrees). Increasing value is upward.
     ElevationAngle,
+    /// Metres above a radar antenna, used as the cross-section vertical
+    /// axis (`Section` domain). Distinct from `Height` so the
+    /// CoverageJSON `VerticalCRS` axis can carry the antenna-relative
+    /// label rather than a generic "Height" — the value is *not* metres
+    /// above mean sea level.
+    HeightAboveAntenna,
     /// Ordinal model / hybrid level. Increasing value is downward.
     ModelLevel,
     /// Isentropic (potential-temperature) level (K). Increasing value is upward.
@@ -32,6 +38,7 @@ impl VerticalKind {
             VerticalKind::Pressure => "hPa",
             VerticalKind::Height => "m",
             VerticalKind::ElevationAngle => "deg",
+            VerticalKind::HeightAboveAntenna => "m",
             VerticalKind::ModelLevel => "1",
             VerticalKind::Isentropic => "K",
         }
@@ -43,6 +50,7 @@ impl VerticalKind {
             VerticalKind::Pressure => "Pressure",
             VerticalKind::Height => "Height",
             VerticalKind::ElevationAngle => "Elevation angle",
+            VerticalKind::HeightAboveAntenna => "Height above antenna",
             VerticalKind::ModelLevel => "Model level",
             VerticalKind::Isentropic => "Isentropic level",
         }
@@ -53,7 +61,10 @@ impl VerticalKind {
     pub fn direction(self) -> &'static str {
         match self {
             VerticalKind::Pressure | VerticalKind::ModelLevel => "down",
-            VerticalKind::Height | VerticalKind::ElevationAngle | VerticalKind::Isentropic => "up",
+            VerticalKind::Height
+            | VerticalKind::ElevationAngle
+            | VerticalKind::HeightAboveAntenna
+            | VerticalKind::Isentropic => "up",
         }
     }
 }

--- a/crates/core/src/vertical.rs
+++ b/crates/core/src/vertical.rs
@@ -67,6 +67,49 @@ impl VerticalKind {
             | VerticalKind::Isentropic => "up",
         }
     }
+
+    /// Vertical reference system string for OGC EDR collection metadata
+    /// (`extent.vertical.vrs`). The OGC EDR 1.1 schema marks `vrs` as a
+    /// required string with no standard URI for non-altimetric kinds
+    /// (radar elevation, model level, isentropic), so we emit a WKT2
+    /// `VERTCRS[...]` describing the axis. For `Height` an EPSG URI is
+    /// available and preferred; everything else uses an inline WKT.
+    pub fn vrs(self) -> &'static str {
+        match self {
+            // EPSG:5714 = "MSL height", the closest match for altimetric height.
+            VerticalKind::Height => "http://www.opengis.net/def/crs/EPSG/0/5714",
+            // EPSG:5798 = "WMO standard atmospheric pressure" — pressure altitude.
+            VerticalKind::Pressure => "http://www.opengis.net/def/crs/EPSG/0/5798",
+            VerticalKind::ElevationAngle => {
+                "VERTCRS[\"Elevation angle\",\
+                 VDATUM[\"Antenna horizon\"],\
+                 CS[vertical,1],\
+                 AXIS[\"Elevation (deg)\",up],\
+                 UNIT[\"degree\",0.0174532925199433]]"
+            }
+            VerticalKind::HeightAboveAntenna => {
+                "VERTCRS[\"Height above antenna\",\
+                 VDATUM[\"Antenna phase centre\"],\
+                 CS[vertical,1],\
+                 AXIS[\"Height (m)\",up],\
+                 UNIT[\"metre\",1]]"
+            }
+            VerticalKind::ModelLevel => {
+                "VERTCRS[\"Model level\",\
+                 VDATUM[\"Model surface\"],\
+                 CS[vertical,1],\
+                 AXIS[\"Level\",down],\
+                 UNIT[\"unity\",1]]"
+            }
+            VerticalKind::Isentropic => {
+                "VERTCRS[\"Isentropic\",\
+                 VDATUM[\"Potential temperature\"],\
+                 CS[vertical,1],\
+                 AXIS[\"Theta (K)\",up],\
+                 UNIT[\"kelvin\",1]]"
+            }
+        }
+    }
 }
 
 /// A collection's single vertical axis: the kind of coordinate plus the

--- a/crates/engine-odim/src/volume_engine.rs
+++ b/crates/engine-odim/src/volume_engine.rs
@@ -135,8 +135,12 @@ pub fn destination_point(lon0: f64, lat0: f64, distance_m: f64, bearing_deg: f64
     let lat = sin_lat.asin();
     let y = brg.sin() * ang.sin() * lat0_r.cos();
     let x = ang.cos() - lat0_r.sin() * sin_lat;
+    // Normalise longitude into (−180, 180]: a path starting near ±180°
+    // can otherwise return a lon outside that range, which would leak
+    // into the CoverageJSON `Section` nodes verbatim.
     let lon = lon0_r + y.atan2(x);
-    (lon.to_degrees(), lat.to_degrees())
+    let lon_deg = (lon.to_degrees() + 540.0).rem_euclid(360.0) - 180.0;
+    (lon_deg, lat.to_degrees())
 }
 
 // ---------------------------------------------------------------------------
@@ -1598,11 +1602,16 @@ fn angle_window(z: Option<&[f64]>, volume: &PolarVolume) -> Result<(f64, f64), D
 /// at `TRAJECTORY_MAX_Z_LEVELS`. Selecting a lower top elevation angle (a
 /// narrower `z`) therefore zooms the vertical axis onto that band.
 fn height_axis(hi_angle_deg: f64, max_ground_dist_m: f64) -> Vec<f64> {
-    // The ground distance is a close slant-range proxy at the low
-    // elevation angles that dominate radar coverage — accurate enough for
-    // an axis ceiling.
-    let r = max_ground_dist_m.max(1_000.0);
-    let (_, h) = slant_to_ground_height(r, hi_angle_deg.max(0.0));
+    // `slant_to_ground_height` wants a slant range, so convert the path's
+    // farthest *ground* distance to slant via `ground / cos(el)` (exact
+    // for a flat beam, and the dominant term at radar elevation angles).
+    // Using the ground distance directly would under-size the ceiling by
+    // ~cos(el) — ~3.5 % (≈ 420 m on a 100 km path) at 15°, clipping
+    // real coverage near the top of the beam.
+    let el = hi_angle_deg.max(0.0);
+    let cos_el = el.to_radians().cos().max(1e-3);
+    let r = (max_ground_dist_m / cos_el).max(1_000.0);
+    let (_, h) = slant_to_ground_height(r, el);
     let top = h.clamp(TRAJECTORY_DEFAULT_Z_STEP_M, 25_000.0);
     let n =
         ((top / TRAJECTORY_DEFAULT_Z_STEP_M).ceil() as usize + 1).clamp(2, TRAJECTORY_MAX_Z_LEVELS);
@@ -1701,19 +1710,32 @@ fn sample_polar_slant(
 /// Build one `Section` coverage: the volume's polar field resampled on
 /// `(along-path-distance, height-above-antenna)` and exposed via the
 /// CoverageJSON composite axis `[t, lon, lat]` plus a numeric `z` axis
-/// in metres. `envelope` is the elevation-angle window `[lo, hi]` — cells
-/// whose 4/3-Earth-inverted beam angle falls outside it become nodata, so
-/// the caller's `z` angle selection drives which sweeps contribute.
+/// in metres. `window` is the caller's selected elevation-angle band
+/// `[lo, hi]` (from `z`) — cells whose 4/3-Earth-inverted beam angle
+/// falls outside it become nodata.
+///
+/// The guard actually applied is `window ∩ this volume's own sweep
+/// envelope`: a multi-timestep request derives `window` once from the
+/// newest volume, but an older entry whose scan strategy reached a
+/// lower ceiling must not have a cell that inverts to (say) 20° matched
+/// to its 10° top sweep — intersecting per entry keeps each timestep
+/// honest about the angles it actually surveyed.
 fn volume_section(
     entry: &VolumeEntry,
     path: &[(f64, f64)],
     heights_m: &[f64],
     quantities: &[String],
-    envelope: (f64, f64),
+    window: (f64, f64),
 ) -> Option<QueryResult> {
     if path.len() < 2 || heights_m.is_empty() || quantities.is_empty() {
         return None;
     }
+    // Per-entry effective envelope: the selected window clamped to this
+    // volume's surveyed sweep range. A volume with no finite sweeps is
+    // skipped; one that doesn't cover the window yields all-nodata cells
+    // (an inverted envelope rejects every beam angle).
+    let entry_env = sweep_envelope(&entry.volume)?;
+    let envelope = (window.0.max(entry_env.0), window.1.min(entry_env.1));
     let site = &entry.volume.site;
     let t = entry.volume.time;
     let nodes: Vec<(DateTime<Utc>, f64, f64)> =
@@ -2212,6 +2234,23 @@ mod tests {
         assert!((az - 45.0).abs() < 1e-3, "round-trip bearing, got {az}");
     }
 
+    /// Crossing the antimeridian eastbound keeps the longitude in
+    /// (−180, 180]: starting at 179.9° and travelling east must wrap to a
+    /// small negative longitude, not 180.x°, so the value is valid in a
+    /// CoverageJSON node.
+    #[test]
+    fn destination_point_normalises_longitude_across_antimeridian() {
+        let (lon, _lat) = destination_point(179.9, 0.0, 50_000.0, 90.0);
+        assert!(
+            (-180.0..=180.0).contains(&lon),
+            "lon must be normalised into (−180, 180], got {lon}"
+        );
+        assert!(
+            lon < 0.0,
+            "eastbound past 180° wraps to negative, got {lon}"
+        );
+    }
+
     /// 4/3-Earth forward + inverse are mutual inverses to sub-metre /
     /// sub-mdeg residuals over the radar-relevant envelope
     /// (≤ 250 km range, 0°–30° elevation, up to 20 km height). This is
@@ -2382,19 +2421,73 @@ mod tests {
     /// the selected top angle and is clamped to ≤ 25 km.
     #[test]
     fn height_axis_tracks_top_angle_and_caps() {
-        // A 5° beam at 100 km ground distance reaches a few km up.
-        let low = height_axis(5.0, 100_000.0);
+        // A 2° beam at 30 km ground distance reaches ~1 km up.
+        let low = height_axis(2.0, 30_000.0);
         assert!(low.first() == Some(&0.0), "axis starts at 0");
         assert!(low.windows(2).all(|w| w[1] > w[0]), "monotonic ascending");
         assert!(*low.last().unwrap() <= 25_000.0);
         // A higher top angle reaches higher (taller axis ceiling).
-        let high = height_axis(15.0, 100_000.0);
+        let high = height_axis(15.0, 30_000.0);
         assert!(*high.last().unwrap() > *low.last().unwrap());
+        // The slant correction (ground/cos el) makes the 15° ceiling a
+        // touch higher than using the ground distance as slant directly —
+        // a few hundred metres on a 30 km path — so real coverage near the
+        // top of the beam isn't clipped. (Both are well under the 25 km
+        // cap at 30 km, so the correction is observable here.)
+        let (_, h_ground_as_slant) = slant_to_ground_height(30_000.0, 15.0);
+        assert!(*high.last().unwrap() <= 25_000.0, "below the cap at 30 km");
+        assert!(
+            *high.last().unwrap() > h_ground_as_slant,
+            "cos-corrected ceiling {} must exceed the ground-as-slant value {}",
+            high.last().unwrap(),
+            h_ground_as_slant
+        );
         // A near-vertical beam at long range is capped at 25 km, not
         // hundreds of km.
         let capped = height_axis(89.0, 200_000.0);
         assert!(*capped.last().unwrap() <= 25_000.0 + 1.0);
         assert!(capped.len() <= 100, "level count capped");
+    }
+
+    /// `volume_section` clamps the caller's angle window to *this volume's*
+    /// surveyed sweep range. A window wider than the volume's sweeps (as
+    /// happens when the window is derived from a newer, deeper scan) must
+    /// not fabricate data: a cell that inverts to an elevation the volume
+    /// never scanned stays nodata rather than snapping to its top sweep.
+    #[test]
+    fn volume_section_clamps_window_to_per_volume_sweeps() {
+        let (site_lon, site_lat) = (25.0, 60.0);
+        // The synthetic volume has a single 0.5° sweep.
+        let vol = synthetic_volume(site_lon, site_lat);
+        let e = entry(vol, "v0");
+
+        // A node ~10 km due east: at height 0 the beam grazes the surface
+        // (el ≈ 0°, inside the 0.5° sweep envelope ±1°); at 1500 m it
+        // climbs to el ≈ 8–9° — inside the *window* (0.5–25°) but outside
+        // this volume's actual range, so it must be nodata.
+        let dlon_10km = 10_000.0 / (EARTH_RADIUS_M * site_lat.to_radians().cos()) * 180.0
+            / std::f64::consts::PI;
+        let path = vec![(site_lon, site_lat), (site_lon + dlon_10km, site_lat)];
+        let heights = vec![0.0, 1500.0];
+        let window = (0.5, 25.0); // wider than the volume's 0.5° sweep
+
+        let qr = volume_section(&e, &path, &heights, &["DBZH".to_string()], window)
+            .expect("section produced");
+        let nd = qr.ranges.get("DBZH").expect("DBZH range");
+        // Layout is row-major [node][height]; the far node is index 1, so
+        // its first cell starts at `heights.len()`.
+        let nz = heights.len();
+        let far_surface = nd.values[nz]; // (10 km, 0 m)
+        let far_high = nd.values[nz + 1]; // (10 km, 1500 m)
+        assert!(
+            far_surface.is_some(),
+            "the surface cell grazes the 0.5° sweep and must sample"
+        );
+        assert!(
+            far_high.is_none(),
+            "a cell at ~8° must stay nodata — the volume never scanned that \
+             angle, even though it's inside the requested window"
+        );
     }
 
     /// Build a synthetic single-site, single-sweep, single-moment

--- a/crates/engine-odim/src/volume_engine.rs
+++ b/crates/engine-odim/src/volume_engine.rs
@@ -55,7 +55,7 @@ use arc_swap::ArcSwap;
 use chrono::{DateTime, Utc};
 use ds_core::edr_engine::EdrEngine;
 use ds_core::error::DataServerError;
-use ds_core::feature::{parse_area_coords, parse_point_coords};
+use ds_core::feature::{parse_area_coords, parse_linestring_coords, parse_point_coords};
 use ds_core::map_engine::{MapEngine, OutputCrs, RasterInfo, RasterTile};
 use ds_core::model::{
     CoverageResponse, DomainDescription, Location, NdArray, ParameterDescription, QueryResult,
@@ -120,6 +120,92 @@ pub fn ground_distance_bearing(lon0: f64, lat0: f64, lon1: f64, lat1: f64) -> (f
     let bearing = y.atan2(x).to_degrees().rem_euclid(360.0);
 
     (distance, bearing)
+}
+
+/// Forward great-circle destination point: starting at `(lon0, lat0)`
+/// (degrees), travel `distance_m` along bearing `bearing_deg` and return
+/// the destination `(lon, lat)` (degrees). Used for path resampling
+/// along a LINESTRING segment.
+pub fn destination_point(lon0: f64, lat0: f64, distance_m: f64, bearing_deg: f64) -> (f64, f64) {
+    let ang = distance_m / EARTH_RADIUS_M;
+    let lat0_r = lat0.to_radians();
+    let lon0_r = lon0.to_radians();
+    let brg = bearing_deg.to_radians();
+    let sin_lat = lat0_r.sin() * ang.cos() + lat0_r.cos() * ang.sin() * brg.cos();
+    let lat = sin_lat.asin();
+    let y = brg.sin() * ang.sin() * lat0_r.cos();
+    let x = ang.cos() - lat0_r.sin() * sin_lat;
+    let lon = lon0_r + y.atan2(x);
+    (lon.to_degrees(), lat.to_degrees())
+}
+
+// ---------------------------------------------------------------------------
+// 4/3-Earth beam geometry (cross-section path)
+// ---------------------------------------------------------------------------
+//
+// The standard radar-meteorology "effective Earth" model: treat the
+// atmosphere's average refractivity gradient as if the Earth's radius
+// were 4/3 of its true value, then trace beams as straight lines through
+// that fictitious sphere. Forward and inverse maps come from Doviak &
+// Zrnić (1993), §2.2.3 — used by the cross-section sampler to translate
+// between the polar sweep coordinate (slant range, elevation angle) and
+// the human-meaningful display coordinate (ground distance from radar,
+// height above antenna).
+//
+// This is *only* used by the new `query_trajectory` cross-section path.
+// The legacy `sample_sweep_moment` (used by position/area queries) and
+// `polar_sample` (used by Map/WMS) stay on their ground-range interim —
+// migrating those is a separate ticket.
+
+/// 4/3 of the mean Earth radius, in metres — the effective radius used
+/// to model standard atmospheric refraction.
+pub(crate) const FOUR_THIRDS_EARTH_M: f64 = 4.0 / 3.0 * EARTH_RADIUS_M;
+
+/// Forward map: `(slant_range_m, elevation_angle_deg)` → `(ground_distance_m,
+/// height_above_antenna_m)` under the 4/3-Earth model.
+///
+/// `h = sqrt(r² + R'² + 2·r·R'·sin(el)) − R'`
+/// `s = R' · atan(r·cos(el) / (r·sin(el) + R'))`
+///
+/// where `R' = 4/3 · R_earth`. `r` is slant range in metres, `el` is in
+/// degrees.
+pub(crate) fn slant_to_ground_height(slant_range_m: f64, elangle_deg: f64) -> (f64, f64) {
+    let r = slant_range_m;
+    let el = elangle_deg.to_radians();
+    let rp = FOUR_THIRDS_EARTH_M;
+    let h = (r * r + rp * rp + 2.0 * r * rp * el.sin()).sqrt() - rp;
+    let s = rp * (r * el.cos() / (r * el.sin() + rp)).atan();
+    (s, h)
+}
+
+/// Inverse: `(ground_distance_m, height_above_antenna_m)` →
+/// `(slant_range_m, elevation_angle_deg)`. Closed-form companion to
+/// [`slant_to_ground_height`]; the algebra is in Doviak & Zrnić (1993)
+/// §2.2.3 / Rinehart (2004) §3.5.
+///
+/// Given target point `(s, h)` on the effective-Earth sphere, parametrise
+/// the antenna at radius `R'` and the target at radius `R' + h` separated
+/// by the central angle `θ = s / R'`. Then by the law of cosines:
+///
+/// `r² = R'² + (R'+h)² − 2·R'·(R'+h)·cos(θ)`
+///
+/// and the elevation angle measured from the local horizontal at the
+/// antenna is:
+///
+/// `el = atan2((R'+h)·cos(θ) − R', (R'+h)·sin(θ))`
+pub(crate) fn ground_height_to_slant(
+    ground_distance_m: f64,
+    height_above_antenna_m: f64,
+) -> (f64, f64) {
+    let s = ground_distance_m;
+    let h = height_above_antenna_m;
+    let rp = FOUR_THIRDS_EARTH_M;
+    let rh = rp + h;
+    let theta = s / rp;
+    let (sin_th, cos_th) = theta.sin_cos();
+    let r = (rp * rp + rh * rh - 2.0 * rp * rh * cos_th).sqrt().max(0.0);
+    let el = (rh * cos_th - rp).atan2(rh * sin_th);
+    (r, el.to_degrees())
 }
 
 // ---------------------------------------------------------------------------
@@ -1387,6 +1473,235 @@ fn level_series(
     }
 }
 
+// ---------------------------------------------------------------------------
+// Trajectory cross-section (`Section` domain)
+// ---------------------------------------------------------------------------
+
+/// Cross-section sampling parameters.
+const TRAJECTORY_NODE_SPACING_M: f64 = 500.0;
+/// Hard cap on along-path nodes — protects against a 1000-km path
+/// allocating ~2000 columns × hundreds of z levels.
+const TRAJECTORY_MAX_NODES: usize = 1024;
+/// Default vertical step (metres) when `z` is absent.
+const TRAJECTORY_DEFAULT_Z_STEP_M: f64 = 250.0;
+/// Hard cap on z levels.
+const TRAJECTORY_MAX_Z_LEVELS: usize = 100;
+
+/// Resample a polyline `vertices` (WGS84 `(lon, lat)`) into evenly-spaced
+/// nodes along the great-circle path, ~`TRAJECTORY_NODE_SPACING_M` apart,
+/// with the endpoints preserved and a `TRAJECTORY_MAX_NODES` cap.
+///
+/// Returns an empty vec only when the polyline has < 2 vertices — the
+/// caller has already validated that via `parse_linestring_coords`.
+fn resample_path(vertices: &[(f64, f64)]) -> Vec<(f64, f64)> {
+    if vertices.len() < 2 {
+        return Vec::new();
+    }
+    // Per-segment ground length + bearing — cheap (one haversine call per
+    // segment), cached so the sampling loop does not pay it per node.
+    let mut seg_len = Vec::with_capacity(vertices.len() - 1);
+    let mut seg_brg = Vec::with_capacity(vertices.len() - 1);
+    let mut total = 0.0_f64;
+    for w in vertices.windows(2) {
+        let (lon0, lat0) = w[0];
+        let (lon1, lat1) = w[1];
+        let (d, b) = ground_distance_bearing(lon0, lat0, lon1, lat1);
+        seg_len.push(d);
+        seg_brg.push(b);
+        total += d;
+    }
+    if total <= 0.0 {
+        // Degenerate polyline (all vertices coincide) — return endpoints
+        // verbatim so the caller still produces a Section, with the
+        // single-cell domain telling the user what happened.
+        return vec![vertices[0], *vertices.last().unwrap()];
+    }
+    let n = ((total / TRAJECTORY_NODE_SPACING_M).ceil() as usize + 1)
+        .clamp(2, TRAJECTORY_MAX_NODES);
+    let step = total / (n - 1) as f64;
+
+    let mut out = Vec::with_capacity(n);
+    out.push(vertices[0]);
+    // Walk the path: track cumulative distance into the current segment.
+    let mut seg = 0usize;
+    let mut into = 0.0_f64;
+    for i in 1..(n - 1) {
+        let target = i as f64 * step;
+        // Advance through segments until `target` falls inside the
+        // current one. `total > 0` and `target < total` guarantees
+        // termination without overflow.
+        while seg + 1 < seg_len.len() && into + seg_len[seg] < target {
+            into += seg_len[seg];
+            seg += 1;
+        }
+        let remaining = target - into;
+        let (start_lon, start_lat) = vertices[seg];
+        out.push(destination_point(
+            start_lon,
+            start_lat,
+            remaining,
+            seg_brg[seg],
+        ));
+    }
+    out.push(*vertices.last().unwrap());
+    out
+}
+
+/// Resolve the cross-section z (height-above-antenna) axis. `z`
+/// semantics for trajectory queries:
+///   - `None` / empty → 0..top with `TRAJECTORY_DEFAULT_Z_STEP_M`
+///     spacing, where `top` is the radar's highest sweep top height at
+///     200 km slant range (a reasonable ceiling for radar coverage).
+///   - `Some(&[h])` → single-height slice (degenerate Section).
+///   - `Some(&[hmin, hmax])` → regularly-spaced levels covering the
+///     range with the default step.
+///   - `Some(&[..])` (3+) → those exact levels, sorted + deduped.
+fn resolve_heights(z: Option<&[f64]>, top_default: f64) -> Vec<f64> {
+    fn regular(min: f64, max: f64) -> Vec<f64> {
+        let lo = min.min(max).max(0.0);
+        let hi = min.max(max).max(lo);
+        if (hi - lo).abs() < f64::EPSILON {
+            return vec![lo];
+        }
+        let n = (((hi - lo) / TRAJECTORY_DEFAULT_Z_STEP_M).ceil() as usize + 1)
+            .clamp(2, TRAJECTORY_MAX_Z_LEVELS);
+        let step = (hi - lo) / (n - 1) as f64;
+        (0..n).map(|i| lo + i as f64 * step).collect()
+    }
+    match z {
+        None | Some(&[]) => regular(0.0, top_default.max(TRAJECTORY_DEFAULT_Z_STEP_M)),
+        Some([h]) => vec![h.max(0.0)],
+        Some([a, b]) => regular(*a, *b),
+        Some(levels) => {
+            let mut v: Vec<f64> = levels.iter().copied().filter(|x| x.is_finite()).collect();
+            v.sort_by(f64::total_cmp);
+            v.dedup_by(|a, b| (*a - *b).abs() < f64::EPSILON);
+            if v.len() > TRAJECTORY_MAX_Z_LEVELS {
+                v.truncate(TRAJECTORY_MAX_Z_LEVELS);
+            }
+            v
+        }
+    }
+}
+
+/// Sample one moment of a polar volume at *slant-range, azimuth* — the
+/// cross-section variant of `sample_sweep_moment`. Picks the sweep
+/// nearest `elangle_deg`, then maps `slant_range` to a range bin and
+/// `azimuth_deg` to an azimuth ray. `None` when the point is outside
+/// the sweep's range or the bin is nodata/undetect.
+///
+/// Distinct from `sample_sweep_moment` so the existing ground-range
+/// interim (used by position/area/Map paths) is untouched: the slant
+/// range here comes from the 4/3-Earth inversion in `volume_section`,
+/// not from a ground-range fixup.
+fn sample_polar_slant(
+    volume: &PolarVolume,
+    quantity: &str,
+    slant_range_m: f64,
+    azimuth_deg: f64,
+    elangle_deg: f64,
+) -> Option<f64> {
+    let sweep = nearest_sweep(volume, elangle_deg)?;
+    if sweep.nrays == 0 || sweep.nbins == 0 {
+        return None;
+    }
+    let moment = sweep.moments.iter().find(|m| m.quantity == *quantity)?;
+    let bin = ((slant_range_m - sweep.rstart) / sweep.rscale).floor() as i64;
+    if bin < 0 || bin >= sweep.nbins as i64 {
+        return None;
+    }
+    let ray = (azimuth_deg / (360.0 / sweep.nrays as f64)).floor() as usize % sweep.nrays;
+    moment.data.sample(
+        ray,
+        bin as usize,
+        moment.gain,
+        moment.offset,
+        moment.nodata,
+        Some(moment.undetect),
+    )
+}
+
+/// Heuristic "top of radar coverage" used when `z` is unspecified. The
+/// height of the highest sweep at 200 km slant range, under the
+/// 4/3-Earth model — gives a meaningful ceiling for the default z axis
+/// without hard-coding an altitude.
+fn coverage_top_default(volume: &PolarVolume) -> f64 {
+    let top_el = volume
+        .sweeps
+        .iter()
+        .map(|s| s.elangle)
+        .filter(|v| v.is_finite())
+        .fold(f64::NEG_INFINITY, f64::max);
+    if top_el.is_finite() {
+        let (_, h) = slant_to_ground_height(200_000.0, top_el);
+        h.max(2_000.0)
+    } else {
+        15_000.0
+    }
+}
+
+/// Build one `Section` coverage: the volume's polar field resampled on
+/// `(along-path-distance, height-above-antenna)` and exposed via the
+/// CoverageJSON composite axis `[t, lon, lat]` plus a numeric `z` axis
+/// in metres.
+fn volume_section(
+    entry: &VolumeEntry,
+    path: &[(f64, f64)],
+    heights_m: &[f64],
+    quantities: &[String],
+) -> Option<QueryResult> {
+    if path.len() < 2 || heights_m.is_empty() || quantities.is_empty() {
+        return None;
+    }
+    let site = &entry.volume.site;
+    let t = entry.volume.time;
+    let nodes: Vec<(DateTime<Utc>, f64, f64)> =
+        path.iter().map(|&(lon, lat)| (t, lon, lat)).collect();
+
+    // Per-node geometry from the radar antenna — computed once and shared
+    // across every quantity and every z level.
+    let geom: Vec<(f64, f64)> = path
+        .iter()
+        .map(|&(lon, lat)| ground_distance_bearing(site.lon, site.lat, lon, lat))
+        .collect();
+
+    let mut ranges = HashMap::new();
+    let mut param_descs = HashMap::new();
+    let nz = heights_m.len();
+    let nn = nodes.len();
+
+    for quantity in quantities {
+        let mut values: Vec<Option<f64>> = Vec::with_capacity(nn * nz);
+        for &(d, bearing) in &geom {
+            for &h in heights_m {
+                let (r, el) = ground_height_to_slant(d, h);
+                values.push(sample_polar_slant(&entry.volume, quantity, r, bearing, el));
+            }
+        }
+        ranges.insert(
+            quantity.clone(),
+            NdArray {
+                shape: vec![nn, nz],
+                axis_names: vec!["composite".to_string(), "z".to_string()],
+                values,
+            },
+        );
+        param_descs.insert(quantity.clone(), quantity_description(quantity));
+    }
+
+    Some(QueryResult {
+        domain: DomainDescription::Section {
+            nodes,
+            z: VerticalCoord {
+                kind: VerticalKind::HeightAboveAntenna,
+                values: heights_m.to_vec(),
+            },
+        },
+        parameters: param_descs,
+        ranges,
+    })
+}
+
 /// Build the EDR coverages for one radar site at WGS84 `(lon, lat)`.
 ///
 /// `(lon, lat)` is both the coverage's domain point and the sample
@@ -1568,6 +1883,7 @@ impl EdrEngine for PolarVolumeEngine {
             "locations".to_string(),
             "position".to_string(),
             "area".to_string(),
+            "trajectory".to_string(),
         ]
     }
 
@@ -1654,6 +1970,97 @@ impl EdrEngine for PolarVolumeEngine {
         }
         Ok(CoverageResponse::Collection(coverages))
     }
+
+    /// Trajectory query — a vertical cross-section along a WKT
+    /// `LINESTRING`. Returns a `Section` coverage per timestep: the
+    /// composite axis carries one `(t, lon, lat)` triple per along-path
+    /// node; the `z` axis is height above the antenna in metres.
+    ///
+    /// **Single radar per cross-section**: the site nearest the path
+    /// centroid is picked, and the whole Section is sampled against
+    /// that one volume. Path nodes outside that radar's coverage simply
+    /// receive nodata. Multi-radar stitching is a deliberate follow-up.
+    fn query_trajectory(
+        &self,
+        coords: &str,
+        datetime: Option<(DateTime<Utc>, DateTime<Utc>)>,
+        parameters: Option<&[String]>,
+        z: Option<&[f64]>,
+    ) -> Result<CoverageResponse, DataServerError> {
+        let vertices = parse_linestring_coords(coords)?;
+        let path = resample_path(&vertices);
+        if path.len() < 2 {
+            return Err(DataServerError::InvalidParameter(
+                "LINESTRING must trace a non-degenerate path".into(),
+            ));
+        }
+
+        let catalog = self.catalog.load();
+        // Path centroid (mean lon/lat) — good enough for picking which
+        // radar owns the line at v1 (no multi-radar stitching).
+        let (cx, cy) = {
+            let (sx, sy) = path
+                .iter()
+                .fold((0.0_f64, 0.0_f64), |(ax, ay), &(x, y)| (ax + x, ay + y));
+            let n = path.len() as f64;
+            (sx / n, sy / n)
+        };
+        let nod = nearest_site(&catalog, cx, cy)
+            .ok_or_else(|| {
+                DataServerError::LocationNotFound("PVOL catalog has no radar sites".into())
+            })?
+            .to_string();
+        let volumes = catalog.by_site.get(&nod).ok_or_else(|| {
+            DataServerError::Engine("internal: nearest_site returned a missing by_site key".into())
+        })?;
+
+        // Time filter — same logic as site_coverages.
+        let selected: Vec<&VolumeEntry> = match datetime {
+            Some((start, end)) => volumes
+                .iter()
+                .filter(|e| e.volume.time >= start && e.volume.time <= end)
+                .collect(),
+            None => volumes.iter().collect(),
+        };
+        if selected.is_empty() {
+            return Err(DataServerError::LocationNotFound(
+                "No PVOL data available for the requested time range".into(),
+            ));
+        }
+
+        let quantities = resolve_quantities(&selected, parameters)?;
+
+        // Vertical axis defaults derive from the most recent volume's
+        // sweep envelope — a heterogeneous fleet then still gets a
+        // matching scale.
+        let top_default = coverage_top_default(&selected.last().unwrap().volume);
+        let heights = resolve_heights(z, top_default);
+        if heights.is_empty() {
+            return Err(DataServerError::InvalidParameter(
+                "trajectory `z` resolved to an empty axis".into(),
+            ));
+        }
+
+        let coverages: Vec<QueryResult> = selected
+            .iter()
+            .filter_map(|e| volume_section(e, &path, &heights, &quantities))
+            .collect();
+        if coverages.is_empty() {
+            return Err(DataServerError::LocationNotFound(
+                "No PVOL volumes produced a section for the requested path".into(),
+            ));
+        }
+        if coverages.len() == 1 {
+            // Single timestep — emit one Coverage rather than a one-item
+            // collection, matching the `query_location` precedent for
+            // pinned-level requests.
+            Ok(CoverageResponse::Single(
+                coverages.into_iter().next().unwrap(),
+            ))
+        } else {
+            Ok(CoverageResponse::Collection(coverages))
+        }
+    }
 }
 
 #[cfg(test)]
@@ -1705,6 +2112,86 @@ mod tests {
     fn distance_zero_at_site() {
         let (d, _az) = ground_distance_bearing(25.0, 60.0, 25.0, 60.0);
         assert!(d < 1e-6, "distance at site ≈ 0, got {d}");
+    }
+
+    /// `destination_point` plus `ground_distance_bearing` are inverses
+    /// up to spherical-trig round-off — moving 50 km along bearing 45°
+    /// from a starting point gives back distance 50 km and bearing 45°.
+    #[test]
+    fn destination_point_roundtrips_via_distance_bearing() {
+        let (lon0, lat0) = (25.0, 60.0);
+        let (lon1, lat1) = destination_point(lon0, lat0, 50_000.0, 45.0);
+        let (d, az) = ground_distance_bearing(lon0, lat0, lon1, lat1);
+        assert!((d - 50_000.0).abs() < 1.0, "round-trip distance, got {d}");
+        assert!((az - 45.0).abs() < 1e-3, "round-trip bearing, got {az}");
+    }
+
+    /// 4/3-Earth forward + inverse are mutual inverses to sub-metre /
+    /// sub-mdeg residuals over the radar-relevant envelope
+    /// (≤ 250 km range, 0°–30° elevation, up to 20 km height). This is
+    /// the round-trip check; the next test pins absolute values against
+    /// a Doviak reference.
+    #[test]
+    fn four_thirds_earth_roundtrips() {
+        for &r in &[1_000.0_f64, 50_000.0, 100_000.0, 200_000.0, 250_000.0] {
+            for &el in &[0.5_f64, 1.5, 5.0, 15.0, 30.0] {
+                let (s, h) = slant_to_ground_height(r, el);
+                let (r2, el2) = ground_height_to_slant(s, h);
+                assert!(
+                    (r - r2).abs() < 0.5,
+                    "slant round-trip residual @ r={r} el={el}: r2={r2}"
+                );
+                assert!(
+                    (el - el2).abs() < 1e-6,
+                    "elangle round-trip residual @ r={r} el={el}: el2={el2}"
+                );
+            }
+        }
+    }
+
+    /// Absolute pins (not round-trip) against the 4/3-Earth model: at
+    /// elevation 0° the beam grazes the surface, so a 100 km slant
+    /// range gives ground distance ≈ 99.95 km and height ≈ 587 m
+    /// (R'/(2R'+r) curvature drop). At elevation 90° the beam goes
+    /// straight up: ground distance ≈ 0, height ≈ r. Both follow from
+    /// the formula given in `slant_to_ground_height`.
+    #[test]
+    fn four_thirds_earth_absolute_reference() {
+        // Zero elevation, 100 km range: height = √(r² + R'²) − R'
+        //                              = √(1e10 + R'²) − R' ≈ 587 m
+        let (s, h) = slant_to_ground_height(100_000.0, 0.0);
+        let expected_h =
+            (100_000.0_f64.powi(2) + FOUR_THIRDS_EARTH_M.powi(2)).sqrt() - FOUR_THIRDS_EARTH_M;
+        assert!(
+            (h - expected_h).abs() < 0.01,
+            "el=0 r=100km: h={h}, expected {expected_h}"
+        );
+        // Ground distance for el=0 ≈ R' · atan(r/R') ≈ r at radar range.
+        // The drop from r is the curvature correction (~50 m at 100 km).
+        assert!((s - 99_950.0).abs() < 60.0, "el=0 r=100km: s={s}");
+
+        // 90° elevation: everything points straight up.
+        let (s, h) = slant_to_ground_height(50_000.0, 90.0);
+        assert!(s.abs() < 1e-3, "el=90 r=50km: s={s} should be ~0");
+        assert!(
+            (h - 50_000.0).abs() < 1.0,
+            "el=90 r=50km: h={h} should be ~50000"
+        );
+
+        // 1° elevation, 50 km range. Under 4/3-Earth, h ≈ 1020 m
+        // (≈ r·sin(el) ≈ 873 m plus the ~147 m curvature drop). The
+        // ground distance is r·cos(el) less ~10 m of curvature
+        // correction — `s ≈ 49982.6 m` — looser tolerance than the
+        // straight-line approximation would suggest.
+        let (s, h) = slant_to_ground_height(50_000.0, 1.0);
+        assert!(
+            (s - 49_983.0).abs() < 5.0,
+            "el=1 r=50km: s={s} should be ~49983"
+        );
+        assert!(
+            (h - 1_020.0).abs() < 10.0,
+            "el=1 r=50km: h={h} should be ~1020"
+        );
     }
 
     /// Build a synthetic single-site, single-sweep, single-moment

--- a/crates/engine-odim/src/volume_engine.rs
+++ b/crates/engine-odim/src/volume_engine.rs
@@ -1605,6 +1605,16 @@ fn sample_polar_slant(
     if sweep.nrays == 0 || sweep.nbins == 0 {
         return None;
     }
+    // A malformed sweep with `rscale <= 0` would silently mis-sample:
+    // `rscale = 0` makes the divisor zero (a NaN cast to `i64` becomes
+    // 0, sampling the first bin with wrong-range data); `rscale < 0`
+    // flips the bin direction and can land inside `[0, nbins)` for a
+    // physically wrong gate. ODIM_H5 guarantees `rscale > 0`, but a
+    // defensive guard here is cheap and keeps a corrupted file from
+    // ever surfacing fabricated values.
+    if !sweep.rscale.is_finite() || sweep.rscale <= 0.0 {
+        return None;
+    }
     let moment = sweep.moments.iter().find(|m| m.quantity == *quantity)?;
     let bin = ((slant_range_m - sweep.rstart) / sweep.rscale).floor() as i64;
     if bin < 0 || bin >= sweep.nbins as i64 {
@@ -2192,6 +2202,32 @@ mod tests {
             (h - 1_020.0).abs() < 10.0,
             "el=1 r=50km: h={h} should be ~1020"
         );
+    }
+
+    /// `sample_polar_slant` returns `None` for malformed sweep geometry
+    /// (`rscale` zero, negative, or non-finite) rather than fabricating
+    /// a bin-0 sample. ODIM_H5 guarantees `rscale > 0`, but a corrupted
+    /// file would otherwise produce a `NaN as i64 == 0` cast and report
+    /// the first bin's value at every requested range.
+    #[test]
+    fn sample_polar_slant_rejects_malformed_rscale() {
+        let (site_lon, site_lat) = (25.0, 60.0);
+        let mut vol = synthetic_volume(site_lon, site_lat);
+        let azimuth = 90.0;
+        let elangle = 0.5;
+        let range_m = 10_000.0;
+
+        // Baseline: well-formed sweep returns a finite sample.
+        let v = sample_polar_slant(&vol, "DBZH", range_m, azimuth, elangle);
+        assert!(v.is_some(), "well-formed sweep must sample");
+
+        for bad in [0.0_f64, -1_000.0, f64::NAN, f64::INFINITY] {
+            vol.sweeps[0].rscale = bad;
+            assert!(
+                sample_polar_slant(&vol, "DBZH", range_m, azimuth, elangle).is_none(),
+                "rscale={bad} must yield None, not fabricated data"
+            );
+        }
     }
 
     /// Build a synthetic single-site, single-sweep, single-moment

--- a/crates/engine-odim/src/volume_engine.rs
+++ b/crates/engine-odim/src/volume_engine.rs
@@ -1554,26 +1554,42 @@ fn resample_path(vertices: &[(f64, f64)]) -> Vec<(f64, f64)> {
 /// arrives as the angles in range). `None`/empty selects the volume's
 /// full sweep span. The window is clamped to the volume's actual sweep
 /// range so a heterogeneous fleet (a site missing an advertised angle)
-/// degrades to nodata rather than fabricating data. `None` only when the
-/// volume has no finite sweeps.
-fn angle_window(z: Option<&[f64]>, volume: &PolarVolume) -> Option<(f64, f64)> {
-    let (smin, smax) = sweep_envelope(volume)?;
-    match z.filter(|s| !s.is_empty()) {
-        None => Some((smin, smax)),
-        Some(zs) => {
-            let mut lo = f64::INFINITY;
-            let mut hi = f64::NEG_INFINITY;
-            for &v in zs.iter().filter(|v| v.is_finite()) {
-                lo = lo.min(v);
-                hi = hi.max(v);
-            }
-            if !lo.is_finite() {
-                return Some((smin, smax));
-            }
-            // Clamp into the site's surveyed range.
-            Some((lo.max(smin), hi.min(smax)))
-        }
+/// degrades to nodata rather than fabricating data.
+///
+/// Errors:
+/// - `Engine` when the volume has no finite sweeps (a malformed file).
+/// - `InvalidParameter` when an explicit `z` list falls **entirely**
+///   outside the surveyed range, e.g. `z=40,50` on a 0.5–25° radar — the
+///   clamp would otherwise invert to `(40, 25)` and silently produce an
+///   all-nodata Section. (The interval form is already rejected earlier
+///   by `resolve_z_levels`; this guards the comma-list form, which the
+///   API layer passes through unvalidated.)
+fn angle_window(z: Option<&[f64]>, volume: &PolarVolume) -> Result<(f64, f64), DataServerError> {
+    let (smin, smax) = sweep_envelope(volume)
+        .ok_or_else(|| DataServerError::Engine("PVOL volume has no finite sweep angles".into()))?;
+    let Some(zs) = z.filter(|s| !s.is_empty()) else {
+        return Ok((smin, smax));
+    };
+    let mut lo = f64::INFINITY;
+    let mut hi = f64::NEG_INFINITY;
+    for &v in zs.iter().filter(|v| v.is_finite()) {
+        lo = lo.min(v);
+        hi = hi.max(v);
     }
+    if !lo.is_finite() {
+        return Ok((smin, smax));
+    }
+    // Clamp into the site's surveyed range. An inverted clamp means the
+    // whole request sits beyond the surveyed angles — surface that rather
+    // than returning a silently empty Section.
+    let (clo, chi) = (lo.max(smin), hi.min(smax));
+    if clo > chi {
+        return Err(DataServerError::InvalidParameter(format!(
+            "requested elevation angle(s) {lo}–{hi}° are outside this radar's \
+             surveyed range {smin}–{smax}°"
+        )));
+    }
+    Ok((clo, chi))
 }
 
 /// Build the cross-section height axis (metres above antenna): a regular
@@ -2091,11 +2107,11 @@ impl EdrEngine for PolarVolumeEngine {
 
         // `z` carries the requested elevation angles (resolved by the API
         // layer against the advertised extent). Derive the angle window
-        // and the matching height axis from the most recent volume.
+        // and the matching height axis from the most recent volume. An
+        // out-of-range `z` list surfaces as `InvalidParameter` (400)
+        // rather than a silently empty Section.
         let ref_volume = &selected.last().unwrap().volume;
-        let window = angle_window(z, ref_volume).ok_or_else(|| {
-            DataServerError::Engine("PVOL volume has no finite sweep angles".into())
-        })?;
+        let window = angle_window(z, ref_volume)?;
         // The path's farthest ground distance from the radar sizes the
         // height-axis ceiling for the selected top angle.
         let max_ground_dist = path
@@ -2327,7 +2343,8 @@ mod tests {
     }
 
     /// `angle_window` selects the requested elevation-angle span, clamped
-    /// to the volume's actual sweep range; `None` selects the full span.
+    /// to the volume's actual sweep range; `None` selects the full span;
+    /// a request entirely above the top sweep is a 400, not silent nodata.
     #[test]
     fn angle_window_selects_and_clamps() {
         let (site_lon, site_lat) = (25.0, 60.0);
@@ -2344,11 +2361,21 @@ mod tests {
             .collect();
 
         // No z → full sweep span.
-        assert_eq!(angle_window(None, &vol), Some((0.5, 15.0)));
+        assert_eq!(angle_window(None, &vol).unwrap(), (0.5, 15.0));
         // A sub-range → exactly that window.
-        assert_eq!(angle_window(Some(&[1.5, 5.0, 9.0]), &vol), Some((1.5, 9.0)));
-        // A request past the top sweep clamps to the surveyed range.
-        assert_eq!(angle_window(Some(&[5.0, 45.0]), &vol), Some((5.0, 15.0)));
+        assert_eq!(
+            angle_window(Some(&[1.5, 5.0, 9.0]), &vol).unwrap(),
+            (1.5, 9.0)
+        );
+        // A request straddling the top sweep clamps to the surveyed range.
+        assert_eq!(angle_window(Some(&[5.0, 45.0]), &vol).unwrap(), (5.0, 15.0));
+        // A discrete list entirely above the top sweep would invert the
+        // clamp to (40, 15) → would silently produce an all-nodata
+        // Section. It must be a clear `InvalidParameter` instead.
+        match angle_window(Some(&[40.0, 50.0]), &vol) {
+            Err(DataServerError::InvalidParameter(_)) => {}
+            other => panic!("expected InvalidParameter for out-of-range z, got {other:?}"),
+        }
     }
 
     /// `height_axis` builds a monotonic 0..top grid whose ceiling tracks

--- a/crates/engine-odim/src/volume_engine.rs
+++ b/crates/engine-odim/src/volume_engine.rs
@@ -2056,15 +2056,14 @@ impl EdrEngine for PolarVolumeEngine {
         }
 
         let catalog = self.catalog.load();
-        // Path centroid (mean lon/lat) — good enough for picking which
-        // radar owns the line at v1 (no multi-radar stitching).
-        let (cx, cy) = {
-            let (sx, sy) = path
-                .iter()
-                .fold((0.0_f64, 0.0_f64), |(ax, ay), &(x, y)| (ax + x, ay + y));
-            let n = path.len() as f64;
-            (sx / n, sy / n)
-        };
+        // Pick the radar nearest the path's *middle node* (not an
+        // arithmetic-mean centroid) to choose which site owns the line.
+        // A real on-path point is antimeridian-safe — averaging the
+        // longitudes of e.g. 178° and −178° gives 0°, which would pick a
+        // European radar for a Pacific path. The midpoint node is a true
+        // resampled `(lon, lat)` on the great-circle path. (v1: single
+        // radar per cross-section, no multi-radar stitching.)
+        let (cx, cy) = path[path.len() / 2];
         let nod = nearest_site(&catalog, cx, cy)
             .ok_or_else(|| {
                 DataServerError::LocationNotFound("PVOL catalog has no radar sites".into())

--- a/crates/engine-odim/src/volume_engine.rs
+++ b/crates/engine-odim/src/volume_engine.rs
@@ -1515,10 +1515,13 @@ fn resample_path(vertices: &[(f64, f64)]) -> Vec<(f64, f64)> {
         total += d;
     }
     if total <= 0.0 {
-        // Degenerate polyline (all vertices coincide) — return endpoints
-        // verbatim so the caller still produces a Section, with the
-        // single-cell domain telling the user what happened.
-        return vec![vertices[0], *vertices.last().unwrap()];
+        // Degenerate polyline (all vertices coincide). `parse_linestring_coords`
+        // already rejects an all-identical LINESTRING with a 400, so this is
+        // only reachable via a direct call — return a single node so the
+        // caller's `path.len() < 2` guard turns it into an error rather than
+        // emitting a Section with two identical (and schema-invalid)
+        // composite-axis nodes.
+        return vec![vertices[0]];
     }
     let n =
         ((total / TRAJECTORY_NODE_SPACING_M).ceil() as usize + 1).clamp(2, TRAJECTORY_MAX_NODES);
@@ -2447,6 +2450,20 @@ mod tests {
         let capped = height_axis(89.0, 200_000.0);
         assert!(*capped.last().unwrap() <= 25_000.0 + 1.0);
         assert!(capped.len() <= 100, "level count capped");
+    }
+
+    /// A zero-length polyline (all vertices coincident) resamples to a
+    /// *single* node, so `query_trajectory`'s `path.len() < 2` guard turns
+    /// it into a 400 rather than a Section with duplicate composite nodes.
+    /// (`parse_linestring_coords` rejects this upstream too; this guards a
+    /// direct call.)
+    #[test]
+    fn resample_path_degenerate_returns_single_node() {
+        let coincident = vec![(25.0, 60.0), (25.0, 60.0)];
+        assert_eq!(resample_path(&coincident).len(), 1);
+        // A real path still resamples to ≥2 nodes.
+        let real = vec![(25.0, 60.0), (25.5, 60.5)];
+        assert!(resample_path(&real).len() >= 2);
     }
 
     /// `volume_section` clamps the caller's angle window to *this volume's*

--- a/crates/engine-odim/src/volume_engine.rs
+++ b/crates/engine-odim/src/volume_engine.rs
@@ -1547,51 +1547,51 @@ fn resample_path(vertices: &[(f64, f64)]) -> Vec<(f64, f64)> {
     out
 }
 
-/// Resolve the cross-section z (height-above-antenna) axis. `z`
-/// semantics for trajectory queries:
-///   - `None` / empty → 0..top with `TRAJECTORY_DEFAULT_Z_STEP_M`
-///     spacing, where `top` is the radar's highest sweep top height at
-///     200 km slant range (a reasonable ceiling for radar coverage).
-///   - `Some(&[h])` → single-height slice (degenerate Section).
-///   - `Some(&[hmin, hmax])` → regularly-spaced levels covering the
-///     range with the default step.
-///   - `Some(&[..])` (3+) → those exact levels, sorted + deduped.
-fn resolve_heights(z: Option<&[f64]>, top_default: f64) -> Vec<f64> {
-    fn regular(min: f64, max: f64) -> Vec<f64> {
-        let lo = min.min(max).max(0.0);
-        let hi = min.max(max).max(lo);
-        if (hi - lo).abs() < f64::EPSILON {
-            return vec![lo];
-        }
-        let n = (((hi - lo) / TRAJECTORY_DEFAULT_Z_STEP_M).ceil() as usize + 1)
-            .clamp(2, TRAJECTORY_MAX_Z_LEVELS);
-        let step = (hi - lo) / (n - 1) as f64;
-        (0..n).map(|i| lo + i as f64 * step).collect()
-    }
-    match z {
-        None | Some(&[]) => regular(0.0, top_default.max(TRAJECTORY_DEFAULT_Z_STEP_M)),
-        // Negative values are rejected upstream in `query_trajectory`,
-        // so each arm here can take its input verbatim. `.max(0.0)`
-        // kept on the single-value arm as belt-and-braces (the kind
-        // could one day be called from a non-trajectory path).
-        Some([h]) => vec![h.max(0.0)],
-        Some([a, b]) => regular(*a, *b),
-        Some(levels) => {
-            // Dedup tolerance is 1 mm rather than `f64::EPSILON`:
-            // metre-scale heights produced by floating-point arithmetic
-            // can differ by sub-millimetre noise, which `EPSILON`
-            // (~2.2e-16) would not collapse. 1 mm is sub-resolution for
-            // every meteorological vertical axis here. Flagged by
-            // claude-review on PR #275.
-            let mut v: Vec<f64> = levels.iter().copied().filter(|x| x.is_finite()).collect();
-            v.sort_by(f64::total_cmp);
-            v.dedup_by(|a, b| (*a - *b).abs() < 1e-3);
-            if v.len() > TRAJECTORY_MAX_Z_LEVELS {
-                v.truncate(TRAJECTORY_MAX_Z_LEVELS);
+/// The elevation-angle window `[lo, hi]` (degrees) for a cross-section.
+///
+/// `z` carries the requested elevation angles (resolved by the API layer
+/// against the collection's advertised extent — an interval `0.3/15`
+/// arrives as the angles in range). `None`/empty selects the volume's
+/// full sweep span. The window is clamped to the volume's actual sweep
+/// range so a heterogeneous fleet (a site missing an advertised angle)
+/// degrades to nodata rather than fabricating data. `None` only when the
+/// volume has no finite sweeps.
+fn angle_window(z: Option<&[f64]>, volume: &PolarVolume) -> Option<(f64, f64)> {
+    let (smin, smax) = sweep_envelope(volume)?;
+    match z.filter(|s| !s.is_empty()) {
+        None => Some((smin, smax)),
+        Some(zs) => {
+            let mut lo = f64::INFINITY;
+            let mut hi = f64::NEG_INFINITY;
+            for &v in zs.iter().filter(|v| v.is_finite()) {
+                lo = lo.min(v);
+                hi = hi.max(v);
             }
-            v
+            if !lo.is_finite() {
+                return Some((smin, smax));
+            }
+            // Clamp into the site's surveyed range.
+            Some((lo.max(smin), hi.min(smax)))
         }
     }
+}
+
+/// Build the cross-section height axis (metres above antenna): a regular
+/// `0..top` grid where `top` is the height of the `hi_angle` beam at the
+/// path's farthest ground distance, clamped to `[step, 25 km]` and capped
+/// at `TRAJECTORY_MAX_Z_LEVELS`. Selecting a lower top elevation angle (a
+/// narrower `z`) therefore zooms the vertical axis onto that band.
+fn height_axis(hi_angle_deg: f64, max_ground_dist_m: f64) -> Vec<f64> {
+    // The ground distance is a close slant-range proxy at the low
+    // elevation angles that dominate radar coverage — accurate enough for
+    // an axis ceiling.
+    let r = max_ground_dist_m.max(1_000.0);
+    let (_, h) = slant_to_ground_height(r, hi_angle_deg.max(0.0));
+    let top = h.clamp(TRAJECTORY_DEFAULT_Z_STEP_M, 25_000.0);
+    let n =
+        ((top / TRAJECTORY_DEFAULT_Z_STEP_M).ceil() as usize + 1).clamp(2, TRAJECTORY_MAX_Z_LEVELS);
+    let step = top / (n - 1) as f64;
+    (0..n).map(|i| i as f64 * step).collect()
 }
 
 /// Tolerance (degrees) for the sweep-envelope guard in
@@ -1682,47 +1682,22 @@ fn sample_polar_slant(
     )
 }
 
-/// Heuristic "top of radar coverage" used when `z` is unspecified. The
-/// height of the highest sweep at 200 km slant range, under the
-/// 4/3-Earth model — gives a meaningful ceiling for the default z axis
-/// without hard-coding an altitude. Clamped to `[2 km, 25 km]` so a
-/// vertically pointing or 90°-pointing research radar does not blow
-/// the default axis up past the troposphere (flagged by claude-review
-/// on PR #275 — `TRAJECTORY_MAX_Z_LEVELS = 100` would otherwise produce
-/// km-spaced default levels for top-el ≈ 90°).
-fn coverage_top_default(volume: &PolarVolume) -> f64 {
-    let top_el = volume
-        .sweeps
-        .iter()
-        .map(|s| s.elangle)
-        .filter(|v| v.is_finite())
-        .fold(f64::NEG_INFINITY, f64::max);
-    let raw = if top_el.is_finite() {
-        let (_, h) = slant_to_ground_height(200_000.0, top_el);
-        h
-    } else {
-        15_000.0
-    };
-    raw.clamp(2_000.0, 25_000.0)
-}
-
 /// Build one `Section` coverage: the volume's polar field resampled on
 /// `(along-path-distance, height-above-antenna)` and exposed via the
 /// CoverageJSON composite axis `[t, lon, lat]` plus a numeric `z` axis
-/// in metres.
+/// in metres. `envelope` is the elevation-angle window `[lo, hi]` — cells
+/// whose 4/3-Earth-inverted beam angle falls outside it become nodata, so
+/// the caller's `z` angle selection drives which sweeps contribute.
 fn volume_section(
     entry: &VolumeEntry,
     path: &[(f64, f64)],
     heights_m: &[f64],
     quantities: &[String],
+    envelope: (f64, f64),
 ) -> Option<QueryResult> {
     if path.len() < 2 || heights_m.is_empty() || quantities.is_empty() {
         return None;
     }
-    // Pre-compute the sweep envelope once per volume — `sample_polar_slant`
-    // would otherwise refold over every sweep on every cell. A volume with
-    // no finite sweep angles cannot be sampled at all.
-    let envelope = sweep_envelope(&entry.volume)?;
     let site = &entry.volume.site;
     let t = entry.volume.time;
     let nodes: Vec<(DateTime<Utc>, f64, f64)> =
@@ -2051,7 +2026,15 @@ impl EdrEngine for PolarVolumeEngine {
     /// Trajectory query — a vertical cross-section along a WKT
     /// `LINESTRING`. Returns a `Section` coverage per timestep: the
     /// composite axis carries one `(t, lon, lat)` triple per along-path
-    /// node; the `z` axis is height above the antenna in metres.
+    /// node; the `z` axis is **height above the antenna in metres**
+    /// (derived via the 4/3-Earth beam geometry).
+    ///
+    /// `z` *selects elevation angles* — it matches the collection's
+    /// advertised vertical extent (sweep angles in degrees), resolved by
+    /// the API layer so an interval `z=0.3/15` arrives as the angles in
+    /// range. The selected `[min, max]` angle window bounds which sweeps
+    /// contribute and sizes the derived height axis; cells whose beam
+    /// angle falls outside the window are nodata. `None` uses every sweep.
     ///
     /// **Single radar per cross-section**: the site nearest the path
     /// centroid is picked, and the whole Section is sampled against
@@ -2069,18 +2052,6 @@ impl EdrEngine for PolarVolumeEngine {
         if path.len() < 2 {
             return Err(DataServerError::InvalidParameter(
                 "LINESTRING must trace a non-degenerate path".into(),
-            ));
-        }
-        // Reject negative `z` values up-front. `resolve_heights` would
-        // otherwise clamp them silently (single-value arm) or pass them
-        // through (3+ arm), advertising a "Height above antenna"
-        // (direction: up) axis with negative values that are physically
-        // impossible. A 400 surfaces the mistake to the caller rather
-        // than burying it in an all-None response row. Found by
-        // claude-review on PR #275.
-        if z.is_some_and(|levels| levels.iter().any(|&h| h < 0.0)) {
-            return Err(DataServerError::InvalidParameter(
-                "trajectory `z` values must be ≥ 0 (metres above antenna)".into(),
             ));
         }
 
@@ -2119,27 +2090,22 @@ impl EdrEngine for PolarVolumeEngine {
 
         let quantities = resolve_quantities(&selected, parameters)?;
 
-        // Vertical axis defaults derive from the most recent volume's
-        // sweep envelope — a heterogeneous fleet then still gets a
-        // matching scale.
-        let top_default = coverage_top_default(&selected.last().unwrap().volume);
-        let heights = resolve_heights(z, top_default);
-        // When the caller passed explicit levels and the 1 mm-tolerance
-        // dedup collapsed some, surface that — it's a benign noise-removal
-        // most of the time, but logging it means a user who fat-fingered
-        // two near-identical levels can see why their axis shrank rather
-        // than silently getting fewer rows than requested.
-        if let Some(requested) = z {
-            if requested.len() > 2 && heights.len() < requested.len() {
-                tracing::debug!(
-                    "[{}] trajectory z: {} requested level(s) collapsed to {} after \
-                     1mm-tolerance dedup",
-                    self.collection_id,
-                    requested.len(),
-                    heights.len()
-                );
-            }
-        }
+        // `z` carries the requested elevation angles (resolved by the API
+        // layer against the advertised extent). Derive the angle window
+        // and the matching height axis from the most recent volume.
+        let ref_volume = &selected.last().unwrap().volume;
+        let window = angle_window(z, ref_volume).ok_or_else(|| {
+            DataServerError::Engine("PVOL volume has no finite sweep angles".into())
+        })?;
+        // The path's farthest ground distance from the radar sizes the
+        // height-axis ceiling for the selected top angle.
+        let max_ground_dist = path
+            .iter()
+            .map(|&(lon, lat)| {
+                ground_distance_bearing(ref_volume.site.lon, ref_volume.site.lat, lon, lat).0
+            })
+            .fold(0.0_f64, f64::max);
+        let heights = height_axis(window.1, max_ground_dist);
         if heights.is_empty() {
             return Err(DataServerError::InvalidParameter(
                 "trajectory `z` resolved to an empty axis".into(),
@@ -2148,7 +2114,7 @@ impl EdrEngine for PolarVolumeEngine {
 
         let coverages: Vec<QueryResult> = selected
             .iter()
-            .filter_map(|e| volume_section(e, &path, &heights, &quantities))
+            .filter_map(|e| volume_section(e, &path, &heights, &quantities, window))
             .collect();
         if coverages.is_empty() {
             return Err(DataServerError::LocationNotFound(
@@ -2361,39 +2327,48 @@ mod tests {
         assert!(sample_polar_slant(&vol, env, "DBZH", range_m, azimuth, f64::NAN).is_none());
     }
 
-    /// `coverage_top_default` is clamped to 25 km even for a research
-    /// volume whose highest sweep is near 90° — without the cap, the
-    /// 4/3-Earth height at 200 km slant range for a 90° beam is 200 km,
-    /// and `resolve_heights` would emit 100 levels spaced 2 km apart.
-    /// Found by claude-review on PR #275.
+    /// `angle_window` selects the requested elevation-angle span, clamped
+    /// to the volume's actual sweep range; `None` selects the full span.
     #[test]
-    fn coverage_top_default_caps_at_25km() {
+    fn angle_window_selects_and_clamps() {
         let (site_lon, site_lat) = (25.0, 60.0);
         let mut vol = synthetic_volume(site_lon, site_lat);
-        // Replace the single 0.5° sweep with a vertically-pointing one.
-        vol.sweeps[0].elangle = 89.5;
-        let top = coverage_top_default(&vol);
-        assert!(
-            top <= 25_000.0 + 1.0,
-            "expected ceiling clamp at 25 km, got {top}"
-        );
-        assert!(top >= 2_000.0, "floor still respected, got {top}");
+        // Give it a fan of sweeps 0.5°..15°.
+        let base = vol.sweeps[0].clone();
+        vol.sweeps = [0.5, 1.5, 5.0, 9.0, 15.0]
+            .iter()
+            .map(|&el| {
+                let mut s = base.clone();
+                s.elangle = el;
+                s
+            })
+            .collect();
+
+        // No z → full sweep span.
+        assert_eq!(angle_window(None, &vol), Some((0.5, 15.0)));
+        // A sub-range → exactly that window.
+        assert_eq!(angle_window(Some(&[1.5, 5.0, 9.0]), &vol), Some((1.5, 9.0)));
+        // A request past the top sweep clamps to the surveyed range.
+        assert_eq!(angle_window(Some(&[5.0, 45.0]), &vol), Some((5.0, 15.0)));
     }
 
-    /// `resolve_heights` collapses near-duplicate explicit levels at a
-    /// millimetre tolerance, not at `f64::EPSILON`. Two levels differing
-    /// by sub-mm noise from float arithmetic must not survive as
-    /// separate axis points.
+    /// `height_axis` builds a monotonic 0..top grid whose ceiling tracks
+    /// the selected top angle and is clamped to ≤ 25 km.
     #[test]
-    fn resolve_heights_dedups_at_millimetre_tolerance() {
-        // 1 mm apart — would NOT dedup at `EPSILON`, but does at 1e-3.
-        let levels = [1_000.0_f64, 1_000.000_001, 2_000.0];
-        let out = resolve_heights(Some(&levels), 15_000.0);
-        assert_eq!(out.len(), 2, "1 mm-apart levels must collapse, got {out:?}");
-        // 1 cm apart — still distinct.
-        let levels = [1_000.0_f64, 1_000.01, 2_000.0];
-        let out = resolve_heights(Some(&levels), 15_000.0);
-        assert_eq!(out.len(), 3, "1 cm-apart levels stay distinct, got {out:?}");
+    fn height_axis_tracks_top_angle_and_caps() {
+        // A 5° beam at 100 km ground distance reaches a few km up.
+        let low = height_axis(5.0, 100_000.0);
+        assert!(low.first() == Some(&0.0), "axis starts at 0");
+        assert!(low.windows(2).all(|w| w[1] > w[0]), "monotonic ascending");
+        assert!(*low.last().unwrap() <= 25_000.0);
+        // A higher top angle reaches higher (taller axis ceiling).
+        let high = height_axis(15.0, 100_000.0);
+        assert!(*high.last().unwrap() > *low.last().unwrap());
+        // A near-vertical beam at long range is capped at 25 km, not
+        // hundreds of km.
+        let capped = height_axis(89.0, 200_000.0);
+        assert!(*capped.last().unwrap() <= 25_000.0 + 1.0);
+        assert!(capped.len() <= 100, "level count capped");
     }
 
     /// Build a synthetic single-site, single-sweep, single-moment

--- a/crates/engine-odim/src/volume_engine.rs
+++ b/crates/engine-odim/src/volume_engine.rs
@@ -1570,12 +1570,22 @@ fn resolve_heights(z: Option<&[f64]>, top_default: f64) -> Vec<f64> {
     }
     match z {
         None | Some(&[]) => regular(0.0, top_default.max(TRAJECTORY_DEFAULT_Z_STEP_M)),
+        // Negative values are rejected upstream in `query_trajectory`,
+        // so each arm here can take its input verbatim. `.max(0.0)`
+        // kept on the single-value arm as belt-and-braces (the kind
+        // could one day be called from a non-trajectory path).
         Some([h]) => vec![h.max(0.0)],
         Some([a, b]) => regular(*a, *b),
         Some(levels) => {
+            // Dedup tolerance is 1 mm rather than `f64::EPSILON`:
+            // metre-scale heights produced by floating-point arithmetic
+            // can differ by sub-millimetre noise, which `EPSILON`
+            // (~2.2e-16) would not collapse. 1 mm is sub-resolution for
+            // every meteorological vertical axis here. Flagged by
+            // claude-review on PR #275.
             let mut v: Vec<f64> = levels.iter().copied().filter(|x| x.is_finite()).collect();
             v.sort_by(f64::total_cmp);
-            v.dedup_by(|a, b| (*a - *b).abs() < f64::EPSILON);
+            v.dedup_by(|a, b| (*a - *b).abs() < 1e-3);
             if v.len() > TRAJECTORY_MAX_Z_LEVELS {
                 v.truncate(TRAJECTORY_MAX_Z_LEVELS);
             }
@@ -1584,11 +1594,42 @@ fn resolve_heights(z: Option<&[f64]>, top_default: f64) -> Vec<f64> {
     }
 }
 
+/// Tolerance (degrees) for the sweep-envelope guard in
+/// `sample_polar_slant`. ~Half a typical beam width — wide enough that
+/// cells slightly outside the surveyed angle still snap to the nearest
+/// sweep, narrow enough that surface cells far from the radar (whose
+/// 4/3-Earth-inverted el drops below the horizon) and over-cone cells
+/// fall out as `None` instead of fabricating data from the closest
+/// sweep.
+const SWEEP_ENVELOPE_TOL_DEG: f64 = 1.0;
+
+/// Cached `(min_elangle, max_elangle)` over a volume's finite sweep
+/// angles — passed into the per-cell sampler so the envelope check
+/// stays O(1) on the hot path. `None` when the volume has no finite
+/// sweep angles (a malformed file).
+fn sweep_envelope(volume: &PolarVolume) -> Option<(f64, f64)> {
+    let (lo, hi) = volume
+        .sweeps
+        .iter()
+        .map(|s| s.elangle)
+        .filter(|v| v.is_finite())
+        .fold((f64::INFINITY, f64::NEG_INFINITY), |(lo, hi), v| {
+            (lo.min(v), hi.max(v))
+        });
+    lo.is_finite().then_some((lo, hi))
+}
+
 /// Sample one moment of a polar volume at *slant-range, azimuth* — the
 /// cross-section variant of `sample_sweep_moment`. Picks the sweep
 /// nearest `elangle_deg`, then maps `slant_range` to a range bin and
 /// `azimuth_deg` to an azimuth ray. `None` when the point is outside
 /// the sweep's range or the bin is nodata/undetect.
+///
+/// `envelope` is the volume's `(min_el, max_el)` precomputed by the
+/// caller — required, not recomputed per call. With up to
+/// `nodes × z_levels × quantities ≈ 5e5` calls per volume and ~20
+/// sweeps each, an in-function fold would burn ~10 M iterations per
+/// request on a serving worker, breaking the CLAUDE.md hot-path rule.
 ///
 /// Distinct from `sample_sweep_moment` so the existing ground-range
 /// interim (used by position/area/Map paths) is untouched: the slant
@@ -1596,6 +1637,7 @@ fn resolve_heights(z: Option<&[f64]>, top_default: f64) -> Vec<f64> {
 /// not from a ground-range fixup.
 fn sample_polar_slant(
     volume: &PolarVolume,
+    envelope: (f64, f64),
     quantity: &str,
     slant_range_m: f64,
     azimuth_deg: f64,
@@ -1605,30 +1647,12 @@ fn sample_polar_slant(
     if sweep.nrays == 0 || sweep.nbins == 0 {
         return None;
     }
-    // Reject targets outside the sweep envelope. Without this,
-    // `nearest_sweep` silently substitutes the lowest sweep's value
-    // for surface cells whose 4/3-Earth-inverted elevation drops below
-    // the horizon (h=0 beyond ~1 km from the radar produces a small
-    // negative angle), and analogously the highest sweep for cells
-    // above the radar's coverage cone — fabricating data far from the
-    // true sample point. The tolerance (~half a typical beam width) is
-    // looser than a beam width so cells slightly outside the surveyed
-    // angle still snap to the nearest sweep instead of dropping out.
-    //
-    // Computed from this volume's sweeps every call so a heterogeneous
-    // network gets per-site envelopes correctly. Cheap (≤ ~20 sweeps).
-    const SWEEP_TOL_DEG: f64 = 1.0;
-    let (min_el, max_el) = volume
-        .sweeps
-        .iter()
-        .map(|s| s.elangle)
-        .filter(|v| v.is_finite())
-        .fold((f64::INFINITY, f64::NEG_INFINITY), |(lo, hi), v| {
-            (lo.min(v), hi.max(v))
-        });
+    // Reject targets outside the sweep envelope (see the constant's doc
+    // for the rationale). Pre-computed envelope keeps this O(1) per cell.
+    let (min_el, max_el) = envelope;
     if !elangle_deg.is_finite()
-        || elangle_deg < min_el - SWEEP_TOL_DEG
-        || elangle_deg > max_el + SWEEP_TOL_DEG
+        || elangle_deg < min_el - SWEEP_ENVELOPE_TOL_DEG
+        || elangle_deg > max_el + SWEEP_ENVELOPE_TOL_DEG
     {
         return None;
     }
@@ -1661,7 +1685,11 @@ fn sample_polar_slant(
 /// Heuristic "top of radar coverage" used when `z` is unspecified. The
 /// height of the highest sweep at 200 km slant range, under the
 /// 4/3-Earth model — gives a meaningful ceiling for the default z axis
-/// without hard-coding an altitude.
+/// without hard-coding an altitude. Clamped to `[2 km, 25 km]` so a
+/// vertically pointing or 90°-pointing research radar does not blow
+/// the default axis up past the troposphere (flagged by claude-review
+/// on PR #275 — `TRAJECTORY_MAX_Z_LEVELS = 100` would otherwise produce
+/// km-spaced default levels for top-el ≈ 90°).
 fn coverage_top_default(volume: &PolarVolume) -> f64 {
     let top_el = volume
         .sweeps
@@ -1669,12 +1697,13 @@ fn coverage_top_default(volume: &PolarVolume) -> f64 {
         .map(|s| s.elangle)
         .filter(|v| v.is_finite())
         .fold(f64::NEG_INFINITY, f64::max);
-    if top_el.is_finite() {
+    let raw = if top_el.is_finite() {
         let (_, h) = slant_to_ground_height(200_000.0, top_el);
-        h.max(2_000.0)
+        h
     } else {
         15_000.0
-    }
+    };
+    raw.clamp(2_000.0, 25_000.0)
 }
 
 /// Build one `Section` coverage: the volume's polar field resampled on
@@ -1690,6 +1719,10 @@ fn volume_section(
     if path.len() < 2 || heights_m.is_empty() || quantities.is_empty() {
         return None;
     }
+    // Pre-compute the sweep envelope once per volume — `sample_polar_slant`
+    // would otherwise refold over every sweep on every cell. A volume with
+    // no finite sweep angles cannot be sampled at all.
+    let envelope = sweep_envelope(&entry.volume)?;
     let site = &entry.volume.site;
     let t = entry.volume.time;
     let nodes: Vec<(DateTime<Utc>, f64, f64)> =
@@ -1712,7 +1745,14 @@ fn volume_section(
         for &(d, bearing) in &geom {
             for &h in heights_m {
                 let (r, el) = ground_height_to_slant(d, h);
-                values.push(sample_polar_slant(&entry.volume, quantity, r, bearing, el));
+                values.push(sample_polar_slant(
+                    &entry.volume,
+                    envelope,
+                    quantity,
+                    r,
+                    bearing,
+                    el,
+                ));
             }
         }
         ranges.insert(
@@ -2031,6 +2071,18 @@ impl EdrEngine for PolarVolumeEngine {
                 "LINESTRING must trace a non-degenerate path".into(),
             ));
         }
+        // Reject negative `z` values up-front. `resolve_heights` would
+        // otherwise clamp them silently (single-value arm) or pass them
+        // through (3+ arm), advertising a "Height above antenna"
+        // (direction: up) axis with negative values that are physically
+        // impossible. A 400 surfaces the mistake to the caller rather
+        // than burying it in an all-None response row. Found by
+        // claude-review on PR #275.
+        if z.is_some_and(|levels| levels.iter().any(|&h| h < 0.0)) {
+            return Err(DataServerError::InvalidParameter(
+                "trajectory `z` values must be ≥ 0 (metres above antenna)".into(),
+            ));
+        }
 
         let catalog = self.catalog.load();
         // Path centroid (mean lon/lat) — good enough for picking which
@@ -2240,18 +2292,19 @@ mod tests {
     fn sample_polar_slant_rejects_malformed_rscale() {
         let (site_lon, site_lat) = (25.0, 60.0);
         let mut vol = synthetic_volume(site_lon, site_lat);
+        let env = sweep_envelope(&vol).expect("synthetic volume has finite sweep");
         let azimuth = 90.0;
         let elangle = 0.5;
         let range_m = 10_000.0;
 
         // Baseline: well-formed sweep returns a finite sample.
-        let v = sample_polar_slant(&vol, "DBZH", range_m, azimuth, elangle);
+        let v = sample_polar_slant(&vol, env, "DBZH", range_m, azimuth, elangle);
         assert!(v.is_some(), "well-formed sweep must sample");
 
         for bad in [0.0_f64, -1_000.0, f64::NAN, f64::INFINITY] {
             vol.sweeps[0].rscale = bad;
             assert!(
-                sample_polar_slant(&vol, "DBZH", range_m, azimuth, elangle).is_none(),
+                sample_polar_slant(&vol, env, "DBZH", range_m, azimuth, elangle).is_none(),
                 "rscale={bad} must yield None, not fabricated data"
             );
         }
@@ -2269,26 +2322,62 @@ mod tests {
     fn sample_polar_slant_rejects_out_of_envelope_elevation() {
         let (site_lon, site_lat) = (25.0, 60.0);
         let vol = synthetic_volume(site_lon, site_lat);
+        let env = sweep_envelope(&vol).unwrap();
         // Synthetic fixture has one sweep at 0.5°. Tolerance is 1°, so
         // targets in [-0.5°, 1.5°] are accepted; everything outside ⇒ None.
         let azimuth = 90.0;
         let range_m = 10_000.0;
 
         // Inside the window — sampled.
-        assert!(sample_polar_slant(&vol, "DBZH", range_m, azimuth, 0.5).is_some());
-        assert!(sample_polar_slant(&vol, "DBZH", range_m, azimuth, 1.4).is_some());
-        assert!(sample_polar_slant(&vol, "DBZH", range_m, azimuth, -0.4).is_some());
+        assert!(sample_polar_slant(&vol, env, "DBZH", range_m, azimuth, 0.5).is_some());
+        assert!(sample_polar_slant(&vol, env, "DBZH", range_m, azimuth, 1.4).is_some());
+        assert!(sample_polar_slant(&vol, env, "DBZH", range_m, azimuth, -0.4).is_some());
 
         // Just outside the window — None.
-        assert!(sample_polar_slant(&vol, "DBZH", range_m, azimuth, 1.6).is_none());
-        assert!(sample_polar_slant(&vol, "DBZH", range_m, azimuth, -0.6).is_none());
+        assert!(sample_polar_slant(&vol, env, "DBZH", range_m, azimuth, 1.6).is_none());
+        assert!(sample_polar_slant(&vol, env, "DBZH", range_m, azimuth, -0.6).is_none());
 
         // Far outside — None (the 90° overhead case that bit the
         // h=large cells at the radar location).
-        assert!(sample_polar_slant(&vol, "DBZH", range_m, azimuth, 90.0).is_none());
+        assert!(sample_polar_slant(&vol, env, "DBZH", range_m, azimuth, 90.0).is_none());
 
         // Non-finite el — None.
-        assert!(sample_polar_slant(&vol, "DBZH", range_m, azimuth, f64::NAN).is_none());
+        assert!(sample_polar_slant(&vol, env, "DBZH", range_m, azimuth, f64::NAN).is_none());
+    }
+
+    /// `coverage_top_default` is clamped to 25 km even for a research
+    /// volume whose highest sweep is near 90° — without the cap, the
+    /// 4/3-Earth height at 200 km slant range for a 90° beam is 200 km,
+    /// and `resolve_heights` would emit 100 levels spaced 2 km apart.
+    /// Found by claude-review on PR #275.
+    #[test]
+    fn coverage_top_default_caps_at_25km() {
+        let (site_lon, site_lat) = (25.0, 60.0);
+        let mut vol = synthetic_volume(site_lon, site_lat);
+        // Replace the single 0.5° sweep with a vertically-pointing one.
+        vol.sweeps[0].elangle = 89.5;
+        let top = coverage_top_default(&vol);
+        assert!(
+            top <= 25_000.0 + 1.0,
+            "expected ceiling clamp at 25 km, got {top}"
+        );
+        assert!(top >= 2_000.0, "floor still respected, got {top}");
+    }
+
+    /// `resolve_heights` collapses near-duplicate explicit levels at a
+    /// millimetre tolerance, not at `f64::EPSILON`. Two levels differing
+    /// by sub-mm noise from float arithmetic must not survive as
+    /// separate axis points.
+    #[test]
+    fn resolve_heights_dedups_at_millimetre_tolerance() {
+        // 1 mm apart — would NOT dedup at `EPSILON`, but does at 1e-3.
+        let levels = [1_000.0_f64, 1_000.000_001, 2_000.0];
+        let out = resolve_heights(Some(&levels), 15_000.0);
+        assert_eq!(out.len(), 2, "1 mm-apart levels must collapse, got {out:?}");
+        // 1 cm apart — still distinct.
+        let levels = [1_000.0_f64, 1_000.01, 2_000.0];
+        let out = resolve_heights(Some(&levels), 15_000.0);
+        assert_eq!(out.len(), 3, "1 cm-apart levels stay distinct, got {out:?}");
     }
 
     /// Build a synthetic single-site, single-sweep, single-moment

--- a/crates/engine-odim/src/volume_engine.rs
+++ b/crates/engine-odim/src/volume_engine.rs
@@ -1605,6 +1605,33 @@ fn sample_polar_slant(
     if sweep.nrays == 0 || sweep.nbins == 0 {
         return None;
     }
+    // Reject targets outside the sweep envelope. Without this,
+    // `nearest_sweep` silently substitutes the lowest sweep's value
+    // for surface cells whose 4/3-Earth-inverted elevation drops below
+    // the horizon (h=0 beyond ~1 km from the radar produces a small
+    // negative angle), and analogously the highest sweep for cells
+    // above the radar's coverage cone — fabricating data far from the
+    // true sample point. The tolerance (~half a typical beam width) is
+    // looser than a beam width so cells slightly outside the surveyed
+    // angle still snap to the nearest sweep instead of dropping out.
+    //
+    // Computed from this volume's sweeps every call so a heterogeneous
+    // network gets per-site envelopes correctly. Cheap (≤ ~20 sweeps).
+    const SWEEP_TOL_DEG: f64 = 1.0;
+    let (min_el, max_el) = volume
+        .sweeps
+        .iter()
+        .map(|s| s.elangle)
+        .filter(|v| v.is_finite())
+        .fold((f64::INFINITY, f64::NEG_INFINITY), |(lo, hi), v| {
+            (lo.min(v), hi.max(v))
+        });
+    if !elangle_deg.is_finite()
+        || elangle_deg < min_el - SWEEP_TOL_DEG
+        || elangle_deg > max_el + SWEEP_TOL_DEG
+    {
+        return None;
+    }
     // A malformed sweep with `rscale <= 0` would silently mis-sample:
     // `rscale = 0` makes the divisor zero (a NaN cast to `i64` becomes
     // 0, sampling the first bin with wrong-range data); `rscale < 0`
@@ -2228,6 +2255,40 @@ mod tests {
                 "rscale={bad} must yield None, not fabricated data"
             );
         }
+    }
+
+    /// `sample_polar_slant` returns `None` for elevation targets outside
+    /// the sweep envelope (above the highest beam or well below the
+    /// lowest). This guards against the silent surface-row substitution
+    /// the 4/3-Earth inversion otherwise causes: at h=0 far from the
+    /// radar, the inverted target el goes slightly negative; without
+    /// this guard `nearest_sweep` still picks the lowest sweep and
+    /// fabricates "ground" reflectivity from a beam aimed well above.
+    /// Found by claude-review on PR #275.
+    #[test]
+    fn sample_polar_slant_rejects_out_of_envelope_elevation() {
+        let (site_lon, site_lat) = (25.0, 60.0);
+        let vol = synthetic_volume(site_lon, site_lat);
+        // Synthetic fixture has one sweep at 0.5°. Tolerance is 1°, so
+        // targets in [-0.5°, 1.5°] are accepted; everything outside ⇒ None.
+        let azimuth = 90.0;
+        let range_m = 10_000.0;
+
+        // Inside the window — sampled.
+        assert!(sample_polar_slant(&vol, "DBZH", range_m, azimuth, 0.5).is_some());
+        assert!(sample_polar_slant(&vol, "DBZH", range_m, azimuth, 1.4).is_some());
+        assert!(sample_polar_slant(&vol, "DBZH", range_m, azimuth, -0.4).is_some());
+
+        // Just outside the window — None.
+        assert!(sample_polar_slant(&vol, "DBZH", range_m, azimuth, 1.6).is_none());
+        assert!(sample_polar_slant(&vol, "DBZH", range_m, azimuth, -0.6).is_none());
+
+        // Far outside — None (the 90° overhead case that bit the
+        // h=large cells at the radar location).
+        assert!(sample_polar_slant(&vol, "DBZH", range_m, azimuth, 90.0).is_none());
+
+        // Non-finite el — None.
+        assert!(sample_polar_slant(&vol, "DBZH", range_m, azimuth, f64::NAN).is_none());
     }
 
     /// Build a synthetic single-site, single-sweep, single-moment

--- a/crates/engine-odim/src/volume_engine.rs
+++ b/crates/engine-odim/src/volume_engine.rs
@@ -2124,6 +2124,22 @@ impl EdrEngine for PolarVolumeEngine {
         // matching scale.
         let top_default = coverage_top_default(&selected.last().unwrap().volume);
         let heights = resolve_heights(z, top_default);
+        // When the caller passed explicit levels and the 1 mm-tolerance
+        // dedup collapsed some, surface that — it's a benign noise-removal
+        // most of the time, but logging it means a user who fat-fingered
+        // two near-identical levels can see why their axis shrank rather
+        // than silently getting fewer rows than requested.
+        if let Some(requested) = z {
+            if requested.len() > 2 && heights.len() < requested.len() {
+                tracing::debug!(
+                    "[{}] trajectory z: {} requested level(s) collapsed to {} after \
+                     1mm-tolerance dedup",
+                    self.collection_id,
+                    requested.len(),
+                    heights.len()
+                );
+            }
+        }
         if heights.is_empty() {
             return Err(DataServerError::InvalidParameter(
                 "trajectory `z` resolved to an empty axis".into(),

--- a/crates/engine-odim/src/volume_engine.rs
+++ b/crates/engine-odim/src/volume_engine.rs
@@ -1516,8 +1516,8 @@ fn resample_path(vertices: &[(f64, f64)]) -> Vec<(f64, f64)> {
         // single-cell domain telling the user what happened.
         return vec![vertices[0], *vertices.last().unwrap()];
     }
-    let n = ((total / TRAJECTORY_NODE_SPACING_M).ceil() as usize + 1)
-        .clamp(2, TRAJECTORY_MAX_NODES);
+    let n =
+        ((total / TRAJECTORY_NODE_SPACING_M).ceil() as usize + 1).clamp(2, TRAJECTORY_MAX_NODES);
     let step = total / (n - 1) as f64;
 
     let mut out = Vec::with_capacity(n);

--- a/crates/engine-odim/tests/integration.rs
+++ b/crates/engine-odim/tests/integration.rs
@@ -847,3 +847,125 @@ fn pvol_edr_query_area_collects_sites() {
         other => panic!("an empty area must be LocationNotFound, got {other:?}"),
     }
 }
+
+// ---------------------------------------------------------------------------
+// PolarVolumeEngine — EdrEngine (M4: trajectory cross-sections)
+// ---------------------------------------------------------------------------
+
+/// A trajectory query returns a `Section` coverage whose composite axis
+/// has one `(t, lon, lat)` triple per along-path node and whose `z`
+/// axis is height above antenna in metres. The range ndarray is
+/// `[nodes, z]`, and at least one cell over the radar's own coverage
+/// must sample a finite value.
+#[test]
+fn pvol_edr_query_trajectory_returns_section() {
+    let Some(engine) = pvol_fixture_engine() else {
+        eprintln!("skipping pvol_edr_query_trajectory_returns_section: fixture absent");
+        return;
+    };
+    // A ~50 km north-bound leg starting south-west of Anjalankoski
+    // (~27.1°E, 60.9°N), so the path crosses the radar's lowest sweep
+    // coverage along its length.
+    let coords = "LINESTRING(27.1 60.6, 27.1 61.1)";
+    let response = EdrEngine::query_trajectory(
+        &engine,
+        coords,
+        None,
+        Some(&["DBZH".to_string()]),
+        Some(&[0.0, 6_000.0]),
+    )
+    .expect("trajectory query inside radar coverage");
+    let qr = match &response {
+        CoverageResponse::Single(q) => q.clone(),
+        CoverageResponse::Collection(c) => {
+            assert!(!c.is_empty(), "a non-empty fixture yields ≥1 section");
+            c[0].clone()
+        }
+    };
+
+    let (nodes, z) = match &qr.domain {
+        DomainDescription::Section { nodes, z } => (nodes, z),
+        other => panic!("expected Section domain, got {other:?}"),
+    };
+    assert!(
+        nodes.len() >= 2,
+        "Section path must keep ≥2 along-path nodes"
+    );
+    assert!(z.values.len() >= 2, "Section z axis must have ≥2 levels");
+
+    let dbzh = qr.ranges.get("DBZH").expect("DBZH range");
+    assert_eq!(dbzh.shape, vec![nodes.len(), z.values.len()]);
+    assert_eq!(
+        dbzh.axis_names,
+        vec!["composite".to_string(), "z".to_string()]
+    );
+    let non_none = dbzh.values.iter().filter(|v| v.is_some()).count();
+    assert!(
+        non_none > 0,
+        "a section over the radar's own coverage must sample ≥1 finite value"
+    );
+}
+
+/// A trajectory whose path lies entirely outside any radar's coverage
+/// still yields a Section, but every cell is nodata. Far-out paths
+/// fall back to the catalog's `nearest_site` and produce a Section
+/// shaped against that site's z extent.
+#[test]
+fn pvol_edr_query_trajectory_out_of_coverage_yields_empty_cells() {
+    let Some(engine) = pvol_fixture_engine() else {
+        eprintln!(
+            "skipping pvol_edr_query_trajectory_out_of_coverage_yields_empty_cells: fixture absent"
+        );
+        return;
+    };
+    // A line near the antipode of FMI radars — every sample is out of
+    // range.
+    let coords = "LINESTRING(-150 -30, -150 -29)";
+    match EdrEngine::query_trajectory(
+        &engine,
+        coords,
+        None,
+        Some(&["DBZH".to_string()]),
+        Some(&[0.0, 4_000.0]),
+    ) {
+        Ok(response) => {
+            let qr = match response {
+                CoverageResponse::Single(q) => q,
+                CoverageResponse::Collection(c) => c.into_iter().next().expect("non-empty fixture"),
+            };
+            let dbzh = qr.ranges.get("DBZH").expect("DBZH range");
+            assert!(
+                dbzh.values.iter().all(Option::is_none),
+                "out-of-coverage trajectory must produce all-None values"
+            );
+        }
+        Err(ds_core::error::DataServerError::LocationNotFound(_)) => {
+            // Acceptable degenerate: every selected volume yielded no
+            // Section (e.g. catalog held no sites for the time range).
+        }
+        Err(e) => panic!("unexpected error for far-from-radar trajectory: {e:?}"),
+    }
+}
+
+/// LINESTRING parsing failures bubble up as `InvalidParameter` so the
+/// API layer can map to HTTP 400.
+#[test]
+fn pvol_edr_query_trajectory_rejects_malformed_linestring() {
+    let Some(engine) = pvol_fixture_engine() else {
+        eprintln!(
+            "skipping pvol_edr_query_trajectory_rejects_malformed_linestring: fixture absent"
+        );
+        return;
+    };
+    for bad in [
+        "POINT(27.1 60.9)",
+        "LINESTRING(27.1 60.9)",
+        "LINESTRINGZ(27.1 60.9 0, 27.1 61.1 100)",
+        "LINESTRING(NaN 60.9, 27.1 61.1)",
+    ] {
+        match EdrEngine::query_trajectory(&engine, bad, None, None, None) {
+            Err(ds_core::error::DataServerError::InvalidParameter(_)) => {}
+            other => panic!("expected InvalidParameter for `{bad}`, got {other:?}"),
+        }
+    }
+}

--- a/crates/engine-odim/tests/integration.rs
+++ b/crates/engine-odim/tests/integration.rs
@@ -865,14 +865,15 @@ fn pvol_edr_query_trajectory_returns_section() {
     };
     // A ~50 km north-bound leg starting south-west of Anjalankoski
     // (~27.1°E, 60.9°N), so the path crosses the radar's lowest sweep
-    // coverage along its length.
+    // coverage along its length. `z` here selects the 0.5°–5° elevation
+    // angle band (the cross-section's vertical axis is derived height).
     let coords = "LINESTRING(27.1 60.6, 27.1 61.1)";
     let response = EdrEngine::query_trajectory(
         &engine,
         coords,
         None,
         Some(&["DBZH".to_string()]),
-        Some(&[0.0, 6_000.0]),
+        Some(&[0.5, 5.0]),
     )
     .expect("trajectory query inside radar coverage");
     let qr = match &response {
@@ -919,14 +920,14 @@ fn pvol_edr_query_trajectory_out_of_coverage_yields_empty_cells() {
         return;
     };
     // A line near the antipode of FMI radars — every sample is out of
-    // range.
+    // range. `z` selects a low elevation-angle band.
     let coords = "LINESTRING(-150 -30, -150 -29)";
     match EdrEngine::query_trajectory(
         &engine,
         coords,
         None,
         Some(&["DBZH".to_string()]),
-        Some(&[0.0, 4_000.0]),
+        Some(&[0.5, 3.0]),
     ) {
         Ok(response) => {
             let qr = match response {

--- a/crates/render/src/lib.rs
+++ b/crates/render/src/lib.rs
@@ -9,7 +9,7 @@ pub use colormap::{
 };
 pub use encode::{encode_jpeg, encode_png, encode_webp};
 pub use metatile::{render_metatiled, MetaTile, MetaTileStats, TileKeyPrefix, TilePixelCache};
-pub use plot::{render_chart, Panel, Series};
+pub use plot::{render_chart, render_heatmap, Heatmap, Panel, Series};
 
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;

--- a/crates/render/src/plot.rs
+++ b/crates/render/src/plot.rs
@@ -294,15 +294,35 @@ fn draw_heatmap_panel(
         return;
     }
 
-    // Fill the plot area: each output pixel maps to a (node, level) cell
-    // by nearest-neighbour. Screen y grows downward and height grows
-    // upward, so the top row is the highest level.
+    let (ymin, ymax) = (hm.y_values[0], hm.y_values[nz - 1]);
+
+    // Fill the plot area. Each output pixel maps to a (node, level) cell:
+    // the column is index-linear in node, the row is *value-linear* in the
+    // vertical coordinate — the pixel's height value is found, then its
+    // nearest level by value. Value-linear matches the y-tick placement
+    // below (`py`), so labels line up even when the z levels are not
+    // uniformly spaced (a caller passing irregular `y_values`).
     let pw = x1 - x0;
     let ph = y1 - y0;
+    let nearest_level = |h: f64| -> usize {
+        // y_values is ascending; pick the index minimising |value − h|.
+        let mut best = 0usize;
+        let mut best_d = f64::INFINITY;
+        for (i, &yv) in hm.y_values.iter().enumerate() {
+            let d = (yv - h).abs();
+            if d < best_d {
+                best_d = d;
+                best = i;
+            }
+        }
+        best
+    };
+    let span = (ymax - ymin).max(f64::EPSILON);
     for sy in 0..ph {
-        // frac 0 at top (max height) → level index from the top.
+        // Screen y grows downward; the top row is the max height value.
         let frac_y = (sy as f64 + 0.5) / ph as f64;
-        let level = (((1.0 - frac_y) * nz as f64) as usize).min(nz - 1);
+        let h = ymax - frac_y * span;
+        let level = nearest_level(h);
         for sx in 0..pw {
             let frac_x = (sx as f64 + 0.5) / pw as f64;
             let node = ((frac_x * nx as f64) as usize).min(nx - 1);
@@ -314,7 +334,6 @@ fn draw_heatmap_panel(
     cv.rect(x0, y0, x1, y1, FRAME);
 
     // Y ticks (height) — value grows up, so the top is the max.
-    let (ymin, ymax) = (hm.y_values[0], hm.y_values[nz - 1]);
     let py = |y: f64| -> i32 {
         let frac = (y - ymin) / (ymax - ymin).max(f64::EPSILON);
         y1 - (frac * (y1 - y0) as f64).round() as i32
@@ -993,6 +1012,40 @@ mod tests {
         // 50% black over white ≈ mid grey.
         let g = over_white([0, 0, 0, 128]);
         assert!(g[0] > 120 && g[0] < 135);
+    }
+
+    #[test]
+    fn heatmap_handles_non_uniform_z_levels() {
+        // Strongly non-uniform z levels (0, 100, 9000 m). Value-linear
+        // cell-fill + tick placement must agree, and the result is a
+        // valid PNG of the requested size. Before the fix the bottom two
+        // bands (0 and 100 m) each occupied a third of the height while
+        // ticks were placed by value — labels floated off their bands.
+        let cmap = crate::colormap::LutColorMap::from_builtin(
+            crate::colormap::BuiltinColormap::Viridis,
+            0.0,
+            30.0,
+        );
+        let hm = Heatmap {
+            title: "DBZH".into(),
+            x_label: "Distance (km)".into(),
+            y_label: "Height (m)".into(),
+            value_label: "dBZ".into(),
+            x_values: vec![0.0, 10.0, 20.0],
+            y_values: vec![0.0, 100.0, 9000.0],
+            values: vec![
+                Some(5.0),
+                Some(10.0),
+                Some(15.0),
+                Some(20.0),
+                Some(25.0),
+                Some(30.0),
+            ],
+            value_min: 0.0,
+            value_max: 30.0,
+        };
+        let png = render_heatmap(&[hm], &cmap, 600, 400).unwrap();
+        assert_eq!(decode_dims(&png), (600, 400));
     }
 
     #[test]

--- a/crates/render/src/plot.rs
+++ b/crates/render/src/plot.rs
@@ -235,9 +235,24 @@ pub fn render_heatmap(
     }
     let width = width.clamp(160, 2000);
     let height = height.clamp(120, 2000);
+
+    // Each stacked panel needs room for its top/bottom margins plus a few
+    // plot rows; below that `draw_heatmap_panel` would silently skip
+    // drawing and return an all-white PNG. Fail loudly with an actionable
+    // message instead (raise `height` or filter to one parameter).
+    const MIN_PANEL_PX: u32 = 64;
+    let n = heatmaps.len() as u32;
+    if height < n * MIN_PANEL_PX {
+        return Err(DataServerError::Render(format!(
+            "image height {height}px is too small for {n} stacked panel(s) \
+             (need ≥ {}px); raise `height` or filter to one parameter with \
+             `parameter-name`",
+            n * MIN_PANEL_PX
+        )));
+    }
     let mut cv = Canvas::new(width, height);
 
-    let n = heatmaps.len() as i32;
+    let n = n as i32;
     let panel_h = cv.h / n;
     for (i, hm) in heatmaps.iter().enumerate() {
         let top = i as i32 * panel_h;
@@ -1012,6 +1027,21 @@ mod tests {
         // 50% black over white ≈ mid grey.
         let g = over_white([0, 0, 0, 128]);
         assert!(g[0] > 120 && g[0] < 135);
+    }
+
+    #[test]
+    fn heatmap_too_small_for_panel_count_errors() {
+        let cmap = crate::colormap::LutColorMap::from_builtin(
+            crate::colormap::BuiltinColormap::Viridis,
+            0.0,
+            1.0,
+        );
+        // 3 panels in a 120px-tall image → 40px each, below the drawable
+        // minimum: a clear error, not a silent all-white PNG.
+        let three = vec![sample_heatmap(), sample_heatmap(), sample_heatmap()];
+        assert!(render_heatmap(&three, &cmap, 600, 120).is_err());
+        // The same three panels in a tall-enough image render fine.
+        assert!(render_heatmap(&three, &cmap, 600, 600).is_ok());
     }
 
     #[test]

--- a/crates/render/src/plot.rs
+++ b/crates/render/src/plot.rs
@@ -13,6 +13,7 @@ use chrono::DateTime;
 
 use ds_core::error::DataServerError;
 
+use crate::colormap::ColorMap;
 use crate::encode_png;
 
 /// One labelled line within a panel. `points` are `(x, y)` in data
@@ -43,6 +44,33 @@ pub struct Panel {
     /// When true x values are epoch seconds and ticks are formatted as time.
     pub x_is_time: bool,
     pub series: Vec<Series>,
+}
+
+/// A 2-D colour-mapped field for [`render_heatmap`] — the EDR `Section`
+/// (radar cross-section) plot. `values` is row-major over the along-path
+/// axis then the vertical axis: `values[node * z_len + level]`, matching
+/// the CoverageJSON `Section` ndarray shape `[n_nodes, n_z]`. A `None`
+/// cell renders with the colormap's nodata colour.
+#[derive(Debug, Clone)]
+pub struct Heatmap {
+    /// Centred title (the parameter label).
+    pub title: String,
+    /// Horizontal-axis caption (e.g. "Distance (km)").
+    pub x_label: String,
+    /// Vertical-axis caption (e.g. "Height above antenna (m)").
+    pub y_label: String,
+    /// Caption for the colour bar (the value unit, e.g. "dBZ").
+    pub value_label: String,
+    /// Monotonic along-path coordinate per column (length `x_len`).
+    pub x_values: Vec<f64>,
+    /// Monotonic vertical coordinate per row (length `z_len`), ascending.
+    pub y_values: Vec<f64>,
+    /// Row-major `[node][level]` cell values; length `x_values.len() *
+    /// y_values.len()`.
+    pub values: Vec<Option<f64>>,
+    /// Colour-bar lower / upper bounds (the colormap's value range).
+    pub value_min: f64,
+    pub value_max: f64,
 }
 
 const BLACK: [u8; 3] = [0x20, 0x20, 0x20];
@@ -190,6 +218,191 @@ pub fn render_chart(panels: &[Panel], width: u32, height: u32) -> Result<Vec<u8>
     }
 
     encode_png(&cv.buf, width, height)
+}
+
+/// Render one or more [`Heatmap`]s (stacked vertically) to PNG bytes —
+/// the EDR cross-section (`Section`) plot. Each heatmap is colour-mapped
+/// with `colormap`; the value range for the colour bar comes from each
+/// heatmap's `value_min`/`value_max`.
+pub fn render_heatmap(
+    heatmaps: &[Heatmap],
+    colormap: &dyn ColorMap,
+    width: u32,
+    height: u32,
+) -> Result<Vec<u8>, DataServerError> {
+    if heatmaps.is_empty() {
+        return Err(DataServerError::Render("no heatmaps to plot".into()));
+    }
+    let width = width.clamp(160, 2000);
+    let height = height.clamp(120, 2000);
+    let mut cv = Canvas::new(width, height);
+
+    let n = heatmaps.len() as i32;
+    let panel_h = cv.h / n;
+    for (i, hm) in heatmaps.iter().enumerate() {
+        let top = i as i32 * panel_h;
+        draw_heatmap_panel(&mut cv, hm, colormap, top, panel_h);
+    }
+    encode_png(&cv.buf, width, height)
+}
+
+/// Composite an RGBA colormap sample over the white canvas background and
+/// return the opaque RGB to store. Nodata (alpha 0) becomes white.
+fn over_white(c: [u8; 4]) -> [u8; 3] {
+    let a = c[3] as u32;
+    if a == 255 {
+        return [c[0], c[1], c[2]];
+    }
+    let blend = |ch: u8| -> u8 { ((ch as u32 * a + 255 * (255 - a)) / 255) as u8 };
+    [blend(c[0]), blend(c[1]), blend(c[2])]
+}
+
+fn draw_heatmap_panel(
+    cv: &mut Canvas,
+    hm: &Heatmap,
+    colormap: &dyn ColorMap,
+    top: i32,
+    panel_h: i32,
+) {
+    // Margins: extra room on the right for the colour bar.
+    let m_left = 58;
+    let m_right = 64;
+    let m_top = 26;
+    let m_bottom = 30;
+
+    let x0 = m_left;
+    let x1 = cv.w - m_right;
+    let y0 = top + m_top;
+    let y1 = top + panel_h - m_bottom;
+    if x1 <= x0 + 4 || y1 <= y0 + 4 {
+        return;
+    }
+
+    // Centred title.
+    let title = hm.title.to_ascii_uppercase();
+    let tw = text_width(&title, 2);
+    cv.text((cv.w - tw) / 2, top + 6, &title, BLACK, 2);
+
+    let nx = hm.x_values.len();
+    let nz = hm.y_values.len();
+    if nx == 0 || nz == 0 || hm.values.len() != nx * nz {
+        cv.rect(x0, y0, x1, y1, FRAME);
+        let msg = "NO DATA";
+        let w = text_width(msg, 2);
+        cv.text((x0 + x1) / 2 - w / 2, (y0 + y1) / 2 - 7, msg, FRAME, 2);
+        draw_heatmap_captions(cv, hm, x0, x1, y1, top);
+        return;
+    }
+
+    // Fill the plot area: each output pixel maps to a (node, level) cell
+    // by nearest-neighbour. Screen y grows downward and height grows
+    // upward, so the top row is the highest level.
+    let pw = x1 - x0;
+    let ph = y1 - y0;
+    for sy in 0..ph {
+        // frac 0 at top (max height) → level index from the top.
+        let frac_y = (sy as f64 + 0.5) / ph as f64;
+        let level = (((1.0 - frac_y) * nz as f64) as usize).min(nz - 1);
+        for sx in 0..pw {
+            let frac_x = (sx as f64 + 0.5) / pw as f64;
+            let node = ((frac_x * nx as f64) as usize).min(nx - 1);
+            let v = hm.values[node * nz + level];
+            let rgb = over_white(colormap.color(v));
+            cv.put(x0 + sx, y0 + sy, rgb);
+        }
+    }
+    cv.rect(x0, y0, x1, y1, FRAME);
+
+    // Y ticks (height) — value grows up, so the top is the max.
+    let (ymin, ymax) = (hm.y_values[0], hm.y_values[nz - 1]);
+    let py = |y: f64| -> i32 {
+        let frac = (y - ymin) / (ymax - ymin).max(f64::EPSILON);
+        y1 - (frac * (y1 - y0) as f64).round() as i32
+    };
+    for t in nice_ticks(ymin, ymax, 5) {
+        if t < ymin || t > ymax {
+            continue;
+        }
+        let yy = py(t);
+        cv.hline(x0 - 3, x0, yy, FRAME);
+        let label = format_value(t);
+        let lw = text_width(&label, 1);
+        cv.text(x0 - 6 - lw, yy - 3, &label, BLACK, 1);
+    }
+
+    // X ticks (distance).
+    let (xmin, xmax) = (hm.x_values[0], hm.x_values[nx - 1]);
+    let px = |x: f64| -> i32 {
+        let frac = (x - xmin) / (xmax - xmin).max(f64::EPSILON);
+        x0 + (frac * (x1 - x0) as f64).round() as i32
+    };
+    for t in nice_ticks(xmin, xmax, 5) {
+        if t < xmin || t > xmax {
+            continue;
+        }
+        let xx = px(t);
+        cv.vline(xx, y1, y1 + 3, FRAME);
+        let label = format_value(t);
+        let lw = text_width(&label, 1);
+        cv.text(xx - lw / 2, y1 + 6, &label, BLACK, 1);
+    }
+
+    draw_colorbar(cv, hm, colormap, x1, y0, y1);
+    draw_heatmap_captions(cv, hm, x0, x1, y1, top);
+}
+
+/// Vertical colour bar just right of the plot frame, with min/mid/max
+/// value ticks.
+fn draw_colorbar(
+    cv: &mut Canvas,
+    hm: &Heatmap,
+    colormap: &dyn ColorMap,
+    x1: i32,
+    y0: i32,
+    y1: i32,
+) {
+    let bar_x = x1 + 10;
+    let bar_w = 12;
+    let h = y1 - y0;
+    if h <= 1 {
+        return;
+    }
+    for sy in 0..h {
+        // Top = max value.
+        let frac = 1.0 - (sy as f64 + 0.5) / h as f64;
+        let v = hm.value_min + frac * (hm.value_max - hm.value_min);
+        let rgb = over_white(colormap.color(Some(v)));
+        for bx in 0..bar_w {
+            cv.put(bar_x + bx, y0 + sy, rgb);
+        }
+    }
+    cv.rect(bar_x, y0, bar_x + bar_w, y1, FRAME);
+
+    // Three labels: max (top), mid, min (bottom).
+    let label_at = |cv: &mut Canvas, frac: f64, v: f64| {
+        let yy = y1 - (frac * h as f64).round() as i32;
+        let label = format_value(v);
+        cv.hline(bar_x + bar_w, bar_x + bar_w + 3, yy, FRAME);
+        cv.text(bar_x + bar_w + 5, yy - 3, &label, BLACK, 1);
+    };
+    let mid = (hm.value_min + hm.value_max) / 2.0;
+    label_at(cv, 1.0, hm.value_max);
+    label_at(cv, 0.5, mid);
+    label_at(cv, 0.0, hm.value_min);
+
+    // Colour-bar caption (the unit) just above the bar.
+    if !hm.value_label.is_empty() {
+        let cap = hm.value_label.to_ascii_uppercase();
+        cv.text(bar_x, y0 - 9, &cap, BLACK, 1);
+    }
+}
+
+fn draw_heatmap_captions(cv: &mut Canvas, hm: &Heatmap, x0: i32, x1: i32, y1: i32, top: i32) {
+    let y_cap = hm.y_label.to_ascii_uppercase();
+    cv.text(4, top + 16, &y_cap, BLACK, 1);
+    let x_cap = hm.x_label.to_ascii_uppercase();
+    let w = text_width(&x_cap, 1);
+    cv.text((x0 + x1) / 2 - w / 2, y1 + 16, &x_cap, BLACK, 1);
 }
 
 fn draw_panel(cv: &mut Canvas, panel: &Panel, top: i32, panel_h: i32) {
@@ -686,6 +899,100 @@ mod tests {
             .timestamp() as f64;
         assert_eq!(format_time(ts, false), "13:45");
         assert_eq!(format_time(ts, true), "05-15 13:45");
+    }
+
+    fn sample_heatmap() -> Heatmap {
+        // 4 nodes × 3 levels, row-major [node][level].
+        let values = vec![
+            Some(10.0),
+            Some(20.0),
+            Some(30.0), // node 0
+            Some(15.0),
+            None,
+            Some(35.0), // node 1 (one nodata cell)
+            Some(5.0),
+            Some(25.0),
+            Some(40.0), // node 2
+            Some(0.0),
+            Some(12.0),
+            Some(28.0), // node 3
+        ];
+        Heatmap {
+            title: "DBZH".into(),
+            x_label: "Distance (km)".into(),
+            y_label: "Height (m)".into(),
+            value_label: "dBZ".into(),
+            x_values: vec![0.0, 10.0, 20.0, 30.0],
+            y_values: vec![0.0, 1000.0, 2000.0],
+            values,
+            value_min: 0.0,
+            value_max: 40.0,
+        }
+    }
+
+    #[test]
+    fn heatmap_renders_valid_png_of_requested_size() {
+        let cmap = crate::colormap::LutColorMap::from_builtin(
+            crate::colormap::BuiltinColormap::Viridis,
+            0.0,
+            40.0,
+        );
+        let png = render_heatmap(&[sample_heatmap()], &cmap, 800, 400).unwrap();
+        assert_eq!(decode_dims(&png), (800, 400));
+    }
+
+    #[test]
+    fn heatmap_render_is_deterministic() {
+        let cmap = crate::colormap::LutColorMap::from_builtin(
+            crate::colormap::BuiltinColormap::RadarDbz,
+            -32.0,
+            95.0,
+        );
+        let a = render_heatmap(&[sample_heatmap()], &cmap, 400, 300).unwrap();
+        let b = render_heatmap(&[sample_heatmap()], &cmap, 400, 300).unwrap();
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn heatmap_empty_is_error() {
+        let cmap = crate::colormap::LutColorMap::from_builtin(
+            crate::colormap::BuiltinColormap::Viridis,
+            0.0,
+            1.0,
+        );
+        assert!(render_heatmap(&[], &cmap, 100, 100).is_err());
+    }
+
+    #[test]
+    fn heatmap_mismatched_values_renders_no_data() {
+        // values length != nx*nz → "NO DATA" panel, but still a valid PNG.
+        let cmap = crate::colormap::LutColorMap::from_builtin(
+            crate::colormap::BuiltinColormap::Viridis,
+            0.0,
+            1.0,
+        );
+        let bad = Heatmap {
+            title: "T".into(),
+            x_label: "x".into(),
+            y_label: "y".into(),
+            value_label: "u".into(),
+            x_values: vec![0.0, 1.0],
+            y_values: vec![0.0, 1.0],
+            values: vec![Some(1.0)], // should be 4
+            value_min: 0.0,
+            value_max: 1.0,
+        };
+        let png = render_heatmap(&[bad], &cmap, 300, 200).unwrap();
+        assert_eq!(decode_dims(&png), (300, 200));
+    }
+
+    #[test]
+    fn over_white_blends_transparent_to_white() {
+        assert_eq!(over_white([0, 0, 0, 0]), [255, 255, 255]);
+        assert_eq!(over_white([10, 20, 30, 255]), [10, 20, 30]);
+        // 50% black over white ≈ mid grey.
+        let g = over_white([0, 0, 0, 128]);
+        assert!(g[0] > 120 && g[0] < 135);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Adds OGC API - EDR **trajectory** queries to the `odim-volume` (PVOL) engine. The response is a CoverageJSON `Section` domain — the radar-meteorology RHI: a vertical slice (range × height) along an arbitrary WKT `LINESTRING`.
- Builds on M3a (sites as locations + position queries) and M3b (`VerticalProfile` per timestep). Closes the trajectory half of **#198** (corridor stays open under the same ticket).
- Part of epic **#195**.

## Design (per /plan dialog)

- **Scope**: trajectory only. Corridor (perpendicular width averaging) is a deliberate follow-up — same `Section` output shape, will reuse the cross-section sampler.
- **Beam height**: 4/3-Earth refraction model (Doviak & Zrnić §2.2.3) inside the new sampler. The existing ground-range interim used by position/area/Map/WMS is **not changed** in this PR.
- **Sampling**: per output `(distance, height)` cell → invert to `(slant range, elevation)` → pick nearest sweep → map slant range to bin, bearing-from-site to ray.
- **Path**: parsed `LINESTRING(lon lat, lon lat, …)` (no Z/M variants) resampled to evenly-spaced nodes (~500 m, capped at 1024).
- **Radar selection**: single site nearest the path centroid wins. Cells outside coverage are nodata. Multi-radar stitching is a follow-up.
- **z semantics for trajectory**: `z=H` ≡ single-height slice, `z=Hmin,Hmax` ≡ regularly-spaced range, `z=H1,H2,…` ≡ explicit levels, absent ≡ 0..coverage-top.

## Changes

- `ds-core`: `EdrEngine::query_trajectory` trait method, `DomainDescription::Section { nodes: Vec<(t, lon, lat)>, z: VerticalCoord }`, `VerticalKind::HeightAboveAntenna`, shared `parse_linestring_coords` WKT parser.
- `engine-odim`: `slant_to_ground_height` / `ground_height_to_slant` (Doviak), `sample_polar_slant`, `resample_path`, `resolve_heights`, `volume_section`, `PolarVolumeEngine::query_trajectory` + `supported_query_types` += `trajectory`.
- `api-edr`: `TrajectoryQueryParams`, `trajectory_query` handler, `/collections/{id}/trajectory` route, `data_queries` advertisement, OpenAPI doc entry (`coords-linestring`, `z-trajectory`), Section arm in `build_domain` / `domain_type_name` / `plot_convert`.
- Tests: Doviak-pinned absolute references + round-trip residuals for the beam-height helpers (`engine-odim` lib); Section CoverageJSON schema validation (`api-edr/tests/covjson_validation.rs`); end-to-end trajectory integration tests against `testdata/radar-fmi-pvol/` (in-coverage, out-of-coverage, malformed LINESTRING).

## Test plan

- [ ] `cargo fmt --all && cargo clippy --workspace --all-targets -- -D warnings` ✅ (clean)
- [ ] `cargo test -p ds-core -p engine-odim -p api-edr` ✅ (119/0 + 22/0 + 191/0)
- [ ] `cargo test -p engine-{csv,geotiff,grib,querydata,postgis,geojson}` ✅
- [ ] `cargo test -p server -p api-{wms,maps,tiles,features} -p ds-{render,mvt,storage}` ✅
- [ ] Schema-validate a real trajectory response against `schemas/coveragejson.json` — covered by the new `section_coverage_validates_against_schema` integration test.
- [ ] Manual smoke (post-merge): hit `GET /edr/collections/<radar>/trajectory?coords=LINESTRING(…)&parameter-name=DBZH` against a deployed `odim-volume` collection; confirm `domainType: "Section"`, composite `[t,x,y]`, and z heights in metres.

## Out of scope (follow-ups)

- `query_corridor` + `corridor-width`/`corridor-height` parameters — stays in #198 after this PR.
- Multi-radar Section stitching.
- Migrating Map/WMS `polar_sample` from ground-range interim to true 4/3-Earth slant-range.
- `f=PNG` plot output for trajectory.
- `LINESTRINGZ` / `LINESTRINGM` (per-node z or time).

🤖 Generated with [Claude Code](https://claude.com/claude-code)