### PR TITLE
feat(api): declare OGC API - Common Part 1 & Part 2 conformance classes

### DIFF
--- a/crates/api-edr/src/handlers.rs
+++ b/crates/api-edr/src/handlers.rs
@@ -518,6 +518,13 @@ pub async fn conformance() -> impl IntoResponse {
             "http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/core",
             "http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/landing-page",
             "http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/oas30",
+            // OGC API - Common - Part 2: Geospatial Data (20-024). Our
+            // /collections + /collections/{id} already satisfy the Collections
+            // and JSON classes structurally; declaring them makes that
+            // discoverable. The HTML class (.../conf/html) is intentionally
+            // omitted — there is no HTML representation of /collections.
+            "http://www.opengis.net/spec/ogcapi-common-2/1.0/conf/collections",
+            "http://www.opengis.net/spec/ogcapi-common-2/1.0/conf/json",
             "http://www.opengis.net/spec/ogcapi-edr-1/1.1/conf/core",
             "http://www.opengis.net/spec/ogcapi-edr-1/1.1/conf/collections",
             "http://www.opengis.net/spec/ogcapi-edr-1/1.1/conf/json",

--- a/crates/api-edr/tests/spec_compliance_tests.rs
+++ b/crates/api-edr/tests/spec_compliance_tests.rs
@@ -713,6 +713,30 @@ async fn finding_18_conformance_has_ogc_common_classes() {
     );
 }
 
+// OGC API - Common - Part 2: Geospatial Data (20-024). #291: /collections +
+// /collections/{id} satisfy the Collections + JSON classes structurally, so
+// they are advertised for discovery. The HTML class is intentionally omitted.
+#[tokio::test]
+async fn declares_ogcapi_common_part2_classes() {
+    let (_status, json) = get_json("/conformance").await;
+    let conforms_to = json["conformsTo"].as_array().unwrap();
+    let uris: Vec<&str> = conforms_to.iter().filter_map(|v| v.as_str()).collect();
+    let has = |needle: &str| uris.iter().any(|u| u.contains(needle));
+
+    assert!(
+        has("ogcapi-common-2/1.0/conf/collections"),
+        "must declare OGC API Common Part 2 Collections class"
+    );
+    assert!(
+        has("ogcapi-common-2/1.0/conf/json"),
+        "must declare OGC API Common Part 2 JSON class"
+    );
+    assert!(
+        !has("ogcapi-common-2/1.0/conf/html"),
+        "must NOT declare the HTML class (no HTML /collections representation)"
+    );
+}
+
 // ===========================================================================
 // FINDING 19: No support for HTTP 308 redirect responses
 // ===========================================================================

--- a/crates/api-maps/src/handlers.rs
+++ b/crates/api-maps/src/handlers.rs
@@ -615,6 +615,15 @@ pub async fn api_docs(State(state): State<AppState>) -> impl IntoResponse {
 pub async fn conformance() -> impl IntoResponse {
     Json(json!({
         "conformsTo": [
+            // OGC API - Common - Part 1: Core (landing page, /conformance,
+            // /api) and Part 2: Geospatial Data (/collections + /collections/
+            // {id}, JSON). Both are satisfied structurally; the HTML class
+            // (.../common-2/.../conf/html) is omitted — no HTML /collections.
+            "http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/core",
+            "http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/landing-page",
+            "http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/oas30",
+            "http://www.opengis.net/spec/ogcapi-common-2/1.0/conf/collections",
+            "http://www.opengis.net/spec/ogcapi-common-2/1.0/conf/json",
             "http://www.opengis.net/spec/ogcapi-maps-1/1.0/conf/core",
             "http://www.opengis.net/spec/ogcapi-maps-1/1.0/conf/collection-map",
             "http://www.opengis.net/spec/ogcapi-maps-1/1.0/conf/styled-map",

--- a/crates/api-maps/tests/integration.rs
+++ b/crates/api-maps/tests/integration.rs
@@ -400,6 +400,33 @@ mod conformance {
             .iter()
             .any(|c| c.as_str().unwrap().contains("conf/tilesets")));
     }
+
+    #[tokio::test]
+    async fn declares_ogcapi_common_part1_and_part2() {
+        // OGC API - Common Part 1 (Core) + Part 2 (Collections, JSON) — the
+        // landing page / conformance / collections resources satisfy them, so
+        // they are advertised for discovery (#291).
+        let (_, json) = get("/conformance").await;
+        let classes = json["conformsTo"].as_array().unwrap();
+        let has = |needle: &str| classes.iter().any(|c| c.as_str().unwrap().contains(needle));
+        assert!(has("ogcapi-common-1/1.0/conf/core"), "Common Part 1 Core");
+        assert!(
+            has("ogcapi-common-2/1.0/conf/collections"),
+            "Common Part 2 Collections"
+        );
+        assert!(has("ogcapi-common-2/1.0/conf/json"), "Common Part 2 JSON");
+    }
+
+    #[tokio::test]
+    async fn omits_common_html_class() {
+        // No HTML representation of /collections — declaring the HTML class
+        // would be a false conformance claim (#291).
+        let (_, json) = get("/conformance").await;
+        let classes = json["conformsTo"].as_array().unwrap();
+        assert!(!classes
+            .iter()
+            .any(|c| c.as_str().unwrap().contains("common-2/1.0/conf/html")));
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/api-tiles/src/handlers.rs
+++ b/crates/api-tiles/src/handlers.rs
@@ -562,6 +562,15 @@ pub async fn api_docs(State(state): State<AppState>) -> impl IntoResponse {
 pub async fn conformance() -> impl IntoResponse {
     Json(json!({
         "conformsTo": [
+            // OGC API - Common - Part 1: Core (landing page, /conformance,
+            // /api) and Part 2: Geospatial Data (/collections + /collections/
+            // {id}, JSON). Both are satisfied structurally; the HTML class
+            // (.../common-2/.../conf/html) is omitted — no HTML /collections.
+            "http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/core",
+            "http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/landing-page",
+            "http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/oas30",
+            "http://www.opengis.net/spec/ogcapi-common-2/1.0/conf/collections",
+            "http://www.opengis.net/spec/ogcapi-common-2/1.0/conf/json",
             "http://www.opengis.net/spec/ogcapi-tiles-1/1.0/conf/core",
             "http://www.opengis.net/spec/ogcapi-tiles-1/1.0/conf/tileset",
             "http://www.opengis.net/spec/ogcapi-tiles-1/1.0/conf/tilesets-list",

--- a/crates/api-tiles/tests/integration.rs
+++ b/crates/api-tiles/tests/integration.rs
@@ -362,6 +362,33 @@ mod conformance {
             .iter()
             .any(|c| c.as_str().unwrap().contains("conf/tilematrixset")));
     }
+
+    #[tokio::test]
+    async fn declares_ogcapi_common_part1_and_part2() {
+        // OGC API - Common Part 1 (Core) + Part 2 (Collections, JSON) — the
+        // landing page / conformance / collections resources satisfy them, so
+        // they are advertised for discovery (#291).
+        let (_, json) = get("/conformance").await;
+        let classes = json["conformsTo"].as_array().unwrap();
+        let has = |needle: &str| classes.iter().any(|c| c.as_str().unwrap().contains(needle));
+        assert!(has("ogcapi-common-1/1.0/conf/core"), "Common Part 1 Core");
+        assert!(
+            has("ogcapi-common-2/1.0/conf/collections"),
+            "Common Part 2 Collections"
+        );
+        assert!(has("ogcapi-common-2/1.0/conf/json"), "Common Part 2 JSON");
+    }
+
+    #[tokio::test]
+    async fn omits_common_html_class() {
+        // No HTML representation of /collections — declaring the HTML class
+        // would be a false conformance claim (#291).
+        let (_, json) = get("/conformance").await;
+        let classes = json["conformsTo"].as_array().unwrap();
+        assert!(!classes
+            .iter()
+            .any(|c| c.as_str().unwrap().contains("common-2/1.0/conf/html")));
+    }
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #291.

## What

All three OGC API surfaces (EDR, Maps, Tiles) already serve `/collections` and
`/collections/{id}` in a shape that conforms structurally to **OGC API - Common
- Part 2: Geospatial Data** ([20-024](https://docs.ogc.org/DRAFTS/20-024.html))
— correct `{links, collections}` envelope, each collection with `id` + `links`
(incl. `self`) + a schema-valid `extent`. They just never advertised it. This
declares the Common conformance classes so a conformance-checking client (OGC
TEAM Engine / ETS) can discover the support.

## Changes (declaration-only — no behavior change)

| `/conformance` now adds | edr | maps | tiles |
|---|---|---|---|
| `ogcapi-common-2/1.0/conf/collections` | ✅ | ✅ | ✅ |
| `ogcapi-common-2/1.0/conf/json` | ✅ | ✅ | ✅ |
| `ogcapi-common-1/1.0/conf/{core,landing-page,oas30}` | (already had) | ✅ | ✅ |

- **Maps/Tiles** were missing even Common **Part 1**, which EDR already
  declared — added for parity (their landing page / conformance / collections
  resources satisfy Part 1 Core).
- The **HTML class** (`…/conf/html`) is intentionally **not** declared — there
  is no HTML representation of `/collections`; claiming it would be false.
- URIs verbatim from the stable draft's conformance Table 1; scheme `http://`
  per OGC identifier convention (matches every existing URI in the codebase).

## Tests

Added a conformance receipt test per crate asserting the new classes are present
and the HTML class is absent. `cargo fmt` + `clippy -D warnings` clean; api-edr
/ api-maps / api-tiles suites all pass.

## Out of scope (noted in #291)

`itemType`, `storageCrs` on EDR, `crs` on Tiles, HTML representations, and
`?f=json|html` negotiation on metadata endpoints — all optional Common Part 2
niceties, deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
