### PR TITLE
feat(engine-odim): per-site PVOL collections (model B); param = bare quantity

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,9 +165,17 @@ radar elevation angle. WMS exposes it as the `ELEVATION` dimension; Maps/Tiles a
 | GeoTIFF | `EdrEngine` + `MapEngine` | EDR (position, area), WMS, Maps, Tiles |
 | GRIB | `EdrEngine` + `MapEngine` | EDR, WMS, Maps, Tiles |
 | ODIM COMP | `EdrEngine` + `MapEngine` | EDR (position, area), WMS, Maps, Tiles |
-| ODIM PVOL | `EdrEngine` + `MapEngine` | EDR (position, locations, area), WMS, Maps, Tiles |
+| ODIM PVOL | `EdrEngine` + `MapEngine` | EDR (position, locations, area, trajectory), WMS, Maps, Tiles |
 | QueryData | `EdrEngine` + `MapEngine` | EDR (position only), WMS, Maps, Tiles |
 | PostGIS | `EdrEngine` + `FeatureEngine` | EDR (position, locations, area), Features |
+
+## ODIM PVOL Engine Notes (per-site collections — model B)
+
+- **One source → N collections.** A single `engine_type = "odim-volume"` config scans a directory / S3 prefix of `.h5` polar volumes spanning a whole radar *network*, then expands into **one OGC collection per radar site** (ODIM `nod`), with id `{base_id}-{nod}` (e.g. `radar-fi-volume-local-h5-fivih`). There is **no** network-level aggregate collection.
+- **The engine owns the source; views serve the API.** `PolarVolumeEngine` (in `engine-odim/src/volume_engine.rs`) does the scan, parse cache, and poll loop and is registered only on the background poll runtime. Each site is served by a cheap `PolarVolumeSiteView` over the engine's shared `Arc<ArcSwap<Catalog>>` — so all views see poll refreshes for free. The engine itself does **not** implement `EdrEngine`/`MapEngine`.
+- **Parameter = bare quantity.** A site collection's parameters are the bare ODIM quantities (`DBZH`, `VRADH`, `ZDR`, `RHOHV`, …) — **never** `<nod>:<quantity>`. The site is the collection (its single EDR location, its spatial/vertical extent), so it has no place in the parameter name. This also lets WMS styling key off the quantity: set per-quantity colormaps with `[[wms.parameters]]` (name = bare quantity) on the source config and every site inherits them.
+- **Auto-split happens in `server/src/admin.rs`** (`load_collections`, the `"odim-volume"` arm): build the engine once, enumerate `engine.site_ids()`, and register one view per site (cloning the base `CollectionConfig` with a per-site id/title). Site discovery is a scan snapshot — sites added later surface on the next `POST /admin/collections/reload`.
+- **Cross-sections.** `query_trajectory` returns a CoverageJSON `Section` (composite `[t,x,y]` axis + numeric `z` = height above antenna, via the 4/3-Earth beam model). `z` selects the elevation-angle band. Vertical axis is elevation angle (`VerticalKind::ElevationAngle`).
 
 ## GeoTIFF Engine Notes
 

--- a/collections.d/radar-fi-volume-local-h5.toml
+++ b/collections.d/radar-fi-volume-local-h5.toml
@@ -1,17 +1,25 @@
 # FMI weather-radar polar volumes (ODIM_H5 PVOL).
 #
 # Each radar site is a stack of elevation sweeps, each with multiple
-# dual-pol moments (TH, DBZH, VRADH, ZDR, RHOHV...). The odim-volume
-# engine renders the lowest sweep of a chosen site as a Cartesian
-# raster; the WMS layer tree is one group per radar site, with the
-# moments as quantity sub-layers (parameter = `<site>:<quantity>`).
+# dual-pol moments (TH, DBZH, VRADH, ZDR, RHOHV...). Under the
+# per-site collection model the odim-volume engine expands this one
+# source into **one OGC collection per radar site** (id =
+# `radar-fi-volume-local-h5-<nod>`, e.g. `…-fivih`). Within a site
+# collection the parameters are the **bare quantities** (`DBZH`,
+# `VRADH`, …) — the site is the collection (its EDR location, its
+# spatial/vertical extent), so it is not part of the parameter name.
+#
+# Because each quantity is now a bare parameter, WMS styling can be set
+# per quantity via `[[wms.parameters]]` below — reflectivity, velocity,
+# and the dual-pol moments each get a fitting colormap and range rather
+# than one reflectivity palette stretched over every moment.
 #
 # data_path points at a local test fixture directory; see
 # `radar-fi-volume-s3-h5` for the S3-streamed sibling.
 
 id = "radar-fi-volume-local-h5"
 title = "FMI — radar polar volumes (local, ODIM_H5)"
-description = "Finnish radar polar volumes (ODIM_H5 PVOL) from local sample files — every elevation sweep and dual-polarisation moment."
+description = "Finnish radar polar volumes (ODIM_H5 PVOL) from local sample files — every elevation sweep and dual-polarisation moment. One collection per radar site."
 engine_type = "odim-volume"
 apis = ["edr", "wms", "maps", "tiles"]
 data_path = "testdata/radar-fmi-pvol"
@@ -20,4 +28,68 @@ data_path = "testdata/radar-fmi-pvol"
 poll_interval_secs = 300
 
 [wms]
+# Collection-level fallback for any quantity without a per-parameter
+# override below (e.g. an unlisted moment renders on the dBZ palette).
 colormap = "radar_dbz"
+
+# Per-quantity colormaps. `name` is the bare ODIM quantity — matched
+# against the site collection's parameter list. Quantities the file
+# doesn't carry are simply ignored.
+
+# Horizontal reflectivity (uncorrected / corrected) — dBZ.
+[[wms.parameters]]
+name = "TH"
+colormap = "radar_dbz"
+[[wms.parameters]]
+name = "DBZH"
+colormap = "radar_dbz"
+
+# Doppler radial velocity — m/s, diverging blue→white→red about zero
+# (toward/away). FMI volumes are dealiased to a ±48 m/s Nyquist band.
+[[wms.parameters]]
+name = "VRADH"
+min = -48.0
+max = 48.0
+[[wms.parameters.color_stops]]
+value = -48.0
+color = "#1a1aff"
+[[wms.parameters.color_stops]]
+value = -24.0
+color = "#66ccff"
+[[wms.parameters.color_stops]]
+value = 0.0
+color = "#f5f5f5"
+[[wms.parameters.color_stops]]
+value = 24.0
+color = "#ff8c66"
+[[wms.parameters.color_stops]]
+value = 48.0
+color = "#cc0000"
+
+# Spectrum width — m/s.
+[[wms.parameters]]
+name = "WRADH"
+colormap = "viridis"
+min = 0.0
+max = 10.0
+
+# Differential reflectivity — dB.
+[[wms.parameters]]
+name = "ZDR"
+colormap = "viridis"
+min = -2.0
+max = 6.0
+
+# Co-polar correlation coefficient — unitless 0..1.
+[[wms.parameters]]
+name = "RHOHV"
+colormap = "viridis"
+min = 0.0
+max = 1.0
+
+# Specific differential phase — °/km.
+[[wms.parameters]]
+name = "KDP"
+colormap = "viridis"
+min = -1.0
+max = 6.0

--- a/collections.d/radar-fi-volume-s3-h5.toml
+++ b/collections.d/radar-fi-volume-s3-h5.toml
@@ -6,22 +6,26 @@
 # `s3://fmi-opendata-radar-volume-hdf5/YYYY/MM/DD/<site>/` with
 # filenames `YYYYMMDDHHMM_<site>_PVOL.h5`.
 #
-# The odim-volume engine renders the lowest elevation sweep of each
-# site as a Cartesian raster; the WMS layer tree is one group per radar
-# site with the dual-pol moments as quantity sub-layers (TH, DBZH,
-# VRADH, ZDR, RHOHV...). Parameter names are `<site>:<quantity>`, e.g.
-# `fivih:DBZH`. On the EDR API each radar site is a location (id = ODIM
-# NOD code) and each quantity is a parameter.
+# Under the per-site collection model this one source expands into
+# **one OGC collection per radar site** (id =
+# `radar-fi-volume-s3-h5-<nod>`, e.g. `…-fivih`), each rendering that
+# site's lowest elevation sweep as a Cartesian raster. Within a site
+# collection the WMS layers are the **bare quantities** (TH, DBZH,
+# VRADH, ZDR, RHOHV...) — no `<site>:` prefix. On the EDR API each site
+# collection has one location (id = ODIM NOD code) and the quantities
+# are its parameters.
 #
 # `prefix_pattern` covers the whole date partition (`%Y/%m/%d/`), so the
-# scan picks up every FMI radar site, not just one. `time_window`
+# scan picks up every FMI radar site, not just one — i.e. every site
+# becomes its own collection. The set of collections is discovered from
+# the scan; a new site appears after the next admin reload. `time_window`
 # bounds both the date-partitioned prefixes listed and the volume
 # timestamps kept — with ~12 sites at 5-min cadence a wide window pulls
 # a lot of multi-MB volumes, so it is deliberately short.
 
 id = "radar-fi-volume-s3-h5"
 title = "FMI — radar polar volumes (S3, ODIM_H5)"
-description = "Finnish radar polar volumes (ODIM_H5 PVOL) streamed from FMI's open-data S3 bucket — every FMI radar site, all elevation sweeps and dual-polarisation moments."
+description = "Finnish radar polar volumes (ODIM_H5 PVOL) streamed from FMI's open-data S3 bucket — every FMI radar site, all elevation sweeps and dual-polarisation moments. One collection per radar site."
 engine_type = "odim-volume"
 apis = ["edr", "wms", "maps", "tiles"]
 
@@ -33,4 +37,59 @@ time_window = "-PT1H"
 poll_interval_secs = 300
 
 [wms]
+# Collection-level fallback; per-quantity colormaps follow (the bare
+# quantity name now matches, so velocity / dual-pol moments each get a
+# fitting palette instead of the dBZ palette stretched over all of them).
 colormap = "radar_dbz"
+
+[[wms.parameters]]
+name = "TH"
+colormap = "radar_dbz"
+[[wms.parameters]]
+name = "DBZH"
+colormap = "radar_dbz"
+
+# Doppler radial velocity — m/s, diverging blue→white→red about zero.
+[[wms.parameters]]
+name = "VRADH"
+min = -48.0
+max = 48.0
+[[wms.parameters.color_stops]]
+value = -48.0
+color = "#1a1aff"
+[[wms.parameters.color_stops]]
+value = -24.0
+color = "#66ccff"
+[[wms.parameters.color_stops]]
+value = 0.0
+color = "#f5f5f5"
+[[wms.parameters.color_stops]]
+value = 24.0
+color = "#ff8c66"
+[[wms.parameters.color_stops]]
+value = 48.0
+color = "#cc0000"
+
+[[wms.parameters]]
+name = "WRADH"
+colormap = "viridis"
+min = 0.0
+max = 10.0
+
+[[wms.parameters]]
+name = "ZDR"
+colormap = "viridis"
+min = -2.0
+max = 6.0
+
+[[wms.parameters]]
+name = "RHOHV"
+colormap = "viridis"
+min = 0.0
+max = 1.0
+
+[[wms.parameters]]
+name = "KDP"
+colormap = "viridis"
+min = -1.0
+max = 6.0

--- a/crates/engine-odim/src/lib.rs
+++ b/crates/engine-odim/src/lib.rs
@@ -27,4 +27,4 @@ pub mod reader;
 pub mod volume_engine;
 
 pub use engine::{EngineError, OdimEngine};
-pub use volume_engine::PolarVolumeEngine;
+pub use volume_engine::{PolarVolumeEngine, PolarVolumeSiteView};

--- a/crates/engine-odim/src/volume_engine.rs
+++ b/crates/engine-odim/src/volume_engine.rs
@@ -353,6 +353,10 @@ struct SiteMeta {
     times: Vec<DateTime<Utc>>,
     /// This site's circular coverage bbox `[w, s, e, n]` (WGS84).
     spatial_extent: Option<[f64; 4]>,
+    /// This site's maximum ground-range coverage radius (metres) — the
+    /// lowest sweep's `nbins·rscale + rstart`. `None` for a malformed
+    /// `rscale`. Used to reject position queries clearly outside coverage.
+    coverage_radius_m: Option<f64>,
     /// This site's sweep elevation angles (degrees).
     vertical: Option<VerticalDimension>,
 }
@@ -823,8 +827,8 @@ fn derive_site_meta(list: &[VolumeEntry]) -> Option<SiteMeta> {
 
     // Coverage radius from the lowest sweep's range gate geometry.
     let radius_m = sweep0.nbins as f64 * sweep0.rscale + sweep0.rstart;
-    let spatial_extent = (radius_m.is_finite() && radius_m > 0.0)
-        .then(|| site_coverage_bbox(site.lon, site.lat, radius_m));
+    let coverage_radius_m = (radius_m.is_finite() && radius_m > 0.0).then_some(radius_m);
+    let spatial_extent = coverage_radius_m.map(|r| site_coverage_bbox(site.lon, site.lat, r));
 
     let mut times: Vec<DateTime<Utc>> = list.iter().map(|e| e.volume.time).collect();
     times.sort_unstable();
@@ -852,6 +856,7 @@ fn derive_site_meta(list: &[VolumeEntry]) -> Option<SiteMeta> {
         quantities,
         times,
         spatial_extent,
+        coverage_radius_m,
         vertical,
     })
 }
@@ -1364,24 +1369,27 @@ fn quantity_description(quantity: &str) -> ParameterDescription {
 }
 
 /// Resolve the quantity set for a PVOL site query: the union of every
-/// sweep's moments in the most recent selected volume — a profile
-/// samples all sweeps, and a quantity may be present only on higher
-/// elevations (e.g. dual-PRF `VRADH`/`WRADH`) — intersected with the
-/// optional `parameters` filter.
+/// sweep's moments across **all** selected volumes — a profile samples all
+/// sweeps, a quantity may be present only on higher elevations (e.g.
+/// dual-PRF `VRADH`/`WRADH`), and a quantity may drop out of the newest
+/// scan (firmware change / reduced strategy) while earlier volumes in the
+/// window still carry it — intersected with the optional `parameters`
+/// filter. `volume_profile`/`level_series` map a missing moment in any one
+/// timestep to `None`, so unioning here never fabricates data; it only
+/// keeps a quantity queryable for the timesteps that actually have it.
 fn resolve_quantities(
     selected: &[&VolumeEntry],
     parameters: Option<&[String]>,
 ) -> Result<Vec<String>, DataServerError> {
     let mut available: Vec<String> = selected
-        .last()
-        .map(|e| {
+        .iter()
+        .flat_map(|e| {
             e.volume
                 .sweeps
                 .iter()
                 .flat_map(|s| s.moments.iter().map(|m| m.quantity.clone()))
-                .collect()
         })
-        .unwrap_or_default();
+        .collect();
     available.sort();
     available.dedup();
     let quantities: Vec<String> = match parameters {
@@ -2280,6 +2288,16 @@ impl EdrEngine for PolarVolumeSiteView {
             return Err(DataServerError::LocationNotFound(location_id.to_string()));
         }
         let catalog = self.catalog.load();
+        // Gate on `by_site_meta`, exactly as `get_locations` does: a site
+        // whose latest volume has no usable moment data is dropped from
+        // `by_site_meta` (but not `by_site`), so without this guard
+        // `query_location` would fall through to `resolve_quantities` and
+        // return a 400 for a location that `get_locations` reports as
+        // absent. Both must agree on a clean 404.
+        let meta = catalog
+            .by_site_meta
+            .get(&self.nod)
+            .ok_or_else(|| DataServerError::LocationNotFound(self.nod.clone()))?;
         let volumes = catalog
             .by_site
             .get(&self.nod)
@@ -2289,11 +2307,7 @@ impl EdrEngine for PolarVolumeSiteView {
             .ok_or_else(|| DataServerError::LocationNotFound(self.nod.clone()))?
             .volume
             .site;
-        let canonical = catalog
-            .by_site_meta
-            .get(&self.nod)
-            .and_then(|m| m.vertical.as_ref())
-            .map(|v| v.levels.as_slice());
+        let canonical = meta.vertical.as_ref().map(|v| v.levels.as_slice());
         site_point_query(
             volumes, site.lon, site.lat, datetime, parameters, z, canonical,
         )
@@ -2362,17 +2376,33 @@ impl EdrEngine for PolarVolumeSiteView {
     ) -> Result<CoverageResponse, DataServerError> {
         let (lat, lon) = parse_point_coords(coords)?;
         let catalog = self.catalog.load();
+        let meta = catalog.by_site_meta.get(&self.nod).ok_or_else(|| {
+            DataServerError::LocationNotFound(format!(
+                "[{}] radar site `{}` has no current metadata",
+                self.collection_id, self.nod
+            ))
+        })?;
+        // Reject a point clearly outside the radar's coverage circle with a
+        // 404 rather than returning HTTP 200 all-null values — which is
+        // indistinguishable from "in range, clear sky". The per-site
+        // collection's advertised spatial extent *is* this coverage circle,
+        // so a point beyond it is outside the collection's domain. (A point
+        // inside coverage with no echo still correctly returns 200 nulls.)
+        if let Some(radius_m) = meta.coverage_radius_m {
+            let (dist, _) = ground_distance_bearing(meta.lon, meta.lat, lon, lat);
+            if dist > radius_m {
+                return Err(DataServerError::LocationNotFound(
+                    "requested point is outside this radar's coverage area".into(),
+                ));
+            }
+        }
         let volumes = catalog.by_site.get(&self.nod).ok_or_else(|| {
             DataServerError::LocationNotFound(format!(
                 "[{}] radar site `{}` has no current volumes",
                 self.collection_id, self.nod
             ))
         })?;
-        let canonical = catalog
-            .by_site_meta
-            .get(&self.nod)
-            .and_then(|m| m.vertical.as_ref())
-            .map(|v| v.levels.as_slice());
+        let canonical = meta.vertical.as_ref().map(|v| v.levels.as_slice());
         site_point_query(volumes, lon, lat, datetime, parameters, z, canonical)
     }
 
@@ -3770,5 +3800,74 @@ mod tests {
         )
         .expect("a higher-sweep-only quantity must render, not 400");
         assert_eq!(tile.values.len(), 16 * 4);
+    }
+
+    /// `resolve_quantities` unions moments across **all** selected volumes,
+    /// so a quantity that drops out of the newest scan is still queryable
+    /// for the earlier timesteps that carry it.
+    #[test]
+    fn resolve_quantities_unions_across_volumes() {
+        // Older volume carries DBZH + VRADH; newer carries DBZH only.
+        let mut older = synthetic_volume(25.0, 60.0);
+        let mut vradh = older.sweeps[0].moments[0].clone();
+        vradh.quantity = "VRADH".to_string();
+        older.sweeps[0].moments.push(vradh);
+        let newer = synthetic_volume(25.0, 60.0); // DBZH only
+
+        let owned = [entry(older, "a"), entry(newer, "b")];
+        let selected: Vec<&VolumeEntry> = owned.iter().collect();
+
+        // VRADH is absent from the newest volume but present in the union.
+        let q = resolve_quantities(&selected, Some(&["VRADH".to_string()]))
+            .expect("VRADH is available in the window's union");
+        assert_eq!(q, vec!["VRADH".to_string()]);
+    }
+
+    /// A position query for a point clearly outside the radar's coverage
+    /// circle is `LocationNotFound` (404), not HTTP 200 all-null.
+    #[test]
+    fn site_view_query_position_outside_coverage_is_404() {
+        // synthetic_volume: 100 bins × 1 km ⇒ ~100 km coverage radius.
+        let mut by_site: HashMap<String, Vec<VolumeEntry>> = HashMap::new();
+        by_site.insert(
+            "fivih".to_string(),
+            vec![entry(synthetic_volume(25.0, 60.0), "v")],
+        );
+        let view = site_view_for(by_site, "fivih");
+
+        // ~5° east at 60°N ≈ 280 km — well beyond the 100 km radius.
+        assert!(
+            matches!(
+                EdrEngine::query_position(&view, "POINT(30.0 60.0)", None, None, None),
+                Err(DataServerError::LocationNotFound(_))
+            ),
+            "a point outside the coverage radius must be 404"
+        );
+        // ~11 km north — inside coverage, resolves to a coverage.
+        assert!(
+            EdrEngine::query_position(&view, "POINT(25.0 60.1)", None, None, None).is_ok(),
+            "a point within coverage must succeed"
+        );
+    }
+
+    /// `query_location` agrees with `get_locations`: a site dropped from
+    /// `by_site_meta` (sweeps but no moments) is a 404, not a 400.
+    #[test]
+    fn site_view_query_location_moment_less_site_is_404() {
+        let mut momentless = synthetic_volume(25.0, 60.0);
+        momentless.sweeps[0].moments.clear();
+        let mut by_site: HashMap<String, Vec<VolumeEntry>> = HashMap::new();
+        by_site.insert("fivih".to_string(), vec![entry(momentless, "m")]);
+        let view = site_view_for(by_site, "fivih");
+
+        // The site is invisible to discovery...
+        assert!(EdrEngine::get_locations(&view)
+            .expect("locations")
+            .is_empty());
+        // ...and a direct query_location returns 404, not InvalidParameter.
+        assert!(matches!(
+            EdrEngine::query_location(&view, "fivih", None, None, None),
+            Err(DataServerError::LocationNotFound(_))
+        ));
     }
 }

--- a/crates/engine-odim/src/volume_engine.rs
+++ b/crates/engine-odim/src/volume_engine.rs
@@ -6,21 +6,23 @@
 //! coordinates — and resamples them into Cartesian raster tiles on the
 //! fly.
 //!
-//! ## Layer model
+//! ## Collection model (model B — per-site collections)
 //!
-//! A PVOL collection covers a radar **network**: a local directory of
-//! `.h5` polar-volume files spanning multiple sites and multiple
-//! acquisition times. Each radar **site** is a layer group; each radar
-//! **quantity** (`DBZH`, `TH`, `VRADH`, `ZDR`, …) is a sub-layer —
-//! exactly like a multi-parameter GRIB collection. The advertised
-//! parameter name is `<nod>:<quantity>` (e.g. `fianj:DBZH`).
+//! A PVOL **source** is a local directory of `.h5` polar-volume files (or
+//! an S3/HTTP prefix) spanning multiple radar **sites** and multiple
+//! acquisition times. [`PolarVolumeEngine`] owns one source: it scans,
+//! parses, caches, and polls — but it is *not* itself an OGC collection.
 //!
-//! The `:` separator is deliberate. WMS layer names are
-//! `collection-id/parameter` and the api-wms handler splits on the
-//! *first* `/`, so the parameter token must not itself contain `/`.
-//! `:` is safe in a WMS `LAYERS=` value and in a Maps/Tiles
-//! `?parameter-name=` query parameter, and reads naturally as a
-//! site-scoped quantity.
+//! Instead, the loader expands one source into **N per-site collections**
+//! (one per ODIM `nod`), each served by a cheap [`PolarVolumeSiteView`]
+//! over the engine's shared catalog. A site collection's parameters are
+//! **bare quantities** (`DBZH`, `TH`, `VRADH`, `ZDR`, …) — the site is the
+//! collection (its EDR location, its spatial/vertical extent), so it has
+//! no business in the parameter name. This matches EDR (where the
+//! parameter list is the quantity, never `<nod>:<quantity>`) and lets WMS
+//! styling key off the bare quantity. WMS layer names are
+//! `collection-id/parameter`; with a bare-quantity parameter the token
+//! never contains the api-wms-significant `/`.
 //!
 //! ## Interim scope (Milestone 2)
 //!
@@ -75,11 +77,6 @@ use crate::pvol::{read_polar_volume, PolarMoment, PolarVolume, Sweep};
 /// the recent tail still straddles yesterday's partition. Mirrors
 /// `OdimEngine`'s constant of the same name.
 const DEFAULT_SCAN_DAYS: u32 = 2;
-
-/// Separator between the ODIM node id and the radar quantity in an
-/// advertised parameter name (`fianj:DBZH`). See the module docs for
-/// why `:` and not `/`.
-pub const SITE_QUANTITY_SEP: char = ':';
 
 /// Mean Earth radius (metres) used by the geodesic helper. A sphere is
 /// the right model here: radar ground range is itself a spherical
@@ -331,29 +328,50 @@ struct VolumeEntry {
     volume: Arc<PolarVolume>,
 }
 
+/// Per-site derived metadata, computed once per scan in [`derive_catalog`].
+///
+/// A [`PolarVolumeSiteView`]'s capability accessors (`raster_info`,
+/// `get_parameters`, extents) read from this snapshot so they stay O(1)
+/// from an `ArcSwap` load (CLAUDE.md hot-path rule) instead of re-deriving
+/// from sweeps on every request. Mirrors the union fields on [`Catalog`]
+/// but scoped to one radar `nod`.
+#[derive(Clone)]
+struct SiteMeta {
+    /// Antenna longitude (WGS84).
+    lon: f64,
+    /// Antenna latitude (WGS84).
+    lat: f64,
+    /// Human place name (ODIM `/what` PLC), if present.
+    plc: Option<String>,
+    /// Map/WMS layer list — `(bare_quantity, title)` from this site's
+    /// lowest sweep. **No `<nod>:` prefix**: under model B the site *is*
+    /// the collection, so the parameter is the bare quantity.
+    parameters: Vec<(String, String)>,
+    /// Bare EDR quantities (lowest sweep), sorted distinct.
+    quantities: Vec<String>,
+    /// This site's distinct volume times, ascending.
+    times: Vec<DateTime<Utc>>,
+    /// This site's circular coverage bbox `[w, s, e, n]` (WGS84).
+    spatial_extent: Option<[f64; 4]>,
+    /// This site's sweep elevation angles (degrees).
+    vertical: Option<VerticalDimension>,
+}
+
 /// The engine's catalog: per-site time-sorted volume lists, plus the
-/// derived metadata `raster_info()` answers from.
+/// per-site derived metadata each [`PolarVolumeSiteView`] answers from.
+///
+/// Under model B there is no network-level collection — each radar site is
+/// its own collection — so the catalog carries only the per-site index and
+/// no union/aggregate metadata.
 struct Catalog {
     /// Volumes grouped by `site.nod`, each list sorted by `time`
     /// ascending.
     by_site: HashMap<String, Vec<VolumeEntry>>,
-    /// `(parameter_name, title)` pairs — one per `<nod>:<quantity>`
-    /// from each site's lowest sweep. Sorted for stable output. This is
-    /// the Map/WMS layer list (site-scoped).
-    parameters: Vec<(String, String)>,
-    /// Distinct ODIM quantity names across every site's lowest sweep,
-    /// sorted — the EDR parameter list. Unlike `parameters` these carry
-    /// no `<site>:` prefix: in EDR the site is the *location* and the
-    /// quantity is the *parameter*.
-    quantities: Vec<String>,
-    /// All distinct volume times across every site, sorted ascending.
-    times: Vec<DateTime<Utc>>,
-    /// Union of per-site coverage bboxes `[w, s, e, n]` in WGS84.
-    spatial_extent: Option<[f64; 4]>,
-    /// The collection's vertical axis — elevation angle (degrees), the
-    /// union of every site's sweep angles. `None` until the catalog has
-    /// at least one volume.
-    vertical: Option<VerticalDimension>,
+    /// Per-site derived metadata keyed by `nod` — the snapshot each
+    /// [`PolarVolumeSiteView`] answers capability queries from. Keys
+    /// match `by_site` (a site with no derivable metadata, e.g. every
+    /// sweep malformed, is simply absent here).
+    by_site_meta: HashMap<String, SiteMeta>,
 }
 
 /// Round an elevation angle to 0.1° so near-identical sweep angles from
@@ -684,9 +702,10 @@ fn build_catalog(
     by_site
 }
 
-/// Finalise the grouped volume map into a [`Catalog`]: sort and cap
-/// each site's list, evict stale parse-cache entries, and derive the
-/// parameter list, temporal extent, and spatial extent.
+/// Finalise the grouped volume map into a [`Catalog`]: sort and cap each
+/// site's list, evict stale parse-cache entries, and derive per-site
+/// metadata. Under model B there is no aggregate/union metadata — each
+/// radar site is its own collection, served by a [`PolarVolumeSiteView`].
 ///
 /// `max_files` caps each site to its most-recent N volumes — an archive
 /// directory (or a wide S3 `time_window`) must not load and cache every
@@ -719,84 +738,72 @@ fn derive_catalog(
         guard.retain(|k, _| kept.contains(k));
     }
 
-    // Derive parameters (Map layers) and quantities (EDR parameters)
-    // from each site's lowest sweep.
-    let mut parameters: Vec<(String, String)> = Vec::new();
-    let mut quantities: Vec<String> = Vec::new();
-    for (nod, list) in &by_site {
-        // Use the most recent volume's lowest sweep for the quantity
-        // list — quantity sets are stable across a site's volumes.
-        let Some(latest) = list.last() else { continue };
-        let Some(sweep0) = latest.volume.sweeps.first() else {
-            continue;
-        };
-        let plc = latest.volume.site.plc.as_deref();
-        for moment in &sweep0.moments {
-            let name = format!("{nod}{SITE_QUANTITY_SEP}{}", moment.quantity);
-            let title = match plc {
-                Some(place) => format!("{place} — {}", moment.quantity),
-                None => name.clone(),
-            };
-            parameters.push((name, title));
-            quantities.push(moment.quantity.clone());
-        }
+    // Per-site metadata snapshots (model B): one `SiteMeta` per site so
+    // each `PolarVolumeSiteView` answers capability queries scoped to its
+    // own radar without re-deriving from sweeps per request.
+    let by_site_meta: HashMap<String, SiteMeta> = by_site
+        .iter()
+        .filter_map(|(nod, list)| Some((nod.clone(), derive_site_meta(list)?)))
+        .collect();
+
+    Catalog {
+        by_site,
+        by_site_meta,
     }
-    parameters.sort_by(|a, b| a.0.cmp(&b.0));
-    // A producer shipping a sweep with a duplicate quantity name would
-    // otherwise advertise the same `<nod>:<quantity>` layer twice.
-    parameters.dedup_by(|a, b| a.0 == b.0);
-    // Quantities recur across sites — collapse to the distinct set.
+}
+
+/// Derive one site's [`SiteMeta`] from its time-sorted volume list.
+///
+/// Returns `None` only for a site whose most-recent volume has no usable
+/// lowest sweep (an entirely malformed file) — such a site is dropped
+/// from `by_site_meta` and its view reports empty metadata.
+fn derive_site_meta(list: &[VolumeEntry]) -> Option<SiteMeta> {
+    let latest = list.last()?;
+    let sweep0 = latest.volume.sweeps.first()?;
+    let site = &latest.volume.site;
+
+    // Map/WMS + EDR quantity set, from the lowest sweep — matching the
+    // global derivation, but bare (no `<nod>:` prefix). Title is just the
+    // quantity: the per-site collection already carries the place name.
+    let mut quantities: Vec<String> = sweep0.moments.iter().map(|m| m.quantity.clone()).collect();
     quantities.sort();
     quantities.dedup();
+    let parameters: Vec<(String, String)> =
+        quantities.iter().map(|q| (q.clone(), q.clone())).collect();
 
-    // Distinct, sorted volume times across all sites.
-    let mut times: Vec<DateTime<Utc>> = by_site
-        .values()
-        .flat_map(|l| l.iter().map(|e| e.volume.time))
-        .collect();
+    // Coverage radius from the lowest sweep's range gate geometry.
+    let radius_m = sweep0.nbins as f64 * sweep0.rscale + sweep0.rstart;
+    let spatial_extent = (radius_m.is_finite() && radius_m > 0.0)
+        .then(|| site_coverage_bbox(site.lon, site.lat, radius_m));
+
+    let mut times: Vec<DateTime<Utc>> = list.iter().map(|e| e.volume.time).collect();
     times.sort_unstable();
     times.dedup();
 
-    // Union of per-site coverage bboxes.
-    let mut spatial_extent: Option<[f64; 4]> = None;
-    for list in by_site.values() {
-        let Some(latest) = list.last() else { continue };
-        let Some(sweep0) = latest.volume.sweeps.first() else {
-            continue;
-        };
-        let site = &latest.volume.site;
-        let radius_m = sweep0.nbins as f64 * sweep0.rscale + sweep0.rstart;
-        let bb = site_coverage_bbox(site.lon, site.lat, radius_m);
-        spatial_extent = Some(match spatial_extent {
-            None => bb,
-            Some([w, s, e, n]) => [w.min(bb[0]), s.min(bb[1]), e.max(bb[2]), n.max(bb[3])],
-        });
-    }
-
-    // Vertical axis: the union of every site's sweep elevation angles
-    // (from each site's most-recent volume), rounded and sorted ascending.
-    let mut levels: Vec<f64> = by_site
-        .values()
-        .filter_map(|list| list.last())
-        .flat_map(|e| e.volume.sweeps.iter().map(|s| round_elevation(s.elangle)))
+    // Elevation-angle axis from the most-recent volume's sweeps, rounded
+    // and deduped — see the matching union derivation above.
+    let mut levels: Vec<f64> = latest
+        .volume
+        .sweeps
+        .iter()
+        .map(|s| round_elevation(s.elangle))
         .collect();
-    // Drop non-finite angles before the extent — see the matching filter in
-    // `volume_profile`. `round_elevation` normalises -0.0 → +0.0, so plain
-    // `dedup` after `sort_by(total_cmp)` collapses every duplicate.
     levels.retain(|v| v.is_finite());
     levels.sort_by(f64::total_cmp);
     levels.dedup();
     let vertical =
         (!levels.is_empty()).then(|| VerticalDimension::new(VerticalKind::ElevationAngle, levels));
 
-    Catalog {
-        by_site,
+    Some(SiteMeta {
+        lon: site.lon,
+        lat: site.lat,
+        plc: site.plc.clone(),
         parameters,
         quantities,
         times,
         spatial_extent,
         vertical,
-    }
+    })
 }
 
 // ---------------------------------------------------------------------------
@@ -876,10 +883,9 @@ impl PolarVolumeEngine {
             );
         } else {
             tracing::info!(
-                "[{collection_id}] PVOL catalog: {} site(s), {} parameter(s), {} time(s)",
+                "[{collection_id}] PVOL catalog: {} site(s), {} volume(s)",
                 catalog.by_site.len(),
-                catalog.parameters.len(),
-                catalog.times.len()
+                catalog.by_site.values().map(|l| l.len()).sum::<usize>(),
             );
         }
 
@@ -979,17 +985,27 @@ impl PolarVolumeEngine {
         match scan_result {
             Ok(Ok(catalog)) => {
                 let prev = self.catalog.load();
+                // Aggregate signals across sites for change detection: site
+                // count, newest volume time, and total volume count.
+                let latest = |c: &Catalog| {
+                    c.by_site_meta
+                        .values()
+                        .filter_map(|m| m.times.last().copied())
+                        .max()
+                };
+                let total_volumes =
+                    |c: &Catalog| c.by_site.values().map(|l| l.len()).sum::<usize>();
                 let changed = prev.by_site.len() != catalog.by_site.len()
-                    || prev.times.last() != catalog.times.last()
-                    || prev.parameters.len() != catalog.parameters.len();
+                    || latest(&prev) != latest(&catalog)
+                    || total_volumes(&prev) != total_volumes(&catalog);
                 if changed {
                     tracing::info!(
-                        "[{}] PVOL catalog refreshed: {} → {} site(s), {} → {} time(s)",
+                        "[{}] PVOL catalog refreshed: {} → {} site(s), {} → {} volume(s)",
                         self.collection_id,
                         prev.by_site.len(),
                         catalog.by_site.len(),
-                        prev.times.len(),
-                        catalog.times.len(),
+                        total_volumes(&prev),
+                        total_volumes(&catalog),
                     );
                 }
                 self.catalog.store(Arc::new(catalog));
@@ -1272,99 +1288,8 @@ fn polar_sample(
     })
 }
 
-/// Split an advertised `<nod>:<quantity>` parameter name into its
-/// `(site, quantity)` parts. Returns `None` when the separator is
-/// absent or either side is empty.
-fn parse_parameter(parameter: &str) -> Option<(&str, &str)> {
-    let (site, quantity) = parameter.split_once(SITE_QUANTITY_SEP)?;
-    if site.is_empty() || quantity.is_empty() {
-        return None;
-    }
-    Some((site, quantity))
-}
-
-impl MapEngine for PolarVolumeEngine {
-    fn get_raster_tile(
-        &self,
-        bbox: [f64; 4],
-        width: u32,
-        height: u32,
-        time: Option<DateTime<Utc>>,
-        output_crs: &OutputCrs,
-        parameter: Option<&str>,
-        z: Option<f64>,
-    ) -> Result<RasterTile, DataServerError> {
-        // A PVOL collection is inherently multi-parameter — the caller
-        // must name a `<nod>:<quantity>` layer.
-        let parameter = parameter.ok_or_else(|| {
-            DataServerError::InvalidParameter(format!(
-                "[{}] PVOL collection requires a `<site>{SITE_QUANTITY_SEP}<quantity>` \
-                 parameter (e.g. `fianj{SITE_QUANTITY_SEP}DBZH`)",
-                self.collection_id
-            ))
-        })?;
-        let (site, quantity) = parse_parameter(parameter).ok_or_else(|| {
-            DataServerError::InvalidParameter(format!(
-                "[{}] unparseable PVOL parameter `{parameter}` — expected \
-                 `<site>{SITE_QUANTITY_SEP}<quantity>`",
-                self.collection_id
-            ))
-        })?;
-
-        let catalog = self.catalog.load();
-        let site_volumes = catalog.by_site.get(site).ok_or_else(|| {
-            DataServerError::InvalidParameter(format!(
-                "[{}] unknown PVOL site `{site}`",
-                self.collection_id
-            ))
-        })?;
-
-        // Select the volume nearest `time` (latest if `None`) — mirrors
-        // `OdimEngine::select_entry`.
-        let entry = match time {
-            Some(target) => site_volumes
-                .iter()
-                .min_by_key(|e| (e.volume.time - target).num_seconds().abs()),
-            None => site_volumes.last(),
-        }
-        .ok_or_else(|| {
-            DataServerError::Engine(format!(
-                "[{}] PVOL site `{site}` has no volumes",
-                self.collection_id
-            ))
-        })?;
-
-        polar_sample(&entry.volume, quantity, bbox, width, height, output_crs, z)
-    }
-
-    fn raster_info(&self) -> RasterInfo {
-        let catalog = self.catalog.load();
-        let parameters = catalog.parameters.clone();
-        let parameter = parameters
-            .first()
-            .map(|(name, _)| name.clone())
-            .unwrap_or_default();
-
-        RasterInfo {
-            native_crs: "CRS:84".to_string(),
-            spatial_extent: catalog.spatial_extent,
-            times: catalog.times.clone(),
-            parameter,
-            // PVOL quantities span multiple physical units (dBZ, m/s,
-            // dB, …); the per-layer unit is not a single collection
-            // constant, so leave it blank.
-            unit: String::new(),
-            parameters,
-            vertical: catalog.vertical.clone(),
-            // Polar volume — no regular CRS84 cell grid, so the spatial grid
-            // resolution is not meaningful here.
-            grid_size: None,
-        }
-    }
-}
-
 // ---------------------------------------------------------------------------
-// EdrEngine
+// Per-site EDR/Map helpers (shared by PolarVolumeSiteView)
 // ---------------------------------------------------------------------------
 
 /// `ParameterDescription` for an ODIM quantity. ODIM moment groups
@@ -1377,21 +1302,6 @@ fn quantity_description(quantity: &str) -> ParameterDescription {
         unit: String::new(),
         observed_property: quantity.to_string(),
     }
-}
-
-/// NOD code of the radar site nearest to `(lon, lat)` by ground
-/// distance. `None` only when the catalog holds no sites.
-fn nearest_site(catalog: &Catalog, lon: f64, lat: f64) -> Option<&str> {
-    catalog
-        .by_site
-        .iter()
-        .filter_map(|(nod, list)| {
-            let site = &list.last()?.volume.site;
-            let (dist, _) = ground_distance_bearing(site.lon, site.lat, lon, lat);
-            Some((nod.as_str(), dist))
-        })
-        .min_by(|a, b| a.1.total_cmp(&b.1))
-        .map(|(nod, _)| nod)
 }
 
 /// Resolve the quantity set for a PVOL site query: the union of every
@@ -1957,26 +1867,128 @@ fn site_coverages(
     }
 }
 
-/// Resolve a requested EDR `z` selector against the catalog's vertical
-/// axis. `None` (or an empty selector) means "every level — a profile".
+/// Resolve a requested EDR `z` selector against a `canonical` set of
+/// advertised sweep angles. `None` (or an empty selector) means "every
+/// level — a profile". `canonical` is the collection's (or site's)
+/// advertised vertical axis; `None` there means the collection exposes no
+/// sweeps to select with `z` (a 400).
 fn resolve_levels(
-    catalog: &Catalog,
+    canonical: Option<&[f64]>,
     z: Option<&[f64]>,
 ) -> Result<Option<Vec<f64>>, DataServerError> {
     let Some(zs) = z.filter(|s| !s.is_empty()) else {
         return Ok(None);
     };
-    let canonical = catalog
-        .vertical
-        .as_ref()
-        .map(|v| v.levels.as_slice())
-        .ok_or_else(|| {
-            DataServerError::InvalidParameter(
-                "this PVOL collection has no elevation sweeps to select with `z`".into(),
-            )
-        })?;
+    let canonical = canonical.ok_or_else(|| {
+        DataServerError::InvalidParameter(
+            "this PVOL collection has no elevation sweeps to select with `z`".into(),
+        )
+    })?;
     let snapped = snap_levels(zs, canonical);
     Ok((!snapped.is_empty()).then_some(snapped))
+}
+
+/// Run a point-style EDR query (position / single-site location) against
+/// one site's `volumes`, sampling at WGS84 `(lon, lat)`: resolve the `z`
+/// selector against the site's `canonical` sweep angles, build the
+/// coverages, and wrap them per [`finalize_single_site`]. Shared by the
+/// network engine (after it picks a site) and each per-site view.
+fn site_point_query(
+    volumes: &[VolumeEntry],
+    lon: f64,
+    lat: f64,
+    datetime: Option<(DateTime<Utc>, DateTime<Utc>)>,
+    parameters: Option<&[String]>,
+    z: Option<&[f64]>,
+    canonical: Option<&[f64]>,
+) -> Result<CoverageResponse, DataServerError> {
+    let levels = resolve_levels(canonical, z)?;
+    let covs = site_coverages(volumes, lon, lat, datetime, parameters, levels.as_deref())?;
+    finalize_single_site(covs, &levels)
+}
+
+/// Parse + resample a WKT `LINESTRING` into the evenly-spaced node path a
+/// cross-section samples, rejecting a degenerate (< 2-node) path. Shared
+/// by the network engine's and the per-site view's `query_trajectory`.
+fn resample_section_path(coords: &str) -> Result<Vec<(f64, f64)>, DataServerError> {
+    let vertices = parse_linestring_coords(coords)?;
+    let path = resample_path(&vertices);
+    if path.len() < 2 {
+        return Err(DataServerError::InvalidParameter(
+            "LINESTRING must trace a non-degenerate path".into(),
+        ));
+    }
+    Ok(path)
+}
+
+/// Build the trajectory cross-section coverage(s) for one site's
+/// `volumes` along an already-resampled `path`. Time-filters the volumes,
+/// resolves quantities + the `z` angle window, sizes the height axis from
+/// the path's farthest reach, and emits one `Section` per timestep
+/// (`Single` for one step, `Collection` otherwise). Shared by the network
+/// engine (after it picks the nearest site) and each per-site view.
+fn site_trajectory(
+    volumes: &[VolumeEntry],
+    path: &[(f64, f64)],
+    datetime: Option<(DateTime<Utc>, DateTime<Utc>)>,
+    parameters: Option<&[String]>,
+    z: Option<&[f64]>,
+) -> Result<CoverageResponse, DataServerError> {
+    let selected: Vec<&VolumeEntry> = match datetime {
+        Some((start, end)) => volumes
+            .iter()
+            .filter(|e| e.volume.time >= start && e.volume.time <= end)
+            .collect(),
+        None => volumes.iter().collect(),
+    };
+    if selected.is_empty() {
+        return Err(DataServerError::LocationNotFound(
+            "No PVOL data available for the requested time range".into(),
+        ));
+    }
+
+    let quantities = resolve_quantities(&selected, parameters)?;
+
+    // `z` carries the requested elevation angles (resolved by the API
+    // layer against the advertised extent). Derive the angle window and
+    // the matching height axis from the most recent volume. An
+    // out-of-range `z` list surfaces as `InvalidParameter` (400) rather
+    // than a silently empty Section.
+    let ref_volume = &selected.last().unwrap().volume;
+    let window = angle_window(z, ref_volume)?;
+    // The path's farthest ground distance from the radar sizes the
+    // height-axis ceiling for the selected top angle.
+    let max_ground_dist = path
+        .iter()
+        .map(|&(lon, lat)| {
+            ground_distance_bearing(ref_volume.site.lon, ref_volume.site.lat, lon, lat).0
+        })
+        .fold(0.0_f64, f64::max);
+    let heights = height_axis(window.1, max_ground_dist);
+    if heights.is_empty() {
+        return Err(DataServerError::InvalidParameter(
+            "trajectory `z` resolved to an empty axis".into(),
+        ));
+    }
+
+    let coverages: Vec<QueryResult> = selected
+        .iter()
+        .filter_map(|e| volume_section(e, path, &heights, &quantities, window))
+        .collect();
+    if coverages.is_empty() {
+        return Err(DataServerError::LocationNotFound(
+            "No PVOL volumes produced a section for the requested path".into(),
+        ));
+    }
+    if coverages.len() == 1 {
+        // Single timestep — emit one Coverage rather than a one-item
+        // collection, matching the `query_location` precedent.
+        Ok(CoverageResponse::Single(
+            coverages.into_iter().next().unwrap(),
+        ))
+    } else {
+        Ok(CoverageResponse::Collection(coverages))
+    }
 }
 
 /// Wrap one site's coverages: a request pinned to exactly one level is a
@@ -2003,31 +2015,161 @@ fn finalize_single_site(
     Ok(CoverageResponse::Collection(covs))
 }
 
-impl EdrEngine for PolarVolumeEngine {
-    /// One EDR location per radar site — `id` is the ODIM NOD code and
-    /// the point geometry is the antenna position.
-    fn get_locations(&self) -> Result<Vec<Location>, DataServerError> {
-        let catalog = self.catalog.load();
-        let mut locations: Vec<Location> = catalog
-            .by_site
-            .iter()
-            .filter_map(|(nod, list)| {
-                let site = &list.last()?.volume.site;
-                Some(Location {
-                    id: nod.clone(),
-                    label: site.plc.clone().unwrap_or_else(|| nod.clone()),
-                    latitude: site.lat,
-                    longitude: site.lon,
-                })
-            })
-            .collect();
-        locations.sort_by(|a, b| a.id.cmp(&b.id));
-        Ok(locations)
+// ---------------------------------------------------------------------------
+// Per-site collections (model B)
+// ---------------------------------------------------------------------------
+
+impl PolarVolumeEngine {
+    /// NOD codes of every radar site currently in the catalog, sorted.
+    ///
+    /// The loader calls this after construction (one synchronous scan has
+    /// already run) to expand this one source config into N per-site OGC
+    /// collections — one [`site_view`](Self::site_view) each. The set is a
+    /// snapshot: sites appearing or disappearing between polls are only
+    /// reflected on the next admin reload, which re-runs the expansion.
+    pub fn site_ids(&self) -> Vec<String> {
+        let mut ids: Vec<String> = self.catalog.load().by_site.keys().cloned().collect();
+        ids.sort();
+        ids
     }
 
-    /// Query one radar site by NOD code. With no `z` the result is a
-    /// `CoverageCollection` of `VerticalProfile`s (one per timestep);
-    /// with `z` it is a `PointSeries` per selected elevation sweep.
+    /// Human place name (ODIM `/what` PLC) for site `nod`, if the catalog
+    /// holds one — used to title the per-site collection. `None` when the
+    /// site is unknown or carries no place name.
+    pub fn site_label(&self, nod: &str) -> Option<String> {
+        self.catalog.load().by_site_meta.get(nod)?.plc.clone()
+    }
+
+    /// Build a [`PolarVolumeSiteView`] scoped to radar `nod`, sharing this
+    /// engine's live catalog (`ArcSwap`) so the view tracks poll-loop
+    /// updates without re-parsing. `collection_id` is the per-site OGC
+    /// collection id (`{base}-{nod}`) used in the view's error messages.
+    pub fn site_view(&self, nod: &str, collection_id: &str) -> PolarVolumeSiteView {
+        PolarVolumeSiteView {
+            catalog: self.catalog.clone(),
+            nod: nod.to_string(),
+            collection_id: collection_id.to_string(),
+        }
+    }
+}
+
+/// A single radar site exposed as its own OGC collection (model B).
+///
+/// Where [`PolarVolumeEngine`] owns the source scan, parse cache, and poll
+/// loop for a whole radar *network*, a `PolarVolumeSiteView` is a thin,
+/// cheap handle scoped to one site `nod`: its `MapEngine`/`EdrEngine`
+/// surface advertises **bare quantity** parameters (`DBZH`, `VRADH`, …),
+/// a single location (the antenna), and the one site's spatial/vertical/
+/// temporal extents. Many views share one engine's `Arc<ArcSwap<Catalog>>`,
+/// so they all see poll-loop refreshes for free.
+///
+/// The site is not a sub-resource of a network collection: under model B
+/// there is no network-level collection at all — each radar is registered
+/// independently. The parse cache, poll loop, and shutdown all live on the
+/// owning engine.
+pub struct PolarVolumeSiteView {
+    /// Live catalog shared with the owning [`PolarVolumeEngine`].
+    catalog: Arc<ArcSwap<Catalog>>,
+    /// ODIM NOD code this view is scoped to.
+    nod: String,
+    /// Per-site OGC collection id (`{base}-{nod}`), for error messages.
+    collection_id: String,
+}
+
+impl MapEngine for PolarVolumeSiteView {
+    fn get_raster_tile(
+        &self,
+        bbox: [f64; 4],
+        width: u32,
+        height: u32,
+        time: Option<DateTime<Utc>>,
+        output_crs: &OutputCrs,
+        parameter: Option<&str>,
+        z: Option<f64>,
+    ) -> Result<RasterTile, DataServerError> {
+        // A per-site PVOL collection is still multi-parameter — one layer
+        // per radar quantity — but the layer name is now the bare quantity
+        // (no `<site>:` prefix): the site *is* the collection.
+        let quantity = parameter.ok_or_else(|| {
+            DataServerError::InvalidParameter(format!(
+                "[{}] PVOL collection requires a quantity parameter (e.g. `DBZH`)",
+                self.collection_id
+            ))
+        })?;
+
+        let catalog = self.catalog.load();
+        let site_volumes = catalog.by_site.get(&self.nod).ok_or_else(|| {
+            // The site aged out of the catalog since this view was
+            // registered (source change / `max_files`). A reload would
+            // drop the collection; until then report no data, not a 500.
+            DataServerError::LocationNotFound(format!(
+                "[{}] radar site `{}` has no current volumes",
+                self.collection_id, self.nod
+            ))
+        })?;
+
+        // Select the volume nearest `time` (latest if `None`).
+        let entry = match time {
+            Some(target) => site_volumes
+                .iter()
+                .min_by_key(|e| (e.volume.time - target).num_seconds().abs()),
+            None => site_volumes.last(),
+        }
+        .ok_or_else(|| {
+            DataServerError::LocationNotFound(format!(
+                "[{}] radar site `{}` has no volumes",
+                self.collection_id, self.nod
+            ))
+        })?;
+
+        polar_sample(&entry.volume, quantity, bbox, width, height, output_crs, z)
+    }
+
+    fn raster_info(&self) -> RasterInfo {
+        let catalog = self.catalog.load();
+        let meta = catalog.by_site_meta.get(&self.nod);
+        let parameters = meta.map(|m| m.parameters.clone()).unwrap_or_default();
+        let parameter = parameters
+            .first()
+            .map(|(name, _)| name.clone())
+            .unwrap_or_default();
+
+        RasterInfo {
+            native_crs: "CRS:84".to_string(),
+            spatial_extent: meta.and_then(|m| m.spatial_extent),
+            times: meta.map(|m| m.times.clone()).unwrap_or_default(),
+            parameter,
+            // PVOL quantities span multiple physical units; the per-layer
+            // unit is not a single collection constant — leave it blank.
+            unit: String::new(),
+            parameters,
+            vertical: meta.and_then(|m| m.vertical.clone()),
+            grid_size: None,
+        }
+    }
+}
+
+impl EdrEngine for PolarVolumeSiteView {
+    /// Exactly one EDR location — this radar site — `id` is the NOD code
+    /// and the point geometry is the antenna position.
+    fn get_locations(&self) -> Result<Vec<Location>, DataServerError> {
+        let catalog = self.catalog.load();
+        Ok(catalog
+            .by_site_meta
+            .get(&self.nod)
+            .map(|m| {
+                vec![Location {
+                    id: self.nod.clone(),
+                    label: m.plc.clone().unwrap_or_else(|| self.nod.clone()),
+                    latitude: m.lat,
+                    longitude: m.lon,
+                }]
+            })
+            .unwrap_or_default())
+    }
+
+    /// Query this radar site by NOD code. The only valid `location_id` is
+    /// the view's own `nod`; any other is `LocationNotFound`.
     fn query_location(
         &self,
         location_id: &str,
@@ -2035,53 +2177,70 @@ impl EdrEngine for PolarVolumeEngine {
         parameters: Option<&[String]>,
         z: Option<&[f64]>,
     ) -> Result<CoverageResponse, DataServerError> {
+        if location_id != self.nod {
+            return Err(DataServerError::LocationNotFound(location_id.to_string()));
+        }
         let catalog = self.catalog.load();
         let volumes = catalog
             .by_site
-            .get(location_id)
-            .ok_or_else(|| DataServerError::LocationNotFound(location_id.to_string()))?;
-        // The location *is* the radar site, so the coverage point is
-        // the antenna itself.
+            .get(&self.nod)
+            .ok_or_else(|| DataServerError::LocationNotFound(self.nod.clone()))?;
         let site = &volumes
             .last()
-            .ok_or_else(|| DataServerError::LocationNotFound(location_id.to_string()))?
+            .ok_or_else(|| DataServerError::LocationNotFound(self.nod.clone()))?
             .volume
             .site;
-        let levels = resolve_levels(&catalog, z)?;
-        let covs = site_coverages(
-            volumes,
-            site.lon,
-            site.lat,
-            datetime,
-            parameters,
-            levels.as_deref(),
-        )?;
-        finalize_single_site(covs, &levels)
+        let canonical = catalog
+            .by_site_meta
+            .get(&self.nod)
+            .and_then(|m| m.vertical.as_ref())
+            .map(|v| v.levels.as_slice());
+        site_point_query(
+            volumes, site.lon, site.lat, datetime, parameters, z, canonical,
+        )
     }
 
     fn get_parameters(&self) -> Vec<String> {
-        self.catalog.load().quantities.clone()
+        self.catalog
+            .load()
+            .by_site_meta
+            .get(&self.nod)
+            .map(|m| m.quantities.clone())
+            .unwrap_or_default()
     }
 
     fn get_vertical_extent(&self) -> Option<VerticalDimension> {
-        self.catalog.load().vertical.clone()
+        self.catalog
+            .load()
+            .by_site_meta
+            .get(&self.nod)
+            .and_then(|m| m.vertical.clone())
     }
 
     fn get_temporal_extent(&self) -> Option<(DateTime<Utc>, DateTime<Utc>)> {
         let catalog = self.catalog.load();
-        Some((*catalog.times.first()?, *catalog.times.last()?))
+        let m = catalog.by_site_meta.get(&self.nod)?;
+        Some((*m.times.first()?, *m.times.last()?))
     }
 
-    /// PVOL volumes arrive at discrete (typically 5-min) steps, so
-    /// advertise the exact timestamps rather than just the interval —
-    /// same rationale as the COMP engine.
+    /// Advertise the exact volume timestamps — same rationale as the
+    /// network engine and the COMP engine.
     fn get_available_times(&self) -> Option<Vec<DateTime<Utc>>> {
-        let times = self.catalog.load().times.clone();
+        let catalog = self.catalog.load();
+        let times = catalog
+            .by_site_meta
+            .get(&self.nod)
+            .map(|m| m.times.clone())
+            .unwrap_or_default();
         (!times.is_empty()).then_some(times)
     }
 
     fn get_spatial_extent(&self) -> Option<[f64; 4]> {
-        self.catalog.load().spatial_extent
+        self.catalog
+            .load()
+            .by_site_meta
+            .get(&self.nod)
+            .and_then(|m| m.spatial_extent)
     }
 
     fn supported_query_types(&self) -> Vec<String> {
@@ -2093,8 +2252,8 @@ impl EdrEngine for PolarVolumeEngine {
         ]
     }
 
-    /// Position query against the radar site nearest the requested
-    /// point — same `z`-driven shape as [`query_location`].
+    /// Position query — same `z`-driven shape as [`query_location`](Self::query_location),
+    /// but always against this one site (no nearest-radar pick).
     fn query_position(
         &self,
         coords: &str,
@@ -2104,23 +2263,24 @@ impl EdrEngine for PolarVolumeEngine {
     ) -> Result<CoverageResponse, DataServerError> {
         let (lat, lon) = parse_point_coords(coords)?;
         let catalog = self.catalog.load();
-        let nod = nearest_site(&catalog, lon, lat).ok_or_else(|| {
-            DataServerError::LocationNotFound("PVOL catalog has no radar sites".into())
+        let volumes = catalog.by_site.get(&self.nod).ok_or_else(|| {
+            DataServerError::LocationNotFound(format!(
+                "[{}] radar site `{}` has no current volumes",
+                self.collection_id, self.nod
+            ))
         })?;
-        // `nearest_site` returns a key it read from `by_site`, so the
-        // lookup cannot miss — but a graceful error beats a panicking
-        // request thread should a refactor ever break that invariant.
-        let volumes = catalog.by_site.get(nod).ok_or_else(|| {
-            DataServerError::Engine("internal: nearest_site returned a missing by_site key".into())
-        })?;
-        let levels = resolve_levels(&catalog, z)?;
-        let covs = site_coverages(volumes, lon, lat, datetime, parameters, levels.as_deref())?;
-        finalize_single_site(covs, &levels)
+        let canonical = catalog
+            .by_site_meta
+            .get(&self.nod)
+            .and_then(|m| m.vertical.as_ref())
+            .map(|v| v.levels.as_slice());
+        site_point_query(volumes, lon, lat, datetime, parameters, z, canonical)
     }
 
-    /// Area query — a `CoverageCollection` flattening every in-polygon
-    /// radar site's coverages (a `VerticalProfile` per timestep with no
-    /// `z`, a `PointSeries` per level with `z`).
+    /// Area query — a `CoverageCollection` of this site's coverages, but
+    /// only when the antenna falls inside the requested polygon (a per-site
+    /// collection holds exactly one radar). Sampled at the antenna itself,
+    /// matching the network engine's in-polygon-site semantics.
     fn query_area(
         &self,
         coords: &str,
@@ -2130,70 +2290,39 @@ impl EdrEngine for PolarVolumeEngine {
     ) -> Result<CoverageResponse, DataServerError> {
         let polygon = parse_area_coords(coords)?;
         let catalog = self.catalog.load();
-        let levels = resolve_levels(&catalog, z)?;
-
-        // Stable, sorted iteration so the collection order is
-        // deterministic across requests.
-        let mut nods: Vec<&String> = catalog.by_site.keys().collect();
-        nods.sort();
-
-        let mut coverages = Vec::new();
-        for nod in nods {
-            let volumes = &catalog.by_site[nod];
-            let Some(site) = volumes.last().map(|e| &e.volume.site) else {
-                continue;
-            };
-            if !polygon.contains(site.lon, site.lat) {
-                continue;
-            }
-            match site_coverages(
-                volumes,
-                site.lon,
-                site.lat,
-                datetime,
-                parameters,
-                levels.as_deref(),
-            ) {
-                Ok(covs) => coverages.extend(covs),
-                // A site inside the polygon is skipped — not fatal to
-                // the whole area query — when it has no data in the
-                // requested window (`LocationNotFound`) or none of the
-                // requested quantities (`InvalidParameter`): a
-                // heterogeneous network mixes single- and dual-pol
-                // radars, so a `ZDR` filter legitimately misses some
-                // sites while matching others.
-                Err(
-                    DataServerError::LocationNotFound(_) | DataServerError::InvalidParameter(_),
-                ) => continue,
-                Err(e) => return Err(e),
-            }
-        }
-
-        if coverages.is_empty() {
+        let meta = catalog.by_site_meta.get(&self.nod).ok_or_else(|| {
+            DataServerError::LocationNotFound(format!(
+                "[{}] radar site `{}` has no current volumes",
+                self.collection_id, self.nod
+            ))
+        })?;
+        if !polygon.contains(meta.lon, meta.lat) {
             return Err(DataServerError::LocationNotFound(
-                "No radar sites with data found within the requested area".into(),
+                "the radar site is not within the requested area".into(),
             ));
         }
-        Ok(CoverageResponse::Collection(coverages))
+        let volumes = catalog.by_site.get(&self.nod).ok_or_else(|| {
+            DataServerError::LocationNotFound(format!(
+                "[{}] radar site `{}` has no current volumes",
+                self.collection_id, self.nod
+            ))
+        })?;
+        let canonical = meta.vertical.as_ref().map(|v| v.levels.as_slice());
+        let levels = resolve_levels(canonical, z)?;
+        let covs = site_coverages(
+            volumes,
+            meta.lon,
+            meta.lat,
+            datetime,
+            parameters,
+            levels.as_deref(),
+        )?;
+        Ok(CoverageResponse::Collection(covs))
     }
 
-    /// Trajectory query — a vertical cross-section along a WKT
-    /// `LINESTRING`. Returns a `Section` coverage per timestep: the
-    /// composite axis carries one `(t, lon, lat)` triple per along-path
-    /// node; the `z` axis is **height above the antenna in metres**
-    /// (derived via the 4/3-Earth beam geometry).
-    ///
-    /// `z` *selects elevation angles* — it matches the collection's
-    /// advertised vertical extent (sweep angles in degrees), resolved by
-    /// the API layer so an interval `z=0.3/15` arrives as the angles in
-    /// range. The selected `[min, max]` angle window bounds which sweeps
-    /// contribute and sizes the derived height axis; cells whose beam
-    /// angle falls outside the window are nodata. `None` uses every sweep.
-    ///
-    /// **Single radar per cross-section**: the site nearest the path
-    /// centroid is picked, and the whole Section is sampled against
-    /// that one volume. Path nodes outside that radar's coverage simply
-    /// receive nodata. Multi-radar stitching is a deliberate follow-up.
+    /// Trajectory cross-section along a WKT `LINESTRING`, always against
+    /// this one site (no nearest-radar pick). Same `Section` output shape
+    /// as the network engine's [`query_trajectory`](PolarVolumeEngine).
     fn query_trajectory(
         &self,
         coords: &str,
@@ -2201,89 +2330,15 @@ impl EdrEngine for PolarVolumeEngine {
         parameters: Option<&[String]>,
         z: Option<&[f64]>,
     ) -> Result<CoverageResponse, DataServerError> {
-        let vertices = parse_linestring_coords(coords)?;
-        let path = resample_path(&vertices);
-        if path.len() < 2 {
-            return Err(DataServerError::InvalidParameter(
-                "LINESTRING must trace a non-degenerate path".into(),
-            ));
-        }
-
+        let path = resample_section_path(coords)?;
         let catalog = self.catalog.load();
-        // Pick the radar nearest the path's *middle node* (not an
-        // arithmetic-mean centroid) to choose which site owns the line.
-        // A real on-path point is antimeridian-safe — averaging the
-        // longitudes of e.g. 178° and −178° gives 0°, which would pick a
-        // European radar for a Pacific path. The midpoint node is a true
-        // resampled `(lon, lat)` on the great-circle path. (v1: single
-        // radar per cross-section, no multi-radar stitching.)
-        let (cx, cy) = path[path.len() / 2];
-        let nod = nearest_site(&catalog, cx, cy)
-            .ok_or_else(|| {
-                DataServerError::LocationNotFound("PVOL catalog has no radar sites".into())
-            })?
-            .to_string();
-        let volumes = catalog.by_site.get(&nod).ok_or_else(|| {
-            DataServerError::Engine("internal: nearest_site returned a missing by_site key".into())
-        })?;
-
-        // Time filter — same logic as site_coverages.
-        let selected: Vec<&VolumeEntry> = match datetime {
-            Some((start, end)) => volumes
-                .iter()
-                .filter(|e| e.volume.time >= start && e.volume.time <= end)
-                .collect(),
-            None => volumes.iter().collect(),
-        };
-        if selected.is_empty() {
-            return Err(DataServerError::LocationNotFound(
-                "No PVOL data available for the requested time range".into(),
-            ));
-        }
-
-        let quantities = resolve_quantities(&selected, parameters)?;
-
-        // `z` carries the requested elevation angles (resolved by the API
-        // layer against the advertised extent). Derive the angle window
-        // and the matching height axis from the most recent volume. An
-        // out-of-range `z` list surfaces as `InvalidParameter` (400)
-        // rather than a silently empty Section.
-        let ref_volume = &selected.last().unwrap().volume;
-        let window = angle_window(z, ref_volume)?;
-        // The path's farthest ground distance from the radar sizes the
-        // height-axis ceiling for the selected top angle.
-        let max_ground_dist = path
-            .iter()
-            .map(|&(lon, lat)| {
-                ground_distance_bearing(ref_volume.site.lon, ref_volume.site.lat, lon, lat).0
-            })
-            .fold(0.0_f64, f64::max);
-        let heights = height_axis(window.1, max_ground_dist);
-        if heights.is_empty() {
-            return Err(DataServerError::InvalidParameter(
-                "trajectory `z` resolved to an empty axis".into(),
-            ));
-        }
-
-        let coverages: Vec<QueryResult> = selected
-            .iter()
-            .filter_map(|e| volume_section(e, &path, &heights, &quantities, window))
-            .collect();
-        if coverages.is_empty() {
-            return Err(DataServerError::LocationNotFound(
-                "No PVOL volumes produced a section for the requested path".into(),
-            ));
-        }
-        if coverages.len() == 1 {
-            // Single timestep — emit one Coverage rather than a one-item
-            // collection, matching the `query_location` precedent for
-            // pinned-level requests.
-            Ok(CoverageResponse::Single(
-                coverages.into_iter().next().unwrap(),
+        let volumes = catalog.by_site.get(&self.nod).ok_or_else(|| {
+            DataServerError::LocationNotFound(format!(
+                "[{}] radar site `{}` has no current volumes",
+                self.collection_id, self.nod
             ))
-        } else {
-            Ok(CoverageResponse::Collection(coverages))
-        }
+        })?;
+        site_trajectory(volumes, &path, datetime, parameters, z)
     }
 }
 
@@ -2988,16 +3043,6 @@ mod tests {
         }
     }
 
-    /// `parse_parameter` round-trips a `<nod>:<quantity>` name and
-    /// rejects malformed inputs.
-    #[test]
-    fn parse_parameter_splits_and_rejects() {
-        assert_eq!(parse_parameter("fianj:DBZH"), Some(("fianj", "DBZH")));
-        assert_eq!(parse_parameter("nodbzh"), None);
-        assert_eq!(parse_parameter(":DBZH"), None);
-        assert_eq!(parse_parameter("fianj:"), None);
-    }
-
     /// `site_coverage_bbox` brackets the centre and widens with radius.
     #[test]
     fn site_coverage_bbox_brackets_centre() {
@@ -3328,41 +3373,121 @@ mod tests {
         }
     }
 
-    /// `nearest_site` picks the site with the smallest ground distance.
-    #[test]
-    fn nearest_site_picks_closest() {
-        let mut by_site: HashMap<String, Vec<VolumeEntry>> = HashMap::new();
-        by_site.insert(
-            "west".to_string(),
-            vec![entry(synthetic_volume(20.0, 60.0), "w")],
-        );
-        by_site.insert(
-            "east".to_string(),
-            vec![entry(synthetic_volume(30.0, 60.0), "e")],
-        );
-        let catalog = Catalog {
-            by_site,
-            parameters: vec![],
-            quantities: vec![],
-            times: vec![],
-            spatial_extent: None,
-            vertical: None,
-        };
-        assert_eq!(nearest_site(&catalog, 29.0, 60.0), Some("east"));
-        assert_eq!(nearest_site(&catalog, 21.0, 60.0), Some("west"));
+    /// Build a [`PolarVolumeSiteView`] over a synthetic catalog scoped to
+    /// `nod` — mirrors what `PolarVolumeEngine::site_view` produces, but
+    /// without a real source scan.
+    fn site_view_for(by_site: HashMap<String, Vec<VolumeEntry>>, nod: &str) -> PolarVolumeSiteView {
+        let cache = Mutex::new(HashMap::new());
+        let catalog = derive_catalog(by_site, &cache, None);
+        PolarVolumeSiteView {
+            catalog: Arc::new(ArcSwap::from_pointee(catalog)),
+            nod: nod.to_string(),
+            collection_id: format!("test-{nod}"),
+        }
     }
 
-    /// An empty catalog has no nearest site.
+    /// Model B: a per-site view advertises **bare** quantities (no
+    /// `<nod>:` prefix), a single EDR location (the antenna), and the
+    /// site's own coverage extent — even when the catalog holds other
+    /// sites.
     #[test]
-    fn nearest_site_empty_catalog_is_none() {
-        let catalog = Catalog {
-            by_site: HashMap::new(),
-            parameters: vec![],
-            quantities: vec![],
-            times: vec![],
-            spatial_extent: None,
-            vertical: None,
-        };
-        assert_eq!(nearest_site(&catalog, 25.0, 60.0), None);
+    fn site_view_advertises_bare_quantities_and_single_location() {
+        let mut by_site: HashMap<String, Vec<VolumeEntry>> = HashMap::new();
+        by_site.insert(
+            "fivih".to_string(),
+            vec![entry(synthetic_volume(25.0, 60.0), "v")],
+        );
+        by_site.insert(
+            "fianj".to_string(),
+            vec![entry(synthetic_volume(27.0, 60.9), "a")],
+        );
+        let view = site_view_for(by_site, "fivih");
+
+        // Map/WMS parameters are the bare quantity — no `fivih:` prefix.
+        let info = MapEngine::raster_info(&view);
+        let names: Vec<&str> = info.parameters.iter().map(|(n, _)| n.as_str()).collect();
+        assert_eq!(
+            names,
+            vec!["DBZH"],
+            "per-site layer must be the bare quantity, got {names:?}"
+        );
+        assert!(
+            info.spatial_extent.is_some(),
+            "a per-site view reports its own coverage bbox"
+        );
+        assert!(
+            info.vertical.is_some(),
+            "a per-site view reports its own elevation axis"
+        );
+
+        // EDR parameter list is bare too.
+        assert_eq!(
+            EdrEngine::get_parameters(&view),
+            vec!["DBZH".to_string()],
+            "EDR parameter list is the bare quantity"
+        );
+
+        // Exactly one EDR location — this radar.
+        let locs = EdrEngine::get_locations(&view).expect("locations");
+        assert_eq!(locs.len(), 1, "a per-site collection has one location");
+        assert_eq!(locs[0].id, "fivih");
+        assert_eq!(locs[0].label, "Test Site");
+    }
+
+    /// The per-site view renders with a bare-quantity parameter, and
+    /// errors cleanly (not a panic) on a missing parameter or a site that
+    /// has no current volumes.
+    #[test]
+    fn site_view_get_raster_tile_uses_bare_quantity() {
+        let mut by_site: HashMap<String, Vec<VolumeEntry>> = HashMap::new();
+        by_site.insert(
+            "fivih".to_string(),
+            vec![entry(synthetic_volume(25.0, 60.0), "v")],
+        );
+        let view = site_view_for(by_site, "fivih");
+
+        let dlon =
+            50_000.0 / (EARTH_RADIUS_M * 60f64.to_radians().cos()) * 180.0 / std::f64::consts::PI;
+        let bbox = [25.0, 59.999, 25.0 + dlon, 60.001];
+        let tile = MapEngine::get_raster_tile(
+            &view,
+            bbox,
+            32,
+            4,
+            None,
+            &OutputCrs::Wgs84,
+            Some("DBZH"),
+            None,
+        )
+        .expect("render with a bare quantity");
+        assert_eq!(tile.values.len(), 32 * 4);
+        assert!(
+            tile.values.iter().any(Option::is_some),
+            "a render over the radar's own coverage samples some echoes"
+        );
+
+        // Missing parameter is a clean 400. (`RasterTile` is not `Debug`,
+        // so assert on the variant rather than `unwrap_err`.)
+        assert!(matches!(
+            MapEngine::get_raster_tile(&view, bbox, 4, 4, None, &OutputCrs::Wgs84, None, None),
+            Err(DataServerError::InvalidParameter(_))
+        ));
+
+        // A view over a site absent from the catalog reports no data, not
+        // a 500.
+        let ghost = site_view_for(HashMap::new(), "ghost");
+        assert!(matches!(
+            MapEngine::get_raster_tile(
+                &ghost,
+                bbox,
+                4,
+                4,
+                None,
+                &OutputCrs::Wgs84,
+                Some("DBZH"),
+                None,
+            ),
+            Err(DataServerError::LocationNotFound(_))
+        ));
     }
 }

--- a/crates/engine-odim/src/volume_engine.rs
+++ b/crates/engine-odim/src/volume_engine.rs
@@ -762,10 +762,21 @@ fn derive_site_meta(list: &[VolumeEntry]) -> Option<SiteMeta> {
     let sweep0 = latest.volume.sweeps.first()?;
     let site = &latest.volume.site;
 
-    // Map/WMS + EDR quantity set, from the lowest sweep — matching the
-    // global derivation, but bare (no `<nod>:` prefix). Title is just the
-    // quantity: the per-site collection already carries the place name.
-    let mut quantities: Vec<String> = sweep0.moments.iter().map(|m| m.quantity.clone()).collect();
+    // Map/WMS + EDR quantity set: the **union** of every sweep's moments
+    // (bare, no `<nod>:` prefix). Title is just the quantity — the per-site
+    // collection already carries the place name. The union (not just the
+    // lowest sweep) is deliberate: a moment that only appears on higher
+    // sweeps (split-cut scan strategies) is still queryable by EDR
+    // (`resolve_quantities` unions across sweeps) and renderable by WMS
+    // (`polar_sample` searches every sweep that carries the quantity), so
+    // the advertised list must include it — otherwise EDR and WMS would
+    // report contradictory parameter sets for the same collection.
+    let mut quantities: Vec<String> = latest
+        .volume
+        .sweeps
+        .iter()
+        .flat_map(|s| s.moments.iter().map(|m| m.quantity.clone()))
+        .collect();
     quantities.sort();
     quantities.dedup();
     let parameters: Vec<(String, String)> =
@@ -1218,29 +1229,39 @@ fn polar_sample(
     output_crs: &OutputCrs,
     z: Option<f64>,
 ) -> Result<RasterTile, DataServerError> {
-    // M1 sorts `sweeps` ascending by elangle, so `first()` is the lowest.
-    let sweep = match z {
-        Some(target) => nearest_sweep(volume, target),
-        None => volume.sweeps.first(),
-    }
-    .ok_or_else(|| {
-        DataServerError::Engine(format!(
-            "PVOL site `{}` has no elevation sweeps",
+    // Pick the sweep that actually carries `quantity`: nearest to `z` (or
+    // the lowest when `z` is absent) *among the sweeps that contain the
+    // moment*. A blind lowest/nearest pick would 400 on a quantity that is
+    // only present on higher sweeps (split-cut scan strategies), even
+    // though it is advertised (the parameter list unions across sweeps).
+    // `sweeps` is sorted ascending by elangle (M1), so the first matching
+    // candidate is the lowest sweep that has the quantity.
+    let mut candidates = volume
+        .sweeps
+        .iter()
+        .filter(|s| s.moments.iter().any(|m| m.quantity == quantity))
+        .peekable();
+    if candidates.peek().is_none() {
+        return Err(DataServerError::InvalidParameter(format!(
+            "quantity `{quantity}` is not present in any sweep of PVOL site `{}`",
             volume.site.nod.as_deref().unwrap_or("?")
-        ))
-    })?;
+        )));
+    }
+    let sweep = match z {
+        Some(target) => candidates.min_by(|a, b| {
+            (a.elangle - target)
+                .abs()
+                .total_cmp(&(b.elangle - target).abs())
+        }),
+        None => candidates.next(),
+    }
+    .expect("non-empty candidate set checked above");
 
     let moment = sweep
         .moments
         .iter()
         .find(|m| m.quantity == quantity)
-        .ok_or_else(|| {
-            DataServerError::InvalidParameter(format!(
-                "quantity `{quantity}` is not present in the lowest sweep of \
-                 PVOL site `{}`",
-                volume.site.nod.as_deref().unwrap_or("?")
-            ))
-        })?;
+        .expect("candidate sweep contains the quantity");
 
     let (site_lon, site_lat) = (volume.site.lon, volume.site.lat);
     if sweep.nrays == 0 || sweep.nbins == 0 {
@@ -2056,6 +2077,13 @@ impl PolarVolumeEngine {
         sites
     }
 
+    /// The base collection id of this source (the `{base}` in each per-site
+    /// `{base}-{nod}` collection id). Used by `/health` to key per-site
+    /// temporal extents.
+    pub fn collection_id(&self) -> &str {
+        &self.collection_id
+    }
+
     /// Build a [`PolarVolumeSiteView`] scoped to radar `nod`, sharing this
     /// engine's live catalog (`ArcSwap`) so the view tracks poll-loop
     /// updates without re-parsing. `collection_id` is the per-site OGC
@@ -2333,16 +2361,11 @@ impl EdrEngine for PolarVolumeSiteView {
             parameters,
             levels.as_deref(),
         )?;
-        // Guard against an empty collection (every volume produced no
-        // plottable coverage) — an empty `CoverageCollection` is invalid
-        // CoverageJSON and should be a 404, not HTTP 200. Mirrors the
-        // network engine's dropped `query_area` is-empty check.
-        if covs.is_empty() {
-            return Err(DataServerError::LocationNotFound(
-                "no PVOL data for this site in the requested time window".into(),
-            ));
-        }
-        Ok(CoverageResponse::Collection(covs))
+        // Same shaping as position/location: a single-`z` request collapses
+        // to a bare `Coverage`, every other shape is a `Collection`, and an
+        // all-empty result is `LocationNotFound` (404) rather than an empty
+        // collection served as HTTP 200.
+        finalize_single_site(covs, &levels)
     }
 
     /// Trajectory cross-section along a WKT `LINESTRING`, always against
@@ -3588,5 +3611,81 @@ mod tests {
             ),
             "an all-empty area coverage must be LocationNotFound"
         );
+    }
+
+    /// A per-site `area` query collapses to a bare `Coverage` for a single
+    /// `z` level (matching position/location), and stays a `Collection`
+    /// otherwise.
+    #[test]
+    fn site_view_area_single_z_collapses_to_single() {
+        let mut by_site: HashMap<String, Vec<VolumeEntry>> = HashMap::new();
+        by_site.insert(
+            "fivih".to_string(),
+            vec![entry(synthetic_volume(25.0, 60.0), "v")],
+        );
+        let view = site_view_for(by_site, "fivih");
+
+        // Single elevation angle (the fixture's only sweep) → one Coverage.
+        assert!(
+            matches!(
+                EdrEngine::query_area(&view, "24.0,59.0,26.0,61.0", None, None, Some(&[0.5])),
+                Ok(CoverageResponse::Single(_))
+            ),
+            "a single-z area query must collapse to a bare Coverage"
+        );
+        // No z → a Collection (one VerticalProfile per timestep).
+        assert!(matches!(
+            EdrEngine::query_area(&view, "24.0,59.0,26.0,61.0", None, None, None),
+            Ok(CoverageResponse::Collection(_))
+        ));
+    }
+
+    /// A quantity present only on a higher-elevation sweep (a split-cut
+    /// strategy) is still advertised in the parameter list **and** renders
+    /// without a 400 — the advertised list unions across sweeps and
+    /// `polar_sample` searches every sweep that carries the quantity.
+    #[test]
+    fn site_view_advertises_and_renders_higher_sweep_only_quantity() {
+        // sweep0 @0.5° carries DBZH; add a 1.5° sweep carrying VRADH only.
+        let mut vol = synthetic_volume(25.0, 60.0);
+        let mut sweep1 = vol.sweeps[0].clone();
+        sweep1.elangle = 1.5;
+        sweep1.moments[0].quantity = "VRADH".to_string();
+        vol.sweeps.push(sweep1);
+
+        let mut by_site: HashMap<String, Vec<VolumeEntry>> = HashMap::new();
+        by_site.insert("fivih".to_string(), vec![entry(vol, "v")]);
+        let view = site_view_for(by_site, "fivih");
+
+        // Both quantities are advertised (union across sweeps).
+        let params = EdrEngine::get_parameters(&view);
+        assert!(
+            params.contains(&"DBZH".to_string()) && params.contains(&"VRADH".to_string()),
+            "lowest- and higher-sweep quantities must both be advertised, got {params:?}"
+        );
+        let info = MapEngine::raster_info(&view);
+        let names: Vec<&str> = info.parameters.iter().map(|(n, _)| n.as_str()).collect();
+        assert!(
+            names.contains(&"VRADH"),
+            "WMS layer list must include VRADH"
+        );
+
+        // VRADH (only on the 1.5° sweep) renders at default `z` instead of
+        // 400ing because the lowest sweep lacks it.
+        let dlon =
+            50_000.0 / (EARTH_RADIUS_M * 60f64.to_radians().cos()) * 180.0 / std::f64::consts::PI;
+        let bbox = [25.0, 59.999, 25.0 + dlon, 60.001];
+        let tile = MapEngine::get_raster_tile(
+            &view,
+            bbox,
+            16,
+            4,
+            None,
+            &OutputCrs::Wgs84,
+            Some("VRADH"),
+            None,
+        )
+        .expect("a higher-sweep-only quantity must render, not 400");
+        assert_eq!(tile.values.len(), 16 * 4);
     }
 }

--- a/crates/engine-odim/src/volume_engine.rs
+++ b/crates/engine-odim/src/volume_engine.rs
@@ -722,22 +722,14 @@ fn build_catalog(
 }
 
 /// Whether `nod` is safe to embed verbatim in a URL-routed collection id
-/// (`{base}-{nod}`) and a WMS `LAYERS` token: ASCII alphanumeric plus
-/// interior `-`/`_`, with an **alphanumeric first and last char** so a
-/// degenerate code like `"-"` can't yield a double-hyphen id (`"{base}--"`)
-/// or a trailing-separator layer name. ODIM NODs are pure ASCII
-/// alphanumeric, so this passes every well-formed code.
+/// (`{base}-{nod}`) and a WMS `LAYERS` token: non-empty and **purely ASCII
+/// alphanumeric**. ODIM NODs are exactly that (5 chars, e.g. `fivih`), so
+/// this passes every well-formed code. Forbidding the `-` separator inside
+/// a nod also makes the per-site id `{base}-{nod}` unambiguous — two
+/// different sources can never derive the same id (`radar-a` + `b-fivih`
+/// vs `radar-a-b` + `fivih` would otherwise both yield `radar-a-b-fivih`).
 fn is_url_safe_nod(nod: &str) -> bool {
-    let mut chars = nod.chars();
-    let Some(first) = chars.next() else {
-        return false;
-    };
-    let last = nod.chars().next_back().unwrap_or(first);
-    first.is_ascii_alphanumeric()
-        && last.is_ascii_alphanumeric()
-        && nod
-            .chars()
-            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+    !nod.is_empty() && nod.chars().all(|c| c.is_ascii_alphanumeric())
 }
 
 /// Finalise the grouped volume map into a [`Catalog`]: sort and cap each
@@ -2490,6 +2482,16 @@ impl EdrEngine for PolarVolumeSiteView {
     ) -> Result<CoverageResponse, DataServerError> {
         let path = resample_section_path(coords)?;
         let catalog = self.catalog.load();
+        // Gate on `by_site_meta` first, like `query_location`/`query_position`/
+        // `query_area`: a site absent from `by_site_meta` (sweeps with no
+        // moment datasets) is a 404, not a 400 fall-through via
+        // `resolve_quantities`.
+        if !catalog.by_site_meta.contains_key(&self.nod) {
+            return Err(DataServerError::LocationNotFound(format!(
+                "[{}] radar site `{}` has no current volumes",
+                self.collection_id, self.nod
+            )));
+        }
         let volumes = catalog.by_site.get(&self.nod).ok_or_else(|| {
             DataServerError::LocationNotFound(format!(
                 "[{}] radar site `{}` has no current volumes",
@@ -3709,13 +3711,14 @@ mod tests {
     /// id.
     #[test]
     fn is_url_safe_nod_accepts_codes_rejects_routing_breakers() {
-        for ok in ["fivih", "fianj", "se1", "uk-abc_2"] {
+        for ok in ["fivih", "fianj", "se1", "ukabc2"] {
             assert!(is_url_safe_nod(ok), "{ok} should be accepted");
         }
-        // Routing-breakers, plus degenerate boundary separators that would
-        // yield a double-hyphen id (`{base}--`) or a trailing-separator layer.
+        // Routing-breakers, degenerate boundary separators, and any nod with
+        // a `-`/`_` (which could make `{base}-{nod}` collide across sources).
         for bad in [
-            "", "fi/bad", "fi?x", "fi#x", "fi bad", "fiäö", "a.b", "-", "_", "-a", "a-", "_x", "x_",
+            "", "fi/bad", "fi?x", "fi#x", "fi bad", "fiäö", "a.b", "-", "_", "-a", "a-", "_x",
+            "x_", "b-fivih", "uk-abc_2",
         ] {
             assert!(!is_url_safe_nod(bad), "{bad:?} should be rejected");
         }
@@ -3896,6 +3899,17 @@ mod tests {
         // ...and a direct query_location returns 404, not InvalidParameter.
         assert!(matches!(
             EdrEngine::query_location(&view, "fivih", None, None, None),
+            Err(DataServerError::LocationNotFound(_))
+        ));
+        // ...and so does query_trajectory (same by_site_meta gate).
+        assert!(matches!(
+            EdrEngine::query_trajectory(
+                &view,
+                "LINESTRING(24.5 60.3, 24.5 60.9)",
+                None,
+                None,
+                None
+            ),
             Err(DataServerError::LocationNotFound(_))
         ));
     }

--- a/crates/engine-odim/src/volume_engine.rs
+++ b/crates/engine-odim/src/volume_engine.rs
@@ -693,6 +693,21 @@ fn build_catalog(
             continue;
         };
 
+        // The NOD becomes part of a URL-routed collection id (`{base}-{nod}`)
+        // and a WMS `LAYERS` token, so reject anything that isn't a clean
+        // path segment. ODIM NODs are spec'd as 5 ASCII-alphanumeric chars
+        // (2-letter country + 3-letter station), so this only fires on a
+        // malformed/adversarial file — a NOD with `/` would make the
+        // collection permanently unreachable (Axum stops `{id}` at the first
+        // `/`), and `?`/`#`/space/non-ASCII would corrupt routing or the IRI.
+        if !is_url_safe_nod(&nod) {
+            tracing::warn!(
+                "[{collection_id}] skipping PVOL file `{id}`: NOD `{nod}` contains \
+                 characters invalid in a URL path segment (expected ASCII alphanumeric)"
+            );
+            continue;
+        }
+
         by_site
             .entry(nod)
             .or_default()
@@ -700,6 +715,17 @@ fn build_catalog(
     }
 
     by_site
+}
+
+/// Whether `nod` is safe to embed verbatim in a URL-routed collection id
+/// (`{base}-{nod}`) and a WMS `LAYERS` token: non-empty and ASCII
+/// alphanumeric plus `-`/`_`. ODIM NODs are pure ASCII alphanumeric, so
+/// this passes every well-formed code and rejects routing-breaking input.
+fn is_url_safe_nod(nod: &str) -> bool {
+    !nod.is_empty()
+        && nod
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
 }
 
 /// Finalise the grouped volume map into a [`Catalog`]: sort and cap each
@@ -779,6 +805,19 @@ fn derive_site_meta(list: &[VolumeEntry]) -> Option<SiteMeta> {
         .collect();
     quantities.sort();
     quantities.dedup();
+    // A volume with sweep structs but no moment datasets in any of them
+    // (a malformed file) yields no quantities. Exclude such a site rather
+    // than register a zero-parameter collection whose default WMS layer is
+    // broken and whose every render 400s — `sweeps.first()?` above only
+    // guards the no-sweeps case, not the no-moments case.
+    if quantities.is_empty() {
+        let nod = site.nod.as_deref().unwrap_or("?");
+        tracing::warn!(
+            "PVOL site `{nod}`: latest volume has sweeps but no moment data — \
+             excluding from registered sites"
+        );
+        return None;
+    }
     let parameters: Vec<(String, String)> =
         quantities.iter().map(|q| (q.clone(), q.clone())).collect();
 
@@ -2082,6 +2121,22 @@ impl PolarVolumeEngine {
     /// temporal extents.
     pub fn collection_id(&self) -> &str {
         &self.collection_id
+    }
+
+    /// Per-site `(nod, volume times)` from **one** catalog snapshot, sorted
+    /// by `nod`. Lets `/health` build each site's temporal extent without
+    /// allocating a `PolarVolumeSiteView` per site (one `ArcSwap` load for
+    /// the whole network, not one per site) — keeping the per-request
+    /// accessor O(1)-from-a-snapshot per the CLAUDE.md hot-path rule.
+    pub fn site_times(&self) -> Vec<(String, Vec<DateTime<Utc>>)> {
+        let catalog = self.catalog.load();
+        let mut out: Vec<(String, Vec<DateTime<Utc>>)> = catalog
+            .by_site_meta
+            .iter()
+            .map(|(nod, meta)| (nod.clone(), meta.times.clone()))
+            .collect();
+        out.sort_by(|a, b| a.0.cmp(&b.0));
+        out
     }
 
     /// Build a [`PolarVolumeSiteView`] scoped to radar `nod`, sharing this
@@ -3577,6 +3632,34 @@ mod tests {
         };
         // The view for `good` advertises its quantity; metadata is present.
         assert!(!MapEngine::raster_info(&view).parameters.is_empty());
+    }
+
+    /// A volume with sweep structs but no moment datasets has no derivable
+    /// metadata, so the site is excluded (never registered as a
+    /// zero-parameter collection). `sweeps.first()?` only guards the
+    /// no-sweeps case.
+    #[test]
+    fn derive_site_meta_excludes_moment_less_site() {
+        let mut momentless = synthetic_volume(25.0, 60.0);
+        momentless.sweeps[0].moments.clear();
+        let list = vec![entry(momentless, "m")];
+        assert!(
+            derive_site_meta(&list).is_none(),
+            "a site whose sweeps carry no moments must yield no SiteMeta"
+        );
+    }
+
+    /// `is_url_safe_nod` accepts well-formed ODIM codes and rejects any NOD
+    /// that would break URL routing if used in a `{base}-{nod}` collection
+    /// id.
+    #[test]
+    fn is_url_safe_nod_accepts_codes_rejects_routing_breakers() {
+        for ok in ["fivih", "fianj", "se1", "uk-abc_2"] {
+            assert!(is_url_safe_nod(ok), "{ok} should be accepted");
+        }
+        for bad in ["", "fi/bad", "fi?x", "fi#x", "fi bad", "fiäö", "a.b"] {
+            assert!(!is_url_safe_nod(bad), "{bad:?} should be rejected");
+        }
     }
 
     /// When every selected volume yields no plottable coverage (a sweep

--- a/crates/engine-odim/src/volume_engine.rs
+++ b/crates/engine-odim/src/volume_engine.rs
@@ -2478,11 +2478,16 @@ impl EdrEngine for PolarVolumeSiteView {
             parameters,
             levels.as_deref(),
         )?;
-        // Same shaping as position/location: a single-`z` request collapses
-        // to a bare `Coverage`, every other shape is a `Collection`, and an
-        // all-empty result is `LocationNotFound` (404) rather than an empty
-        // collection served as HTTP 200.
-        finalize_single_site(covs, &levels)
+        // An `area` query ALWAYS returns a `CoverageCollection` per OGC EDR —
+        // unlike position/location it does NOT collapse a single-`z` result
+        // to a bare `Coverage`. An all-empty result is `LocationNotFound`
+        // (404), not an empty collection served as HTTP 200.
+        if covs.is_empty() {
+            return Err(DataServerError::LocationNotFound(
+                "no PVOL data for this site in the requested time window".into(),
+            ));
+        }
+        Ok(CoverageResponse::Collection(covs))
     }
 
     /// Trajectory cross-section along a WKT `LINESTRING`, always against
@@ -3774,11 +3779,11 @@ mod tests {
         );
     }
 
-    /// A per-site `area` query collapses to a bare `Coverage` for a single
-    /// `z` level (matching position/location), and stays a `Collection`
-    /// otherwise.
+    /// A per-site `area` query ALWAYS returns a `CoverageCollection` per OGC
+    /// EDR — even for a single `z` level it does not collapse to a bare
+    /// `Coverage` (unlike position/location).
     #[test]
-    fn site_view_area_single_z_collapses_to_single() {
+    fn site_view_area_always_returns_collection() {
         let mut by_site: HashMap<String, Vec<VolumeEntry>> = HashMap::new();
         by_site.insert(
             "fivih".to_string(),
@@ -3786,15 +3791,15 @@ mod tests {
         );
         let view = site_view_for(by_site, "fivih");
 
-        // Single elevation angle (the fixture's only sweep) → one Coverage.
+        // Single elevation angle → still a CoverageCollection.
         assert!(
             matches!(
                 EdrEngine::query_area(&view, "24.0,59.0,26.0,61.0", None, None, Some(&[0.5])),
-                Ok(CoverageResponse::Single(_))
+                Ok(CoverageResponse::Collection(_))
             ),
-            "a single-z area query must collapse to a bare Coverage"
+            "a single-z area query must stay a CoverageCollection"
         );
-        // No z → a Collection (one VerticalProfile per timestep).
+        // No z → also a Collection (one VerticalProfile per timestep).
         assert!(matches!(
             EdrEngine::query_area(&view, "24.0,59.0,26.0,61.0", None, None, None),
             Ok(CoverageResponse::Collection(_))

--- a/crates/engine-odim/src/volume_engine.rs
+++ b/crates/engine-odim/src/volume_engine.rs
@@ -1940,7 +1940,20 @@ fn site_coverages(
             let times: Vec<DateTime<Utc>> = selected.iter().map(|e| e.volume.time).collect();
             Ok(lvls
                 .iter()
-                .map(|&lvl| level_series(&selected, lon, lat, lvl, &quantities, &times))
+                // Drop a level whose series is all-null across every quantity
+                // and timestep (the requested point is out of range, or the
+                // nearest sweep carries no data) — otherwise an all-null
+                // `PointSeries` would serve HTTP 200, indistinguishable from
+                // clear sky. With every level dropped, `finalize_single_site`
+                // turns the empty result into a 404.
+                .filter_map(|&lvl| {
+                    let qr = level_series(&selected, lon, lat, lvl, &quantities, &times);
+                    let all_null = qr
+                        .ranges
+                        .values()
+                        .all(|a| a.values.iter().all(Option::is_none));
+                    (!all_null).then_some(qr)
+                })
                 .collect())
         }
     }
@@ -2076,30 +2089,20 @@ fn finalize_single_site(
     covs: Vec<QueryResult>,
     levels: &Option<Vec<f64>>,
 ) -> Result<CoverageResponse, DataServerError> {
-    if matches!(levels, Some(l) if l.len() == 1) {
-        // `site_coverages` builds exactly one coverage per requested
-        // level, so a single-level request yields exactly one. A missing
-        // coverage would be an internal invariant violation — surface it
-        // as a logged 500, not an opaque `spawn_blocking` panic.
-        return covs
-            .into_iter()
-            .next()
-            .map(CoverageResponse::Single)
-            .ok_or_else(|| {
-                DataServerError::Engine(
-                    "internal: single-level query produced no coverage (invariant violated)".into(),
-                )
-            });
-    }
-    // Every selected volume produced no plottable coverage (e.g. a
-    // corrupted batch where every sweep's elevation angle is non-finite).
-    // An empty `CoverageCollection` is invalid CoverageJSON and would
-    // serve HTTP 200 for what is really "no data" — surface a 404 instead,
-    // matching the CLAUDE.md "no data in window → LocationNotFound" rule.
+    // No plottable coverage — every profile/level was dropped because it
+    // sampled no data (out of range, or all-null). An empty
+    // `CoverageCollection` is invalid CoverageJSON and would serve HTTP 200
+    // for what is really "no data", so surface a 404, matching the CLAUDE.md
+    // "no data in window → LocationNotFound" rule. Checked first so it
+    // covers both the single-level and multi-coverage shapes.
     if covs.is_empty() {
         return Err(DataServerError::LocationNotFound(
             "no PVOL data for this site in the requested time window".into(),
         ));
+    }
+    if matches!(levels, Some(l) if l.len() == 1) {
+        // A single pinned level yields exactly one (non-null) coverage.
+        return Ok(CoverageResponse::Single(covs.into_iter().next().unwrap()));
     }
     Ok(CoverageResponse::Collection(covs))
 }
@@ -2206,17 +2209,29 @@ impl MapEngine for PolarVolumeSiteView {
         parameter: Option<&str>,
         z: Option<f64>,
     ) -> Result<RasterTile, DataServerError> {
-        // A per-site PVOL collection is still multi-parameter — one layer
-        // per radar quantity — but the layer name is now the bare quantity
-        // (no `<site>:` prefix): the site *is* the collection.
-        let quantity = parameter.ok_or_else(|| {
-            DataServerError::InvalidParameter(format!(
-                "[{}] PVOL collection requires a quantity parameter (e.g. `DBZH`)",
-                self.collection_id
-            ))
-        })?;
-
         let catalog = self.catalog.load();
+        // A per-site PVOL collection is still multi-parameter — one layer per
+        // radar quantity (the bare quantity, no `<site>:` prefix). When no
+        // quantity is named (a bare `LAYERS={site}` WMS request, or a Maps /
+        // Tiles request with no `?parameter-name=`), default to the site's
+        // primary (first advertised) quantity — the same as
+        // `raster_info().parameter` — instead of erroring, matching the GRIB
+        // engine's default-parameter behaviour.
+        let quantity = match parameter {
+            Some(q) => q,
+            None => catalog
+                .by_site_meta
+                .get(&self.nod)
+                .and_then(|m| m.quantities.first())
+                .map(|s| s.as_str())
+                .ok_or_else(|| {
+                    DataServerError::InvalidParameter(format!(
+                        "[{}] PVOL collection has no quantities to render",
+                        self.collection_id
+                    ))
+                })?,
+        };
+
         let site_volumes = catalog.by_site.get(&self.nod).ok_or_else(|| {
             // The site aged out of the catalog since this view was
             // registered (source change / `max_files`). A reload would
@@ -2270,21 +2285,21 @@ impl MapEngine for PolarVolumeSiteView {
 
 impl EdrEngine for PolarVolumeSiteView {
     /// Exactly one EDR location — this radar site — `id` is the NOD code
-    /// and the point geometry is the antenna position.
+    /// and the point geometry is the antenna position. A 404 (not an empty
+    /// list) when the site has dropped from `by_site_meta`, so the locations
+    /// list and `query_location` agree on the same data condition.
     fn get_locations(&self) -> Result<Vec<Location>, DataServerError> {
         let catalog = self.catalog.load();
-        Ok(catalog
+        let m = catalog
             .by_site_meta
             .get(&self.nod)
-            .map(|m| {
-                vec![Location {
-                    id: self.nod.clone(),
-                    label: m.plc.clone().unwrap_or_else(|| self.nod.clone()),
-                    latitude: m.lat,
-                    longitude: m.lon,
-                }]
-            })
-            .unwrap_or_default())
+            .ok_or_else(|| DataServerError::LocationNotFound(self.nod.clone()))?;
+        Ok(vec![Location {
+            id: self.nod.clone(),
+            label: m.plc.clone().unwrap_or_else(|| self.nod.clone()),
+            latitude: m.lat,
+            longitude: m.lon,
+        }])
     }
 
     /// Query this radar site by NOD code. The only valid `location_id` is
@@ -3626,12 +3641,13 @@ mod tests {
             "a render over the radar's own coverage samples some echoes"
         );
 
-        // Missing parameter is a clean 400. (`RasterTile` is not `Debug`,
-        // so assert on the variant rather than `unwrap_err`.)
-        assert!(matches!(
-            MapEngine::get_raster_tile(&view, bbox, 4, 4, None, &OutputCrs::Wgs84, None, None),
-            Err(DataServerError::InvalidParameter(_))
-        ));
+        // No parameter named → render the site's primary (first) quantity,
+        // not a 400, so a bare `LAYERS={site}` WMS / Maps request works.
+        assert!(
+            MapEngine::get_raster_tile(&view, bbox, 32, 4, None, &OutputCrs::Wgs84, None, None)
+                .is_ok(),
+            "a bare (no-parameter) render must default to the primary quantity"
+        );
 
         // A view over a site absent from the catalog reports no data, not
         // a 500.
@@ -3892,10 +3908,12 @@ mod tests {
         by_site.insert("fivih".to_string(), vec![entry(momentless, "m")]);
         let view = site_view_for(by_site, "fivih");
 
-        // The site is invisible to discovery...
-        assert!(EdrEngine::get_locations(&view)
-            .expect("locations")
-            .is_empty());
+        // The site is invisible to discovery — get_locations 404s, matching
+        // query_location (not an empty 200 list).
+        assert!(matches!(
+            EdrEngine::get_locations(&view),
+            Err(DataServerError::LocationNotFound(_))
+        ));
         // ...and a direct query_location returns 404, not InvalidParameter.
         assert!(matches!(
             EdrEngine::query_location(&view, "fivih", None, None, None),
@@ -3909,6 +3927,35 @@ mod tests {
                 None,
                 None,
                 None
+            ),
+            Err(DataServerError::LocationNotFound(_))
+        ));
+    }
+
+    /// A z-pinned query whose level series is all-null (the nearest sweep
+    /// carries no data for the requested quantity) is a 404, not an HTTP 200
+    /// all-null `PointSeries`.
+    #[test]
+    fn site_view_z_level_all_null_is_404() {
+        // sweep0 @0.5° has DBZH; an added 15° sweep has VRADH only.
+        let mut vol = synthetic_volume(25.0, 60.0);
+        let mut hi = vol.sweeps[0].clone();
+        hi.elangle = 15.0;
+        hi.moments[0].quantity = "VRADH".to_string();
+        vol.sweeps.push(hi);
+        let mut by_site: HashMap<String, Vec<VolumeEntry>> = HashMap::new();
+        by_site.insert("fivih".to_string(), vec![entry(vol, "v")]);
+        let view = site_view_for(by_site, "fivih");
+
+        // DBZH pinned to z=15°: the 15° sweep carries no DBZH → all-null →
+        // 404. (~11 km north keeps the point well inside coverage.)
+        assert!(matches!(
+            EdrEngine::query_position(
+                &view,
+                "POINT(25.0 60.1)",
+                None,
+                Some(&["DBZH".to_string()]),
+                Some(&[15.0]),
             ),
             Err(DataServerError::LocationNotFound(_))
         ));

--- a/crates/engine-odim/src/volume_engine.rs
+++ b/crates/engine-odim/src/volume_engine.rs
@@ -722,11 +722,19 @@ fn build_catalog(
 }
 
 /// Whether `nod` is safe to embed verbatim in a URL-routed collection id
-/// (`{base}-{nod}`) and a WMS `LAYERS` token: non-empty and ASCII
-/// alphanumeric plus `-`/`_`. ODIM NODs are pure ASCII alphanumeric, so
-/// this passes every well-formed code and rejects routing-breaking input.
+/// (`{base}-{nod}`) and a WMS `LAYERS` token: ASCII alphanumeric plus
+/// interior `-`/`_`, with an **alphanumeric first and last char** so a
+/// degenerate code like `"-"` can't yield a double-hyphen id (`"{base}--"`)
+/// or a trailing-separator layer name. ODIM NODs are pure ASCII
+/// alphanumeric, so this passes every well-formed code.
 fn is_url_safe_nod(nod: &str) -> bool {
-    !nod.is_empty()
+    let mut chars = nod.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    let last = nod.chars().next_back().unwrap_or(first);
+    first.is_ascii_alphanumeric()
+        && last.is_ascii_alphanumeric()
         && nod
             .chars()
             .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
@@ -784,12 +792,11 @@ fn derive_catalog(
 
 /// Derive one site's [`SiteMeta`] from its time-sorted volume list.
 ///
-/// Returns `None` only for a site whose most-recent volume has no usable
-/// lowest sweep (an entirely malformed file) — such a site is dropped
-/// from `by_site_meta` and its view reports empty metadata.
+/// Returns `None` for a site whose most-recent volume has no sweeps or no
+/// moment datasets (an entirely malformed file) — such a site is dropped
+/// from `by_site_meta` and is never registered as a collection.
 fn derive_site_meta(list: &[VolumeEntry]) -> Option<SiteMeta> {
     let latest = list.last()?;
-    let sweep0 = latest.volume.sweeps.first()?;
     let site = &latest.volume.site;
 
     // Map/WMS + EDR quantity set: the **union** of every sweep's moments
@@ -825,9 +832,22 @@ fn derive_site_meta(list: &[VolumeEntry]) -> Option<SiteMeta> {
     let parameters: Vec<(String, String)> =
         quantities.iter().map(|q| (q.clone(), q.clone())).collect();
 
-    // Coverage radius from the lowest sweep's range gate geometry.
-    let radius_m = sweep0.nbins as f64 * sweep0.rscale + sweep0.rstart;
-    let coverage_radius_m = (radius_m.is_finite() && radius_m > 0.0).then_some(radius_m);
+    // Coverage radius = the **maximum** range-gate reach across all sweeps
+    // (skipping sweeps with a malformed `rscale`). Quantities are unioned
+    // across sweeps, so a moment may live only on a longer-range higher
+    // sweep; using the lowest sweep's radius alone would wrongly reject an
+    // in-range query for such a quantity. `None` only when *no* sweep has
+    // usable geometry. `spatial_extent` derives from the same radius so the
+    // advertised extent covers the union of sweep ranges.
+    let coverage_radius_m = latest
+        .volume
+        .sweeps
+        .iter()
+        .filter_map(|s| {
+            let r = s.nbins as f64 * s.rscale + s.rstart;
+            (s.rscale.is_finite() && s.rscale > 0.0 && r.is_finite() && r > 0.0).then_some(r)
+        })
+        .max_by(f64::total_cmp);
     let spatial_extent = coverage_radius_m.map(|r| site_coverage_bbox(site.lon, site.lat, r));
 
     let mut times: Vec<DateTime<Utc>> = list.iter().map(|e| e.volume.time).collect();
@@ -2385,16 +2405,21 @@ impl EdrEngine for PolarVolumeSiteView {
         // Reject a point clearly outside the radar's coverage circle with a
         // 404 rather than returning HTTP 200 all-null values — which is
         // indistinguishable from "in range, clear sky". The per-site
-        // collection's advertised spatial extent *is* this coverage circle,
-        // so a point beyond it is outside the collection's domain. (A point
-        // inside coverage with no echo still correctly returns 200 nulls.)
-        if let Some(radius_m) = meta.coverage_radius_m {
-            let (dist, _) = ground_distance_bearing(meta.lon, meta.lat, lon, lat);
-            if dist > radius_m {
-                return Err(DataServerError::LocationNotFound(
-                    "requested point is outside this radar's coverage area".into(),
-                ));
-            }
+        // collection's advertised spatial extent *is* this coverage circle
+        // (the max range across all sweeps), so a point beyond it is outside
+        // the collection's domain. A point inside coverage with no echo
+        // still correctly returns 200 nulls. **Fail closed**: a site with no
+        // usable range geometry (`coverage_radius_m == None`, every sweep
+        // has a malformed `rscale`) can only ever produce all-null samples,
+        // so a position query there is a 404, not a misleading 200.
+        let radius_m = meta.coverage_radius_m.ok_or_else(|| {
+            DataServerError::LocationNotFound("this radar site has no usable range geometry".into())
+        })?;
+        let (dist, _) = ground_distance_bearing(meta.lon, meta.lat, lon, lat);
+        if dist > radius_m {
+            return Err(DataServerError::LocationNotFound(
+                "requested point is outside this radar's coverage area".into(),
+            ));
         }
         let volumes = catalog.by_site.get(&self.nod).ok_or_else(|| {
             DataServerError::LocationNotFound(format!(
@@ -3687,7 +3712,11 @@ mod tests {
         for ok in ["fivih", "fianj", "se1", "uk-abc_2"] {
             assert!(is_url_safe_nod(ok), "{ok} should be accepted");
         }
-        for bad in ["", "fi/bad", "fi?x", "fi#x", "fi bad", "fiäö", "a.b"] {
+        // Routing-breakers, plus degenerate boundary separators that would
+        // yield a double-hyphen id (`{base}--`) or a trailing-separator layer.
+        for bad in [
+            "", "fi/bad", "fi?x", "fi#x", "fi bad", "fiäö", "a.b", "-", "_", "-a", "a-", "_x", "x_",
+        ] {
             assert!(!is_url_safe_nod(bad), "{bad:?} should be rejected");
         }
     }
@@ -3867,6 +3896,55 @@ mod tests {
         // ...and a direct query_location returns 404, not InvalidParameter.
         assert!(matches!(
             EdrEngine::query_location(&view, "fivih", None, None, None),
+            Err(DataServerError::LocationNotFound(_))
+        ));
+    }
+
+    /// The coverage radius is the **max** across sweeps: a point beyond the
+    /// lowest sweep's range but within a longer-range higher sweep is in
+    /// coverage (not 404), since a quantity may live only on that sweep.
+    #[test]
+    fn site_view_coverage_radius_uses_max_sweep_range() {
+        let mut vol = synthetic_volume(25.0, 60.0);
+        vol.sweeps[0].nbins = 50; // sweep0 ≈ 50 km
+        let mut sweep1 = vol.sweeps[0].clone();
+        sweep1.elangle = 3.0;
+        sweep1.nbins = 120; // sweep1 ≈ 120 km
+        vol.sweeps.push(sweep1);
+        let mut by_site: HashMap<String, Vec<VolumeEntry>> = HashMap::new();
+        by_site.insert("fivih".to_string(), vec![entry(vol, "v")]);
+        let view = site_view_for(by_site, "fivih");
+
+        // ~70 km north: beyond sweep0's 50 km but within sweep1's 120 km.
+        let dlat_70 = 70_000.0 / EARTH_RADIUS_M * 180.0 / std::f64::consts::PI;
+        let near = format!("POINT(25.0 {})", 60.0 + dlat_70);
+        assert!(
+            EdrEngine::query_position(&view, &near, None, None, None).is_ok(),
+            "a point within the longest sweep's range must not be rejected"
+        );
+        // ~200 km: beyond every sweep → 404.
+        let dlat_200 = 200_000.0 / EARTH_RADIUS_M * 180.0 / std::f64::consts::PI;
+        let far = format!("POINT(25.0 {})", 60.0 + dlat_200);
+        assert!(matches!(
+            EdrEngine::query_position(&view, &far, None, None, None),
+            Err(DataServerError::LocationNotFound(_))
+        ));
+    }
+
+    /// A site whose only sweep has a malformed `rscale` (no usable range
+    /// geometry, `coverage_radius_m == None`) fails closed: a position query
+    /// is a 404, not a misleading HTTP 200 all-null.
+    #[test]
+    fn site_view_query_position_malformed_rscale_is_404() {
+        let mut vol = synthetic_volume(25.0, 60.0);
+        vol.sweeps[0].rscale = 0.0;
+        let mut by_site: HashMap<String, Vec<VolumeEntry>> = HashMap::new();
+        by_site.insert("fivih".to_string(), vec![entry(vol, "v")]);
+        let view = site_view_for(by_site, "fivih");
+
+        // Even at the antenna itself — no usable geometry → fail closed.
+        assert!(matches!(
+            EdrEngine::query_position(&view, "POINT(25.0 60.0)", None, None, None),
             Err(DataServerError::LocationNotFound(_))
         ));
     }

--- a/crates/engine-odim/src/volume_engine.rs
+++ b/crates/engine-odim/src/volume_engine.rs
@@ -970,20 +970,25 @@ impl PolarVolumeEngine {
 
     /// Re-scan the source and atomically swap the catalog.
     ///
-    /// The scan — directory walk or S3 `list` + multi-MB `get`s plus
-    /// HDF5 parsing — is blocking, so it runs on `spawn_blocking` rather
-    /// than stalling a Tokio worker. Mirrors `OdimEngine::poll_once`.
+    /// The scan — directory walk or S3 `list` + multi-MB `get`s plus HDF5
+    /// parsing — is blocking, and runs **directly on the background poll
+    /// runtime worker**, NOT via `spawn_blocking`. For a `Source::Remote`,
+    /// `scan_source` reaches into `ds-storage`, whose `block_in_place`
+    /// **panics** on a `spawn_blocking` pool thread but is valid on a
+    /// multi-thread-runtime worker (`poll_runtime()` is `new_multi_thread`).
+    /// Wrapping in `spawn_blocking` would silently fail every S3 refresh
+    /// (the `JoinError` is caught, but the catalog never updates — new
+    /// volumes are dropped until an admin reload). Mirrors the GRIB /
+    /// GeoTIFF / QueryData poll loops, which also call their blocking scan
+    /// directly on the poll runtime.
     async fn poll_once(&self) {
-        let collection_id = self.collection_id.clone();
-        let source = self.source.clone();
-        let cache = Arc::clone(&self.parse_cache);
-        let max_files = self.max_files;
-        let scan_result = tokio::task::spawn_blocking(move || {
-            scan_source(&collection_id, &source, &cache, max_files)
-        })
-        .await;
-        match scan_result {
-            Ok(Ok(catalog)) => {
+        match scan_source(
+            &self.collection_id,
+            &self.source,
+            &self.parse_cache,
+            self.max_files,
+        ) {
+            Ok(catalog) => {
                 let prev = self.catalog.load();
                 // Aggregate signals across sites for change detection: site
                 // count, newest volume time, and total volume count.
@@ -1010,14 +1015,8 @@ impl PolarVolumeEngine {
                 }
                 self.catalog.store(Arc::new(catalog));
             }
-            Ok(Err(e)) => {
+            Err(e) => {
                 tracing::warn!("[{}] PVOL catalog refresh failed: {e}", self.collection_id);
-            }
-            Err(join_err) => {
-                tracing::error!(
-                    "[{}] PVOL catalog refresh task panicked: {join_err}",
-                    self.collection_id
-                );
             }
         }
     }
@@ -2012,6 +2011,16 @@ fn finalize_single_site(
                 )
             });
     }
+    // Every selected volume produced no plottable coverage (e.g. a
+    // corrupted batch where every sweep's elevation angle is non-finite).
+    // An empty `CoverageCollection` is invalid CoverageJSON and would
+    // serve HTTP 200 for what is really "no data" — surface a 404 instead,
+    // matching the CLAUDE.md "no data in window → LocationNotFound" rule.
+    if covs.is_empty() {
+        return Err(DataServerError::LocationNotFound(
+            "no PVOL data for this site in the requested time window".into(),
+        ));
+    }
     Ok(CoverageResponse::Collection(covs))
 }
 
@@ -2020,24 +2029,31 @@ fn finalize_single_site(
 // ---------------------------------------------------------------------------
 
 impl PolarVolumeEngine {
-    /// NOD codes of every radar site currently in the catalog, sorted.
+    /// `(nod, label)` for every radar site with usable metadata, sorted by
+    /// `nod`, from **one** catalog snapshot.
     ///
     /// The loader calls this after construction (one synchronous scan has
-    /// already run) to expand this one source config into N per-site OGC
-    /// collections — one [`site_view`](Self::site_view) each. The set is a
-    /// snapshot: sites appearing or disappearing between polls are only
-    /// reflected on the next admin reload, which re-runs the expansion.
-    pub fn site_ids(&self) -> Vec<String> {
-        let mut ids: Vec<String> = self.catalog.load().by_site.keys().cloned().collect();
-        ids.sort();
-        ids
-    }
-
-    /// Human place name (ODIM `/what` PLC) for site `nod`, if the catalog
-    /// holds one — used to title the per-site collection. `None` when the
-    /// site is unknown or carries no place name.
-    pub fn site_label(&self, nod: &str) -> Option<String> {
-        self.catalog.load().by_site_meta.get(nod)?.plc.clone()
+    /// already run) to expand this source config into N per-site OGC
+    /// collections — one [`site_view`](Self::site_view) per entry. `label`
+    /// is the site's place name (ODIM `/what` PLC) or its `nod` when none.
+    ///
+    /// Enumerates `by_site_meta`, **not** `by_site`: a site whose latest
+    /// volume has no usable lowest sweep is absent from `by_site_meta`, so
+    /// registering it would yield a collection with no parameters/extent
+    /// (every WMS GetMap then 400s). Returning `(nod, label)` from a single
+    /// snapshot also keeps the registered id and title consistent even if a
+    /// background poll swaps the catalog mid-registration. Snapshot — sites
+    /// appearing or disappearing between polls surface on the next admin
+    /// reload, which re-runs the expansion.
+    pub fn sites(&self) -> Vec<(String, String)> {
+        let catalog = self.catalog.load();
+        let mut sites: Vec<(String, String)> = catalog
+            .by_site_meta
+            .iter()
+            .map(|(nod, meta)| (nod.clone(), meta.plc.clone().unwrap_or_else(|| nod.clone())))
+            .collect();
+        sites.sort_by(|a, b| a.0.cmp(&b.0));
+        sites
     }
 
     /// Build a [`PolarVolumeSiteView`] scoped to radar `nod`, sharing this
@@ -2317,6 +2333,15 @@ impl EdrEngine for PolarVolumeSiteView {
             parameters,
             levels.as_deref(),
         )?;
+        // Guard against an empty collection (every volume produced no
+        // plottable coverage) — an empty `CoverageCollection` is invalid
+        // CoverageJSON and should be a 404, not HTTP 200. Mirrors the
+        // network engine's dropped `query_area` is-empty check.
+        if covs.is_empty() {
+            return Err(DataServerError::LocationNotFound(
+                "no PVOL data for this site in the requested time window".into(),
+            ));
+        }
         Ok(CoverageResponse::Collection(covs))
     }
 
@@ -3489,5 +3514,79 @@ mod tests {
             ),
             Err(DataServerError::LocationNotFound(_))
         ));
+    }
+
+    /// A site whose latest volume has no usable lowest sweep is kept in
+    /// `by_site` but excluded from `by_site_meta` — so `sites()` (which the
+    /// loader enumerates) never registers a parameter-less, broken
+    /// collection for it. Regression guard for the `site_ids`-over-`by_site`
+    /// bug.
+    #[test]
+    fn derive_catalog_excludes_sweepless_site_from_meta() {
+        let mut by_site: HashMap<String, Vec<VolumeEntry>> = HashMap::new();
+        by_site.insert(
+            "good".to_string(),
+            vec![entry(synthetic_volume(25.0, 60.0), "g")],
+        );
+        // A site whose latest volume carries no sweeps — no derivable metadata.
+        let mut sweepless = synthetic_volume(26.0, 60.0);
+        sweepless.sweeps.clear();
+        by_site.insert("bad".to_string(), vec![entry(sweepless, "b")]);
+
+        let cache = Mutex::new(HashMap::new());
+        let catalog = derive_catalog(by_site, &cache, None);
+
+        // Both survive in `by_site` (non-empty volume lists)...
+        assert!(catalog.by_site.contains_key("good"));
+        assert!(catalog.by_site.contains_key("bad"));
+        // ...but only the one with a usable lowest sweep has metadata.
+        assert!(catalog.by_site_meta.contains_key("good"));
+        assert!(
+            !catalog.by_site_meta.contains_key("bad"),
+            "a sweepless site must be absent from by_site_meta so it is never registered"
+        );
+
+        // `sites()` (via an engine over this catalog) returns only `good`.
+        let view = PolarVolumeSiteView {
+            catalog: Arc::new(ArcSwap::from_pointee(catalog)),
+            nod: "good".into(),
+            collection_id: "test".into(),
+        };
+        // The view for `good` advertises its quantity; metadata is present.
+        assert!(!MapEngine::raster_info(&view).parameters.is_empty());
+    }
+
+    /// When every selected volume yields no plottable coverage (a sweep
+    /// whose elevation angle is non-finite ⇒ `volume_profile` returns
+    /// `None`), an EDR point query returns `LocationNotFound` (404), not an
+    /// empty `CoverageCollection` served as HTTP 200. Regression guard for
+    /// the dropped is-empty check.
+    #[test]
+    fn site_view_empty_coverage_is_location_not_found() {
+        let mut nan_vol = synthetic_volume(25.0, 60.0);
+        nan_vol.sweeps[0].elangle = f64::NAN;
+        let mut by_site: HashMap<String, Vec<VolumeEntry>> = HashMap::new();
+        by_site.insert("nanv".to_string(), vec![entry(nan_vol, "n")]);
+        let view = site_view_for(by_site, "nanv");
+
+        // No `z`: the only sweep has a non-finite angle, so the profile is
+        // empty and the collection would be empty → must be a 404.
+        // (`CoverageResponse` is not `Debug`, so assert on the variant.)
+        assert!(
+            matches!(
+                EdrEngine::query_position(&view, "POINT(25.0 60.0)", None, None, None),
+                Err(DataServerError::LocationNotFound(_))
+            ),
+            "an all-empty point coverage must be LocationNotFound, not HTTP 200"
+        );
+
+        // Same for an area query whose polygon contains the antenna.
+        assert!(
+            matches!(
+                EdrEngine::query_area(&view, "24.0,59.0,26.0,61.0", None, None, None),
+                Err(DataServerError::LocationNotFound(_))
+            ),
+            "an all-empty area coverage must be LocationNotFound"
+        );
     }
 }

--- a/crates/engine-odim/tests/integration.rs
+++ b/crates/engine-odim/tests/integration.rs
@@ -617,14 +617,15 @@ fn pvol_engine_remote_scan_discovers_fmi_volume() {
     );
 }
 
-/// A `get_raster_tile` call with no `parameter` (or an unparseable
-/// one) on a PVOL collection is a clean error, not a panic.
+/// A `get_raster_tile` call with no `parameter` defaults to the site's
+/// primary (first) quantity — a bare `LAYERS={site}` WMS / Maps request
+/// renders the primary moment rather than erroring.
 #[test]
-fn pvol_engine_rejects_missing_parameter() {
+fn pvol_bare_render_defaults_to_primary_quantity() {
     let fixture = Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("../../testdata/radar-fmi-pvol/202605191050_fivih_PVOL.h5");
     if !fixture.exists() {
-        eprintln!("skipping pvol_engine_rejects_missing_parameter: fixture absent");
+        eprintln!("skipping pvol_bare_render_defaults_to_primary_quantity: fixture absent");
         return;
     }
     let data_dir = fixture.parent().unwrap().to_str().unwrap();
@@ -648,20 +649,19 @@ fn pvol_engine_rejects_missing_parameter() {
         engine_odim::PolarVolumeEngine::new("fivih-pvol-test", Some(data_dir), &config).unwrap();
     let view = engine.site_view("fivih", "fivih-pvol-test-fivih");
 
-    // `RasterTile` has no `Debug`, so match rather than `unwrap_err`.
-    match view.get_raster_tile(
-        [23.4, 59.6, 25.6, 61.5],
-        8,
-        8,
-        None,
-        &OutputCrs::Wgs84,
-        None,
-        None,
-    ) {
-        Err(ds_core::error::DataServerError::InvalidParameter(_)) => {}
-        Err(other) => panic!("missing parameter must be InvalidParameter, got {other:?}"),
-        Ok(_) => panic!("missing parameter on a PVOL collection must error"),
-    }
+    // No parameter named → render the primary quantity (Ok), not a 400.
+    let tile = view
+        .get_raster_tile(
+            [23.4, 59.6, 25.6, 61.5],
+            8,
+            8,
+            None,
+            &OutputCrs::Wgs84,
+            None,
+            None,
+        )
+        .expect("a bare (no-parameter) render must default to the primary quantity");
+    assert_eq!(tile.values.len(), 8 * 8);
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/engine-odim/tests/integration.rs
+++ b/crates/engine-odim/tests/integration.rs
@@ -565,9 +565,9 @@ fn pvol_engine_remote_scan_discovers_fmi_volume() {
 
     // The `fivih` site must surface — view it under model B.
     assert!(
-        engine.site_ids().iter().any(|n| n == "fivih"),
+        engine.sites().iter().any(|(n, _)| n == "fivih"),
         "remote scan must discover the `fivih` site, got {:?}",
-        engine.site_ids()
+        engine.sites()
     );
     let view = engine.site_view("fivih", "fivih-remote-test-fivih");
 

--- a/crates/engine-odim/tests/integration.rs
+++ b/crates/engine-odim/tests/integration.rs
@@ -410,20 +410,18 @@ fn edr_query_area_masks_outside_polygon() {
 // PolarVolumeEngine — ODIM polar-volume (PVOL) MapEngine
 // ---------------------------------------------------------------------------
 
-/// End-to-end render against the real FMI Anjalankoski polar volume
-/// (`testdata/radar-fmi-pvol/202605150000_fianj_PVOL.h5`).
+/// End-to-end render against the real FMI Vihti polar volume
+/// (`testdata/radar-fmi-pvol/202605191050_fivih_PVOL.h5`).
 ///
 /// The 15 MB fixture is **not committed to git**, so this test skips
 /// gracefully when it is absent — CI stays green; a local checkout
 /// with the fixture exercises the full PVOL render pipeline.
 #[test]
-fn pvol_engine_renders_fmi_anjalankoski_volume() {
+fn pvol_engine_renders_fmi_vihti_volume() {
     let fixture = Path::new(env!("CARGO_MANIFEST_DIR"))
-        .join("../../testdata/radar-fmi-pvol/202605150000_fianj_PVOL.h5");
+        .join("../../testdata/radar-fmi-pvol/202605191050_fivih_PVOL.h5");
     if !fixture.exists() {
-        eprintln!(
-            "skipping pvol_engine_renders_fmi_anjalankoski_volume: fixture absent at {fixture:?}"
-        );
+        eprintln!("skipping pvol_engine_renders_fmi_vihti_volume: fixture absent at {fixture:?}");
         return;
     }
 
@@ -453,45 +451,48 @@ fn pvol_engine_renders_fmi_anjalankoski_volume() {
         time_window: None,
     };
 
-    let engine = engine_odim::PolarVolumeEngine::new("fianj-pvol-test", Some(data_dir), &config)
+    let engine = engine_odim::PolarVolumeEngine::new("fivih-pvol-test", Some(data_dir), &config)
         .expect("PolarVolumeEngine::new over the PVOL directory");
 
-    let info = engine.raster_info();
+    // Model B: the source expands into per-site collections. Take the
+    // Vihti site view and render through it.
+    let view = engine.site_view("fivih", "fivih-pvol-test-fivih");
+
+    let info = view.raster_info();
     assert_eq!(info.native_crs, "CRS:84");
-    assert!(!info.times.is_empty(), "PVOL catalog must have a timestep");
+    assert!(!info.times.is_empty(), "PVOL site must have a timestep");
     assert!(
         info.spatial_extent.is_some(),
-        "PVOL catalog must report a coverage bbox"
+        "PVOL site must report a coverage bbox"
     );
 
-    // The FMI Anjalankoski volume's lowest sweep exposes TH (and DBZH).
-    // At least one `fianj:<quantity>` parameter must surface.
-    let fianj_params: Vec<&str> = info
-        .parameters
-        .iter()
-        .map(|(name, _)| name.as_str())
-        .filter(|n| n.starts_with("fianj:"))
-        .collect();
+    // The FMI Vihti lowest sweep exposes TH (and DBZH). Under
+    // model B the parameters are **bare quantities** — no `fivih:` prefix.
+    let params: Vec<&str> = info.parameters.iter().map(|(n, _)| n.as_str()).collect();
     assert!(
-        !fianj_params.is_empty(),
-        "expected fianj:<quantity> parameters, got {:?}",
+        !params.is_empty(),
+        "expected bare-quantity parameters, got {:?}",
         info.parameters
     );
-    // Prefer TH if present (every FMI lowest sweep carries it), else
-    // any available fianj quantity.
-    let render_param = if fianj_params.contains(&"fianj:TH") {
-        "fianj:TH".to_string()
-    } else if fianj_params.contains(&"fianj:DBZH") {
-        "fianj:DBZH".to_string()
+    assert!(
+        params.iter().all(|n| !n.contains(':')),
+        "per-site parameters must be bare quantities, got {params:?}"
+    );
+    // Prefer TH if present (every FMI lowest sweep carries it), else any.
+    let render_param = if params.contains(&"TH") {
+        "TH"
+    } else if params.contains(&"DBZH") {
+        "DBZH"
     } else {
-        fianj_params[0].to_string()
-    };
+        params[0]
+    }
+    .to_string();
 
-    // Render a tile over the radar's coverage bbox. Anjalankoski sits
-    // near 27.11°E, 60.90°N; a ~2° box centred there is well inside
-    // the ~250 km sweep, so a real volume must produce some echoes.
-    let bbox = [26.0, 60.0, 28.2, 61.8];
-    let tile = engine
+    // Render a tile over the radar's coverage bbox. Vihti sits near
+    // 24.50°E, 60.56°N; a ~2° box centred there is well inside the
+    // ~250 km sweep, so a real volume must produce some echoes.
+    let bbox = [23.4, 59.6, 25.6, 61.5];
+    let tile = view
         .get_raster_tile(
             bbox,
             128,
@@ -501,7 +502,7 @@ fn pvol_engine_renders_fmi_anjalankoski_volume() {
             Some(&render_param),
             None,
         )
-        .expect("PVOL get_raster_tile over the coverage bbox");
+        .expect("PVOL site get_raster_tile over the coverage bbox");
 
     assert_eq!(tile.width, 128);
     assert_eq!(tile.height, 128);
@@ -521,13 +522,13 @@ fn pvol_engine_renders_fmi_anjalankoski_volume() {
 /// real remote code path — the same trick PR #182 used for the COMP
 /// engine.
 ///
-/// Asserts the Anjalankoski (`fianj`) volume is discovered with its
+/// Asserts the Vihti (`fivih`) volume is discovered with its
 /// 13 elevation sweeps. The 15 MB fixture is **not committed to git**,
 /// so the test skips gracefully when it is absent.
 #[test]
 fn pvol_engine_remote_scan_discovers_fmi_volume() {
     let fixture_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../testdata/radar-fmi-pvol");
-    let fixture = fixture_dir.join("202605150000_fianj_PVOL.h5");
+    let fixture = fixture_dir.join("202605191050_fivih_PVOL.h5");
     if !fixture.exists() {
         eprintln!("skipping pvol_engine_remote_scan_discovers_fmi_volume: fixture absent");
         return;
@@ -544,24 +545,33 @@ fn pvol_engine_remote_scan_discovers_fmi_volume() {
     )
     .expect("build a DataStore over the fixture directory");
 
-    // The FMI Anjalankoski polar volume carries 13 elevation sweeps —
+    // The FMI Vihti polar volume is a multi-sweep elevation stack
+    // (9 distinct angles, 0.3°–9°, with low-elevation split cuts) —
     // assert that directly from the parsed fixture so the remote-scan
     // path below is verified against a known volume shape.
     let bytes = std::fs::read(&fixture).expect("read PVOL fixture bytes");
     let volume = engine_odim::pvol::read_polar_volume(&bytes).expect("parse PVOL fixture");
-    assert_eq!(volume.site.nod.as_deref(), Some("fianj"));
-    assert_eq!(
-        volume.sweeps.len(),
-        13,
-        "FMI Anjalankoski volume has 13 elevation sweeps"
+    assert_eq!(volume.site.nod.as_deref(), Some("fivih"));
+    assert!(
+        volume.sweeps.len() >= 9,
+        "FMI Vihti volume has ≥9 elevation sweeps, got {}",
+        volume.sweeps.len()
     );
 
     // Empty prefix scans the store root, where the fixture lives.
     let engine =
-        engine_odim::PolarVolumeEngine::new_remote_for_test("fianj-remote-test", store, "")
+        engine_odim::PolarVolumeEngine::new_remote_for_test("fivih-remote-test", store, "")
             .expect("PolarVolumeEngine remote scan over the fixture directory");
 
-    let info = engine.raster_info();
+    // The `fivih` site must surface — view it under model B.
+    assert!(
+        engine.site_ids().iter().any(|n| n == "fivih"),
+        "remote scan must discover the `fivih` site, got {:?}",
+        engine.site_ids()
+    );
+    let view = engine.site_view("fivih", "fivih-remote-test-fivih");
+
+    let info = view.raster_info();
     assert_eq!(info.native_crs, "CRS:84");
     assert!(
         !info.times.is_empty(),
@@ -572,32 +582,26 @@ fn pvol_engine_remote_scan_discovers_fmi_volume() {
         "remote scan must report a coverage bbox"
     );
 
-    // The `fianj` site must surface with `fianj:<quantity>` parameters.
-    let fianj_params: Vec<&str> = info
-        .parameters
-        .iter()
-        .map(|(name, _)| name.as_str())
-        .filter(|n| n.starts_with("fianj:"))
-        .collect();
+    // Parameters are bare quantities (no `fivih:` prefix).
+    let params: Vec<&str> = info.parameters.iter().map(|(n, _)| n.as_str()).collect();
     assert!(
-        !fianj_params.is_empty(),
-        "remote scan must discover fianj:<quantity> parameters, got {:?}",
+        !params.is_empty() && params.iter().all(|n| !n.contains(':')),
+        "remote scan must discover bare-quantity parameters, got {:?}",
         info.parameters
     );
 
-    // The FMI Anjalankoski polar volume has 13 elevation sweeps — a
-    // render over its coverage bbox proves the streamed-then-parsed
-    // volume is intact end-to-end.
-    let render_param = fianj_params
+    // A render over the radar's coverage bbox proves the
+    // streamed-then-parsed volume is intact end-to-end.
+    let render_param = params
         .iter()
-        .find(|n| **n == "fianj:TH")
-        .or_else(|| fianj_params.iter().find(|n| **n == "fianj:DBZH"))
+        .find(|n| **n == "TH")
+        .or_else(|| params.iter().find(|n| **n == "DBZH"))
         .copied()
-        .unwrap_or(fianj_params[0])
+        .unwrap_or(params[0])
         .to_string();
-    let tile = engine
+    let tile = view
         .get_raster_tile(
-            [26.0, 60.0, 28.2, 61.8],
+            [23.4, 59.6, 25.6, 61.5],
             64,
             64,
             None,
@@ -618,7 +622,7 @@ fn pvol_engine_remote_scan_discovers_fmi_volume() {
 #[test]
 fn pvol_engine_rejects_missing_parameter() {
     let fixture = Path::new(env!("CARGO_MANIFEST_DIR"))
-        .join("../../testdata/radar-fmi-pvol/202605150000_fianj_PVOL.h5");
+        .join("../../testdata/radar-fmi-pvol/202605191050_fivih_PVOL.h5");
     if !fixture.exists() {
         eprintln!("skipping pvol_engine_rejects_missing_parameter: fixture absent");
         return;
@@ -641,11 +645,12 @@ fn pvol_engine_rejects_missing_parameter() {
         time_window: None,
     };
     let engine =
-        engine_odim::PolarVolumeEngine::new("fianj-pvol-test", Some(data_dir), &config).unwrap();
+        engine_odim::PolarVolumeEngine::new("fivih-pvol-test", Some(data_dir), &config).unwrap();
+    let view = engine.site_view("fivih", "fivih-pvol-test-fivih");
 
     // `RasterTile` has no `Debug`, so match rather than `unwrap_err`.
-    match engine.get_raster_tile(
-        [26.0, 60.0, 28.0, 62.0],
+    match view.get_raster_tile(
+        [23.4, 59.6, 25.6, 61.5],
         8,
         8,
         None,
@@ -663,12 +668,15 @@ fn pvol_engine_rejects_missing_parameter() {
 // PolarVolumeEngine — EdrEngine (M3a: sites as locations + position queries)
 // ---------------------------------------------------------------------------
 
-/// Build a PVOL engine over the local `radar-fmi-pvol` fixture
-/// directory, or `None` when the (uncommitted, 15 MB) fixture is
-/// absent — so these tests skip gracefully in CI.
-fn pvol_fixture_engine() -> Option<engine_odim::PolarVolumeEngine> {
+/// Build the per-site `PolarVolumeSiteView` for the Vihti (`fivih`)
+/// radar over the local `radar-fmi-pvol` fixture directory, or `None` when
+/// the (uncommitted, 15 MB) fixture is absent — so these tests skip
+/// gracefully in CI. Under model B each radar site is its own collection,
+/// served by such a view; the owning engine may be dropped because the
+/// view holds an `Arc` of the shared catalog.
+fn pvol_fixture_view() -> Option<engine_odim::PolarVolumeSiteView> {
     let fixture_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../testdata/radar-fmi-pvol");
-    if !fixture_dir.join("202605150000_fianj_PVOL.h5").exists() {
+    if !fixture_dir.join("202605191050_fivih_PVOL.h5").exists() {
         return None;
     }
     let config = OdimConfig {
@@ -687,53 +695,52 @@ fn pvol_fixture_engine() -> Option<engine_odim::PolarVolumeEngine> {
         prefix_pattern: None,
         time_window: None,
     };
-    Some(
-        engine_odim::PolarVolumeEngine::new(
-            "fianj-edr-test",
-            Some(fixture_dir.to_str().expect("utf8 fixture dir")),
-            &config,
-        )
-        .expect("PolarVolumeEngine::new over the PVOL fixture directory"),
+    let engine = engine_odim::PolarVolumeEngine::new(
+        "fivih-edr-test",
+        Some(fixture_dir.to_str().expect("utf8 fixture dir")),
+        &config,
     )
+    .expect("PolarVolumeEngine::new over the PVOL fixture directory");
+    Some(engine.site_view("fivih", "fivih-edr-test-fivih"))
 }
 
 /// `get_locations` exposes each radar site as an EDR location keyed by
 /// its ODIM NOD code, with the antenna position as the point geometry.
 #[test]
 fn pvol_edr_get_locations_lists_sites() {
-    let Some(engine) = pvol_fixture_engine() else {
+    let Some(view) = pvol_fixture_view() else {
         eprintln!("skipping pvol_edr_get_locations_lists_sites: fixture absent");
         return;
     };
-    let locations = EdrEngine::get_locations(&engine).expect("get_locations");
+    let locations = EdrEngine::get_locations(&view).expect("get_locations");
     assert!(
         !locations.is_empty(),
         "the PVOL fixture must surface at least one radar site"
     );
-    let fianj = locations
+    let fivih = locations
         .iter()
-        .find(|l| l.id == "fianj")
-        .expect("Anjalankoski site keyed by NOD code `fianj`");
-    // Anjalankoski sits near 27.1°E, 60.9°N.
+        .find(|l| l.id == "fivih")
+        .expect("Vihti site keyed by NOD code `fivih`");
+    // Vihti sits near 24.50°E, 60.56°N.
     assert!(
-        (26.0..28.5).contains(&fianj.longitude) && (60.0..61.8).contains(&fianj.latitude),
-        "fianj antenna near 27.1E/60.9N, got {},{}",
-        fianj.longitude,
-        fianj.latitude
+        (23.5..25.5).contains(&fivih.longitude) && (60.0..61.0).contains(&fivih.latitude),
+        "fivih antenna near 24.50E/60.56N, got {},{}",
+        fivih.longitude,
+        fivih.latitude
     );
-    assert!(!fianj.label.is_empty(), "a location carries a label");
+    assert!(!fivih.label.is_empty(), "a location carries a label");
 }
 
 /// A position query with no `z` returns a `CoverageCollection` of
 /// `VerticalProfile`s — one per timestep — sampling every sweep.
 #[test]
 fn pvol_edr_query_position_returns_vertical_profiles() {
-    let Some(engine) = pvol_fixture_engine() else {
+    let Some(view) = pvol_fixture_view() else {
         eprintln!("skipping pvol_edr_query_position_returns_vertical_profiles: fixture absent");
         return;
     };
-    // ~30 km north of Anjalankoski — inside the lowest sweep.
-    let response = EdrEngine::query_position(&engine, "POINT(27.1 61.2)", None, None, None)
+    // ~30 km north of Vihti — inside the lowest sweep.
+    let response = EdrEngine::query_position(&view, "POINT(24.5 60.85)", None, None, None)
         .expect("position query inside radar coverage");
     let coverages = match response {
         CoverageResponse::Collection(c) => c,
@@ -743,7 +750,7 @@ fn pvol_edr_query_position_returns_vertical_profiles() {
     for qr in &coverages {
         match &qr.domain {
             DomainDescription::VerticalProfile { x, y, z, .. } => {
-                assert!((*x - 27.1).abs() < 1e-9 && (*y - 61.2).abs() < 1e-9);
+                assert!((*x - 24.5).abs() < 1e-9 && (*y - 60.85).abs() < 1e-9);
                 assert!(!z.values.is_empty(), "a profile spans the sweep angles");
                 for arr in qr.ranges.values() {
                     assert_eq!(arr.shape, vec![z.values.len()]);
@@ -763,14 +770,14 @@ fn pvol_edr_query_position_returns_vertical_profiles() {
 /// `PointSeries` (a `Single` coverage).
 #[test]
 fn pvol_edr_query_position_with_z_returns_point_series() {
-    let Some(engine) = pvol_fixture_engine() else {
+    let Some(view) = pvol_fixture_view() else {
         eprintln!("skipping pvol_edr_query_position_with_z_returns_point_series: fixture absent");
         return;
     };
-    let vertical = EdrEngine::get_vertical_extent(&engine).expect("PVOL has a vertical extent");
+    let vertical = EdrEngine::get_vertical_extent(&view).expect("PVOL has a vertical extent");
     let level = vertical.levels[0];
     let response =
-        EdrEngine::query_position(&engine, "POINT(27.1 61.2)", None, None, Some(&[level]))
+        EdrEngine::query_position(&view, "POINT(24.5 60.85)", None, None, Some(&[level]))
             .expect("z-pinned position query");
     let result = match response {
         CoverageResponse::Single(qr) => qr,
@@ -788,12 +795,12 @@ fn pvol_edr_query_position_with_z_returns_point_series() {
 /// an unknown id is `LocationNotFound` (HTTP 404), not a panic.
 #[test]
 fn pvol_edr_query_location_by_nod() {
-    let Some(engine) = pvol_fixture_engine() else {
+    let Some(view) = pvol_fixture_view() else {
         eprintln!("skipping pvol_edr_query_location_by_nod: fixture absent");
         return;
     };
-    let response = EdrEngine::query_location(&engine, "fianj", None, None, None)
-        .expect("query_location for the fianj site");
+    let response = EdrEngine::query_location(&view, "fivih", None, None, None)
+        .expect("query_location for the fivih site");
     let coverages = match response {
         CoverageResponse::Collection(c) => c,
         CoverageResponse::Single(_) => panic!("a no-z site query must return a Collection"),
@@ -806,7 +813,7 @@ fn pvol_edr_query_location_by_nod() {
         ));
     }
 
-    match EdrEngine::query_location(&engine, "nosuchsite", None, None, None) {
+    match EdrEngine::query_location(&view, "nosuchsite", None, None, None) {
         Err(ds_core::error::DataServerError::LocationNotFound(_)) => {}
         other => panic!("unknown location id must be LocationNotFound, got {other:?}"),
     }
@@ -816,18 +823,18 @@ fn pvol_edr_query_location_by_nod() {
 /// polygon far from any radar is `LocationNotFound`.
 #[test]
 fn pvol_edr_query_area_collects_sites() {
-    let Some(engine) = pvol_fixture_engine() else {
+    let Some(view) = pvol_fixture_view() else {
         eprintln!("skipping pvol_edr_query_area_collects_sites: fixture absent");
         return;
     };
-    // A bbox enclosing Anjalankoski (27.1E, 60.9N).
-    let result = EdrEngine::query_area(&engine, "25.0,59.0,29.0,62.5", None, None, None)
-        .expect("area query enclosing the fianj site");
+    // A bbox enclosing Vihti (24.50E, 60.56N).
+    let result = EdrEngine::query_area(&view, "23.0,59.0,26.0,62.0", None, None, None)
+        .expect("area query enclosing the fivih site");
     match result {
         CoverageResponse::Collection(coverages) => {
             assert!(
                 !coverages.is_empty(),
-                "the polygon encloses fianj, so the collection is non-empty"
+                "the polygon encloses fivih, so the collection is non-empty"
             );
             for qr in &coverages {
                 assert!(matches!(
@@ -842,7 +849,7 @@ fn pvol_edr_query_area_collects_sites() {
     }
 
     // A polygon far from any FMI radar matches nothing.
-    match EdrEngine::query_area(&engine, "0.0,0.0,1.0,1.0", None, None, None) {
+    match EdrEngine::query_area(&view, "0.0,0.0,1.0,1.0", None, None, None) {
         Err(ds_core::error::DataServerError::LocationNotFound(_)) => {}
         other => panic!("an empty area must be LocationNotFound, got {other:?}"),
     }
@@ -859,17 +866,17 @@ fn pvol_edr_query_area_collects_sites() {
 /// must sample a finite value.
 #[test]
 fn pvol_edr_query_trajectory_returns_section() {
-    let Some(engine) = pvol_fixture_engine() else {
+    let Some(view) = pvol_fixture_view() else {
         eprintln!("skipping pvol_edr_query_trajectory_returns_section: fixture absent");
         return;
     };
-    // A ~50 km north-bound leg starting south-west of Anjalankoski
-    // (~27.1°E, 60.9°N), so the path crosses the radar's lowest sweep
-    // coverage along its length. `z` here selects the 0.5°–5° elevation
-    // angle band (the cross-section's vertical axis is derived height).
-    let coords = "LINESTRING(27.1 60.6, 27.1 61.1)";
+    // A ~65 km north-bound leg through Vihti (~24.50°E, 60.56°N), so the
+    // path crosses the radar's lowest sweep coverage along its length.
+    // `z` here selects the 0.5°–5° elevation angle band (the
+    // cross-section's vertical axis is derived height).
+    let coords = "LINESTRING(24.5 60.3, 24.5 60.9)";
     let response = EdrEngine::query_trajectory(
-        &engine,
+        &view,
         coords,
         None,
         Some(&["DBZH".to_string()]),
@@ -907,13 +914,14 @@ fn pvol_edr_query_trajectory_returns_section() {
     );
 }
 
-/// A trajectory whose path lies entirely outside any radar's coverage
-/// still yields a Section, but every cell is nodata. Far-out paths
-/// fall back to the catalog's `nearest_site` and produce a Section
-/// shaped against that site's z extent.
+/// A trajectory whose path lies entirely outside this site's coverage
+/// still yields a Section, but every cell is nodata: a per-site view
+/// always samples its own radar (no nearest-site pick), so a far-out path
+/// produces a Section shaped against this site's z extent with all-None
+/// cells.
 #[test]
 fn pvol_edr_query_trajectory_out_of_coverage_yields_empty_cells() {
-    let Some(engine) = pvol_fixture_engine() else {
+    let Some(view) = pvol_fixture_view() else {
         eprintln!(
             "skipping pvol_edr_query_trajectory_out_of_coverage_yields_empty_cells: fixture absent"
         );
@@ -923,7 +931,7 @@ fn pvol_edr_query_trajectory_out_of_coverage_yields_empty_cells() {
     // range. `z` selects a low elevation-angle band.
     let coords = "LINESTRING(-150 -30, -150 -29)";
     match EdrEngine::query_trajectory(
-        &engine,
+        &view,
         coords,
         None,
         Some(&["DBZH".to_string()]),
@@ -952,7 +960,7 @@ fn pvol_edr_query_trajectory_out_of_coverage_yields_empty_cells() {
 /// API layer can map to HTTP 400.
 #[test]
 fn pvol_edr_query_trajectory_rejects_malformed_linestring() {
-    let Some(engine) = pvol_fixture_engine() else {
+    let Some(view) = pvol_fixture_view() else {
         eprintln!(
             "skipping pvol_edr_query_trajectory_rejects_malformed_linestring: fixture absent"
         );
@@ -964,7 +972,7 @@ fn pvol_edr_query_trajectory_rejects_malformed_linestring() {
         "LINESTRINGZ(27.1 60.9 0, 27.1 61.1 100)",
         "LINESTRING(NaN 60.9, 27.1 61.1)",
     ] {
-        match EdrEngine::query_trajectory(&engine, bad, None, None, None) {
+        match EdrEngine::query_trajectory(&view, bad, None, None, None) {
             Err(ds_core::error::DataServerError::InvalidParameter(_)) => {}
             other => panic!("expected InvalidParameter for `{bad}`, got {other:?}"),
         }

--- a/crates/engine-odim/tests/integration.rs
+++ b/crates/engine-odim/tests/integration.rs
@@ -732,6 +732,24 @@ fn pvol_edr_get_locations_lists_sites() {
 }
 
 /// A position query with no `z` returns a `CoverageCollection` of
+/// A position query for a point far outside the real radar's coverage
+/// (Kansas vs a Finnish radar) is `LocationNotFound` (404), not HTTP 200
+/// all-null — exercises the coverage-radius guard on real data.
+#[test]
+fn pvol_edr_position_outside_coverage_is_404() {
+    let Some(view) = pvol_fixture_view() else {
+        eprintln!("skipping pvol_edr_position_outside_coverage_is_404: fixture absent");
+        return;
+    };
+    assert!(
+        matches!(
+            EdrEngine::query_position(&view, "POINT(-100 40)", None, None, None),
+            Err(ds_core::error::DataServerError::LocationNotFound(_))
+        ),
+        "a point ~7000 km from the radar must be outside coverage (404)"
+    );
+}
+
 /// `VerticalProfile`s — one per timestep — sampling every sweep.
 #[test]
 fn pvol_edr_query_position_returns_vertical_profiles() {

--- a/crates/server/src/admin.rs
+++ b/crates/server/src/admin.rs
@@ -2062,6 +2062,21 @@ pub async fn health_handler(State(state): State<AdminState>) -> impl IntoRespons
     let mut data_ages: HashMap<String, i64> = HashMap::new();
     let mut temporal_info: HashMap<String, serde_json::Value> = HashMap::new();
 
+    // Helper: build temporal extent { interval, values? } from a sorted
+    // (first..last) timestamp list.
+    fn temporal_from_times(times: &[chrono::DateTime<chrono::Utc>]) -> Option<serde_json::Value> {
+        let first = times.first()?;
+        let last = times.last()?;
+        let mut obj = serde_json::Map::new();
+        obj.insert(
+            "interval".to_string(),
+            json!([[first.to_rfc3339(), last.to_rfc3339()]]),
+        );
+        let values: Vec<String> = times.iter().map(|t| t.to_rfc3339()).collect();
+        obj.insert("values".to_string(), json!(values));
+        Some(json!(obj))
+    }
+
     // Helper: build temporal extent from any EdrEngine
     fn build_temporal(engine: &dyn ds_core::edr_engine::EdrEngine) -> Option<serde_json::Value> {
         let (start, end) = engine.get_temporal_extent()?;
@@ -2119,19 +2134,19 @@ pub async fn health_handler(State(state): State<AdminState>) -> impl IntoRespons
     {
         // PVOL sources expand into one per-site collection each
         // (`{base}-{nod}`); the engine is keyed by `{base}` and does not
-        // implement `EdrEngine`, so build each site's temporal extent from
-        // its `PolarVolumeSiteView` and key it by the per-site id to match
-        // the `{base}-{nod}` health entries.
+        // implement `EdrEngine`. `site_times()` returns every site's
+        // timestamps from one catalog snapshot, so the temporal extents are
+        // built without allocating a view per site (O(1)-from-a-snapshot per
+        // request). Key each by the `{base}-{nod}` id to match the health
+        // entries.
         let engines = state
             .odim_volume_engines
             .read()
             .unwrap_or_else(|e| e.into_inner());
         for engine in engines.iter() {
-            for (nod, _label) in engine.sites() {
-                let id = format!("{}-{}", engine.collection_id(), nod);
-                let view = engine.site_view(&nod, &id);
-                if let Some(temporal) = build_temporal(&view) {
-                    temporal_info.insert(id, temporal);
+            for (nod, times) in engine.site_times() {
+                if let Some(temporal) = temporal_from_times(&times) {
+                    temporal_info.insert(format!("{}-{}", engine.collection_id(), nod), temporal);
                 }
             }
         }

--- a/crates/server/src/admin.rs
+++ b/crates/server/src/admin.rs
@@ -1176,80 +1176,118 @@ pub fn load_collections(
 
                 odim_volume_engines.push(engine.clone());
 
-                if collection.apis.contains(&"edr".to_string()) {
-                    edr_engines.insert(
-                        collection.id.clone(),
-                        engine.clone() as Arc<dyn ds_core::edr_engine::EdrEngine>,
+                // Model B: one PVOL source expands into N per-site OGC
+                // collections — one per radar `nod`, parameter = bare
+                // quantity. The owning engine keeps the single scan, parse
+                // cache, and poll loop; each site gets a cheap
+                // `PolarVolumeSiteView` over the shared catalog. The site
+                // set is the catalog snapshot taken by `new`'s synchronous
+                // scan; sites that appear later surface on the next reload
+                // (which re-runs this expansion).
+                let site_ids = engine.site_ids();
+                if site_ids.is_empty() {
+                    tracing::warn!(
+                        "Collection '{}': PVOL source has no radar sites yet — no per-site \
+                         collections registered. Reload once volume files arrive.",
+                        collection.id
                     );
-                    edr_collections.insert(collection.id.clone(), collection.clone());
-                    info!("Collection '{}': wired to EDR API", collection.id);
+                    // Keep the source visible in `/health` even with no
+                    // data, so an empty-bucket misconfiguration isn't silent.
+                    health.push(CollectionHealth {
+                        id: collection.id.clone(),
+                        engine_type: "odim-volume".into(),
+                        status: CollectionStatus::Degraded,
+                        error: Some("no radar sites discovered yet".into()),
+                    });
                 }
+                for nod in &site_ids {
+                    let site_id = format!("{}-{}", collection.id, nod);
+                    let label = engine.site_label(nod).unwrap_or_else(|| nod.clone());
+                    let view = Arc::new(engine.site_view(nod, &site_id));
 
-                // PVOL is multi-parameter (one layer per <site>:<quantity>).
-                let raster_params =
-                    ds_core::map_engine::MapEngine::raster_info(engine.as_ref()).parameters;
+                    // Per-site collection config: inherit the base
+                    // (`apis`, `[wms]` styling, …) and override identity.
+                    let mut site_cfg = collection.clone();
+                    site_cfg.id = site_id.clone();
+                    site_cfg.title = format!("{} — {label}", collection.title);
+                    site_cfg.description =
+                        format!("{} (radar site {label} / {nod})", collection.description);
 
-                if collection.apis.contains(&"wms".to_string()) {
-                    map_engines.insert(
-                        collection.id.clone(),
-                        engine.clone() as Arc<dyn ds_core::map_engine::MapEngine>,
-                    );
-                    map_collections.insert(collection.id.clone(), collection.clone());
-                    let styles = build_styles(collection, &bundle_index);
-                    map_styles.insert(collection.id.clone(), styles);
-                    if !raster_params.is_empty() {
-                        register_parameter_layer_styles(
-                            collection,
-                            &raster_params,
-                            &mut map_styles,
-                            &bundle_index,
+                    if collection.apis.contains(&"edr".to_string()) {
+                        edr_engines.insert(
+                            site_id.clone(),
+                            view.clone() as Arc<dyn ds_core::edr_engine::EdrEngine>,
                         );
+                        edr_collections.insert(site_id.clone(), site_cfg.clone());
                     }
-                    info!("Collection '{}': wired to WMS API", collection.id);
-                }
-                if collection.apis.contains(&"maps".to_string()) {
-                    maps_engines.insert(
-                        collection.id.clone(),
-                        engine.clone() as Arc<dyn ds_core::map_engine::MapEngine>,
-                    );
-                    maps_collections.insert(collection.id.clone(), collection.clone());
-                    let styles = build_styles(collection, &bundle_index);
-                    maps_styles.insert(collection.id.clone(), styles);
-                    if !raster_params.is_empty() {
-                        register_parameter_layer_styles(
-                            collection,
-                            &raster_params,
-                            &mut maps_styles,
-                            &bundle_index,
-                        );
-                    }
-                    info!("Collection '{}': wired to Maps API", collection.id);
-                }
-                if collection.apis.contains(&"tiles".to_string()) {
-                    tiles_engines.insert(
-                        collection.id.clone(),
-                        engine.clone() as Arc<dyn ds_core::map_engine::MapEngine>,
-                    );
-                    tiles_collections.insert(collection.id.clone(), collection.clone());
-                    let styles = build_styles(collection, &bundle_index);
-                    tiles_styles.insert(collection.id.clone(), styles);
-                    if !raster_params.is_empty() {
-                        register_parameter_layer_styles(
-                            collection,
-                            &raster_params,
-                            &mut tiles_styles,
-                            &bundle_index,
-                        );
-                    }
-                    info!("Collection '{}': wired to Tiles API", collection.id);
-                }
 
-                health.push(CollectionHealth {
-                    id: collection.id.clone(),
-                    engine_type: "odim-volume".into(),
-                    status: CollectionStatus::Ready,
-                    error: None,
-                });
+                    // Per-site, multi-parameter: one layer per bare quantity.
+                    let raster_params =
+                        ds_core::map_engine::MapEngine::raster_info(view.as_ref()).parameters;
+
+                    if collection.apis.contains(&"wms".to_string()) {
+                        map_engines.insert(
+                            site_id.clone(),
+                            view.clone() as Arc<dyn ds_core::map_engine::MapEngine>,
+                        );
+                        map_collections.insert(site_id.clone(), site_cfg.clone());
+                        let styles = build_styles(&site_cfg, &bundle_index);
+                        map_styles.insert(site_id.clone(), styles);
+                        if !raster_params.is_empty() {
+                            register_parameter_layer_styles(
+                                &site_cfg,
+                                &raster_params,
+                                &mut map_styles,
+                                &bundle_index,
+                            );
+                        }
+                    }
+                    if collection.apis.contains(&"maps".to_string()) {
+                        maps_engines.insert(
+                            site_id.clone(),
+                            view.clone() as Arc<dyn ds_core::map_engine::MapEngine>,
+                        );
+                        maps_collections.insert(site_id.clone(), site_cfg.clone());
+                        let styles = build_styles(&site_cfg, &bundle_index);
+                        maps_styles.insert(site_id.clone(), styles);
+                        if !raster_params.is_empty() {
+                            register_parameter_layer_styles(
+                                &site_cfg,
+                                &raster_params,
+                                &mut maps_styles,
+                                &bundle_index,
+                            );
+                        }
+                    }
+                    if collection.apis.contains(&"tiles".to_string()) {
+                        tiles_engines.insert(
+                            site_id.clone(),
+                            view.clone() as Arc<dyn ds_core::map_engine::MapEngine>,
+                        );
+                        tiles_collections.insert(site_id.clone(), site_cfg.clone());
+                        let styles = build_styles(&site_cfg, &bundle_index);
+                        tiles_styles.insert(site_id.clone(), styles);
+                        if !raster_params.is_empty() {
+                            register_parameter_layer_styles(
+                                &site_cfg,
+                                &raster_params,
+                                &mut tiles_styles,
+                                &bundle_index,
+                            );
+                        }
+                    }
+
+                    info!(
+                        "Collection '{}': wired per-site radar collection '{site_id}' ({label})",
+                        collection.id
+                    );
+                    health.push(CollectionHealth {
+                        id: site_id,
+                        engine_type: "odim-volume".into(),
+                        status: CollectionStatus::Ready,
+                        error: None,
+                    });
+                }
             }
             "postgis" => {
                 let postgis_cfg = match collection.postgis.as_ref() {

--- a/crates/server/src/admin.rs
+++ b/crates/server/src/admin.rs
@@ -1214,6 +1214,33 @@ pub fn load_collections(
                 }
                 for (nod, label) in &sites {
                     let site_id = format!("{}-{}", collection.id, nod);
+
+                    // Defence-in-depth against a derived-id collision. NODs
+                    // are alphanumeric (so two odim-volume sources can't
+                    // derive the same id), but an *inline* `[[collections]]`
+                    // entry could be named `{base}-{nod}` by hand. Skip with
+                    // an error rather than silently overwriting a registry
+                    // entry. NOTE: per-quantity WMS/Maps styles are
+                    // snapshotted from `raster_info()` at load — if a poll
+                    // later brings in a *new* moment for a site, its layer
+                    // falls back to the collection default colormap until the
+                    // next `POST /admin/collections/reload` (same load-time
+                    // snapshot as GeoTIFF/QueryData; PVOL moment sets are
+                    // firmware-dependent, so a reload is required when they
+                    // change).
+                    if edr_collections.contains_key(&site_id)
+                        || map_collections.contains_key(&site_id)
+                        || maps_collections.contains_key(&site_id)
+                        || tiles_collections.contains_key(&site_id)
+                    {
+                        tracing::error!(
+                            "Collection '{}': per-site id '{site_id}' collides with an \
+                             already-registered collection — skipping this site",
+                            collection.id
+                        );
+                        continue;
+                    }
+
                     let view = Arc::new(engine.site_view(nod, &site_id));
 
                     // Per-site collection config: inherit the base
@@ -1916,7 +1943,7 @@ pub async fn reload_handler(
     // reload would freeze the live registry with dead loops and no new ones
     // spawned (the guard returns before the spawn block).
 
-    let result = load_collections(
+    let mut result = load_collections(
         &config.collections,
         &config.style_bundles,
         &base_url,
@@ -1962,6 +1989,47 @@ pub async fn reload_handler(
                 "configured": config.collections.len()
             })),
         ));
+    }
+
+    // Surface a vanished per-site radar in `/health`. A site that was
+    // `Ready` in the live registry but is absent from the new scan (its
+    // files aged out of the time window, or the radar went offline) would
+    // otherwise just disappear from `/collections` with no `/health` trace.
+    // Push a `Degraded` entry so monitoring can see it — but only when the
+    // site's base source is still configured (a fully-removed source is a
+    // config change, not a data gap). Degraded, so it doesn't affect the
+    // `ready` guard above.
+    {
+        let old_health = state.health.read().unwrap_or_else(|e| e.into_inner());
+        let new_ids: std::collections::HashSet<&str> =
+            result.health.iter().map(|h| h.id.as_str()).collect();
+        let new_bases: Vec<String> = result
+            .odim_volume_engines
+            .iter()
+            .map(|e| e.collection_id().to_string())
+            .collect();
+        let vanished: Vec<String> = old_health
+            .iter()
+            .filter(|h| h.engine_type == "odim-volume" && h.status == CollectionStatus::Ready)
+            .filter(|h| !new_ids.contains(h.id.as_str()))
+            .filter(|h| {
+                new_bases.iter().any(|b| {
+                    h.id.strip_prefix(b.as_str())
+                        .is_some_and(|r| r.starts_with('-'))
+                })
+            })
+            .map(|h| h.id.clone())
+            .collect();
+        drop(old_health);
+        for id in vanished {
+            tracing::warn!("Reload: radar site collection '{id}' is no longer present in the scan");
+            result.health.push(CollectionHealth {
+                id,
+                engine_type: "odim-volume".into(),
+                status: CollectionStatus::Degraded,
+                error: Some("site no longer present in the latest scan".into()),
+            });
+        }
     }
 
     // Reload accepted — now shut down the old poll loops (the new ones are

--- a/crates/server/src/admin.rs
+++ b/crates/server/src/admin.rs
@@ -2147,15 +2147,18 @@ pub async fn reload_handler(
         .write()
         .unwrap_or_else(|e| e.into_inner()) = result.postgis_engines;
 
+    let degraded = loaded.saturating_sub(ready);
     info!(
-        "Reload complete: {}/{} collections loaded",
-        loaded,
+        "Reload complete: {ready} ready ({degraded} degraded) of {} configured",
         config.collections.len()
     );
 
     Ok(Json(json!({
         "status": "ok",
-        "loaded": loaded,
+        // `ready` = fully-working collections; `degraded` wire no servable
+        // routes (e.g. an empty odim-volume source) but aren't failures.
+        "ready": ready,
+        "degraded": degraded,
         "configured": config.collections.len(),
         "collections": result.health
     })))

--- a/crates/server/src/admin.rs
+++ b/crates/server/src/admin.rs
@@ -1190,19 +1190,19 @@ pub fn load_collections(
                 // swaps the catalog mid-registration.
                 let sites = engine.sites();
                 if sites.is_empty() {
+                    // Register nothing and add NO health entry: a `Degraded`
+                    // placeholder here would count toward the reload guard's
+                    // "loaded" tally (`status != Failed`), letting a
+                    // transient empty scan (S3 hiccup) replace a working
+                    // registry with zero per-site collections. With no
+                    // entry, an empty source contributes 0 — so if it is the
+                    // only collection the guard correctly keeps the old
+                    // state. The WARN keeps the misconfiguration visible.
                     tracing::warn!(
                         "Collection '{}': PVOL source has no radar sites yet — no per-site \
                          collections registered. Reload once volume files arrive.",
                         collection.id
                     );
-                    // Keep the source visible in `/health` even with no
-                    // data, so an empty-bucket misconfiguration isn't silent.
-                    health.push(CollectionHealth {
-                        id: collection.id.clone(),
-                        engine_type: "odim-volume".into(),
-                        status: CollectionStatus::Degraded,
-                        error: Some("no radar sites discovered yet".into()),
-                    });
                 }
                 for (nod, label) in &sites {
                     let site_id = format!("{}-{}", collection.id, nod);
@@ -2113,6 +2113,26 @@ pub async fn health_handler(State(state): State<AdminState>) -> impl IntoRespons
             let id = engine.collection_id().to_string();
             if let Some(temporal) = build_temporal(engine.as_ref()) {
                 temporal_info.insert(id, temporal);
+            }
+        }
+    }
+    {
+        // PVOL sources expand into one per-site collection each
+        // (`{base}-{nod}`); the engine is keyed by `{base}` and does not
+        // implement `EdrEngine`, so build each site's temporal extent from
+        // its `PolarVolumeSiteView` and key it by the per-site id to match
+        // the `{base}-{nod}` health entries.
+        let engines = state
+            .odim_volume_engines
+            .read()
+            .unwrap_or_else(|e| e.into_inner());
+        for engine in engines.iter() {
+            for (nod, _label) in engine.sites() {
+                let id = format!("{}-{}", engine.collection_id(), nod);
+                let view = engine.site_view(&nod, &id);
+                if let Some(temporal) = build_temporal(&view) {
+                    temporal_info.insert(id, temporal);
+                }
             }
         }
     }

--- a/crates/server/src/admin.rs
+++ b/crates/server/src/admin.rs
@@ -1238,6 +1238,14 @@ pub fn load_collections(
                              already-registered collection — skipping this site",
                             collection.id
                         );
+                        health.push(CollectionHealth {
+                            id: site_id,
+                            engine_type: "odim-volume".into(),
+                            status: CollectionStatus::Failed,
+                            error: Some(
+                                "derived id collides with an already-registered collection".into(),
+                            ),
+                        });
                         continue;
                     }
 
@@ -1950,12 +1958,6 @@ pub async fn reload_handler(
         config.server.metatile_cache_mb,
     );
 
-    let loaded = result
-        .health
-        .iter()
-        .filter(|h| h.status != CollectionStatus::Failed)
-        .count();
-
     // Reload protection counts *fully working* (`Ready`) collections, not
     // just non-`Failed` ones. A `Degraded` placeholder — e.g. an
     // odim-volume source that transiently scanned zero sites, or a postgis
@@ -2013,9 +2015,18 @@ pub async fn reload_handler(
             .filter(|h| h.engine_type == "odim-volume" && h.status == CollectionStatus::Ready)
             .filter(|h| !new_ids.contains(h.id.as_str()))
             .filter(|h| {
+                // `{base}-{nod}` where `nod` is plain alphanumeric (no `-`).
+                // Require the suffix after the base to be exactly `-{nod}`,
+                // not merely to start with `-`, so a still-present base
+                // `radar` doesn't claim a vanished site from a removed
+                // `radar-fi` source: `radar-fi-x`.strip_prefix(`radar`) =
+                // `-fi-x`, whose nod part `fi-x` is not alphanumeric.
                 new_bases.iter().any(|b| {
-                    h.id.strip_prefix(b.as_str())
-                        .is_some_and(|r| r.starts_with('-'))
+                    h.id.strip_prefix(b.as_str()).is_some_and(|r| {
+                        r.strip_prefix('-').is_some_and(|nod| {
+                            !nod.is_empty() && nod.bytes().all(|c| c.is_ascii_alphanumeric())
+                        })
+                    })
                 })
             })
             .map(|h| h.id.clone())
@@ -2147,7 +2158,19 @@ pub async fn reload_handler(
         .write()
         .unwrap_or_else(|e| e.into_inner()) = result.postgis_engines;
 
-    let degraded = loaded.saturating_sub(ready);
+    // Recount from the final `result.health` — the vanished-site block above
+    // appends `Degraded` entries after the guard's `ready` was computed, so
+    // count here to keep the response in sync with the `collections` array.
+    let ready = result
+        .health
+        .iter()
+        .filter(|h| h.status == CollectionStatus::Ready)
+        .count();
+    let degraded = result
+        .health
+        .iter()
+        .filter(|h| h.status == CollectionStatus::Degraded)
+        .count();
     info!(
         "Reload complete: {ready} ready ({degraded} degraded) of {} configured",
         config.collections.len()

--- a/crates/server/src/admin.rs
+++ b/crates/server/src/admin.rs
@@ -1184,8 +1184,12 @@ pub fn load_collections(
                 // set is the catalog snapshot taken by `new`'s synchronous
                 // scan; sites that appear later surface on the next reload
                 // (which re-runs this expansion).
-                let site_ids = engine.site_ids();
-                if site_ids.is_empty() {
+                // `(nod, label)` from one snapshot — enumerates only sites
+                // with usable metadata, so no empty/broken collection is
+                // registered, and the id+title stay consistent if a poll
+                // swaps the catalog mid-registration.
+                let sites = engine.sites();
+                if sites.is_empty() {
                     tracing::warn!(
                         "Collection '{}': PVOL source has no radar sites yet — no per-site \
                          collections registered. Reload once volume files arrive.",
@@ -1200,9 +1204,8 @@ pub fn load_collections(
                         error: Some("no radar sites discovered yet".into()),
                     });
                 }
-                for nod in &site_ids {
+                for (nod, label) in &sites {
                     let site_id = format!("{}-{}", collection.id, nod);
-                    let label = engine.site_label(nod).unwrap_or_else(|| nod.clone());
                     let view = Arc::new(engine.site_view(nod, &site_id));
 
                     // Per-site collection config: inherit the base

--- a/crates/server/src/admin.rs
+++ b/crates/server/src/admin.rs
@@ -1190,19 +1190,27 @@ pub fn load_collections(
                 // swaps the catalog mid-registration.
                 let sites = engine.sites();
                 if sites.is_empty() {
-                    // Register nothing and add NO health entry: a `Degraded`
-                    // placeholder here would count toward the reload guard's
-                    // "loaded" tally (`status != Failed`), letting a
-                    // transient empty scan (S3 hiccup) replace a working
-                    // registry with zero per-site collections. With no
-                    // entry, an empty source contributes 0 — so if it is the
-                    // only collection the guard correctly keeps the old
-                    // state. The WARN keeps the misconfiguration visible.
+                    // No sites yet (empty/not-yet-populated source). Register
+                    // nothing but DO push a `Degraded` health entry so the
+                    // server still boots and waits for the first poll —
+                    // matching the geotiff/querydata/grib "no data yet"
+                    // convention. The startup guard (main.rs) counts
+                    // `status != Failed`, so without this entry an all-empty
+                    // PVOL deployment would `exit(1)` on boot. The *reload*
+                    // guard counts `status == Ready` instead, so this
+                    // placeholder does NOT let a transient empty scan replace
+                    // a working registry — see `reload_handler`.
                     tracing::warn!(
                         "Collection '{}': PVOL source has no radar sites yet — no per-site \
                          collections registered. Reload once volume files arrive.",
                         collection.id
                     );
+                    health.push(CollectionHealth {
+                        id: collection.id.clone(),
+                        engine_type: "odim-volume".into(),
+                        status: CollectionStatus::Degraded,
+                        error: Some("no radar sites found yet (waiting for .h5 files)".into()),
+                    });
                 }
                 for (nod, label) in &sites {
                     let site_id = format!("{}-{}", collection.id, nod);
@@ -1948,7 +1956,22 @@ pub async fn reload_handler(
         .filter(|h| h.status != CollectionStatus::Failed)
         .count();
 
-    if loaded == 0 && !config.collections.is_empty() {
+    // Reload protection counts *fully working* (`Ready`) collections, not
+    // just non-`Failed` ones. A `Degraded` placeholder — e.g. an
+    // odim-volume source that transiently scanned zero sites, or a postgis
+    // collection whose DB is momentarily down — wires no servable routes,
+    // so it must not satisfy the guard and let an empty/degraded reload
+    // replace a working live registry. (Startup in `main.rs` deliberately
+    // uses the looser `!= Failed`: at boot there is no live state to
+    // protect, so the server should start degraded and wait for the first
+    // poll rather than refuse to boot.)
+    let ready = result
+        .health
+        .iter()
+        .filter(|h| h.status == CollectionStatus::Ready)
+        .count();
+
+    if ready == 0 && !config.collections.is_empty() {
         // Restore old GeoTIFF engines (they were shut down)
         // This is a best-effort recovery — the old engines' poll loops won't restart,
         // but cached data is still servable.

--- a/crates/server/src/admin.rs
+++ b/crates/server/src/admin.rs
@@ -1910,38 +1910,11 @@ pub async fn reload_handler(
 
     let base_url = config.server.base_url();
 
-    // Shut down old poll loops
-    {
-        let old_geotiff = state
-            .geotiff_engines
-            .read()
-            .unwrap_or_else(|e| e.into_inner());
-        for engine in old_geotiff.iter() {
-            engine.shutdown();
-        }
-        let old_querydata = state
-            .querydata_engines
-            .read()
-            .unwrap_or_else(|e| e.into_inner());
-        for engine in old_querydata.iter() {
-            engine.shutdown();
-        }
-        let old_grib = state.grib_engines.read().unwrap_or_else(|e| e.into_inner());
-        for engine in old_grib.iter() {
-            engine.shutdown();
-        }
-        let old_odim = state.odim_engines.read().unwrap_or_else(|e| e.into_inner());
-        for engine in old_odim.iter() {
-            engine.shutdown();
-        }
-        let old_odim_volume = state
-            .odim_volume_engines
-            .read()
-            .unwrap_or_else(|e| e.into_inner());
-        for engine in old_odim_volume.iter() {
-            engine.shutdown();
-        }
-    }
+    // NOTE: old poll loops are shut down *after* the reload guard below, not
+    // here. If the guard rejects the reload (no `Ready` collection), the old
+    // engines and their poll loops must stay alive — otherwise a rejected
+    // reload would freeze the live registry with dead loops and no new ones
+    // spawned (the guard returns before the spawn block).
 
     let result = load_collections(
         &config.collections,
@@ -1972,9 +1945,12 @@ pub async fn reload_handler(
         .count();
 
     if ready == 0 && !config.collections.is_empty() {
-        // Restore old GeoTIFF engines (they were shut down)
-        // This is a best-effort recovery — the old engines' poll loops won't restart,
-        // but cached data is still servable.
+        // Reject the reload and keep the live state. The old engines were
+        // NOT shut down (that happens below, only on accept), so their poll
+        // loops keep running and recover on their own — e.g. a transiently
+        // unreachable PostGIS DB, or an odim-volume source that momentarily
+        // scanned zero sites. The newly-built engines in `result` are simply
+        // dropped (their poll loops were never spawned).
         tracing::error!(
             "Reload produced 0 working collections from {} configured. Keeping old state.",
             config.collections.len()
@@ -1986,6 +1962,51 @@ pub async fn reload_handler(
                 "configured": config.collections.len()
             })),
         ));
+    }
+
+    // Reload accepted — now shut down the old poll loops (the new ones are
+    // spawned just below, then state is swapped atomically).
+    {
+        for engine in state
+            .geotiff_engines
+            .read()
+            .unwrap_or_else(|e| e.into_inner())
+            .iter()
+        {
+            engine.shutdown();
+        }
+        for engine in state
+            .querydata_engines
+            .read()
+            .unwrap_or_else(|e| e.into_inner())
+            .iter()
+        {
+            engine.shutdown();
+        }
+        for engine in state
+            .grib_engines
+            .read()
+            .unwrap_or_else(|e| e.into_inner())
+            .iter()
+        {
+            engine.shutdown();
+        }
+        for engine in state
+            .odim_engines
+            .read()
+            .unwrap_or_else(|e| e.into_inner())
+            .iter()
+        {
+            engine.shutdown();
+        }
+        for engine in state
+            .odim_volume_engines
+            .read()
+            .unwrap_or_else(|e| e.into_inner())
+            .iter()
+        {
+            engine.shutdown();
+        }
     }
 
     // Spawn poll loops for new engines on the dedicated background runtime


### PR DESCRIPTION
## Summary

Implements **model B** for the ODIM `odim-volume` (PVOL) engine (issue #281): one source config now auto-expands into **one OGC collection per radar site** (id `{base}-{nod}`, e.g. `radar-fi-volume-local-h5-fivih`) instead of a single network collection whose parameters were `<nod>:<quantity>`.

Each site is served by a new **`PolarVolumeSiteView`** over the owning engine's shared `Arc<ArcSwap<Catalog>>`, advertising the **bare ODIM quantities** (`DBZH`, `VRADH`, `ZDR`, `RHOHV`, …) as parameters. The site *is* the collection (its single EDR location, its spatial/vertical extent), so it has no place in the parameter name — consistent with EDR, and it lets WMS styling key off the quantity.

## Why

The old `<site>:<quantity>` naming conflated spatial selection with variable identity: it leaked into styling (a style bundle applied one colormap to *every* moment → "strange colors" for velocity/dual-pol), was inconsistent with EDR's bare-quantity parameter list, exploded the layer tree, and a single collection extent could not describe a whole multi-site network.

## Changes

- **engine-odim**: `PolarVolumeEngine` keeps the scan / parse cache / poll loop but **no longer implements `EdrEngine`/`MapEngine`**. Removed the `<site>:<quantity>` surface (`parse_parameter`, `nearest_site`, `SITE_QUANTITY_SEP`, and the union/aggregate `Catalog` fields). `Catalog` now carries per-site `by_site_meta` for O(1) capability reads (hot-path rule). New `PolarVolumeSiteView` + `site_ids()` / `site_label()` / `site_view()`. Point/trajectory query bodies refactored into shared `site_point_query` / `site_trajectory` helpers used by the view.
- **server/admin**: the `load_collections` `"odim-volume"` arm builds the engine once, enumerates `site_ids()`, and registers one view per site into EDR/WMS/Maps/Tiles + styles (cloning the base `CollectionConfig` → per-site id/title). An empty source surfaces a single `Degraded` `/health` entry. The split re-runs on `POST /admin/collections/reload`.
- **WMS styling**: per-quantity colormaps now key off the bare quantity via `[[wms.parameters]]`. Both PVOL configs gain sensible palettes (radar_dbz for DBZH/TH, a diverging velocity ramp for VRADH, viridis+ranges for ZDR/RHOHV/KDP) — fixing the one-dBZ-palette-stretched-over-everything problem.
- **tests**: repointed the PVOL integration tests from the absent `fianj` fixture to the present `fivih` (Vihti) fixture, so they actually run (they were silently skipping). Added unit tests for the view (bare quantities, single location, clean errors).
- **CLAUDE.md**: new "ODIM PVOL Engine Notes (model B)" section.

## Verification

- `cargo test -p engine-odim`: 95 unit + 22 integration pass (run against the real Vihti fixture). `cargo test -p server`: green. `cargo test --workspace`: green. clippy clean; fmt applied.
- **Live** (`--collections=radar-fi-volume-local-h5`): registers `radar-fi-volume-local-h5-fivih`; EDR metadata shows bare quantities + elevation-angle `vrs`; Maps + WMS render `DBZH`/`VRADH`/`ZDR`/`RHOHV` (HTTP 200, distinct palettes); EDR `/trajectory` returns a CoverageJSON `Section`.

## Notes

- **Breaking for PVOL URLs**: collections are now `{base}-{nod}` and parameters are bare quantities — intended per the locked design decision (per-site only, no network aggregate).
- Site discovery is a scan snapshot; sites appearing later surface on the next admin reload.

Closes #281.

🤖 Generated with [Claude Code](https://claude.com/claude-code)