### PR TITLE
refactor(ds-core): extract shared OGC API extent model (#263)

### DIFF
--- a/crates/api-features/src/handlers.rs
+++ b/crates/api-features/src/handlers.rs
@@ -498,14 +498,14 @@ fn build_collection_metadata(
         "numberItems": total
     });
 
-    // Add spatial extent if available
+    // Add spatial extent if available. A Features collection contributes only
+    // a bbox (no grid/temporal/vertical), but it shares the one extent builder
+    // in `ds_core::ogc_extent` so the `/features` shape can't drift from
+    // `/maps` and `/tiles` (issue #263).
     if let Some(bbox) = engine.spatial_extent() {
-        metadata["extent"] = json!({
-            "spatial": {
-                "bbox": [bbox],
-                "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
-            }
-        });
+        if let Some(extent) = ds_core::ogc_extent::build_extent(Some(bbox), None, "", &[], None) {
+            metadata["extent"] = serde_json::to_value(extent).expect("Extent serializes to JSON");
+        }
     }
 
     metadata

--- a/crates/api-maps/src/handlers.rs
+++ b/crates/api-maps/src/handlers.rs
@@ -181,81 +181,18 @@ fn build_collection_metadata(
 /// Build the OGC API Common Part 2 `extent` object (spatial, temporal,
 /// vertical) including the `grid` resolution descriptors. Returns `None` when
 /// the collection advertises no spatial, temporal, or vertical extent.
+///
+/// The assembly lives in `ds_core::ogc_extent` so Maps, Tiles, and Features
+/// share one definition (issue #263).
 fn build_extent(info: &ds_core::map_engine::RasterInfo) -> Option<serde_json::Value> {
-    let mut extent = serde_json::Map::new();
-
-    if let Some(bbox) = info.spatial_extent {
-        let mut spatial = json!({
-            "bbox": [bbox],
-            "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
-        });
-        // Per-axis grid resolution in CRS84 degrees, derived from the native
-        // cell counts and the WGS84 bbox. Only for geographic (lon/lat) grids:
-        // for projected sources the cells aren't degree-regular, so a single
-        // CRS84-degree resolution would imply a regularity that doesn't hold.
-        // `crs84_bbox_spans` keeps the spans positive across the anti-meridian.
-        // Check the CRS first (cheap), then compute spans — mirrors api-tiles.
-        if let Some([nx, ny]) = info.grid_size {
-            if nx > 0 && ny > 0 && ds_core::geo::is_crs84_grid(&info.native_crs) {
-                let (lon_span, lat_span) = ds_core::geo::crs84_bbox_spans(bbox);
-                // Skip a degenerate (zero-span) bbox too: 0.0/nx would emit
-                // "resolution": 0.0, which is invalid per OGC API Common Part 2.
-                if lon_span > 0.0 && lat_span > 0.0 {
-                    spatial["grid"] = json!([
-                        { "cellsCount": nx, "resolution": lon_span / nx as f64 },
-                        { "cellsCount": ny, "resolution": lat_span / ny as f64 }
-                    ]);
-                }
-            }
-        }
-        extent.insert("spatial".to_string(), spatial);
-    }
-
-    if !info.times.is_empty() {
-        let start = info.times.first().map(|t| t.to_rfc3339());
-        let end = info.times.last().map(|t| t.to_rfc3339());
-        if let (Some(start), Some(end)) = (start, end) {
-            let mut temporal = json!({
-                "interval": [[start, end]],
-                "trs": "http://www.opengis.net/def/uom/ISO-8601/0/Gregorian"
-            });
-            // Shared descriptor from ds-core so Maps and Tiles can't drift.
-            if let Some(grid) = ds_core::datetime::temporal_grid(&info.times) {
-                temporal["grid"] =
-                    serde_json::to_value(grid).expect("TemporalGrid serializes to JSON");
-            }
-            extent.insert("temporal".to_string(), temporal);
-        }
-    }
-
-    // Vertical — keep `interval` + `values` (back-compat) and additively add
-    // the OGC API Common Part 2 form (`unit` + `grid.coordinates`). `vrs` is
-    // omitted: the only kind in use (radar elevation angle) has no standard
-    // OGC vertical-CRS URI.
-    if let Some(vertical) = &info.vertical {
-        // Only emit the vertical extent when there are levels: OGC API Common
-        // Part 2 requires `interval` to be a non-null array when the extent
-        // object is present, so an empty `VerticalDimension` is omitted rather
-        // than emitting `"interval": null`.
-        if let Some((lo, hi)) = vertical.extent() {
-            let levels = &vertical.levels;
-            extent.insert(
-                "vertical".to_string(),
-                json!({
-                    "interval": [[lo, hi]],
-                    "values": levels,
-                    "unit": vertical.unit(),
-                    "grid": { "coordinates": levels }
-                }),
-            );
-        }
-    }
-
-    if extent.is_empty() {
-        None
-    } else {
-        Some(serde_json::Value::Object(extent))
-    }
+    let extent = ds_core::ogc_extent::build_extent(
+        info.spatial_extent,
+        info.grid_size,
+        &info.native_crs,
+        &info.times,
+        info.vertical.as_ref(),
+    )?;
+    Some(serde_json::to_value(extent).expect("Extent serializes to JSON"))
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/api-tiles/src/handlers.rs
+++ b/crates/api-tiles/src/handlers.rs
@@ -187,90 +187,27 @@ fn build_collection_metadata(
 /// vertical) including the `grid` resolution descriptors. The spatial bbox
 /// falls back to `feature_extent` for vector collections that have no
 /// `RasterInfo`. Returns `None` when there is no extent to advertise.
+///
+/// The assembly lives in `ds_core::ogc_extent` so Maps, Tiles, and Features
+/// share one definition (issue #263).
 fn build_extent(
     raster_info: Option<&ds_core::map_engine::RasterInfo>,
     feature_extent: Option<[f64; 4]>,
 ) -> Option<serde_json::Value> {
-    let mut extent = serde_json::Map::new();
-
     let spatial_extent = raster_info
         .and_then(|i| i.spatial_extent)
         .or(feature_extent);
-    if let Some(bbox) = spatial_extent {
-        let mut spatial = json!({
-            "bbox": [bbox],
-            "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
-        });
-        // Per-axis grid resolution in CRS84 degrees, derived from the native
-        // cell counts (raster collections only) and the WGS84 bbox. Only for
-        // geographic (lon/lat) grids: a projected source's cells aren't
-        // degree-regular, so a single CRS84-degree resolution would imply a
-        // regularity that doesn't hold. `crs84_bbox_spans` keeps the spans
-        // positive across the anti-meridian.
-        if let Some([nx, ny]) = raster_info
-            .filter(|i| ds_core::geo::is_crs84_grid(&i.native_crs))
-            .and_then(|i| i.grid_size)
-        {
-            let (lon_span, lat_span) = ds_core::geo::crs84_bbox_spans(bbox);
-            // Skip a degenerate (zero-span) bbox: 0.0/nx would emit
-            // "resolution": 0.0, which is invalid per OGC API Common Part 2.
-            if nx > 0 && ny > 0 && lon_span > 0.0 && lat_span > 0.0 {
-                spatial["grid"] = json!([
-                    { "cellsCount": nx, "resolution": lon_span / nx as f64 },
-                    { "cellsCount": ny, "resolution": lat_span / ny as f64 }
-                ]);
-            }
-        }
-        extent.insert("spatial".to_string(), spatial);
-    }
-
-    if let Some(info) = raster_info {
-        if !info.times.is_empty() {
-            let start = info.times.first().map(|t| t.to_rfc3339());
-            let end = info.times.last().map(|t| t.to_rfc3339());
-            if let (Some(start), Some(end)) = (start, end) {
-                let mut temporal = json!({
-                    "interval": [[start, end]],
-                    "trs": "http://www.opengis.net/def/uom/ISO-8601/0/Gregorian"
-                });
-                // Shared descriptor from ds-core so Maps and Tiles can't drift.
-                if let Some(grid) = ds_core::datetime::temporal_grid(&info.times) {
-                    temporal["grid"] =
-                        serde_json::to_value(grid).expect("TemporalGrid serializes to JSON");
-                }
-                extent.insert("temporal".to_string(), temporal);
-            }
-        }
-
-        // Vertical — keep `interval` + `values` (back-compat) and additively
-        // add the OGC API Common Part 2 form (`unit` + `grid.coordinates`).
-        // `vrs` is omitted: the only kind in use (radar elevation angle) has
-        // no standard OGC vertical-CRS URI.
-        if let Some(vertical) = &info.vertical {
-            // Only emit the vertical extent when there are levels: OGC API
-            // Common Part 2 requires `interval` to be a non-null array when the
-            // extent object is present, so an empty `VerticalDimension` is
-            // omitted rather than emitting `"interval": null`.
-            if let Some((lo, hi)) = vertical.extent() {
-                let levels = &vertical.levels;
-                extent.insert(
-                    "vertical".to_string(),
-                    json!({
-                        "interval": [[lo, hi]],
-                        "values": levels,
-                        "unit": vertical.unit(),
-                        "grid": { "coordinates": levels }
-                    }),
-                );
-            }
-        }
-    }
-
-    if extent.is_empty() {
-        None
-    } else {
-        Some(serde_json::Value::Object(extent))
-    }
+    // Temporal/vertical/grid come from the raster source only; vector-only
+    // collections contribute just the (feature) bbox. An absent `native_crs`
+    // is harmless: with `grid_size = None` the grid block is skipped anyway.
+    let extent = ds_core::ogc_extent::build_extent(
+        spatial_extent,
+        raster_info.and_then(|i| i.grid_size),
+        raster_info.map(|i| i.native_crs.as_str()).unwrap_or(""),
+        raster_info.map(|i| i.times.as_slice()).unwrap_or(&[]),
+        raster_info.and_then(|i| i.vertical.as_ref()),
+    )?;
+    Some(serde_json::to_value(extent).expect("Extent serializes to JSON"))
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -7,6 +7,7 @@ pub mod feature_engine;
 pub mod geo;
 pub mod map_engine;
 pub mod model;
+pub mod ogc_extent;
 pub mod openapi;
 pub mod resample;
 pub mod vertical;

--- a/crates/core/src/ogc_extent.rs
+++ b/crates/core/src/ogc_extent.rs
@@ -1,0 +1,258 @@
+//! OGC API – Common Part 2 `extent` object, modeled as `serde::Serialize`
+//! types so the Maps, Tiles, and Features `/collections{,/{id}}` builders share
+//! a single definition and the JSON shape can't drift between `/maps/...`,
+//! `/tiles/...`, and `/features/...`. ds-core never builds `serde_json::Value`
+//! (architecture rule), so the API crates turn an [`Extent`] into JSON with
+//! `serde_json::to_value`.
+//!
+//! **EDR is intentionally not a consumer.** OGC API – EDR 1.1 mandates a
+//! different extent shape: string-typed vertical `interval`/`values`, a `vrs`
+//! reference system, and a `temporal.values` list instead of a
+//! `temporal.grid`. `api-edr` therefore keeps its own builder.
+
+use crate::datetime::{temporal_grid, TemporalGrid};
+use crate::geo::{crs84_bbox_spans, is_crs84_grid};
+use crate::vertical::VerticalDimension;
+use chrono::{DateTime, Utc};
+use serde::Serialize;
+
+const CRS84_URI: &str = "http://www.opengis.net/def/crs/OGC/1.3/CRS84";
+const ISO8601_TRS: &str = "http://www.opengis.net/def/uom/ISO-8601/0/Gregorian";
+
+/// OGC API – Common Part 2 `extent` object. At least one of the three
+/// sub-extents is present whenever [`build_extent`] returns `Some`.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct Extent {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub spatial: Option<SpatialExtent>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub temporal: Option<TemporalExtent>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub vertical: Option<VerticalExtent>,
+}
+
+/// `extent.spatial`: a single WGS84 (CRS84) bbox plus, for geographic grids
+/// only, the per-axis cell resolution.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct SpatialExtent {
+    pub bbox: Vec<[f64; 4]>,
+    pub crs: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub grid: Option<Vec<GridAxis>>,
+}
+
+/// One axis of the spatial `grid` resolution descriptor.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct GridAxis {
+    #[serde(rename = "cellsCount")]
+    pub cells_count: u32,
+    pub resolution: f64,
+}
+
+/// `extent.temporal`: one `[start, end]` RFC 3339 interval plus the shared
+/// [`TemporalGrid`] cadence descriptor.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct TemporalExtent {
+    pub interval: Vec<[String; 2]>,
+    pub trs: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub grid: Option<TemporalGrid>,
+}
+
+/// `extent.vertical`: numeric `[lo, hi]` interval, the level values, the unit
+/// symbol, and the level coordinates. `vrs` is omitted — the only kind in use
+/// (radar elevation angle) has no standard OGC vertical-CRS URI.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct VerticalExtent {
+    pub interval: Vec<[f64; 2]>,
+    pub values: Vec<f64>,
+    pub unit: String,
+    pub grid: VerticalGrid,
+}
+
+/// `extent.vertical.grid`: the explicit level coordinates.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct VerticalGrid {
+    pub coordinates: Vec<f64>,
+}
+
+/// Assemble the OGC API – Common Part 2 `extent` object from the primitive
+/// inputs every Map/Feature engine already exposes. Returns `None` when the
+/// collection advertises no spatial, temporal, or vertical extent.
+///
+/// - `spatial_extent` — WGS84 bbox `[west, south, east, north]`. Callers with a
+///   raster source pass its bbox; vector-only callers (Tiles, Features) pass a
+///   feature bbox.
+/// - `grid_size` / `native_crs` — native cell counts `[nx, ny]` and CRS label.
+///   The per-axis `grid` resolution is emitted **only** for geographic
+///   (lon/lat) grids: projected cells aren't degree-regular, so a single
+///   CRS84-degree resolution would imply a regularity that doesn't hold. Pass
+///   `grid_size = None` (e.g. vector collections) to omit the grid entirely.
+/// - `times` — ascending timestamp series; empty omits the temporal extent.
+/// - `vertical` — optional vertical dimension; an empty one is omitted.
+pub fn build_extent(
+    spatial_extent: Option<[f64; 4]>,
+    grid_size: Option<[u32; 2]>,
+    native_crs: &str,
+    times: &[DateTime<Utc>],
+    vertical: Option<&VerticalDimension>,
+) -> Option<Extent> {
+    let spatial = spatial_extent.map(|bbox| {
+        // Grid resolution only for geographic grids with positive spans.
+        // `crs84_bbox_spans` keeps the spans positive across the anti-meridian.
+        let grid = grid_size.and_then(|[nx, ny]| {
+            if nx > 0 && ny > 0 && is_crs84_grid(native_crs) {
+                let (lon_span, lat_span) = crs84_bbox_spans(bbox);
+                // Skip a degenerate (zero-span) bbox: 0.0/nx would emit
+                // "resolution": 0.0, which is invalid per OGC API Common Part 2.
+                if lon_span > 0.0 && lat_span > 0.0 {
+                    return Some(vec![
+                        GridAxis {
+                            cells_count: nx,
+                            resolution: lon_span / nx as f64,
+                        },
+                        GridAxis {
+                            cells_count: ny,
+                            resolution: lat_span / ny as f64,
+                        },
+                    ]);
+                }
+            }
+            None
+        });
+        SpatialExtent {
+            bbox: vec![bbox],
+            crs: CRS84_URI,
+            grid,
+        }
+    });
+
+    // Temporal — present only when there is at least one timestamp. The
+    // `grid` cadence descriptor needs two (handled by `temporal_grid`).
+    let temporal = match (times.first(), times.last()) {
+        (Some(first), Some(last)) => Some(TemporalExtent {
+            interval: vec![[first.to_rfc3339(), last.to_rfc3339()]],
+            trs: ISO8601_TRS,
+            grid: temporal_grid(times),
+        }),
+        _ => None,
+    };
+
+    // Vertical — omitted when the dimension carries no levels: Part 2 requires
+    // a non-null `interval` when the extent object is present.
+    let vertical = vertical.and_then(|v| {
+        v.extent().map(|(lo, hi)| VerticalExtent {
+            interval: vec![[lo, hi]],
+            values: v.levels.clone(),
+            unit: v.unit().to_string(),
+            grid: VerticalGrid {
+                coordinates: v.levels.clone(),
+            },
+        })
+    });
+
+    if spatial.is_none() && temporal.is_none() && vertical.is_none() {
+        None
+    } else {
+        Some(Extent {
+            spatial,
+            temporal,
+            vertical,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::vertical::{VerticalDimension, VerticalKind};
+    use chrono::TimeZone;
+
+    fn t(s: &str) -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339(s).unwrap().with_timezone(&Utc)
+    }
+
+    #[test]
+    fn empty_inputs_yield_none() {
+        assert!(build_extent(None, None, "CRS:84", &[], None).is_none());
+    }
+
+    #[test]
+    fn spatial_only_has_no_grid_without_grid_size() {
+        let e = build_extent(Some([20.0, 60.0, 30.0, 70.0]), None, "", &[], None).unwrap();
+        let s = e.spatial.unwrap();
+        assert_eq!(s.bbox, vec![[20.0, 60.0, 30.0, 70.0]]);
+        assert_eq!(s.crs, CRS84_URI);
+        assert!(s.grid.is_none());
+        assert!(e.temporal.is_none() && e.vertical.is_none());
+    }
+
+    #[test]
+    fn geographic_grid_emits_resolution() {
+        let e = build_extent(
+            Some([0.0, 0.0, 10.0, 5.0]),
+            Some([10, 5]),
+            "CRS:84",
+            &[],
+            None,
+        )
+        .unwrap();
+        let grid = e.spatial.unwrap().grid.unwrap();
+        assert_eq!(grid[0].cells_count, 10);
+        assert!((grid[0].resolution - 1.0).abs() < 1e-12);
+        assert_eq!(grid[1].cells_count, 5);
+        assert!((grid[1].resolution - 1.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn projected_grid_omits_resolution() {
+        let e = build_extent(
+            Some([0.0, 0.0, 10.0, 5.0]),
+            Some([10, 5]),
+            "EPSG:3067",
+            &[],
+            None,
+        )
+        .unwrap();
+        assert!(e.spatial.unwrap().grid.is_none());
+    }
+
+    #[test]
+    fn temporal_regular_series_emits_grid() {
+        let times = vec![
+            t("2026-06-02T00:00:00Z"),
+            t("2026-06-02T01:00:00Z"),
+            t("2026-06-02T02:00:00Z"),
+        ];
+        let e = build_extent(None, None, "", &times, None).unwrap();
+        let tmp = e.temporal.unwrap();
+        assert_eq!(
+            tmp.interval,
+            vec![[
+                "2026-06-02T00:00:00+00:00".to_string(),
+                "2026-06-02T02:00:00+00:00".to_string()
+            ]]
+        );
+        assert!(matches!(tmp.grid, Some(TemporalGrid::Regular { .. })));
+    }
+
+    #[test]
+    fn single_timestamp_has_no_grid() {
+        let times = vec![Utc.with_ymd_and_hms(2026, 6, 2, 0, 0, 0).unwrap()];
+        let e = build_extent(None, None, "", &times, None).unwrap();
+        assert!(e.temporal.unwrap().grid.is_none());
+    }
+
+    #[test]
+    fn vertical_extent_round_trips() {
+        let vd = VerticalDimension {
+            kind: VerticalKind::ElevationAngle,
+            levels: vec![0.5, 1.5, 3.0],
+        };
+        let e = build_extent(None, None, "", &[], Some(&vd)).unwrap();
+        let v = e.vertical.unwrap();
+        assert_eq!(v.interval, vec![[0.5, 3.0]]);
+        assert_eq!(v.values, vec![0.5, 1.5, 3.0]);
+        assert_eq!(v.grid.coordinates, vec![0.5, 1.5, 3.0]);
+    }
+}


### PR DESCRIPTION
Closes #263.

## Problem

The OGC API – Common Part 2 `extent` JSON shape was built in three places:
`build_extent` in **api-maps** and **api-tiles** (near-identical), and an
inline spatial-extent block in **api-features**. Any fix to one had to be
mirrored to the others or the `/maps`, `/tiles`, and `/features` collection
extents would silently diverge — flagged repeatedly in the #261 review.

## Change

- New **`ds_core::ogc_extent`** module: `Extent` / `SpatialExtent` /
  `TemporalExtent` / `VerticalExtent` / `GridAxis` / `VerticalGrid` as
  `#[derive(Serialize)]` types, plus one `build_extent(...)` taking the
  primitive inputs every Map/Feature engine already exposes. Reuses the
  helpers already in ds-core (`datetime::temporal_grid`, `geo::is_crs84_grid`,
  `geo::crs84_bbox_spans`, `vertical::VerticalDimension`).
- **api-maps**, **api-tiles**, **api-features** now call it and convert with
  `serde_json::to_value` (ds-core never builds `serde_json::Value`).

## Byte-identical

serde_json's `Map` is a `BTreeMap` here (no `preserve_order` feature), so key
order is alphabetical regardless of struct field order — output is unchanged.
All existing suites pass **unchanged**:

| crate | tests |
|---|---|
| ds-core (incl. 7 new `ogc_extent` unit tests) | 129 |
| api-maps integration | 68 |
| api-tiles integration | 75 |
| api-features | 59 |

## Scope note — EDR intentionally excluded

OGC API – EDR 1.1 mandates a different extent shape (string-typed vertical
`interval`/`values`, a required `vrs`, and `temporal.values` instead of
`temporal.grid`). Migrating EDR would change its output and break EDR-schema
validation, so `api-edr` keeps its own builder. Documented in the module header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)