### PR TITLE
fix(api-maps,api-tiles): client render errors are 400, not 500

### DIFF
--- a/crates/api-maps/src/handlers.rs
+++ b/crates/api-maps/src/handlers.rs
@@ -979,9 +979,20 @@ async fn render_map(
             // not a 500 that hides it behind "Internal server error".
             return Err(match e {
                 DSE::InvalidParameter(_) | DSE::InvalidBbox(_) | DSE::InvalidDatetime(_) => {
+                    // 4xx-class: traced at DEBUG (not WARN) so a misconfigured
+                    // client is still diagnosable server-side without inflating
+                    // the warn stream with routine bad requests.
+                    tracing::debug!(
+                        "Maps render bad-request for collection '{}': {e}",
+                        collection_id
+                    );
                     MapsError::BadRequest(e.to_string())
                 }
                 DSE::CollectionNotFound(_) | DSE::LocationNotFound(_) => {
+                    tracing::debug!(
+                        "Maps render not-found for collection '{}': {e}",
+                        collection_id
+                    );
                     MapsError::NotFound(e.to_string())
                 }
                 _ => {

--- a/crates/api-maps/src/handlers.rs
+++ b/crates/api-maps/src/handlers.rs
@@ -972,8 +972,23 @@ async fn render_map(
             (cached, "EMPTY", "image/png")
         }
         Err(e) => {
-            tracing::warn!("Maps render error for collection '{}': {e}", collection_id);
-            return Err(MapsError::Internal(format!("Render failed: {e}")));
+            use ds_core::error::DataServerError as DSE;
+            // A client mistake (e.g. a multi-parameter PVOL collection
+            // rendered without a `<site>:<quantity>` parameter, or a bad
+            // bbox/datetime) is a 400 with the engine's helpful message —
+            // not a 500 that hides it behind "Internal server error".
+            return Err(match e {
+                DSE::InvalidParameter(_) | DSE::InvalidBbox(_) | DSE::InvalidDatetime(_) => {
+                    MapsError::BadRequest(e.to_string())
+                }
+                DSE::CollectionNotFound(_) | DSE::LocationNotFound(_) => {
+                    MapsError::NotFound(e.to_string())
+                }
+                _ => {
+                    tracing::warn!("Maps render error for collection '{}': {e}", collection_id);
+                    MapsError::Internal(format!("Render failed: {e}"))
+                }
+            });
         }
     };
 

--- a/crates/api-maps/tests/integration.rs
+++ b/crates/api-maps/tests/integration.rs
@@ -75,12 +75,93 @@ impl MapEngine for MockMapEngine {
     }
 }
 
+/// A `MapEngine` whose `get_raster_tile` always returns `InvalidParameter`
+/// — mirrors a multi-parameter PVOL collection rendered without a
+/// `<site>:<quantity>` selection. Used to verify the handler classifies a
+/// client mistake as 400, not 500.
+struct InvalidParamEngine;
+
+impl MapEngine for InvalidParamEngine {
+    fn get_raster_tile(
+        &self,
+        _bbox: [f64; 4],
+        _width: u32,
+        _height: u32,
+        _time: Option<chrono::DateTime<chrono::Utc>>,
+        _output_crs: &OutputCrs,
+        _parameter: Option<&str>,
+        _z: Option<f64>,
+    ) -> Result<RasterTile, DataServerError> {
+        Err(DataServerError::InvalidParameter(
+            "collection requires a `<site>:<quantity>` parameter (e.g. `fivih:DBZH`)".into(),
+        ))
+    }
+
+    fn raster_info(&self) -> RasterInfo {
+        MockMapEngine::make_info()
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
 fn build_router() -> axum::Router {
     build_router_with_apis(vec!["maps".to_string()])
+}
+
+/// Build a Maps router backed by a caller-supplied engine (otherwise
+/// identical to `build_router`), for exercising engine error paths.
+fn build_router_with_engine(engine: Arc<dyn MapEngine>) -> axum::Router {
+    let mut engines = HashMap::new();
+    let mut collections = HashMap::new();
+    let mut styles_map = HashMap::new();
+    engines.insert("radar".to_string(), engine);
+    collections.insert(
+        "radar".to_string(),
+        CollectionConfig {
+            id: "radar".to_string(),
+            title: "Test Radar".to_string(),
+            description: "Test radar data".to_string(),
+            data_path: None,
+            apis: vec!["maps".to_string()],
+            engine_type: "odim-volume".to_string(),
+            geotiff: None,
+            querydata: None,
+            wms: None,
+            grib: None,
+            odim: None,
+            postgis: None,
+            preview: None,
+        },
+    );
+    let cmap = Arc::new(LutColorMap::from_builtin(
+        BuiltinColormap::Viridis,
+        0.0,
+        1.0,
+    ));
+    let mut layer_styles = HashMap::new();
+    layer_styles.insert(
+        "default".to_string(),
+        StyleInfo {
+            name: "default".to_string(),
+            title: "Default".to_string(),
+            colormap: cmap,
+            min: 0.0,
+            max: 1.0,
+            parameter: None,
+        },
+    );
+    styles_map.insert("radar".to_string(), layer_styles);
+    let state = Arc::new(ArcSwap::from_pointee(MapsState {
+        engines,
+        collections,
+        styles: styles_map,
+        render_semaphore: Arc::new(tokio::sync::Semaphore::new(4)),
+        rendered_cache: Arc::new(RenderedCache::new(16)),
+        base_url: String::new(),
+    }));
+    api_maps::router(state)
 }
 
 fn build_router_with_apis(apis: Vec<String>) -> axum::Router {
@@ -592,6 +673,30 @@ mod get_map {
     async fn unknown_collection_returns_404() {
         let (status, _) = get("/collections/nonexistent/map?bbox=10,55,30,70").await;
         assert_eq!(status, StatusCode::NOT_FOUND);
+    }
+
+    /// An engine `InvalidParameter` from `get_raster_tile` (e.g. a
+    /// multi-parameter PVOL collection rendered without a
+    /// `<site>:<quantity>` selection) is a **400 with the engine's
+    /// message**, not a 500 that hides it. Regression for the reported
+    /// "internal server error" on a parameterless PVOL maps request.
+    #[tokio::test]
+    async fn render_invalid_parameter_is_400_with_message() {
+        let app = build_router_with_engine(Arc::new(InvalidParamEngine));
+        let (status, json) = get_on(
+            app,
+            "/collections/radar/map?bbox=10,55,30,70&width=64&height=48",
+        )
+        .await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert_eq!(json["code"], "BadRequest");
+        assert!(
+            json["description"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("parameter"),
+            "the helpful engine message must reach the client, got {json}"
+        );
     }
 
     #[tokio::test]

--- a/crates/api-tiles/src/handlers.rs
+++ b/crates/api-tiles/src/handlers.rs
@@ -1269,8 +1269,22 @@ async fn render_tile(
     .map_err(|e| TilesError::Internal(format!("Render task failed: {e}")))?;
 
     let maybe_bytes = render_result.map_err(|e| {
-        tracing::warn!("Tiles render error for collection '{}': {e}", collection_id);
-        TilesError::Internal(format!("Render failed: {e}"))
+        use ds_core::error::DataServerError as DSE;
+        // A client mistake (multi-parameter collection rendered without a
+        // parameter, bad bbox/datetime) is a 400 with the engine's message,
+        // not a 500 that hides it.
+        match e {
+            DSE::InvalidParameter(_) | DSE::InvalidBbox(_) | DSE::InvalidDatetime(_) => {
+                TilesError::BadRequest(e.to_string())
+            }
+            DSE::CollectionNotFound(_) | DSE::LocationNotFound(_) => {
+                TilesError::NotFound(e.to_string())
+            }
+            _ => {
+                tracing::warn!("Tiles render error for collection '{}': {e}", collection_id);
+                TilesError::Internal(format!("Render failed: {e}"))
+            }
+        }
     })?;
 
     // Empty tiles return the pre-generated transparent PNG without caching;

--- a/crates/api-tiles/src/handlers.rs
+++ b/crates/api-tiles/src/handlers.rs
@@ -1275,9 +1275,19 @@ async fn render_tile(
         // not a 500 that hides it.
         match e {
             DSE::InvalidParameter(_) | DSE::InvalidBbox(_) | DSE::InvalidDatetime(_) => {
+                // 4xx-class: DEBUG (not WARN) so a misconfigured client stays
+                // diagnosable without flooding the warn stream.
+                tracing::debug!(
+                    "Tiles render bad-request for collection '{}': {e}",
+                    collection_id
+                );
                 TilesError::BadRequest(e.to_string())
             }
             DSE::CollectionNotFound(_) | DSE::LocationNotFound(_) => {
+                tracing::debug!(
+                    "Tiles render not-found for collection '{}': {e}",
+                    collection_id
+                );
                 TilesError::NotFound(e.to_string())
             }
             _ => {

--- a/crates/api-tiles/tests/integration.rs
+++ b/crates/api-tiles/tests/integration.rs
@@ -563,9 +563,10 @@ mod get_tile {
 
     /// An engine `InvalidParameter` from `get_raster_tile` (e.g. a
     /// multi-parameter PVOL collection tiled without a `<site>:<quantity>`
-    /// selection) is a 400, not a 500.
+    /// selection) is a 400 **with the engine's message in the body**, not
+    /// a 500 — parity with the maps regression test.
     #[tokio::test]
-    async fn render_invalid_parameter_is_400() {
+    async fn render_invalid_parameter_is_400_with_message() {
         let app = build_router_with_engine(Arc::new(InvalidParamEngine));
         let req = Request::builder()
             .uri("/collections/radar/tiles/WebMercatorQuad/0/0/0")
@@ -573,6 +574,16 @@ mod get_tile {
             .unwrap();
         let resp = app.oneshot(req).await.unwrap();
         assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let body = resp.into_body().collect().await.unwrap().to_bytes();
+        let json: Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["code"], "BadRequest");
+        assert!(
+            json["description"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("parameter"),
+            "the helpful engine message must reach the client, got {json}"
+        );
     }
 
     #[tokio::test]

--- a/crates/api-tiles/tests/integration.rs
+++ b/crates/api-tiles/tests/integration.rs
@@ -76,6 +76,33 @@ impl MapEngine for MockMapEngine {
     }
 }
 
+/// A `MapEngine` whose `get_raster_tile` always returns `InvalidParameter`
+/// — mirrors a multi-parameter PVOL collection tiled without a
+/// `<site>:<quantity>` selection. Used to verify the handler returns 400,
+/// not 500.
+struct InvalidParamEngine;
+
+impl MapEngine for InvalidParamEngine {
+    fn get_raster_tile(
+        &self,
+        _bbox: [f64; 4],
+        _width: u32,
+        _height: u32,
+        _time: Option<chrono::DateTime<chrono::Utc>>,
+        _output_crs: &OutputCrs,
+        _parameter: Option<&str>,
+        _z: Option<f64>,
+    ) -> Result<RasterTile, DataServerError> {
+        Err(DataServerError::InvalidParameter(
+            "collection requires a `<site>:<quantity>` parameter (e.g. `fivih:DBZH`)".into(),
+        ))
+    }
+
+    fn raster_info(&self) -> RasterInfo {
+        MockMapEngine::make_info()
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -140,6 +167,63 @@ fn build_router() -> axum::Router {
     );
     styles_map.insert("radar".to_string(), layer_styles);
 
+    let state = Arc::new(ArcSwap::from_pointee(TilesState {
+        map_engines: engines,
+        collections,
+        styles: styles_map,
+        feature_engines: HashMap::new(),
+        feature_collections: HashMap::new(),
+        render_semaphore: Arc::new(tokio::sync::Semaphore::new(4)),
+        rendered_cache: Arc::new(RenderedCache::new(16)),
+        vector_tile_cache: Arc::new(VectorTileCache::new(16)),
+        base_url: String::new(),
+    }));
+    api_tiles::router(state)
+}
+
+/// A Tiles router backed by a caller-supplied engine, for exercising
+/// engine error paths.
+fn build_router_with_engine(engine: Arc<dyn MapEngine>) -> axum::Router {
+    let mut engines = HashMap::new();
+    let mut collections = HashMap::new();
+    let mut styles_map = HashMap::new();
+    engines.insert("radar".to_string(), engine);
+    collections.insert(
+        "radar".to_string(),
+        CollectionConfig {
+            id: "radar".to_string(),
+            title: "Test Radar".to_string(),
+            description: "Test radar data".to_string(),
+            data_path: None,
+            apis: vec!["tiles".to_string()],
+            engine_type: "odim-volume".to_string(),
+            geotiff: None,
+            querydata: None,
+            wms: None,
+            grib: None,
+            odim: None,
+            postgis: None,
+            preview: None,
+        },
+    );
+    let cmap = Arc::new(LutColorMap::from_builtin(
+        BuiltinColormap::Viridis,
+        0.0,
+        1.0,
+    ));
+    let mut layer_styles = HashMap::new();
+    layer_styles.insert(
+        "default".to_string(),
+        StyleInfo {
+            name: "default".to_string(),
+            title: "Default".to_string(),
+            colormap: cmap,
+            min: 0.0,
+            max: 1.0,
+            parameter: None,
+        },
+    );
+    styles_map.insert("radar".to_string(), layer_styles);
     let state = Arc::new(ArcSwap::from_pointee(TilesState {
         map_engines: engines,
         collections,
@@ -475,6 +559,20 @@ mod get_tile {
         let (status, _, _) =
             get_raw("/collections/radar/tiles/WebMercatorQuad/0/0/0?elevation=0.5").await;
         assert_eq!(status, StatusCode::BAD_REQUEST);
+    }
+
+    /// An engine `InvalidParameter` from `get_raster_tile` (e.g. a
+    /// multi-parameter PVOL collection tiled without a `<site>:<quantity>`
+    /// selection) is a 400, not a 500.
+    #[tokio::test]
+    async fn render_invalid_parameter_is_400() {
+        let app = build_router_with_engine(Arc::new(InvalidParamEngine));
+        let req = Request::builder()
+            .uri("/collections/radar/tiles/WebMercatorQuad/0/0/0")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Fixes an opaque **500 Internal Server Error** on Maps/Tiles requests that are actually client mistakes.

A `MapEngine::get_raster_tile` error was unconditionally wrapped in `Internal` → HTTP 500. So rendering a multi-parameter PVOL collection without a `<site>:<quantity>` parameter returned a generic "Internal server error", hiding the engine's helpful message.

**Reported request** (a parameterless PVOL maps render):
```
GET /maps/collections/radar-fi-volume-local-h5/map?bbox=...&crs=EPSG:3857&f=image/png
→ 500 {"code":"ServerError","description":"Internal server error"}
```
Now:
```
→ 400 {"code":"BadRequest","description":"Invalid parameter: [radar-fi-volume-local-h5] PVOL collection requires a `<site>:<quantity>` parameter (e.g. `fianj:DBZH`)"}
```
…and adding `&parameter-name=fivih:DBZH` renders the tile (200).

## Change

Both the Maps and Tiles render handlers now classify the engine error:
- `InvalidParameter` / `InvalidBbox` / `InvalidDatetime` → **400** with the message (user-facing by design, safe to surface)
- `CollectionNotFound` / `LocationNotFound` → **404**
- everything else → **500** (internal detail still dropped, per the no-leak rule)

## Test plan

- [x] `cargo test -p api-maps -p api-tiles` — new tests assert an engine `InvalidParameter` yields 400 (with the message reaching the client) on both `/map` and a tile request; maps 66, tiles 73 pass.
- [x] `cargo clippy -p api-maps -p api-tiles --all-targets -- -D warnings` clean.
- [x] Live: reproduced the reported 500 → now 400 with the actionable message; `&parameter-name=fivih:DBZH` renders the Web-Mercator radar tile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)