### PR TITLE
perf(engine-odim): lazy PVOL pixel loading — bounded RAM, non-blocking scan

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -891,6 +891,7 @@ dependencies = [
  "ds-storage",
  "hdf5-reader",
  "ndarray",
+ "quick_cache",
  "regex",
  "serde",
  "tempfile",

--- a/crates/api-edr/src/handlers.rs
+++ b/crates/api-edr/src/handlers.rs
@@ -863,10 +863,12 @@ pub async fn trajectory_query(
     // nodes × z-levels × quantities × timesteps `sample_polar_slant`
     // iterations (millions, seconds of CPU). Run it on the blocking pool
     // so it doesn't park a request-serving worker and head-of-line-block
-    // other requests. Safe here: the trajectory path reads an in-memory
-    // `ArcSwap` catalog snapshot and never touches `DataStore` (whose
-    // `block_in_place` would panic on a `spawn_blocking` thread). The
-    // general "wrap every EdrEngine query" work is tracked in #178.
+    // other requests. spawn_blocking is also *required* for correctness under
+    // lazy pixel loading: an S3 cache miss now fetches via `DataStore::get_on`
+    // (`handle.block_on`), which is valid on a `spawn_blocking` thread but
+    // would be the panicking `block_in_place` path if run directly on a worker.
+    // Offloading the other EdrEngine queries (position/area/locations) the same
+    // way is tracked in #178.
     let engine = engine.clone();
     let coords = params.coords.clone();
     let result = tokio::task::spawn_blocking(move || {

--- a/crates/api-edr/src/handlers.rs
+++ b/crates/api-edr/src/handlers.rs
@@ -865,10 +865,11 @@ pub async fn trajectory_query(
     // so it doesn't park a request-serving worker and head-of-line-block
     // other requests. spawn_blocking is also *required* for correctness under
     // lazy pixel loading: an S3 cache miss now fetches via `DataStore::get_on`
-    // (`handle.block_on`), which is valid on a `spawn_blocking` thread but
-    // would be the panicking `block_in_place` path if run directly on a worker.
-    // Offloading the other EdrEngine queries (position/area/locations) the same
-    // way is tracked in #178.
+    // (`handle.block_on`), the valid bridge on a `spawn_blocking` pool thread —
+    // the plain `DataStore::get` uses `block_in_place`, which *panics* on a
+    // spawn_blocking thread (it is only valid on a multi-thread runtime worker).
+    // The still-direct position/area/locations queries keep `DataStore::get`
+    // precisely because they run on a worker; offloading them is tracked in #178.
     let engine = engine.clone();
     let coords = params.coords.clone();
     let result = tokio::task::spawn_blocking(move || {

--- a/crates/engine-odim/Cargo.toml
+++ b/crates/engine-odim/Cargo.toml
@@ -10,6 +10,7 @@ hdf5-reader = "0.4"
 ndarray = "0.17"
 chrono = { version = "0.4", features = ["serde"] }
 arc-swap = "1"
+quick_cache = "0.6"
 regex = "1"
 tokio = { version = "1", features = ["macros", "rt", "sync", "time"] }
 tracing = "0.1"

--- a/crates/engine-odim/src/lib.rs
+++ b/crates/engine-odim/src/lib.rs
@@ -30,4 +30,4 @@ pub mod volume_engine;
 
 pub use engine::{EngineError, OdimEngine};
 pub use pixel_cache::PixelCache;
-pub use volume_engine::{PolarVolumeEngine, PolarVolumeSiteView};
+pub use volume_engine::{pixel_cache_metrics, PolarVolumeEngine, PolarVolumeSiteView};

--- a/crates/engine-odim/src/lib.rs
+++ b/crates/engine-odim/src/lib.rs
@@ -22,10 +22,12 @@
 pub mod catalog;
 pub mod edr;
 pub mod engine;
+pub mod pixel_cache;
 pub mod proj;
 pub mod pvol;
 pub mod reader;
 pub mod volume_engine;
 
 pub use engine::{EngineError, OdimEngine};
+pub use pixel_cache::PixelCache;
 pub use volume_engine::{PolarVolumeEngine, PolarVolumeSiteView};

--- a/crates/engine-odim/src/pixel_cache.rs
+++ b/crates/engine-odim/src/pixel_cache.rs
@@ -29,9 +29,22 @@ impl quick_cache::Weighter<PixelKey, Arc<RawPixels>> for PixelWeighter {
     }
 }
 
+/// Count cap on the negative (known-bad) cache. Bounds the memory a burst of
+/// distinct failing keys can pin; entries age out by LRU so a transient
+/// failure is retried once evicted.
+const NEGATIVE_CAPACITY_ITEMS: usize = 4096;
+
 /// Thread-safe, byte-bounded LRU of decoded moment arrays.
 pub struct PixelCache {
     inner: Cache<PixelKey, Arc<RawPixels>, PixelWeighter>,
+    /// Count-bounded LRU of keys whose pixel read/decode failed. A per-cell
+    /// sampler loop (e.g. `volume_section`, thousands of cells) would otherwise
+    /// re-fetch and re-count a failed moment on every cell, since a failure
+    /// caches nothing — one transient S3 error inflated `pvol_pixel_read_
+    /// failures_total` by thousands and hammered the store (PR #290 review).
+    /// Recording the failure here makes the retry a single no-op lookup and
+    /// the metric increment happen once.
+    negative: Cache<PixelKey, ()>,
     capacity_bytes: u64,
     hits: AtomicU64,
     misses: AtomicU64,
@@ -47,6 +60,7 @@ impl PixelCache {
         let estimated_items = ((capacity_bytes / (256 * 1024)).max(16)) as usize;
         PixelCache {
             inner: Cache::with_weighter(estimated_items, capacity_bytes.max(1), PixelWeighter),
+            negative: Cache::new(NEGATIVE_CAPACITY_ITEMS),
             capacity_bytes,
             hits: AtomicU64::new(0),
             misses: AtomicU64::new(0),
@@ -80,6 +94,34 @@ impl PixelCache {
         self.inner.insert(key, pixels);
     }
 
+    /// Whether `(file_id, dataset_path)` recently failed to read/decode and
+    /// should be treated as nodata without re-fetching. Always `false` when
+    /// the cache is disabled (diagnostic mode re-reads every sample).
+    pub fn is_known_bad(&self, file_id: &str, dataset_path: &str) -> bool {
+        if self.capacity_bytes == 0 {
+            return false;
+        }
+        let key: PixelKey = (Arc::from(file_id), Arc::from(dataset_path));
+        self.negative.get(&key).is_some()
+    }
+
+    /// Record a failed read for `(file_id, dataset_path)`. Returns `true` when
+    /// this key was not already known-bad — the caller increments the failure
+    /// metric only then, so one logical failure counts once instead of once
+    /// per cell. When the cache is disabled there is no dedup store, so it
+    /// returns `true` every time (matching the re-read-everything mode).
+    pub fn mark_bad(&self, file_id: &str, dataset_path: &str) -> bool {
+        if self.capacity_bytes == 0 {
+            return true;
+        }
+        let key: PixelKey = (Arc::from(file_id), Arc::from(dataset_path));
+        if self.negative.get(&key).is_some() {
+            return false;
+        }
+        self.negative.insert(key, ());
+        true
+    }
+
     /// Current resident weight (bytes) — for metrics.
     pub fn weight(&self) -> u64 {
         self.inner.weight()
@@ -96,5 +138,34 @@ impl PixelCache {
             self.hits.load(Ordering::Relaxed),
             self.misses.load(Ordering::Relaxed),
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn negative_cache_dedups_failures() {
+        let c = PixelCache::new(64);
+        assert!(!c.is_known_bad("file-a", "/d"));
+        // First failure for a key is "new" (caller counts it once); the key is
+        // then known-bad and a repeat mark is a no-op.
+        assert!(c.mark_bad("file-a", "/d"), "first mark is new");
+        assert!(c.is_known_bad("file-a", "/d"));
+        assert!(!c.mark_bad("file-a", "/d"), "repeat mark must not recount");
+        // A different key (or dataset) is tracked independently.
+        assert!(c.mark_bad("file-b", "/d"));
+        assert!(c.mark_bad("file-a", "/other"));
+    }
+
+    #[test]
+    fn disabled_cache_never_negative_caches() {
+        // Capacity 0 = diagnostic re-read-everything mode: no dedup store, so
+        // mark_bad always reports "new" and is_known_bad never reports bad.
+        let c = PixelCache::new(0);
+        assert!(c.mark_bad("x", "/d"));
+        assert!(c.mark_bad("x", "/d"));
+        assert!(!c.is_known_bad("x", "/d"));
     }
 }

--- a/crates/engine-odim/src/pixel_cache.rs
+++ b/crates/engine-odim/src/pixel_cache.rs
@@ -95,31 +95,31 @@ impl PixelCache {
     }
 
     /// Whether `(file_id, dataset_path)` recently failed to read/decode and
-    /// should be treated as nodata without re-fetching. Always `false` when
-    /// the cache is disabled (diagnostic mode re-reads every sample).
+    /// should be treated as nodata without re-fetching. The negative cache is
+    /// independent of the byte capacity, so this stays effective even in the
+    /// disabled (`capacity_mb == 0`) diagnostic mode — otherwise a failing
+    /// moment would re-storm the store / re-flood logs there (PR #290 review).
     pub fn is_known_bad(&self, file_id: &str, dataset_path: &str) -> bool {
-        if self.capacity_bytes == 0 {
-            return false;
-        }
         let key: PixelKey = (Arc::from(file_id), Arc::from(dataset_path));
         self.negative.get(&key).is_some()
     }
 
     /// Record a failed read for `(file_id, dataset_path)`. Returns `true` when
-    /// this key was not already known-bad — the caller increments the failure
-    /// metric only then, so one logical failure counts once instead of once
-    /// per cell. When the cache is disabled there is no dedup store, so it
-    /// returns `true` every time (matching the re-read-everything mode).
+    /// this call was the first to record the key — the caller increments the
+    /// failure metric only then, so one logical failure counts once instead of
+    /// once per cell. The check-and-insert is atomic via the cache's
+    /// placeholder guard (`get_or_insert_with` runs the closure only for the
+    /// winning caller), so concurrent failures of the same key still count once
+    /// (no get/insert TOCTOU race — PR #290 review).
     pub fn mark_bad(&self, file_id: &str, dataset_path: &str) -> bool {
-        if self.capacity_bytes == 0 {
-            return true;
-        }
         let key: PixelKey = (Arc::from(file_id), Arc::from(dataset_path));
-        if self.negative.get(&key).is_some() {
-            return false;
-        }
-        self.negative.insert(key, ());
-        true
+        let mut newly = false;
+        let _: Result<(), std::convert::Infallible> =
+            self.negative.get_or_insert_with(&key, || {
+                newly = true;
+                Ok(())
+            });
+        newly
     }
 
     /// Current resident weight (bytes) — for metrics.
@@ -160,12 +160,28 @@ mod tests {
     }
 
     #[test]
-    fn disabled_cache_never_negative_caches() {
-        // Capacity 0 = diagnostic re-read-everything mode: no dedup store, so
-        // mark_bad always reports "new" and is_known_bad never reports bad.
+    fn negative_cache_stays_active_when_positive_disabled() {
+        // Capacity 0 disables the *positive* pixel cache (every successful
+        // sample re-reads), but the negative cache must stay active so a
+        // failing moment isn't re-fetched / re-logged per cell in diagnostic
+        // mode (PR #290 review r3).
         let c = PixelCache::new(0);
-        assert!(c.mark_bad("x", "/d"));
-        assert!(c.mark_bad("x", "/d"));
-        assert!(!c.is_known_bad("x", "/d"));
+        assert!(c.mark_bad("x", "/d"), "first failure is new");
+        assert!(
+            !c.mark_bad("x", "/d"),
+            "repeat deduped even with the positive cache off"
+        );
+        assert!(c.is_known_bad("x", "/d"));
+    }
+
+    #[test]
+    fn mark_bad_counts_once_under_repeated_calls() {
+        // The winning caller gets "new"; every later call for the same key is
+        // a dedup (no double-count of the failure metric).
+        let c = PixelCache::new(64);
+        assert!(c.mark_bad("k", "/d"));
+        for _ in 0..100 {
+            assert!(!c.mark_bad("k", "/d"));
+        }
     }
 }

--- a/crates/engine-odim/src/pixel_cache.rs
+++ b/crates/engine-odim/src/pixel_cache.rs
@@ -1,0 +1,100 @@
+//! Bounded LRU cache of decoded PVOL moment pixel arrays (#289).
+//!
+//! The polar-volume catalog holds only metadata (see
+//! [`crate::pvol::PolarMoment`]); a moment's raw `RawPixels` array is read
+//! lazily on first use and cached here, byte-weighted, so the full sweep
+//! stack of a whole radar network is never resident at once. Mirrors the
+//! GeoTIFF/GRIB `quick_cache` byte-weighted caches.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+use quick_cache::sync::Cache;
+
+use crate::reader::RawPixels;
+
+/// Cache key: the file identity (local path string or S3 object key) plus
+/// the HDF5 dataset path of the moment (`/datasetN/dataM/data`). File ids
+/// are globally unique, so one cache can be shared across every collection.
+type PixelKey = (Arc<str>, Arc<str>);
+
+/// Byte-weights each entry by its decoded array size (plus key/Arc overhead).
+#[derive(Clone)]
+struct PixelWeighter;
+
+impl quick_cache::Weighter<PixelKey, Arc<RawPixels>> for PixelWeighter {
+    fn weight(&self, key: &PixelKey, val: &Arc<RawPixels>) -> u64 {
+        // Decoded array bytes + the two key strings + Arc/control overhead.
+        val.size_bytes() as u64 + key.0.len() as u64 + key.1.len() as u64 + 64
+    }
+}
+
+/// Thread-safe, byte-bounded LRU of decoded moment arrays.
+pub struct PixelCache {
+    inner: Cache<PixelKey, Arc<RawPixels>, PixelWeighter>,
+    capacity_bytes: u64,
+    hits: AtomicU64,
+    misses: AtomicU64,
+}
+
+impl PixelCache {
+    /// Build a cache capped at `capacity_mb` megabytes. A cache below ~1 MB
+    /// (or 0) is treated as disabled — `get` always misses and `insert` is a
+    /// no-op — so a misconfiguration can't silently hold one giant entry.
+    pub fn new(capacity_mb: u64) -> Self {
+        let capacity_bytes = capacity_mb.saturating_mul(1024 * 1024);
+        // One FMI moment ≈ 360×500×2 ≈ 360 KB; estimate items at ~256 KB.
+        let estimated_items = ((capacity_bytes / (256 * 1024)).max(16)) as usize;
+        PixelCache {
+            inner: Cache::with_weighter(estimated_items, capacity_bytes.max(1), PixelWeighter),
+            capacity_bytes,
+            hits: AtomicU64::new(0),
+            misses: AtomicU64::new(0),
+        }
+    }
+
+    /// Look up a cached array. Counts a hit/miss for `/metrics`.
+    pub fn get(&self, file_id: &str, dataset_path: &str) -> Option<Arc<RawPixels>> {
+        if self.capacity_bytes == 0 {
+            return None;
+        }
+        let key: PixelKey = (Arc::from(file_id), Arc::from(dataset_path));
+        match self.inner.get(&key) {
+            Some(v) => {
+                self.hits.fetch_add(1, Ordering::Relaxed);
+                Some(v)
+            }
+            None => {
+                self.misses.fetch_add(1, Ordering::Relaxed);
+                None
+            }
+        }
+    }
+
+    /// Insert a freshly-decoded array. No-op when disabled.
+    pub fn insert(&self, file_id: &str, dataset_path: &str, pixels: Arc<RawPixels>) {
+        if self.capacity_bytes == 0 {
+            return;
+        }
+        let key: PixelKey = (Arc::from(file_id), Arc::from(dataset_path));
+        self.inner.insert(key, pixels);
+    }
+
+    /// Current resident weight (bytes) — for metrics.
+    pub fn weight(&self) -> u64 {
+        self.inner.weight()
+    }
+
+    /// Configured byte capacity.
+    pub fn capacity(&self) -> u64 {
+        self.capacity_bytes
+    }
+
+    /// Cumulative `(hits, misses)`.
+    pub fn stats(&self) -> (u64, u64) {
+        (
+            self.hits.load(Ordering::Relaxed),
+            self.misses.load(Ordering::Relaxed),
+        )
+    }
+}

--- a/crates/engine-odim/src/pixel_cache.rs
+++ b/crates/engine-odim/src/pixel_cache.rs
@@ -67,22 +67,28 @@ impl PixelCache {
         }
     }
 
-    /// Look up a cached array. Counts a hit/miss for `/metrics`.
+    /// Look up a cached array, counting a hit for `/metrics`. A miss is **not**
+    /// counted here: the loader records a genuine miss via [`Self::record_miss`]
+    /// only after ruling out a negative-cache (known-bad) short-circuit, so a
+    /// bad-key skip doesn't inflate `pvol_pixel_cache_misses_total` (PR #290
+    /// review r4). Keeping `is_known_bad` *after* this on the loader's hot path
+    /// means a good-key access stays a single lookup.
     pub fn get(&self, file_id: &str, dataset_path: &str) -> Option<Arc<RawPixels>> {
         if self.capacity_bytes == 0 {
             return None;
         }
         let key: PixelKey = (Arc::from(file_id), Arc::from(dataset_path));
-        match self.inner.get(&key) {
-            Some(v) => {
-                self.hits.fetch_add(1, Ordering::Relaxed);
-                Some(v)
-            }
-            None => {
-                self.misses.fetch_add(1, Ordering::Relaxed);
-                None
-            }
+        let hit = self.inner.get(&key);
+        if hit.is_some() {
+            self.hits.fetch_add(1, Ordering::Relaxed);
         }
+        hit
+    }
+
+    /// Count one genuine positive-cache miss — i.e. a key that is neither
+    /// cached nor known-bad, so the loader is about to fetch + decode it.
+    pub fn record_miss(&self) {
+        self.misses.fetch_add(1, Ordering::Relaxed);
     }
 
     /// Insert a freshly-decoded array. No-op when disabled.
@@ -172,6 +178,18 @@ mod tests {
             "repeat deduped even with the positive cache off"
         );
         assert!(c.is_known_bad("x", "/d"));
+    }
+
+    #[test]
+    fn miss_counted_only_by_record_miss_not_by_get() {
+        // A `get` that misses must NOT bump the miss counter — a known-bad skip
+        // would otherwise count as a phantom positive-cache miss (PR #290 r4).
+        let c = PixelCache::new(64);
+        let (h0, m0) = c.stats();
+        assert!(c.get("absent", "/d").is_none());
+        assert_eq!(c.stats(), (h0, m0), "get() miss must not be counted");
+        c.record_miss();
+        assert_eq!(c.stats(), (h0, m0 + 1), "record_miss() counts the miss");
     }
 
     #[test]

--- a/crates/engine-odim/src/pvol.rs
+++ b/crates/engine-odim/src/pvol.rs
@@ -51,6 +51,13 @@ pub struct RadarSite {
 }
 
 /// A single radar moment (quantity) within one elevation sweep.
+///
+/// **Metadata only** — the bulky pixel array is *not* held here. A scan
+/// parses every moment's scaling/identity attributes (cheap) but defers
+/// the `/datasetN/dataM/data` array, which is read lazily on demand via
+/// [`read_moment_pixels`] (keyed by [`Self::dataset_path`]) and cached by
+/// the engine. This keeps a parsed [`PolarVolume`] at KB scale so a whole
+/// radar network's catalog fits in memory; see issue #289.
 #[derive(Debug, Clone)]
 pub struct PolarMoment {
     /// ODIM quantity name, e.g. `"DBZH"`, `"VRADH"`, `"ZDR"`.
@@ -63,8 +70,10 @@ pub struct PolarMoment {
     pub nodata: f64,
     /// Raw value indicating "no echo detected".
     pub undetect: f64,
-    /// Raw data array, indexed `[ray, bin]` — shape `(nrays, nbins)`.
-    pub data: RawPixels,
+    /// HDF5 path of this moment's raw data array
+    /// (`/datasetN/dataM/data`), for the lazy pixel read. The array is
+    /// shape `(nrays, nbins)`, indexed `[ray, bin]`.
+    pub dataset_path: String,
 }
 
 /// One elevation sweep of a polar volume: all moments measured at a
@@ -370,7 +379,24 @@ fn read_moment(
     let nodata = read_scaling("nodata", None)?;
     let undetect = read_scaling("undetect", None)?;
 
-    let data = read_moment_array(file, &format!("{data_path}/data"), nrays, nbins)?;
+    // Validate the data array exists and matches the sweep's declared
+    // `(nrays, nbins)` at scan time — cheap (a shape/metadata check, not a
+    // decode), so a malformed file is rejected up front rather than only on
+    // first render. The array bytes are read lazily via `read_moment_pixels`.
+    let dataset_path = format!("{data_path}/data");
+    let ds = file
+        .dataset(&dataset_path)
+        .map_err(|_| ReadError::MissingGroup(dataset_path.clone()))?;
+    let shape = ds.shape();
+    if shape.len() != 2 {
+        return Err(ReadError::UnsupportedRank(shape.len()));
+    }
+    if shape[0] as usize != nrays || shape[1] as usize != nbins {
+        return Err(ReadError::DatasetRead(format!(
+            "{dataset_path}: array shape {:?} doesn't match sweep metadata {nrays}x{nbins}",
+            (shape[0], shape[1])
+        )));
+    }
 
     Ok(PolarMoment {
         quantity,
@@ -378,8 +404,25 @@ fn read_moment(
         offset,
         nodata,
         undetect,
-        data,
+        dataset_path,
     })
+}
+
+/// Read one moment's raw pixel array on demand from the volume's bytes.
+///
+/// The lazy companion to [`read_polar_volume`]: re-parse the HDF5 file
+/// (cheap — structure only) and decode just the single
+/// `/datasetN/dataM/data` dataset named by [`PolarMoment::dataset_path`].
+/// `nrays`/`nbins` come from the owning sweep. Used by the engine's
+/// bounded pixel cache so the full sweep stack is never resident.
+pub fn read_moment_pixels(
+    bytes: &[u8],
+    dataset_path: &str,
+    nrays: usize,
+    nbins: usize,
+) -> Result<RawPixels, ReadError> {
+    let file = Hdf5File::from_bytes(bytes).map_err(|e| ReadError::OpenFailed(e.to_string()))?;
+    read_moment_array(&file, dataset_path, nrays, nbins)
 }
 
 /// Combine ODIM's split `/what/date` (`YYYYMMDD`) and `/what/time`
@@ -518,13 +561,15 @@ mod tests {
             "sweep[0] should expose ZDR, got {quantities:?}"
         );
 
-        // Each moment's array shape matches its own sweep's grid —
-        // read_polar_volume validates this internally, so assert it
-        // holds across every sweep/moment pair.
+        // Pixel arrays are read lazily — verify `read_moment_pixels` decodes
+        // each moment's `/datasetN/dataM/data` at the declared
+        // `(nrays, nbins)` for every sweep/moment pair.
         for sweep in &vol.sweeps {
             for m in &sweep.moments {
+                let px = read_moment_pixels(&bytes, &m.dataset_path, sweep.nrays, sweep.nbins)
+                    .unwrap_or_else(|e| panic!("read pixels for {}: {e}", m.quantity));
                 assert_eq!(
-                    m.data.shape(),
+                    px.shape(),
                     (sweep.nrays, sweep.nbins),
                     "moment {} array shape vs sweep grid",
                     m.quantity

--- a/crates/engine-odim/src/reader.rs
+++ b/crates/engine-odim/src/reader.rs
@@ -171,6 +171,18 @@ impl RawPixels {
         }
         Some(raw * gain + offset)
     }
+
+    /// Approximate heap footprint of the backing array, in bytes — element
+    /// count times element size. Byte-weights the engine's lazy-pixel LRU.
+    pub fn size_bytes(&self) -> usize {
+        let (h, w) = self.shape();
+        let elem = match self {
+            RawPixels::U8(_) => 1,
+            RawPixels::U16(_) => 2,
+            RawPixels::F64(_) => 8,
+        };
+        h * w * elem
+    }
 }
 
 /// A parsed ODIM composite ready for sampling. Carries the raw

--- a/crates/engine-odim/src/volume_engine.rs
+++ b/crates/engine-odim/src/volume_engine.rs
@@ -70,7 +70,36 @@ use ds_storage::discovery::{expand_prefix_for_dates, expand_prefix_pattern, Time
 
 use crate::catalog::MAX_REMOTE_FILE_SIZE;
 use crate::engine::EngineError;
-use crate::pvol::{read_polar_volume, PolarMoment, PolarVolume, Sweep};
+use crate::pixel_cache::PixelCache;
+use crate::pvol::{read_moment_pixels, read_polar_volume, PolarMoment, PolarVolume, Sweep};
+use crate::reader::RawPixels;
+
+/// Default lazy-pixel cache size (MB) when `MC_PVOL_PIXEL_CACHE_MB` is
+/// unset. One shared budget bounds resident decoded pixels across every
+/// PVOL collection, so the engine scales to a full radar network without
+/// holding every sweep stack in RAM (#289).
+const DEFAULT_PIXEL_CACHE_MB: u64 = 1024;
+
+/// Read the configured lazy-pixel cache size from the environment, or the
+/// default. `0` disables caching (every sample re-reads — diagnostic only).
+fn pixel_cache_mb() -> u64 {
+    std::env::var("MC_PVOL_PIXEL_CACHE_MB")
+        .ok()
+        .and_then(|s| s.trim().parse::<u64>().ok())
+        .unwrap_or(DEFAULT_PIXEL_CACHE_MB)
+}
+
+/// Process-global decoded-pixel LRU, shared by every PVOL collection so a
+/// single byte-budget bounds resident pixels across the whole radar
+/// network. Sized once from the environment on first use (#289).
+static PIXEL_CACHE: std::sync::LazyLock<PixelCache> =
+    std::sync::LazyLock::new(|| PixelCache::new(pixel_cache_mb()));
+
+/// Accessor for the global pixel cache, for tests to seed/inspect it.
+#[cfg(test)]
+pub(crate) fn pixel_cache() -> &'static PixelCache {
+    &PIXEL_CACHE
+}
 
 /// Days of date-partitioned prefixes to scan when an S3 source has no
 /// `time_window`. Two days covers the just-after-midnight case where
@@ -308,6 +337,66 @@ fn source_label(source: &Source) -> String {
             prefix_pattern,
             ..
         } => format!("s3 {endpoint}/{bucket}/{prefix_pattern}"),
+    }
+}
+
+/// Re-fetch one volume file's raw bytes by its [`FileId`] — a local path
+/// read or an S3 `get`. Used by the lazy pixel reader on a cache miss.
+fn fetch_file_bytes(source: &Source, file_id: &str) -> Result<Vec<u8>, String> {
+    match source {
+        Source::Local { .. } => {
+            std::fs::read(file_id).map_err(|e| format!("read `{file_id}`: {e}"))
+        }
+        Source::Remote { store, .. } => {
+            use ds_storage::object_store::path::Path as ObjectPath;
+            let object = ObjectPath::from(file_id);
+            store
+                .get(&object)
+                .map(|b| b.to_vec())
+                .map_err(|e| format!("get `{file_id}`: {e}"))
+        }
+    }
+}
+
+/// Lazy-pixel access context threaded through the samplers: just the file
+/// source, used to re-fetch a volume's bytes on a [`PIXEL_CACHE`] miss.
+/// The catalog holds only metadata, so a moment's `RawPixels` is fetched
+/// here on first use and cached in the global LRU (#289).
+#[derive(Clone, Copy)]
+struct Pixels<'a> {
+    source: &'a Source,
+}
+
+impl Pixels<'_> {
+    /// Fetch a moment's decoded pixel array — cache hit, or read the one
+    /// `/datasetN/dataM/data` dataset from the (re-fetched) file bytes and
+    /// cache it. `None` on any I/O / decode error (the caller treats a
+    /// missing array as nodata, so a single corrupt file degrades to
+    /// transparent rather than failing the whole request).
+    fn moment(
+        &self,
+        file_id: &str,
+        moment: &PolarMoment,
+        nrays: usize,
+        nbins: usize,
+    ) -> Option<Arc<RawPixels>> {
+        if let Some(p) = PIXEL_CACHE.get(file_id, &moment.dataset_path) {
+            return Some(p);
+        }
+        let bytes = fetch_file_bytes(self.source, file_id)
+            .map_err(|e| tracing::warn!("PVOL lazy pixel read failed: {e}"))
+            .ok()?;
+        let raw = read_moment_pixels(&bytes, &moment.dataset_path, nrays, nbins)
+            .map_err(|e| {
+                tracing::warn!(
+                    "PVOL pixel decode `{}` in `{file_id}`: {e}",
+                    moment.dataset_path
+                )
+            })
+            .ok()?;
+        let arc = Arc::new(raw);
+        PIXEL_CACHE.insert(file_id, &moment.dataset_path, arc.clone());
+        Some(arc)
     }
 }
 
@@ -885,22 +974,22 @@ fn derive_site_meta(list: &[VolumeEntry]) -> Option<SiteMeta> {
 pub struct PolarVolumeEngine {
     collection_id: String,
     /// Local directory or S3/HTTP object store, re-scanned by the poll loop.
-    source: Source,
+    /// Behind an `Arc` so per-site views can hold it cheaply for lazy pixel
+    /// re-fetches.
+    source: Arc<Source>,
     /// Per-site cap on retained volumes (`OdimConfig.max_files`) — keeps
     /// an archive source from loading every file into the catalog.
     max_files: Option<usize>,
     /// Lock-free catalog snapshot for `raster_info()` + `get_raster_tile`.
     catalog: Arc<ArcSwap<Catalog>>,
-    /// Multi-entry parse cache keyed by file identity (local path
-    /// string or S3 object key — see [`FileId`]). A PVOL network of
-    /// ~10 sites at 5-min cadence keeps tens of volumes resident; HDF5
-    /// parsing (and, for S3, the multi-MB download) dominates, so
-    /// caching every parsed volume keeps both the poll loop and hot
-    /// tile requests cheap. The key is a `String`, not a `PathBuf`,
-    /// because S3 object keys are not filesystem paths.
+    /// Parse cache of **metadata-only** [`PolarVolume`]s keyed by file
+    /// identity (local path string or S3 object key — see [`FileId`]) so a
+    /// poll doesn't re-parse unchanged files' structure. Tiny now that
+    /// pixel arrays are excluded (#289): a whole network's catalog fits in
+    /// memory. Behind an `Arc` so a scan can be moved off `self`.
     ///
-    /// Behind an `Arc` so a `poll_once` scan can be moved onto a
-    /// `spawn_blocking` task without borrowing `self`.
+    /// (Decoded pixel arrays live in the process-global [`pixel_cache`] LRU,
+    /// not here — one byte-budget for the whole radar network.)
     parse_cache: Arc<Mutex<HashMap<FileId, Arc<PolarVolume>>>>,
     poll_interval: Duration,
     shutdown: AtomicBool,
@@ -938,7 +1027,7 @@ impl PolarVolumeEngine {
             );
         }
 
-        let source = build_source(collection_id, data_path, config)?;
+        let source = Arc::new(build_source(collection_id, data_path, config)?);
 
         let parse_cache = Arc::new(Mutex::new(HashMap::new()));
         let catalog = scan_source(collection_id, &source, &parse_cache, config.max_files)?;
@@ -1006,13 +1095,13 @@ impl PolarVolumeEngine {
         store: ds_storage::DataStore,
         prefix_pattern: &str,
     ) -> Result<Self, EngineError> {
-        let source = Source::Remote {
+        let source = Arc::new(Source::Remote {
             store,
             endpoint: "test://local".to_string(),
             bucket: "test".to_string(),
             prefix_pattern: prefix_pattern.to_string(),
             time_window: None,
-        };
+        });
         let parse_cache = Arc::new(Mutex::new(HashMap::new()));
         let catalog = scan_source(collection_id, &source, &parse_cache, None)?;
         Ok(Self {
@@ -1098,6 +1187,7 @@ impl PolarVolumeEngine {
 fn sample_sweep_moment(
     sweep: &Sweep,
     moment: &PolarMoment,
+    pixels: &RawPixels,
     site_lon: f64,
     site_lat: f64,
     lon: f64,
@@ -1131,7 +1221,7 @@ fn sample_sweep_moment(
     let ray = (az / (360.0 / sweep.nrays as f64)).floor() as usize % sweep.nrays;
 
     // `RawPixels` is indexed [ray, bin].
-    moment.data.sample(
+    pixels.sample(
         ray,
         bin as usize,
         moment.gain,
@@ -1156,6 +1246,7 @@ fn sample_sweep_moment(
 /// peaks versus a linear-reflectivity average, but avoids per-moment
 /// unit-aware conversion for what is a smoothing pass.
 fn bilinear_cell(
+    pixels: &RawPixels,
     moment: &PolarMoment,
     nrays: usize,
     nbins: usize,
@@ -1184,7 +1275,7 @@ fn bilinear_cell(
             if bin < 0 || bin >= nbins as i64 {
                 continue; // range edge — drop this neighbour
             }
-            if let Some(v) = moment.data.sample(
+            if let Some(v) = pixels.sample(
                 ray,
                 bin as usize,
                 moment.gain,
@@ -1208,6 +1299,7 @@ fn bilinear_cell(
 fn sample_sweep_moment_bilinear(
     sweep: &Sweep,
     moment: &PolarMoment,
+    pixels: &RawPixels,
     site_lon: f64,
     site_lat: f64,
     lon: f64,
@@ -1238,7 +1330,7 @@ fn sample_sweep_moment_bilinear(
     // `i` starts at azimuth `i * 360/nrays`.
     let ray_f = az / (360.0 / sweep.nrays as f64);
 
-    bilinear_cell(moment, sweep.nrays, sweep.nbins, ray_f, bin_f)
+    bilinear_cell(pixels, moment, sweep.nrays, sweep.nbins, ray_f, bin_f)
 }
 
 /// The sweep whose elevation angle is nearest `target` degrees. `None`
@@ -1276,8 +1368,11 @@ fn nearest_sweep(volume: &PolarVolume, target: f64) -> Option<&Sweep> {
 ///
 /// `z` selects the elevation sweep: `Some(angle)` renders the sweep
 /// nearest that angle, `None` renders the lowest sweep.
+#[allow(clippy::too_many_arguments)]
 fn polar_sample(
     volume: &PolarVolume,
+    file_id: &str,
+    pix: Pixels,
     quantity: &str,
     bbox: [f64; 4],
     width: u32,
@@ -1326,6 +1421,19 @@ fn polar_sample(
         ));
     }
 
+    // Lazily fetch this one moment's pixel array (cache hit, or read the
+    // single dataset from the re-fetched file bytes) — once, before the
+    // per-pixel loop. A read failure yields an all-transparent tile rather
+    // than a 500: the file may have rotated out from under us, and the next
+    // poll/request recovers.
+    let Some(pixels) = pix.moment(file_id, moment, sweep.nrays, sweep.nbins) else {
+        return Ok(RasterTile {
+            width,
+            height,
+            values: vec![None; (width as usize) * (height as usize)],
+        });
+    };
+
     // Polar sampling is inherently per-pixel (each output pixel resolves to a
     // ground distance + bearing from the site), so unlike the gridded engines
     // this loop maps each pixel's WGS84 lon/lat with the shared
@@ -1352,7 +1460,7 @@ fn polar_sample(
             }
 
             values.push(sample_sweep_moment_bilinear(
-                sweep, moment, site_lon, site_lat, lon, lat,
+                sweep, moment, &pixels, site_lon, site_lat, lon, lat,
             ));
         }
     }
@@ -1441,6 +1549,7 @@ fn snap_levels(requested: &[f64], canonical: &[f64]) -> Vec<f64> {
 /// `z` axis.
 fn volume_profile(
     entry: &VolumeEntry,
+    pix: Pixels,
     lon: f64,
     lat: f64,
     quantities: &[String],
@@ -1495,7 +1604,8 @@ fn volume_profile(
                     })
                     .and_then(|sweep| {
                         let moment = sweep.moments.iter().find(|m| m.quantity == *quantity)?;
-                        sample_sweep_moment(sweep, moment, site_lon, site_lat, lon, lat)
+                        let pixels = pix.moment(&entry.id, moment, sweep.nrays, sweep.nbins)?;
+                        sample_sweep_moment(sweep, moment, &pixels, site_lon, site_lat, lon, lat)
                     })
             })
             .collect();
@@ -1529,6 +1639,7 @@ fn volume_profile(
 /// sweep nearest `level` in each selected volume, sampled at `(lon, lat)`.
 fn level_series(
     selected: &[&VolumeEntry],
+    pix: Pixels,
     lon: f64,
     lat: f64,
     level: f64,
@@ -1543,9 +1654,11 @@ fn level_series(
             .map(|e| {
                 let sweep = nearest_sweep(&e.volume, level)?;
                 let moment = sweep.moments.iter().find(|m| &m.quantity == quantity)?;
+                let pixels = pix.moment(&e.id, moment, sweep.nrays, sweep.nbins)?;
                 sample_sweep_moment(
                     sweep,
                     moment,
+                    &pixels,
                     e.volume.site.lon,
                     e.volume.site.lat,
                     lon,
@@ -1765,8 +1878,11 @@ fn sweep_envelope(volume: &PolarVolume) -> Option<(f64, f64)> {
 /// interim (used by position/area/Map paths) is untouched: the slant
 /// range here comes from the 4/3-Earth inversion in `volume_section`,
 /// not from a ground-range fixup.
+#[allow(clippy::too_many_arguments)]
 fn sample_polar_slant(
     volume: &PolarVolume,
+    file_id: &str,
+    pix: Pixels,
     envelope: (f64, f64),
     quantity: &str,
     slant_range_m: f64,
@@ -1802,7 +1918,8 @@ fn sample_polar_slant(
         return None;
     }
     let ray = (azimuth_deg / (360.0 / sweep.nrays as f64)).floor() as usize % sweep.nrays;
-    moment.data.sample(
+    let pixels = pix.moment(file_id, moment, sweep.nrays, sweep.nbins)?;
+    pixels.sample(
         ray,
         bin as usize,
         moment.gain,
@@ -1827,6 +1944,7 @@ fn sample_polar_slant(
 /// honest about the angles it actually surveyed.
 fn volume_section(
     entry: &VolumeEntry,
+    pix: Pixels,
     path: &[(f64, f64)],
     heights_m: &[f64],
     quantities: &[String],
@@ -1865,6 +1983,8 @@ fn volume_section(
                 let (r, el) = ground_height_to_slant(d, h);
                 values.push(sample_polar_slant(
                     &entry.volume,
+                    &entry.id,
+                    pix,
                     envelope,
                     quantity,
                     r,
@@ -1908,6 +2028,7 @@ fn volume_section(
 /// `PointSeries` per requested level (a time series at that sweep).
 fn site_coverages(
     volumes: &[VolumeEntry],
+    pix: Pixels,
     lon: f64,
     lat: f64,
     datetime: Option<(DateTime<Utc>, DateTime<Utc>)>,
@@ -1934,7 +2055,7 @@ fn site_coverages(
             .iter()
             // `filter_map` drops volumes that produced no plottable profile
             // (every elangle non-finite — `volume_profile` returns `None`).
-            .filter_map(|e| volume_profile(e, lon, lat, &quantities))
+            .filter_map(|e| volume_profile(e, pix, lon, lat, &quantities))
             .collect()),
         Some(lvls) => {
             let times: Vec<DateTime<Utc>> = selected.iter().map(|e| e.volume.time).collect();
@@ -1947,7 +2068,7 @@ fn site_coverages(
                 // clear sky. With every level dropped, `finalize_single_site`
                 // turns the empty result into a 404.
                 .filter_map(|&lvl| {
-                    let qr = level_series(&selected, lon, lat, lvl, &quantities, &times);
+                    let qr = level_series(&selected, pix, lon, lat, lvl, &quantities, &times);
                     let all_null = qr
                         .ranges
                         .values()
@@ -1985,8 +2106,10 @@ fn resolve_levels(
 /// selector against the site's `canonical` sweep angles, build the
 /// coverages, and wrap them per [`finalize_single_site`]. Shared by the
 /// network engine (after it picks a site) and each per-site view.
+#[allow(clippy::too_many_arguments)]
 fn site_point_query(
     volumes: &[VolumeEntry],
+    pix: Pixels,
     lon: f64,
     lat: f64,
     datetime: Option<(DateTime<Utc>, DateTime<Utc>)>,
@@ -1995,7 +2118,15 @@ fn site_point_query(
     canonical: Option<&[f64]>,
 ) -> Result<CoverageResponse, DataServerError> {
     let levels = resolve_levels(canonical, z)?;
-    let covs = site_coverages(volumes, lon, lat, datetime, parameters, levels.as_deref())?;
+    let covs = site_coverages(
+        volumes,
+        pix,
+        lon,
+        lat,
+        datetime,
+        parameters,
+        levels.as_deref(),
+    )?;
     finalize_single_site(covs, &levels)
 }
 
@@ -2021,6 +2152,7 @@ fn resample_section_path(coords: &str) -> Result<Vec<(f64, f64)>, DataServerErro
 /// engine (after it picks the nearest site) and each per-site view.
 fn site_trajectory(
     volumes: &[VolumeEntry],
+    pix: Pixels,
     path: &[(f64, f64)],
     datetime: Option<(DateTime<Utc>, DateTime<Utc>)>,
     parameters: Option<&[String]>,
@@ -2065,7 +2197,7 @@ fn site_trajectory(
 
     let coverages: Vec<QueryResult> = selected
         .iter()
-        .filter_map(|e| volume_section(e, path, &heights, &quantities, window))
+        .filter_map(|e| volume_section(e, pix, path, &heights, &quantities, window))
         .collect();
     if coverages.is_empty() {
         return Err(DataServerError::LocationNotFound(
@@ -2169,6 +2301,7 @@ impl PolarVolumeEngine {
     pub fn site_view(&self, nod: &str, collection_id: &str) -> PolarVolumeSiteView {
         PolarVolumeSiteView {
             catalog: self.catalog.clone(),
+            source: self.source.clone(),
             nod: nod.to_string(),
             collection_id: collection_id.to_string(),
         }
@@ -2192,6 +2325,9 @@ impl PolarVolumeEngine {
 pub struct PolarVolumeSiteView {
     /// Live catalog shared with the owning [`PolarVolumeEngine`].
     catalog: Arc<ArcSwap<Catalog>>,
+    /// The owning engine's file source, shared so the view can lazily
+    /// re-fetch a volume's bytes to decode a moment's pixels on demand.
+    source: Arc<Source>,
     /// ODIM NOD code this view is scoped to.
     nod: String,
     /// Per-site OGC collection id (`{base}-{nod}`), for error messages.
@@ -2256,7 +2392,20 @@ impl MapEngine for PolarVolumeSiteView {
             ))
         })?;
 
-        polar_sample(&entry.volume, quantity, bbox, width, height, output_crs, z)
+        let pix = Pixels {
+            source: &self.source,
+        };
+        polar_sample(
+            &entry.volume,
+            &entry.id,
+            pix,
+            quantity,
+            bbox,
+            width,
+            height,
+            output_crs,
+            z,
+        )
     }
 
     fn raster_info(&self) -> RasterInfo {
@@ -2335,8 +2484,11 @@ impl EdrEngine for PolarVolumeSiteView {
             .volume
             .site;
         let canonical = meta.vertical.as_ref().map(|v| v.levels.as_slice());
+        let pix = Pixels {
+            source: &self.source,
+        };
         site_point_query(
-            volumes, site.lon, site.lat, datetime, parameters, z, canonical,
+            volumes, pix, site.lon, site.lat, datetime, parameters, z, canonical,
         )
     }
 
@@ -2435,7 +2587,10 @@ impl EdrEngine for PolarVolumeSiteView {
             ))
         })?;
         let canonical = meta.vertical.as_ref().map(|v| v.levels.as_slice());
-        site_point_query(volumes, lon, lat, datetime, parameters, z, canonical)
+        let pix = Pixels {
+            source: &self.source,
+        };
+        site_point_query(volumes, pix, lon, lat, datetime, parameters, z, canonical)
     }
 
     /// Area query — a `CoverageCollection` of this site's coverages, but
@@ -2470,8 +2625,12 @@ impl EdrEngine for PolarVolumeSiteView {
         })?;
         let canonical = meta.vertical.as_ref().map(|v| v.levels.as_slice());
         let levels = resolve_levels(canonical, z)?;
+        let pix = Pixels {
+            source: &self.source,
+        };
         let covs = site_coverages(
             volumes,
+            pix,
             meta.lon,
             meta.lat,
             datetime,
@@ -2518,7 +2677,10 @@ impl EdrEngine for PolarVolumeSiteView {
                 self.collection_id, self.nod
             ))
         })?;
-        site_trajectory(volumes, &path, datetime, parameters, z)
+        let pix = Pixels {
+            source: &self.source,
+        };
+        site_trajectory(volumes, pix, &path, datetime, parameters, z)
     }
 }
 
@@ -2679,19 +2841,39 @@ mod tests {
     fn sample_polar_slant_rejects_malformed_rscale() {
         let (site_lon, site_lat) = (25.0, 60.0);
         let mut vol = synthetic_volume(site_lon, site_lat);
+        seed_synthetic(TEST_FILE);
         let env = sweep_envelope(&vol).expect("synthetic volume has finite sweep");
         let azimuth = 90.0;
         let elangle = 0.5;
         let range_m = 10_000.0;
 
         // Baseline: well-formed sweep returns a finite sample.
-        let v = sample_polar_slant(&vol, env, "DBZH", range_m, azimuth, elangle);
+        let v = sample_polar_slant(
+            &vol,
+            TEST_FILE,
+            test_pixels(),
+            env,
+            "DBZH",
+            range_m,
+            azimuth,
+            elangle,
+        );
         assert!(v.is_some(), "well-formed sweep must sample");
 
         for bad in [0.0_f64, -1_000.0, f64::NAN, f64::INFINITY] {
             vol.sweeps[0].rscale = bad;
             assert!(
-                sample_polar_slant(&vol, env, "DBZH", range_m, azimuth, elangle).is_none(),
+                sample_polar_slant(
+                    &vol,
+                    TEST_FILE,
+                    test_pixels(),
+                    env,
+                    "DBZH",
+                    range_m,
+                    azimuth,
+                    elangle
+                )
+                .is_none(),
                 "rscale={bad} must yield None, not fabricated data"
             );
         }
@@ -2709,6 +2891,7 @@ mod tests {
     fn sample_polar_slant_rejects_out_of_envelope_elevation() {
         let (site_lon, site_lat) = (25.0, 60.0);
         let vol = synthetic_volume(site_lon, site_lat);
+        seed_synthetic(TEST_FILE);
         let env = sweep_envelope(&vol).unwrap();
         // Synthetic fixture has one sweep at 0.5°. Tolerance is 1°, so
         // targets in [-0.5°, 1.5°] are accepted; everything outside ⇒ None.
@@ -2716,20 +2899,90 @@ mod tests {
         let range_m = 10_000.0;
 
         // Inside the window — sampled.
-        assert!(sample_polar_slant(&vol, env, "DBZH", range_m, azimuth, 0.5).is_some());
-        assert!(sample_polar_slant(&vol, env, "DBZH", range_m, azimuth, 1.4).is_some());
-        assert!(sample_polar_slant(&vol, env, "DBZH", range_m, azimuth, -0.4).is_some());
+        assert!(sample_polar_slant(
+            &vol,
+            TEST_FILE,
+            test_pixels(),
+            env,
+            "DBZH",
+            range_m,
+            azimuth,
+            0.5
+        )
+        .is_some());
+        assert!(sample_polar_slant(
+            &vol,
+            TEST_FILE,
+            test_pixels(),
+            env,
+            "DBZH",
+            range_m,
+            azimuth,
+            1.4
+        )
+        .is_some());
+        assert!(sample_polar_slant(
+            &vol,
+            TEST_FILE,
+            test_pixels(),
+            env,
+            "DBZH",
+            range_m,
+            azimuth,
+            -0.4
+        )
+        .is_some());
 
         // Just outside the window — None.
-        assert!(sample_polar_slant(&vol, env, "DBZH", range_m, azimuth, 1.6).is_none());
-        assert!(sample_polar_slant(&vol, env, "DBZH", range_m, azimuth, -0.6).is_none());
+        assert!(sample_polar_slant(
+            &vol,
+            TEST_FILE,
+            test_pixels(),
+            env,
+            "DBZH",
+            range_m,
+            azimuth,
+            1.6
+        )
+        .is_none());
+        assert!(sample_polar_slant(
+            &vol,
+            TEST_FILE,
+            test_pixels(),
+            env,
+            "DBZH",
+            range_m,
+            azimuth,
+            -0.6
+        )
+        .is_none());
 
         // Far outside — None (the 90° overhead case that bit the
         // h=large cells at the radar location).
-        assert!(sample_polar_slant(&vol, env, "DBZH", range_m, azimuth, 90.0).is_none());
+        assert!(sample_polar_slant(
+            &vol,
+            TEST_FILE,
+            test_pixels(),
+            env,
+            "DBZH",
+            range_m,
+            azimuth,
+            90.0
+        )
+        .is_none());
 
         // Non-finite el — None.
-        assert!(sample_polar_slant(&vol, env, "DBZH", range_m, azimuth, f64::NAN).is_none());
+        assert!(sample_polar_slant(
+            &vol,
+            TEST_FILE,
+            test_pixels(),
+            env,
+            "DBZH",
+            range_m,
+            azimuth,
+            f64::NAN
+        )
+        .is_none());
     }
 
     /// `angle_window` selects the requested elevation-angle span, clamped
@@ -2836,8 +3089,15 @@ mod tests {
         let heights = vec![0.0, 1500.0];
         let window = (0.5, 25.0); // wider than the volume's 0.5° sweep
 
-        let qr = volume_section(&e, &path, &heights, &["DBZH".to_string()], window)
-            .expect("section produced");
+        let qr = volume_section(
+            &e,
+            test_pixels(),
+            &path,
+            &heights,
+            &["DBZH".to_string()],
+            window,
+        )
+        .expect("section produced");
         let nd = qr.ranges.get("DBZH").expect("DBZH range");
         // Layout is row-major [node][height]; the far node is index 1, so
         // its first cell starts at `heights.len()`.
@@ -2858,16 +3118,49 @@ mod tests {
     /// Build a synthetic single-site, single-sweep, single-moment
     /// volume whose raw value at `[ray, bin]` encodes the bin index,
     /// so a rendered pixel's sampled value reveals which bin it hit.
-    fn synthetic_volume(lon: f64, lat: f64) -> PolarVolume {
-        let nrays = 360usize;
-        let nbins = 100usize;
-        // raw[ray][bin] = bin  → physical = bin*1.0 + 0.0 = bin.
+    /// The synthetic pixel array used by every test moment: `raw[ray][bin]
+    /// = bin` (360×100 u16), so `physical = bin*1.0 + 0.0 = bin`.
+    fn synthetic_raw() -> RawPixels {
+        let (nrays, nbins) = (360usize, 100usize);
         let mut data = Array2::<u16>::zeros((nrays, nbins));
         for ray in 0..nrays {
             for bin in 0..nbins {
                 data[(ray, bin)] = bin as u16;
             }
         }
+        RawPixels::U16(data)
+    }
+
+    /// Dataset path every synthetic moment advertises (one sweep, one moment).
+    const SYNTHETIC_DS: &str = "/dataset1/data1/data";
+
+    /// A file id for tests that render/sample a bare `synthetic_volume`
+    /// (not wrapped via [`entry`]). Pre-seed it with [`seed_synthetic`].
+    const TEST_FILE: &str = "test-volume.h5";
+
+    /// A dummy file source for the lazy-pixel context; never actually read,
+    /// because tests pre-seed the cache (see [`seed_synthetic`]).
+    static TEST_SOURCE: std::sync::LazyLock<Source> = std::sync::LazyLock::new(|| Source::Local {
+        data_dir: PathBuf::from("/nonexistent-test-pvol"),
+    });
+
+    /// A `Pixels` context over the dummy source — pairs with [`seed_synthetic`].
+    fn test_pixels() -> Pixels<'static> {
+        Pixels {
+            source: &TEST_SOURCE,
+        }
+    }
+
+    /// Seed the global pixel cache with the synthetic array under `file_id`
+    /// so the lazy fetch hits the cache (no file I/O). Call before any
+    /// sampler that resolves pixels for a volume with this `file_id`.
+    fn seed_synthetic(file_id: &str) {
+        pixel_cache().insert(file_id, SYNTHETIC_DS, std::sync::Arc::new(synthetic_raw()));
+    }
+
+    fn synthetic_volume(lon: f64, lat: f64) -> PolarVolume {
+        let nrays = 360usize;
+        let nbins = 100usize;
         let moment = PolarMoment {
             quantity: "DBZH".to_string(),
             gain: 1.0,
@@ -2875,7 +3168,7 @@ mod tests {
             // 65535 is an unused raw value — nothing masks.
             nodata: 65_535.0,
             undetect: 65_534.0,
-            data: RawPixels::U16(data),
+            dataset_path: SYNTHETIC_DS.to_string(),
         };
         let sweep = Sweep {
             elangle: 0.5,
@@ -2909,6 +3202,7 @@ mod tests {
     fn polar_sample_maps_distance_to_bin() {
         let (site_lon, site_lat) = (25.0, 60.0);
         let vol = synthetic_volume(site_lon, site_lat);
+        seed_synthetic(TEST_FILE);
 
         // A box from the site eastward ~50 km. With 1 km bins the
         // sampled value at each pixel equals its ground-distance / 1000.
@@ -2920,7 +3214,18 @@ mod tests {
             site_lon + dlon_50km,
             site_lat + 0.001,
         ];
-        let tile = polar_sample(&vol, "DBZH", bbox, 50, 1, &OutputCrs::Wgs84, None).unwrap();
+        let tile = polar_sample(
+            &vol,
+            TEST_FILE,
+            test_pixels(),
+            "DBZH",
+            bbox,
+            50,
+            1,
+            &OutputCrs::Wgs84,
+            None,
+        )
+        .unwrap();
 
         assert_eq!(tile.values.len(), 50);
         // Leftmost pixel ≈ at the site → bin 0.
@@ -2943,6 +3248,7 @@ mod tests {
     fn polar_sample_beyond_range_is_none() {
         let (site_lon, site_lat) = (25.0, 60.0);
         let vol = synthetic_volume(site_lon, site_lat); // 100 bins × 1 km = 100 km
+        seed_synthetic(TEST_FILE);
 
         // 300 km east — well past the 100 km sweep.
         let dlon = 300_000.0 / (EARTH_RADIUS_M * site_lat.to_radians().cos()) * 180.0
@@ -2953,29 +3259,46 @@ mod tests {
             site_lon + dlon + 0.01,
             site_lat + 0.001,
         ];
-        let tile = polar_sample(&vol, "DBZH", bbox, 4, 1, &OutputCrs::Wgs84, None).unwrap();
+        let tile = polar_sample(
+            &vol,
+            TEST_FILE,
+            test_pixels(),
+            "DBZH",
+            bbox,
+            4,
+            1,
+            &OutputCrs::Wgs84,
+            None,
+        )
+        .unwrap();
         assert!(
             tile.values.iter().all(Option::is_none),
             "pixels past max range must be None"
         );
     }
 
-    /// Build a single moment whose raw `[ray, bin]` value is `set(ray, bin)`.
-    fn moment_with(nrays: usize, nbins: usize, set: impl Fn(usize, usize) -> u16) -> PolarMoment {
+    /// Build a single moment (metadata) plus its raw `[ray, bin]` pixel
+    /// array, where each cell is `set(ray, bin)`.
+    fn moment_with(
+        nrays: usize,
+        nbins: usize,
+        set: impl Fn(usize, usize) -> u16,
+    ) -> (PolarMoment, RawPixels) {
         let mut data = Array2::<u16>::zeros((nrays, nbins));
         for r in 0..nrays {
             for b in 0..nbins {
                 data[(r, b)] = set(r, b);
             }
         }
-        PolarMoment {
+        let moment = PolarMoment {
             quantity: "DBZH".to_string(),
             gain: 1.0,
             offset: 0.0,
             nodata: 65_535.0,
             undetect: 65_534.0,
-            data: RawPixels::U16(data),
-        }
+            dataset_path: SYNTHETIC_DS.to_string(),
+        };
+        (moment, RawPixels::U16(data))
     }
 
     /// Bilinear blends across the two straddling rays (the anti-spoke
@@ -2983,12 +3306,12 @@ mod tests {
     /// bin 10 samples the mean, 30 — not one ray's value.
     #[test]
     fn bilinear_cell_blends_adjacent_rays() {
-        let m = moment_with(360, 20, |r, b| match (r, b) {
+        let (m, px) = moment_with(360, 20, |r, b| match (r, b) {
             (0, 10) => 20,
             (1, 10) => 40,
             _ => 0,
         });
-        let v = bilinear_cell(&m, 360, 20, 0.5, 10.0).unwrap();
+        let v = bilinear_cell(&px, &m, 360, 20, 0.5, 10.0).unwrap();
         assert!((v - 30.0).abs() < 1e-9, "ray blend (20+40)/2, got {v}");
     }
 
@@ -2996,12 +3319,12 @@ mod tests {
     /// blend for a point just inside the last ray.
     #[test]
     fn bilinear_cell_wraps_azimuth_seam() {
-        let m = moment_with(360, 20, |r, b| match (r, b) {
+        let (m, px) = moment_with(360, 20, |r, b| match (r, b) {
             (359, 10) => 10,
             (0, 10) => 30,
             _ => 0,
         });
-        let v = bilinear_cell(&m, 360, 20, 359.5, 10.0).unwrap();
+        let v = bilinear_cell(&px, &m, 360, 20, 359.5, 10.0).unwrap();
         assert!((v - 20.0).abs() < 1e-9, "seam blend (10+30)/2, got {v}");
     }
 
@@ -3011,12 +3334,12 @@ mod tests {
     /// value, not half of it).
     #[test]
     fn bilinear_cell_renormalises_over_masked_neighbours() {
-        let m = moment_with(360, 20, |r, b| match (r, b) {
+        let (m, px) = moment_with(360, 20, |r, b| match (r, b) {
             (0, 10) => 20,
             (1, 10) => 65_535, // nodata
             _ => 0,
         });
-        let v = bilinear_cell(&m, 360, 20, 0.5, 10.0).unwrap();
+        let v = bilinear_cell(&px, &m, 360, 20, 0.5, 10.0).unwrap();
         assert!(
             (v - 20.0).abs() < 1e-9,
             "masked neighbour renormalised away, got {v}"
@@ -3026,16 +3349,16 @@ mod tests {
     /// Every contributing neighbour masked → `None` (transparent).
     #[test]
     fn bilinear_cell_all_masked_is_none() {
-        let m = moment_with(360, 20, |_, b| if b == 10 { 65_535 } else { 0 });
-        assert!(bilinear_cell(&m, 360, 20, 0.5, 10.0).is_none());
+        let (m, px) = moment_with(360, 20, |_, b| if b == 10 { 65_535 } else { 0 });
+        assert!(bilinear_cell(&px, &m, 360, 20, 0.5, 10.0).is_none());
     }
 
     /// A range-edge neighbour (`bin + 1 == nbins`) is dropped, not read
     /// out of bounds; the in-range cell still samples.
     #[test]
     fn bilinear_cell_drops_range_edge_neighbour() {
-        let m = moment_with(360, 20, |_, b| if b == 19 { 42 } else { 0 });
-        let v = bilinear_cell(&m, 360, 20, 5.0, 19.5).unwrap();
+        let (m, px) = moment_with(360, 20, |_, b| if b == 19 { 42 } else { 0 });
+        let v = bilinear_cell(&px, &m, 360, 20, 5.0, 19.5).unwrap();
         assert!((v - 42.0).abs() < 1e-9, "edge neighbour dropped, got {v}");
     }
 
@@ -3052,10 +3375,26 @@ mod tests {
         let dlon = 10_500.0 / (EARTH_RADIUS_M * site_lat.to_radians().cos()) * 180.0
             / std::f64::consts::PI;
         let (lon, lat) = (site_lon + dlon, site_lat);
-        let bilinear = sample_sweep_moment_bilinear(sweep, moment, site_lon, site_lat, lon, lat)
-            .expect("bilinear sample");
-        let nearest =
-            sample_sweep_moment(sweep, moment, site_lon, site_lat, lon, lat).expect("nn sample");
+        let bilinear = sample_sweep_moment_bilinear(
+            sweep,
+            moment,
+            &synthetic_raw(),
+            site_lon,
+            site_lat,
+            lon,
+            lat,
+        )
+        .expect("bilinear sample");
+        let nearest = sample_sweep_moment(
+            sweep,
+            moment,
+            &synthetic_raw(),
+            site_lon,
+            site_lat,
+            lon,
+            lat,
+        )
+        .expect("nn sample");
         assert!(
             (bilinear - 10.5).abs() < 0.1,
             "bilinear interpolates to ≈ 10.5, got {bilinear}"
@@ -3077,6 +3416,7 @@ mod tests {
         assert!(sample_sweep_moment_bilinear(
             &vol.sweeps[0],
             &vol.sweeps[0].moments[0],
+            &synthetic_raw(),
             site_lon,
             site_lat,
             lon,
@@ -3089,6 +3429,7 @@ mod tests {
                 sample_sweep_moment_bilinear(
                     &vol.sweeps[0],
                     &vol.sweeps[0].moments[0],
+                    &synthetic_raw(),
                     site_lon,
                     site_lat,
                     lon,
@@ -3113,6 +3454,7 @@ mod tests {
         assert!(sample_sweep_moment(
             &vol.sweeps[0],
             &vol.sweeps[0].moments[0],
+            &synthetic_raw(),
             site_lon,
             site_lat,
             lon,
@@ -3125,6 +3467,7 @@ mod tests {
                 sample_sweep_moment(
                     &vol.sweeps[0],
                     &vol.sweeps[0].moments[0],
+                    &synthetic_raw(),
                     site_lon,
                     site_lat,
                     lon,
@@ -3152,13 +3495,21 @@ mod tests {
                 data[(r, b)] = r as u16; // value = ray index, constant across bins
             }
         }
+        // This test uses a custom pixel array (value = ray index), so seed
+        // the cache with *this* array under TEST_FILE rather than the
+        // standard `synthetic_raw()`.
+        pixel_cache().insert(
+            TEST_FILE,
+            SYNTHETIC_DS,
+            std::sync::Arc::new(RawPixels::U16(data)),
+        );
         let moment = PolarMoment {
             quantity: "DBZH".to_string(),
             gain: 1.0,
             offset: 0.0,
             nodata: 65_535.0,
             undetect: 65_534.0,
-            data: RawPixels::U16(data),
+            dataset_path: SYNTHETIC_DS.to_string(),
         };
         let sweep = Sweep {
             elangle: 0.5,
@@ -3189,7 +3540,18 @@ mod tests {
             site_lon + 0.25,
             site_lat + 0.25,
         ];
-        let tile = polar_sample(&vol, "DBZH", bbox, 24, 24, &OutputCrs::Wgs84, None).unwrap();
+        let tile = polar_sample(
+            &vol,
+            TEST_FILE,
+            test_pixels(),
+            "DBZH",
+            bbox,
+            24,
+            24,
+            &OutputCrs::Wgs84,
+            None,
+        )
+        .unwrap();
         // Value varies only by ray, so any fractional pixel proves the
         // render blended across rays — impossible for nearest-neighbour.
         let fractional = tile
@@ -3207,9 +3569,12 @@ mod tests {
     #[test]
     fn polar_sample_unknown_quantity_errors() {
         let vol = synthetic_volume(25.0, 60.0);
+        seed_synthetic(TEST_FILE);
         // `RasterTile` has no `Debug`, so match rather than `unwrap_err`.
         match polar_sample(
             &vol,
+            TEST_FILE,
+            test_pixels(),
             "VRADH",
             [24.0, 59.0, 26.0, 61.0],
             4,
@@ -3355,8 +3720,11 @@ mod tests {
 
     // --- EdrEngine helpers -------------------------------------------------
 
-    /// Wrap a synthetic volume in a `VolumeEntry` for catalog tests.
+    /// Wrap a synthetic volume in a `VolumeEntry` for catalog tests, and
+    /// seed the lazy-pixel cache for it so samplers over this entry resolve
+    /// the synthetic array without touching the (nonexistent) source.
     fn entry(volume: PolarVolume, id: &str) -> VolumeEntry {
+        seed_synthetic(id);
         VolumeEntry {
             id: id.to_string(),
             volume: Arc::new(volume),
@@ -3375,6 +3743,7 @@ mod tests {
             / std::f64::consts::PI;
         let covs = site_coverages(
             &volumes,
+            test_pixels(),
             site_lon + dlon,
             site_lat,
             None,
@@ -3407,7 +3776,16 @@ mod tests {
     fn site_coverages_no_z_yields_vertical_profile() {
         let (site_lon, site_lat) = (25.0, 60.0);
         let volumes = vec![entry(synthetic_volume(site_lon, site_lat), "v0")];
-        let covs = site_coverages(&volumes, site_lon, site_lat, None, None, None).unwrap();
+        let covs = site_coverages(
+            &volumes,
+            test_pixels(),
+            site_lon,
+            site_lat,
+            None,
+            None,
+            None,
+        )
+        .unwrap();
         assert_eq!(covs.len(), 1);
         match &covs[0].domain {
             DomainDescription::VerticalProfile { z, .. } => {
@@ -3449,6 +3827,7 @@ mod tests {
         // range, querying both quantities at once.
         let profile = volume_profile(
             &entry(vol, "v0"),
+            test_pixels(),
             site_lon + 0.05,
             site_lat,
             &["DBZH".to_string(), "VRADH".to_string()],
@@ -3499,8 +3878,14 @@ mod tests {
         nan_sweep.elangle = f64::NAN;
         vol.sweeps.push(nan_sweep);
 
-        let profile = volume_profile(&entry(vol, "v0"), site_lon, site_lat, &["DBZH".to_string()])
-            .expect("one finite sweep remains, so a coverage is produced");
+        let profile = volume_profile(
+            &entry(vol, "v0"),
+            test_pixels(),
+            site_lon,
+            site_lat,
+            &["DBZH".to_string()],
+        )
+        .expect("one finite sweep remains, so a coverage is produced");
         match &profile.domain {
             DomainDescription::VerticalProfile { z, .. } => {
                 assert!(
@@ -3525,7 +3910,13 @@ mod tests {
         for s in &mut vol.sweeps {
             s.elangle = f64::NAN;
         }
-        let result = volume_profile(&entry(vol, "v0"), site_lon, site_lat, &["DBZH".to_string()]);
+        let result = volume_profile(
+            &entry(vol, "v0"),
+            test_pixels(),
+            site_lon,
+            site_lat,
+            &["DBZH".to_string()],
+        );
         assert!(result.is_none(), "expected None, got {result:?}");
     }
 
@@ -3536,7 +3927,15 @@ mod tests {
         let past = DateTime::parse_from_rfc3339("2000-01-01T00:00:00Z")
             .unwrap()
             .with_timezone(&Utc);
-        match site_coverages(&volumes, 25.0, 60.0, Some((past, past)), None, None) {
+        match site_coverages(
+            &volumes,
+            test_pixels(),
+            25.0,
+            60.0,
+            Some((past, past)),
+            None,
+            None,
+        ) {
             Err(DataServerError::LocationNotFound(_)) => {}
             other => panic!("expected LocationNotFound, got {other:?}"),
         }
@@ -3547,7 +3946,15 @@ mod tests {
     fn site_coverages_unknown_parameter_errors() {
         let volumes = vec![entry(synthetic_volume(25.0, 60.0), "v0")];
         let filter = ["NONESUCH".to_string()];
-        match site_coverages(&volumes, 25.0, 60.0, None, Some(&filter), None) {
+        match site_coverages(
+            &volumes,
+            test_pixels(),
+            25.0,
+            60.0,
+            None,
+            Some(&filter),
+            None,
+        ) {
             Err(DataServerError::InvalidParameter(_)) => {}
             other => panic!("expected InvalidParameter, got {other:?}"),
         }
@@ -3561,6 +3968,9 @@ mod tests {
         let catalog = derive_catalog(by_site, &cache, None);
         PolarVolumeSiteView {
             catalog: Arc::new(ArcSwap::from_pointee(catalog)),
+            source: Arc::new(Source::Local {
+                data_dir: PathBuf::from("/nonexistent-test-pvol"),
+            }),
             nod: nod.to_string(),
             collection_id: format!("test-{nod}"),
         }
@@ -3705,6 +4115,9 @@ mod tests {
         // `sites()` (via an engine over this catalog) returns only `good`.
         let view = PolarVolumeSiteView {
             catalog: Arc::new(ArcSwap::from_pointee(catalog)),
+            source: Arc::new(Source::Local {
+                data_dir: PathBuf::from("/nonexistent-test-pvol"),
+            }),
             nod: "good".into(),
             collection_id: "test".into(),
         };

--- a/crates/engine-odim/src/volume_engine.rs
+++ b/crates/engine-odim/src/volume_engine.rs
@@ -361,6 +361,22 @@ fn source_label(source: &Source) -> String {
     }
 }
 
+/// Globally-unique [`PIXEL_CACHE`] id for a volume file. A `Local` id is
+/// already an absolute path (unique); a remote object key is unique only
+/// *within its bucket*, so a remote id is qualified with `endpoint`+`bucket`.
+/// Without this, two S3-backed PVOL sources with the same key layout but
+/// different buckets collide in the process-global cache and silently serve
+/// each other's pixels (PR #290 review). The bare `file_id` is still used as
+/// the object path for the fetch itself.
+fn pixel_cache_id<'a>(source: &Source, file_id: &'a str) -> std::borrow::Cow<'a, str> {
+    match source {
+        Source::Local { .. } => std::borrow::Cow::Borrowed(file_id),
+        Source::Remote {
+            endpoint, bucket, ..
+        } => std::borrow::Cow::Owned(format!("{endpoint}\u{1f}{bucket}\u{1f}{file_id}")),
+    }
+}
+
 /// Capture the current runtime handle for the lazy pixel fetch. Call ONLY
 /// from a `spawn_blocking` context (`get_raster_tile` / `query_trajectory`),
 /// where `handle.block_on` is valid and `block_in_place` would panic; the
@@ -433,27 +449,39 @@ impl Pixels<'_> {
         nrays: usize,
         nbins: usize,
     ) -> Option<Arc<RawPixels>> {
-        if let Some(p) = PIXEL_CACHE.get(file_id, &moment.dataset_path) {
+        // Source-qualified key so two S3 sources can't collide in the global
+        // cache (PR #290 review); the bare `file_id` stays the fetch path.
+        let cache_id = pixel_cache_id(self.source, file_id);
+        if let Some(p) = PIXEL_CACHE.get(&cache_id, &moment.dataset_path) {
             return Some(p);
         }
-        let bytes = fetch_file_bytes(self.source, file_id, self.handle)
-            .map_err(|e| {
-                PIXEL_READ_FAILURES.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                tracing::warn!("PVOL lazy pixel read failed: {e}");
-            })
-            .ok()?;
-        let raw = read_moment_pixels(&bytes, &moment.dataset_path, nrays, nbins)
-            .map_err(|e| {
-                PIXEL_READ_FAILURES.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                tracing::warn!(
-                    "PVOL pixel decode `{}` in `{file_id}`: {e}",
-                    moment.dataset_path
-                );
-            })
-            .ok()?;
-        let arc = Arc::new(raw);
-        PIXEL_CACHE.insert(file_id, &moment.dataset_path, arc.clone());
-        Some(arc)
+        // A previously-failed read degrades straight to nodata without
+        // re-fetching — a per-cell sampler loop (e.g. `volume_section`) must
+        // not storm the store, nor re-inflate the failure metric, on one bad
+        // moment (PR #290 review).
+        if PIXEL_CACHE.is_known_bad(&cache_id, &moment.dataset_path) {
+            return None;
+        }
+        let decoded = fetch_file_bytes(self.source, file_id, self.handle).and_then(|bytes| {
+            read_moment_pixels(&bytes, &moment.dataset_path, nrays, nbins)
+                .map_err(|e| format!("decode `{}`: {e}", moment.dataset_path))
+        });
+        match decoded {
+            Ok(raw) => {
+                let arc = Arc::new(raw);
+                PIXEL_CACHE.insert(&cache_id, &moment.dataset_path, arc.clone());
+                Some(arc)
+            }
+            Err(e) => {
+                // Count + log once per key; subsequent cells short-circuit on
+                // `is_known_bad` above.
+                if PIXEL_CACHE.mark_bad(&cache_id, &moment.dataset_path) {
+                    PIXEL_READ_FAILURES.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    tracing::warn!("PVOL lazy pixel read failed for `{file_id}`: {e}");
+                }
+                None
+            }
+        }
     }
 }
 
@@ -3234,6 +3262,68 @@ mod tests {
             "test-volume-unique-{}.h5",
             NEXT.fetch_add(1, Ordering::Relaxed)
         )
+    }
+
+    /// An in-memory-backed `Source::Remote` for tests that only need its
+    /// `endpoint`/`bucket` (e.g. [`pixel_cache_id`]); the store is never read.
+    fn dummy_remote(bucket: &str) -> Source {
+        Source::Remote {
+            store: ds_storage::DataStore::new(std::sync::Arc::new(
+                ds_storage::object_store::memory::InMemory::new(),
+            )),
+            endpoint: "https://s3.example.com".to_string(),
+            bucket: bucket.to_string(),
+            prefix_pattern: "%Y/".to_string(),
+            time_window: None,
+        }
+    }
+
+    #[test]
+    fn pixel_cache_id_local_is_bare_path() {
+        let local = Source::Local {
+            data_dir: PathBuf::from("/x"),
+        };
+        // A local id is already an absolute path — used verbatim.
+        assert_eq!(
+            pixel_cache_id(&local, "/abs/file.h5").as_ref(),
+            "/abs/file.h5"
+        );
+    }
+
+    #[test]
+    fn pixel_cache_id_qualifies_remote_by_bucket() {
+        let a = dummy_remote("bucket-a");
+        let b = dummy_remote("bucket-b");
+        let key = "2026/06/02/0000_fivih_PVOL.h5";
+        // Same object key in two different buckets must NOT collide in the
+        // process-global cache (PR #290 review, finding 1).
+        assert_ne!(pixel_cache_id(&a, key), pixel_cache_id(&b, key));
+        // Stable for the same source + key.
+        assert_eq!(pixel_cache_id(&a, key), pixel_cache_id(&a, key));
+    }
+
+    #[test]
+    fn moment_failure_marks_known_bad_and_returns_none() {
+        // An unseeded id over the `/nonexistent` Local source → the fetch
+        // fails. The failure must be negatively cached so a per-cell loop
+        // short-circuits instead of re-fetching (PR #290 review, finding 4).
+        let file_id = unique_file_id();
+        let mom = PolarMoment {
+            quantity: "DBZH".to_string(),
+            gain: 1.0,
+            offset: 0.0,
+            nodata: 65_535.0,
+            undetect: 65_534.0,
+            dataset_path: SYNTHETIC_DS.to_string(),
+        };
+        let pix = test_pixels();
+        assert!(pix.moment(&file_id, &mom, 360, 100).is_none());
+        assert!(
+            pixel_cache().is_known_bad(&file_id, &mom.dataset_path),
+            "a failed read must be negatively cached"
+        );
+        // Repeat returns None via the negative-cache short-circuit.
+        assert!(pix.moment(&file_id, &mom, 360, 100).is_none());
     }
 
     /// A dummy file source for the lazy-pixel context; never actually read,

--- a/crates/engine-odim/src/volume_engine.rs
+++ b/crates/engine-odim/src/volume_engine.rs
@@ -462,6 +462,9 @@ impl Pixels<'_> {
         if PIXEL_CACHE.is_known_bad(&cache_id, &moment.dataset_path) {
             return None;
         }
+        // Genuine positive-cache miss (not a known-bad skip) — count it here so
+        // the miss metric reflects real fetches, then fetch + decode.
+        PIXEL_CACHE.record_miss();
         // NOTE: this fetches + parses the *whole* `.h5` to extract one dataset
         // (the reader has no slice API), so a file with Q cold moments is
         // downloaded Q times. Batch-decoding all moments on the first miss is

--- a/crates/engine-odim/src/volume_engine.rs
+++ b/crates/engine-odim/src/volume_engine.rs
@@ -462,6 +462,11 @@ impl Pixels<'_> {
         if PIXEL_CACHE.is_known_bad(&cache_id, &moment.dataset_path) {
             return None;
         }
+        // NOTE: this fetches + parses the *whole* `.h5` to extract one dataset
+        // (the reader has no slice API), so a file with Q cold moments is
+        // downloaded Q times. Batch-decoding all moments on the first miss is
+        // tracked in #293 — an S3-transfer optimisation; local re-reads hit the
+        // page cache.
         let decoded = fetch_file_bytes(self.source, file_id, self.handle).and_then(|bytes| {
             read_moment_pixels(&bytes, &moment.dataset_path, nrays, nbins)
                 .map_err(|e| format!("decode `{}`: {e}", moment.dataset_path))

--- a/crates/engine-odim/src/volume_engine.rs
+++ b/crates/engine-odim/src/volume_engine.rs
@@ -101,6 +101,27 @@ pub(crate) fn pixel_cache() -> &'static PixelCache {
     &PIXEL_CACHE
 }
 
+/// Cumulative count of lazy pixel reads that failed (remote/local I/O or
+/// HDF5 decode) and so degraded to a transparent / nodata sample instead of
+/// real data. Before lazy loading a decode failure was a hard catalog
+/// rejection at scan time; now the failure is per-request and otherwise
+/// silent, so this counter (surfaced as `pvol_pixel_read_failures_total` in
+/// `/metrics`) makes the degradation observable (PR #290 review).
+static PIXEL_READ_FAILURES: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+/// Snapshot of the process-global PVOL pixel cache for `/metrics`:
+/// `(hits, misses, resident_bytes, capacity_bytes, read_failures)`.
+pub fn pixel_cache_metrics() -> (u64, u64, u64, u64, u64) {
+    let (hits, misses) = PIXEL_CACHE.stats();
+    (
+        hits,
+        misses,
+        PIXEL_CACHE.weight(),
+        PIXEL_CACHE.capacity(),
+        PIXEL_READ_FAILURES.load(std::sync::atomic::Ordering::Relaxed),
+    )
+}
+
 /// Days of date-partitioned prefixes to scan when an S3 source has no
 /// `time_window`. Two days covers the just-after-midnight case where
 /// the recent tail still straddles yesterday's partition. Mirrors
@@ -340,9 +361,30 @@ fn source_label(source: &Source) -> String {
     }
 }
 
+/// Capture the current runtime handle for the lazy pixel fetch. Call ONLY
+/// from a `spawn_blocking` context (`get_raster_tile` / `query_trajectory`),
+/// where `handle.block_on` is valid and `block_in_place` would panic; the
+/// request-worker query paths pass `None` instead. Uses `try_current` (not
+/// `current`) so unit tests that invoke the trait methods outside any runtime
+/// — always with a `Local` source that ignores the handle — don't panic.
+fn blocking_pixel_handle() -> Option<tokio::runtime::Handle> {
+    tokio::runtime::Handle::try_current().ok()
+}
+
 /// Re-fetch one volume file's raw bytes by its [`FileId`] — a local path
 /// read or an S3 `get`. Used by the lazy pixel reader on a cache miss.
-fn fetch_file_bytes(source: &Source, file_id: &str) -> Result<Vec<u8>, String> {
+///
+/// `handle` picks the async→sync bridge for a remote fetch by the caller's
+/// runtime context (see [`Pixels::handle`]): `Some(handle)` drives the fetch
+/// via `handle.block_on` (valid on a `spawn_blocking` pool thread, where
+/// `block_in_place` *panics*); `None` uses the plain [`DataStore::get`],
+/// whose `block_in_place` is valid on a request-worker thread. A local read
+/// never touches a runtime, so the handle is irrelevant there.
+fn fetch_file_bytes(
+    source: &Source,
+    file_id: &str,
+    handle: Option<&tokio::runtime::Handle>,
+) -> Result<Vec<u8>, String> {
     match source {
         Source::Local { .. } => {
             std::fs::read(file_id).map_err(|e| format!("read `{file_id}`: {e}"))
@@ -350,8 +392,11 @@ fn fetch_file_bytes(source: &Source, file_id: &str) -> Result<Vec<u8>, String> {
         Source::Remote { store, .. } => {
             use ds_storage::object_store::path::Path as ObjectPath;
             let object = ObjectPath::from(file_id);
-            store
-                .get(&object)
+            let bytes = match handle {
+                Some(h) => store.get_on(&object, h),
+                None => store.get(&object),
+            };
+            bytes
                 .map(|b| b.to_vec())
                 .map_err(|e| format!("get `{file_id}`: {e}"))
         }
@@ -365,6 +410,14 @@ fn fetch_file_bytes(source: &Source, file_id: &str) -> Result<Vec<u8>, String> {
 #[derive(Clone, Copy)]
 struct Pixels<'a> {
     source: &'a Source,
+    /// Runtime context for a remote (S3) pixel fetch on a cache miss:
+    /// `Some(handle)` when the caller runs inside `spawn_blocking`
+    /// (`get_raster_tile` / `query_trajectory`) — the fetch then uses
+    /// `handle.block_on` because `block_in_place` panics on a `spawn_blocking`
+    /// pool thread. `None` on a request worker (EDR position / area /
+    /// locations), where the fetch must use `block_in_place` via the plain
+    /// `DataStore::get`. Irrelevant for a `Local` source.
+    handle: Option<&'a tokio::runtime::Handle>,
 }
 
 impl Pixels<'_> {
@@ -383,15 +436,19 @@ impl Pixels<'_> {
         if let Some(p) = PIXEL_CACHE.get(file_id, &moment.dataset_path) {
             return Some(p);
         }
-        let bytes = fetch_file_bytes(self.source, file_id)
-            .map_err(|e| tracing::warn!("PVOL lazy pixel read failed: {e}"))
+        let bytes = fetch_file_bytes(self.source, file_id, self.handle)
+            .map_err(|e| {
+                PIXEL_READ_FAILURES.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                tracing::warn!("PVOL lazy pixel read failed: {e}");
+            })
             .ok()?;
         let raw = read_moment_pixels(&bytes, &moment.dataset_path, nrays, nbins)
             .map_err(|e| {
+                PIXEL_READ_FAILURES.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                 tracing::warn!(
                     "PVOL pixel decode `{}` in `{file_id}`: {e}",
                     moment.dataset_path
-                )
+                );
             })
             .ok()?;
         let arc = Arc::new(raw);
@@ -2392,8 +2449,13 @@ impl MapEngine for PolarVolumeSiteView {
             ))
         })?;
 
+        // Runs inside `spawn_blocking` (api-{wms,maps,tiles} dispatch
+        // `get_raster_tile` there) — drive any S3 pixel fetch on the runtime
+        // handle, since `block_in_place` panics on a `spawn_blocking` thread.
+        let handle = blocking_pixel_handle();
         let pix = Pixels {
             source: &self.source,
+            handle: handle.as_ref(),
         };
         polar_sample(
             &entry.volume,
@@ -2484,8 +2546,13 @@ impl EdrEngine for PolarVolumeSiteView {
             .volume
             .site;
         let canonical = meta.vertical.as_ref().map(|v| v.levels.as_slice());
+        // EDR `query_location` runs directly on the request worker (the
+        // generic api-edr handler does not `spawn_blocking`), so any S3 pixel
+        // fetch must use `block_in_place` (the plain `DataStore::get`) — pass
+        // `None`. `handle.block_on` would panic in this async context.
         let pix = Pixels {
             source: &self.source,
+            handle: None,
         };
         site_point_query(
             volumes, pix, site.lon, site.lat, datetime, parameters, z, canonical,
@@ -2587,8 +2654,11 @@ impl EdrEngine for PolarVolumeSiteView {
             ))
         })?;
         let canonical = meta.vertical.as_ref().map(|v| v.levels.as_slice());
+        // Request-worker path (no `spawn_blocking`) — `None` selects the
+        // `block_in_place` fetch; see `query_location`.
         let pix = Pixels {
             source: &self.source,
+            handle: None,
         };
         site_point_query(volumes, pix, lon, lat, datetime, parameters, z, canonical)
     }
@@ -2625,8 +2695,11 @@ impl EdrEngine for PolarVolumeSiteView {
         })?;
         let canonical = meta.vertical.as_ref().map(|v| v.levels.as_slice());
         let levels = resolve_levels(canonical, z)?;
+        // Request-worker path (no `spawn_blocking`) — `None` selects the
+        // `block_in_place` fetch; see `query_location`.
         let pix = Pixels {
             source: &self.source,
+            handle: None,
         };
         let covs = site_coverages(
             volumes,
@@ -2677,8 +2750,13 @@ impl EdrEngine for PolarVolumeSiteView {
                 self.collection_id, self.nod
             ))
         })?;
+        // Runs inside `spawn_blocking` (api-edr dispatches `query_trajectory`
+        // there) — drive any S3 pixel fetch on the runtime handle, since
+        // `block_in_place` panics on a `spawn_blocking` thread.
+        let handle = blocking_pixel_handle();
         let pix = Pixels {
             source: &self.source,
+            handle: handle.as_ref(),
         };
         site_trajectory(volumes, pix, &path, datetime, parameters, z)
     }
@@ -3136,7 +3214,27 @@ mod tests {
 
     /// A file id for tests that render/sample a bare `synthetic_volume`
     /// (not wrapped via [`entry`]). Pre-seed it with [`seed_synthetic`].
+    ///
+    /// Safe to share across the parallel test run **only** because every
+    /// seeder writes the identical deterministic [`synthetic_raw`] array under
+    /// it — overwrites are no-ops. A test that needs a *different* pixel array
+    /// MUST mint its own key with [`unique_file_id`]; reusing `TEST_FILE` for
+    /// divergent data flakes nondeterministically against the global cache
+    /// (PR #290 review).
     const TEST_FILE: &str = "test-volume.h5";
+
+    /// Mint a process-unique file id so a test's custom pixel array occupies a
+    /// distinct [`PIXEL_CACHE`] key — the cache is a global LRU shared across
+    /// the parallel test run, so divergent arrays under one key clobber each
+    /// other (PR #290 review).
+    fn unique_file_id() -> String {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static NEXT: AtomicU64 = AtomicU64::new(0);
+        format!(
+            "test-volume-unique-{}.h5",
+            NEXT.fetch_add(1, Ordering::Relaxed)
+        )
+    }
 
     /// A dummy file source for the lazy-pixel context; never actually read,
     /// because tests pre-seed the cache (see [`seed_synthetic`]).
@@ -3145,9 +3243,12 @@ mod tests {
     });
 
     /// A `Pixels` context over the dummy source — pairs with [`seed_synthetic`].
+    /// `handle: None` so the remote-fetch path (never hit, since the source is
+    /// `Local` and the cache is pre-seeded) would take the worker bridge.
     fn test_pixels() -> Pixels<'static> {
         Pixels {
             source: &TEST_SOURCE,
+            handle: None,
         }
     }
 
@@ -3495,11 +3596,13 @@ mod tests {
                 data[(r, b)] = r as u16; // value = ray index, constant across bins
             }
         }
-        // This test uses a custom pixel array (value = ray index), so seed
-        // the cache with *this* array under TEST_FILE rather than the
-        // standard `synthetic_raw()`.
+        // This test uses a custom pixel array (value = ray index), divergent
+        // from the standard `synthetic_raw()`. It MUST live under a unique key
+        // so it neither clobbers nor is clobbered by the default-seed tests
+        // sharing the global cache (PR #290 review).
+        let file_id = unique_file_id();
         pixel_cache().insert(
-            TEST_FILE,
+            &file_id,
             SYNTHETIC_DS,
             std::sync::Arc::new(RawPixels::U16(data)),
         );
@@ -3542,7 +3645,7 @@ mod tests {
         ];
         let tile = polar_sample(
             &vol,
-            TEST_FILE,
+            &file_id,
             test_pixels(),
             "DBZH",
             bbox,

--- a/crates/server/src/admin.rs
+++ b/crates/server/src/admin.rs
@@ -2438,26 +2438,24 @@ pub async fn metrics_handler(State(state): State<AdminState>) -> impl IntoRespon
     METATILE_CACHE_ENTRIES.set(wms.tile_cache.len() as i64);
 
     // PVOL lazy pixel cache: process-global (never replaced on reload), so the
-    // cumulative counters are monotonic. Only emit when PVOL collections are
-    // loaded, so non-radar deployments don't carry empty `pvol_*` series.
-    let has_pvol = state
+    // cumulative counters are strictly monotonic — a per-counter
+    // `saturating_sub` delta is correct without the rebaseline branch the
+    // replaceable rendered/metatile caches above need (and `saturating_sub`
+    // can't underflow if a counter ever does appear backward). Only emit when
+    // PVOL collections are loaded, so non-radar deployments don't carry empty
+    // `pvol_*` series. Recover from a poisoned lock (`into_inner`) — a panic
+    // elsewhere must not silently suppress the failure metric.
+    let has_pvol = !state
         .odim_volume_engines
         .read()
-        .map(|e| !e.is_empty())
-        .unwrap_or(false);
+        .unwrap_or_else(|e| e.into_inner())
+        .is_empty();
     if has_pvol {
         let (p_hits, p_misses, p_bytes, p_cap, p_fail) = engine_odim::pixel_cache_metrics();
         let (last_ph, last_pm, last_pf) = counter_state.pvol_pixel;
-        // Defensive rebaseline (the global cache never resets in practice).
-        if p_hits < last_ph || p_misses < last_pm || p_fail < last_pf {
-            PVOL_PIXEL_CACHE_HITS.inc_by(0);
-            PVOL_PIXEL_CACHE_MISSES.inc_by(0);
-            PVOL_PIXEL_READ_FAILURES.inc_by(0);
-        } else {
-            PVOL_PIXEL_CACHE_HITS.inc_by(p_hits - last_ph);
-            PVOL_PIXEL_CACHE_MISSES.inc_by(p_misses - last_pm);
-            PVOL_PIXEL_READ_FAILURES.inc_by(p_fail - last_pf);
-        }
+        PVOL_PIXEL_CACHE_HITS.inc_by(p_hits.saturating_sub(last_ph));
+        PVOL_PIXEL_CACHE_MISSES.inc_by(p_misses.saturating_sub(last_pm));
+        PVOL_PIXEL_READ_FAILURES.inc_by(p_fail.saturating_sub(last_pf));
         counter_state.pvol_pixel = (p_hits, p_misses, p_fail);
         PVOL_PIXEL_CACHE_BYTES.set(p_bytes as i64);
         PVOL_PIXEL_CACHE_CAPACITY_BYTES.set(p_cap as i64);

--- a/crates/server/src/admin.rs
+++ b/crates/server/src/admin.rs
@@ -201,6 +201,54 @@ static RENDERED_CACHE_ENTRIES: LazyLock<IntGauge> = LazyLock::new(|| {
     gauge
 });
 
+// PVOL lazy pixel cache (#289 / PR #290) — global byte-bounded LRU of decoded
+// radar moment arrays, shared across every per-site PVOL collection. The
+// failures counter surfaces the otherwise-silent degradation when a moment's
+// pixels can't be read/decoded at render time (was a hard catalog rejection
+// before lazy loading).
+static PVOL_PIXEL_CACHE_HITS: LazyLock<IntCounter> = LazyLock::new(|| {
+    let counter = IntCounter::new("pvol_pixel_cache_hits_total", "PVOL pixel cache hits").unwrap();
+    REGISTRY.register(Box::new(counter.clone())).unwrap();
+    counter
+});
+
+static PVOL_PIXEL_CACHE_MISSES: LazyLock<IntCounter> = LazyLock::new(|| {
+    let counter =
+        IntCounter::new("pvol_pixel_cache_misses_total", "PVOL pixel cache misses").unwrap();
+    REGISTRY.register(Box::new(counter.clone())).unwrap();
+    counter
+});
+
+static PVOL_PIXEL_CACHE_BYTES: LazyLock<IntGauge> = LazyLock::new(|| {
+    let gauge = IntGauge::new(
+        "pvol_pixel_cache_bytes",
+        "Bytes currently held in the PVOL pixel cache",
+    )
+    .unwrap();
+    REGISTRY.register(Box::new(gauge.clone())).unwrap();
+    gauge
+});
+
+static PVOL_PIXEL_CACHE_CAPACITY_BYTES: LazyLock<IntGauge> = LazyLock::new(|| {
+    let gauge = IntGauge::new(
+        "pvol_pixel_cache_capacity_bytes",
+        "Configured PVOL pixel cache capacity in bytes",
+    )
+    .unwrap();
+    REGISTRY.register(Box::new(gauge.clone())).unwrap();
+    gauge
+});
+
+static PVOL_PIXEL_READ_FAILURES: LazyLock<IntCounter> = LazyLock::new(|| {
+    let counter = IntCounter::new(
+        "pvol_pixel_read_failures_total",
+        "PVOL lazy pixel reads that failed (I/O or decode) and degraded to nodata",
+    )
+    .unwrap();
+    REGISTRY.register(Box::new(counter.clone())).unwrap();
+    counter
+});
+
 // Meta-tile pixel cache (#202) — global, decoded-RGBA tiles for the Web
 // Mercator WMS meta-tiling path. Distinct from the per-collection GeoTIFF
 // compressed-byte tile cache (`tile_cache_*`).
@@ -327,6 +375,9 @@ struct CacheCounterState {
     grid: HashMap<String, (u64, u64)>,
     rendered: (u64, u64),
     metatile: (u64, u64),
+    /// PVOL pixel cache `(hits, misses, read_failures)` — global cache, never
+    /// replaced on reload, so always monotonic.
+    pvol_pixel: (u64, u64, u64),
 }
 
 static RENDER_SEMAPHORE_AVAILABLE: LazyLock<IntGauge> = LazyLock::new(|| {
@@ -2385,6 +2436,32 @@ pub async fn metrics_handler(State(state): State<AdminState>) -> impl IntoRespon
     METATILE_CACHE_BYTES.set(wms.tile_cache.weight() as i64);
     METATILE_CACHE_CAPACITY_BYTES.set(wms.tile_cache.capacity() as i64);
     METATILE_CACHE_ENTRIES.set(wms.tile_cache.len() as i64);
+
+    // PVOL lazy pixel cache: process-global (never replaced on reload), so the
+    // cumulative counters are monotonic. Only emit when PVOL collections are
+    // loaded, so non-radar deployments don't carry empty `pvol_*` series.
+    let has_pvol = state
+        .odim_volume_engines
+        .read()
+        .map(|e| !e.is_empty())
+        .unwrap_or(false);
+    if has_pvol {
+        let (p_hits, p_misses, p_bytes, p_cap, p_fail) = engine_odim::pixel_cache_metrics();
+        let (last_ph, last_pm, last_pf) = counter_state.pvol_pixel;
+        // Defensive rebaseline (the global cache never resets in practice).
+        if p_hits < last_ph || p_misses < last_pm || p_fail < last_pf {
+            PVOL_PIXEL_CACHE_HITS.inc_by(0);
+            PVOL_PIXEL_CACHE_MISSES.inc_by(0);
+            PVOL_PIXEL_READ_FAILURES.inc_by(0);
+        } else {
+            PVOL_PIXEL_CACHE_HITS.inc_by(p_hits - last_ph);
+            PVOL_PIXEL_CACHE_MISSES.inc_by(p_misses - last_pm);
+            PVOL_PIXEL_READ_FAILURES.inc_by(p_fail - last_pf);
+        }
+        counter_state.pvol_pixel = (p_hits, p_misses, p_fail);
+        PVOL_PIXEL_CACHE_BYTES.set(p_bytes as i64);
+        PVOL_PIXEL_CACHE_CAPACITY_BYTES.set(p_cap as i64);
+    }
 
     // Tile cache: per-collection
     if let Ok(engines) = state.geotiff_engines.read() {

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -86,6 +86,28 @@ impl DataStore {
         Ok(result)
     }
 
+    /// Like [`Self::get`], but drives the fetch on an explicitly-provided
+    /// runtime `Handle` (`handle.block_on`) instead of `block_in_place`. Use
+    /// from a `spawn_blocking` pool thread — where `block_in_place` *panics*
+    /// (e.g. the PVOL lazy pixel reader on a render / trajectory request that
+    /// runs inside `spawn_blocking`). Must NOT be called from within a running
+    /// future on a request worker (an async execution context — `handle.block_on`
+    /// panics there); use [`Self::get`] for that.
+    #[allow(clippy::needless_question_mark)]
+    pub fn get_on(
+        &self,
+        path: &ObjectPath,
+        handle: &tokio::runtime::Handle,
+    ) -> Result<Bytes, DataServerError> {
+        let result = self.block_on_with(Some(handle), async {
+            let result = self.inner.get(path).await?;
+            Ok(result.bytes().await?)
+        })?;
+        self.bytes_read
+            .fetch_add(result.len() as u64, Ordering::Relaxed);
+        Ok(result)
+    }
+
     /// Return total bytes read from this store since creation.
     pub fn bytes_read(&self) -> u64 {
         self.bytes_read.load(Ordering::Relaxed)


### PR DESCRIPTION
Fixes the production scaling problem in #289: the PVOL engine parsed every `.h5` and held every sweep's decoded pixels in RAM, blocking startup for minutes at 100% CPU and growing RSS unbounded (3 radars ≈ 24.5 GiB; a 12-radar network ≈ 75 GB → OOM).

## Change

Pixels load **lazily**, on demand, behind a **bounded cache** — the COG pattern the GeoTIFF engine already uses.

- **`PolarMoment` is metadata-only** — it carries the moment's `/datasetN/dataM/data` dataset path, not the array. `read_polar_volume` reads attributes and validates each moment's shape but **does not decode** the pixel datasets, so a scan is cheap and a parsed volume is KB-scale. A whole network's catalog fits in memory → **fast, non-blocking startup**.
- **`read_moment_pixels`** reads one moment's array on demand.
- **Process-global byte-bounded `PixelCache`** (`quick_cache`, byte-weighted like the GeoTIFF/GRIB caches), keyed by `(file_id, dataset_path)`. **One budget bounds resident pixels across every PVOL collection**, sized by `MC_PVOL_PIXEL_CACHE_MB` (default 1024 MiB) → **RSS bounded regardless of radar count or window length**.
- A `Pixels` context threads the file source through the samplers; on a cache miss it re-fetches the file bytes (local read / S3 get), decodes the one dataset, and caches it. A read failure degrades to transparent/nodata, not a 500.

`max_files` stays as the downloader-failure safety valve. Every file in the rolling window remains queryable.

## Verification

- `cargo test -p engine-odim`: **107 lib + 23 integration** pass. The integration tests render and run EDR position/area/trajectory **against the real `fivih` fixture through the lazy path**, so the on-demand read + decode is exercised end-to-end. Server: 49 + 10. Clippy clean.

## Notes / follow-ups

- The metadata scan still reads each file's bytes once (the pure-Rust `hdf5-reader` parses from an in-memory buffer) but **skips the pixel decompression** that was the 100% CPU cost; RSS no longer holds the decoded arrays. A further optimization — reading only attribute regions, or backgrounding the metadata scan — can come later if the transient scan I/O matters at full scale.
- An EDR vertical profile currently re-reads the file once per moment; a per-file batch decode is a cheap follow-up (map rendering, the hot path, already fetches one moment).
- Cache hit/miss are tracked (`PixelCache::stats`) — wiring them into `/metrics` is a small follow-up.
- **Real-world validation is a `nexus` deploy** against the live archives — happy to help test there.

Branch is off `main`; once the docs PR (#288) lands I'll rebase (both touch `lib.rs`).

Closes #289.