### PR TITLE
feat(api): OGC API - Common - Part 4 Searchable Collections (bbox/datetime/q/limit)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,6 +95,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tower",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/api-edr/src/handlers.rs
+++ b/crates/api-edr/src/handlers.rs
@@ -580,7 +580,15 @@ pub async fn collections(
         .collections
         .values()
         .filter_map(|config| {
-            let engine = state.engines.get(&config.id)?;
+            let Some(engine) = state.engines.get(&config.id) else {
+                // A registered collection with no engine (e.g. a partial
+                // reload) would otherwise vanish from /collections silently.
+                tracing::warn!(
+                    collection = %config.id,
+                    "collection has no registered EDR engine; omitting from /collections"
+                );
+                return None;
+            };
             let value = build_collection_metadata(engine.as_ref(), config, base);
             Some((
                 config.id.clone(),

--- a/crates/api-edr/src/handlers.rs
+++ b/crates/api-edr/src/handlers.rs
@@ -611,7 +611,7 @@ pub async fn collections(
 
     let link = |rel: &str, offset: usize, title: Option<&str>| {
         let mut o = json!({
-            "href": format!("{base}/edr/collections{}", sp.query_string(offset)),
+            "href": format!("{base}/edr/collections{}", sp.query_string(params.limit, offset)),
             "rel": rel,
             "type": "application/json"
         });

--- a/crates/api-edr/src/handlers.rs
+++ b/crates/api-edr/src/handlers.rs
@@ -607,7 +607,6 @@ pub async fn collections(
         .map(|r| CollectionMatch {
             title: &r.1,
             description: &r.2,
-            keywords: &[],
             bbox: r.3,
             time: r.4,
         })

--- a/crates/api-edr/src/handlers.rs
+++ b/crates/api-edr/src/handlers.rs
@@ -171,6 +171,26 @@ pub async fn landing_page(State(state): State<AppState>) -> impl IntoResponse {
     }))
 }
 
+/// OpenAPI `parameters` array for the OGC API – Common – Part 4 searchable
+/// `/collections` query parameters. Documented per the CLAUDE.md rule and
+/// Part 4 §5.5.
+fn searchable_collections_parameters() -> serde_json::Value {
+    json!([
+        {"name": "bbox", "in": "query", "required": false, "schema": {"type": "string"},
+         "description": "Filter to collections intersecting this CRS84 bbox: 4 (or 6) comma-separated numbers west,south,east,north."},
+        {"name": "bbox-crs", "in": "query", "required": false, "schema": {"type": "string"},
+         "description": "CRS of the bbox values. Only CRS84 is supported."},
+        {"name": "datetime", "in": "query", "required": false, "schema": {"type": "string"},
+         "description": "Filter to collections whose temporal extent intersects this RFC 3339 instant or interval (start/end, ../end, start/..)."},
+        {"name": "q", "in": "query", "required": false, "schema": {"type": "string"},
+         "description": "Free-text search (comma-separated terms, OR) over collection title and description."},
+        {"name": "limit", "in": "query", "required": false, "schema": {"type": "integer", "minimum": 1, "maximum": 1000},
+         "description": "Maximum number of collections per page (default 1000)."},
+        {"name": "offset", "in": "query", "required": false, "schema": {"type": "integer", "minimum": 0},
+         "description": "Number of matching collections to skip (pagination cursor)."}
+    ])
+}
+
 pub async fn api_definition(State(state): State<AppState>) -> impl IntoResponse {
     let state = state.load_full();
     let mut collection_paths = json!({});
@@ -409,6 +429,7 @@ pub async fn api_definition(State(state): State<AppState>) -> impl IntoResponse 
             "get": {
                 "summary": "List collections",
                 "operationId": "getCollections",
+                "parameters": searchable_collections_parameters(),
                 "responses": {
                     "200": {"description": "List of EDR collections"}
                 }
@@ -525,6 +546,11 @@ pub async fn conformance() -> impl IntoResponse {
             // omitted — there is no HTML representation of /collections.
             "http://www.opengis.net/spec/ogcapi-common-2/1.0/conf/collections",
             "http://www.opengis.net/spec/ogcapi-common-2/1.0/conf/json",
+            // OGC API - Common - Part 4 (Discovery within many collections,
+            // draft 25-046): /collections supports bbox/bbox-crs/datetime/q/
+            // limit filtering + offset pagination (numberMatched/Returned +
+            // next/prev links). Sortable/Filterable/Hierarchical not declared.
+            "http://www.opengis.net/spec/ogcapi-common-4/1.0/conf/searchable-collections",
             "http://www.opengis.net/spec/ogcapi-edr-1/1.1/conf/core",
             "http://www.opengis.net/spec/ogcapi-edr-1/1.1/conf/collections",
             "http://www.opengis.net/spec/ogcapi-edr-1/1.1/conf/json",
@@ -533,31 +559,81 @@ pub async fn conformance() -> impl IntoResponse {
     }))
 }
 
-pub async fn collections(State(state): State<AppState>) -> impl IntoResponse {
+pub async fn collections(
+    State(state): State<AppState>,
+    Query(sp): Query<ds_core::collection_search::SearchQueryParams>,
+) -> Result<Json<serde_json::Value>, HandlerError> {
+    use ds_core::collection_search::{search, CollectionMatch};
+
+    let params = sp.parse().map_err(|e| {
+        (
+            StatusCode::BAD_REQUEST,
+            Json(json!({ "code": "BadRequest", "description": e.to_string() })),
+        )
+    })?;
     let state = state.load_full();
     let base = &state.base_url;
-    let collections: Vec<serde_json::Value> = state
+
+    // (id, title, description, bbox, time, metadata) per collection. Tuple
+    // element types are inferred, so no extra chrono import is needed.
+    let mut rows: Vec<_> = state
         .collections
         .values()
-        .map(|config| {
-            build_collection_metadata(
-                state.engines.get(&config.id).unwrap().as_ref(),
-                config,
-                base,
-            )
+        .filter_map(|config| {
+            let engine = state.engines.get(&config.id)?;
+            let value = build_collection_metadata(engine.as_ref(), config, base);
+            Some((
+                config.id.clone(),
+                config.title.clone(),
+                config.description.clone(),
+                engine.get_spatial_extent(),
+                engine.get_temporal_extent(),
+                value,
+            ))
         })
         .collect();
+    rows.sort_by(|a, b| a.0.cmp(&b.0));
 
-    Json(json!({
+    let matches: Vec<CollectionMatch> = rows
+        .iter()
+        .map(|r| CollectionMatch {
+            title: &r.1,
+            description: &r.2,
+            keywords: &[],
+            bbox: r.3,
+            time: r.4,
+        })
+        .collect();
+    let result = search(&matches, &params);
+    let collections: Vec<serde_json::Value> =
+        result.page.iter().map(|&i| rows[i].5.clone()).collect();
+    let number_returned = collections.len();
+
+    let link = |rel: &str, offset: usize, title: Option<&str>| {
+        let mut o = json!({
+            "href": format!("{base}/edr/collections{}", sp.query_string(offset)),
+            "rel": rel,
+            "type": "application/json"
+        });
+        if let Some(t) = title {
+            o["title"] = json!(t);
+        }
+        o
+    };
+    let mut links = vec![link("self", params.offset, None)];
+    if result.has_next {
+        links.push(link("next", result.next_offset, Some("Next page")));
+    }
+    if result.has_prev {
+        links.push(link("prev", result.prev_offset, Some("Previous page")));
+    }
+
+    Ok(Json(json!({
         "collections": collections,
-        "links": [
-            {
-                "href": format!("{}/edr/collections", state.base_url),
-                "rel": "self",
-                "type": "application/json"
-            }
-        ]
-    }))
+        "numberMatched": result.number_matched,
+        "numberReturned": number_returned,
+        "links": links
+    })))
 }
 
 pub async fn collection(

--- a/crates/api-edr/tests/spec_compliance_tests.rs
+++ b/crates/api-edr/tests/spec_compliance_tests.rs
@@ -672,20 +672,19 @@ async fn data_queries_default_output_format_set_for_all_query_types() {
 // ===========================================================================
 // Spec: GET /collections response SHOULD include numberMatched and
 //   numberReturned for pagination support.
-// Implementation: Only returns "collections" and "links".
-// Fix: Add "numberMatched" and "numberReturned" fields.
+// RESOLVED by OGC API - Common - Part 4 (Searchable Collections): /collections
+//   now returns both count fields alongside self/next/prev pagination links.
 
 #[tokio::test]
-async fn finding_17_collections_missing_count_fields() {
+async fn finding_17_collections_have_count_fields() {
     let (_status, json) = get_json("/collections").await;
-    // SPEC GAP: No pagination info
     assert!(
-        json.get("numberMatched").is_none(),
-        "Documenting: numberMatched not present"
+        json.get("numberMatched").and_then(Value::as_u64).is_some(),
+        "numberMatched must be present (Common Part 4)"
     );
     assert!(
-        json.get("numberReturned").is_none(),
-        "Documenting: numberReturned not present"
+        json.get("numberReturned").and_then(Value::as_u64).is_some(),
+        "numberReturned must be present (Common Part 4)"
     );
 }
 
@@ -1018,3 +1017,47 @@ async fn finding_30c_404_location_not_found() {
 // 28. Landing page structure is valid
 // 29. Collections response structure is valid
 // 30. Error responses work for 400/404 cases
+
+// ===========================================================================
+// OGC API - Common - Part 4: Searchable Collections — handler wiring smoke
+// ===========================================================================
+
+mod part4_searchable {
+    use super::*;
+
+    #[tokio::test]
+    async fn conformance_declares_searchable_collections() {
+        let (_, json) = get_json("/conformance").await;
+        let classes = json["conformsTo"].as_array().unwrap();
+        assert!(classes.iter().any(|c| c
+            .as_str()
+            .unwrap()
+            .contains("common-4/1.0/conf/searchable-collections")));
+    }
+
+    #[tokio::test]
+    async fn collections_has_match_counts() {
+        let (status, json) = get_json("/collections").await;
+        assert_eq!(status, StatusCode::OK);
+        assert!(json["numberMatched"].is_number());
+        assert!(json["numberReturned"].is_number());
+        assert!(json["links"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|l| l["rel"] == "self"));
+    }
+
+    #[tokio::test]
+    async fn invalid_limit_is_400() {
+        let (status, _) = get_json("/collections?limit=0").await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn q_no_match_returns_empty() {
+        let (_, json) = get_json("/collections?q=zzznotaword").await;
+        assert_eq!(json["numberReturned"], 0);
+        assert!(json["collections"].as_array().unwrap().is_empty());
+    }
+}

--- a/crates/api-edr/tests/spec_compliance_tests.rs
+++ b/crates/api-edr/tests/spec_compliance_tests.rs
@@ -263,22 +263,24 @@ async fn finding_04_landing_page_has_service_desc_link() {
 // ===========================================================================
 // FINDING 5: Collections endpoint ignores bbox query parameter
 // ===========================================================================
-// Spec: GET /collections supports optional query parameters: bbox, datetime, f
-// Implementation: collections() handler takes no query parameters at all.
-// Impact: Clients filtering collections by spatial/temporal extent get no filtering.
-// Fix: Add optional bbox/datetime/f query params to collections handler,
-//   filter the collection list accordingly.
+// Spec: GET /collections supports optional query parameters: bbox, datetime, q.
+// RESOLVED by OGC API – Common – Part 4 (Searchable Collections): /collections
+//   now filters by bbox/datetime/q. (The `f` content-negotiation param is
+//   separate — see FINDING 6.)
 
 #[tokio::test]
-async fn finding_05_collections_ignores_bbox_param() {
-    // Passing bbox should not cause an error (it should be accepted gracefully).
-    // Currently the param is simply ignored.
-    let (status, _json) = get_json("/collections?bbox=20,60,30,70").await;
+async fn finding_05_collections_bbox_filtering() {
+    // The mock collection's spatial extent is [19, 59, 32, 71].
+    // An intersecting bbox keeps it; a disjoint bbox filters it out.
+    let (status, hit) = get_json("/collections?bbox=20,60,30,70").await;
+    assert_eq!(status, StatusCode::OK);
     assert_eq!(
-        status,
-        StatusCode::OK,
-        "bbox param should be accepted (even if not yet filtering)"
+        hit["numberMatched"], 1,
+        "intersecting bbox must keep the collection"
     );
+
+    let (_, miss) = get_json("/collections?bbox=-50,-50,-40,-40").await;
+    assert_eq!(miss["numberMatched"], 0, "disjoint bbox must filter it out");
 }
 
 // ===========================================================================

--- a/crates/api-features/Cargo.toml
+++ b/crates/api-features/Cargo.toml
@@ -10,6 +10,7 @@ axum = "0.8"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 chrono = { version = "0.4", features = ["serde"] }
+tracing = "0.1"
 
 [dev-dependencies]
 serde_json = "1"

--- a/crates/api-features/src/handlers.rs
+++ b/crates/api-features/src/handlers.rs
@@ -109,20 +109,43 @@ pub async fn conformance() -> impl IntoResponse {
             // OGC API – Common – Part 1: Core and Part 2: Geospatial Data. The
             // Features landing page, /conformance, /api, and
             // /collections{,/{id}} satisfy these structurally — the same
-            // declaration #292 added for Maps and Tiles. Declaring Part 2 is
-            // also the prerequisite for Common Part 4 "searchable collections".
-            // The HTML class (.../conf/html) is omitted — there is no HTML
-            // representation of /collections yet.
+            // declaration #292 added for Maps and Tiles. The HTML class
+            // (.../conf/html) is omitted — there is no HTML representation of
+            // /collections yet.
             "http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/core",
             "http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/landing-page",
             "http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/oas30",
             "http://www.opengis.net/spec/ogcapi-common-2/1.0/conf/collections",
             "http://www.opengis.net/spec/ogcapi-common-2/1.0/conf/json",
+            // OGC API - Common - Part 4 (Discovery within many collections,
+            // draft 25-046): /collections supports bbox/bbox-crs/datetime/q/
+            // limit filtering + offset pagination. Builds on the Common Part 2
+            // "collections" class declared just above.
+            "http://www.opengis.net/spec/ogcapi-common-4/1.0/conf/searchable-collections",
             "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/core",
             "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/oas30",
             "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/geojson"
         ]
     }))
+}
+
+/// OpenAPI `parameters` array for the OGC API – Common – Part 4 searchable
+/// `/collections` query parameters.
+fn searchable_collections_parameters() -> serde_json::Value {
+    json!([
+        {"name": "bbox", "in": "query", "required": false, "schema": {"type": "string"},
+         "description": "Filter to collections intersecting this CRS84 bbox: 4 (or 6) comma-separated numbers west,south,east,north."},
+        {"name": "bbox-crs", "in": "query", "required": false, "schema": {"type": "string"},
+         "description": "CRS of the bbox values. Only CRS84 is supported."},
+        {"name": "datetime", "in": "query", "required": false, "schema": {"type": "string"},
+         "description": "Filter to collections whose temporal extent intersects this RFC 3339 instant or interval (start/end, ../end, start/..)."},
+        {"name": "q", "in": "query", "required": false, "schema": {"type": "string"},
+         "description": "Free-text search (comma-separated terms, OR) over collection title and description."},
+        {"name": "limit", "in": "query", "required": false, "schema": {"type": "integer", "minimum": 1, "maximum": 1000},
+         "description": "Maximum number of collections per page (default 1000)."},
+        {"name": "offset", "in": "query", "required": false, "schema": {"type": "integer", "minimum": 0},
+         "description": "Number of matching collections to skip (pagination cursor)."}
+    ])
 }
 
 pub async fn api_definition(State(state): State<AppState>) -> impl IntoResponse {
@@ -231,6 +254,7 @@ pub async fn api_definition(State(state): State<AppState>) -> impl IntoResponse 
             "get": {
                 "summary": "List collections",
                 "operationId": "getCollections",
+                "parameters": searchable_collections_parameters(),
                 "responses": {
                     "200": {"description": "List of collections"}
                 }
@@ -348,36 +372,82 @@ pub async fn api_docs(State(state): State<AppState>) -> impl IntoResponse {
     ))
 }
 
-pub async fn collections(State(state): State<AppState>) -> impl IntoResponse {
+pub async fn collections(
+    State(state): State<AppState>,
+    Query(sp): Query<ds_core::collection_search::SearchQueryParams>,
+) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
+    use ds_core::collection_search::{search, CollectionMatch};
+
+    let params = sp.parse().map_err(|e| {
+        (
+            StatusCode::BAD_REQUEST,
+            Json(json!({ "code": "BadRequest", "description": e.to_string() })),
+        )
+    })?;
     let state = state.load_full();
     let base = &state.base_url;
-    let mut collections: Vec<serde_json::Value> = state
+
+    // (id, title, description, bbox, metadata) per collection. Features carry
+    // no temporal extent today, so a `datetime` filter excludes them (per the
+    // Part 4 draft: a collection with no temporal extent doesn't match a
+    // datetime query); tuple element types are inferred.
+    let mut rows: Vec<_> = state
         .collections
         .values()
         .filter_map(|config| {
             let engine = state.engines.get(&config.id)?;
-            Some(build_collection_metadata(engine.as_ref(), config, base))
+            let value = build_collection_metadata(engine.as_ref(), config, base);
+            Some((
+                config.id.clone(),
+                config.title.clone(),
+                config.description.clone(),
+                engine.spatial_extent(),
+                value,
+            ))
         })
         .collect();
+    rows.sort_by(|a, b| a.0.cmp(&b.0));
 
-    // Sort by id for deterministic ordering
-    collections.sort_by(|a, b| {
-        a["id"]
-            .as_str()
-            .unwrap_or("")
-            .cmp(b["id"].as_str().unwrap_or(""))
-    });
+    let matches: Vec<CollectionMatch> = rows
+        .iter()
+        .map(|r| CollectionMatch {
+            title: &r.1,
+            description: &r.2,
+            keywords: &[],
+            bbox: r.3,
+            time: None,
+        })
+        .collect();
+    let result = search(&matches, &params);
+    let collections: Vec<serde_json::Value> =
+        result.page.iter().map(|&i| rows[i].4.clone()).collect();
+    let number_returned = collections.len();
 
-    Json(json!({
+    let link = |rel: &str, offset: usize, title: Option<&str>| {
+        let mut o = json!({
+            "href": format!("{base}/features/collections{}", sp.query_string(offset)),
+            "rel": rel,
+            "type": "application/json"
+        });
+        if let Some(t) = title {
+            o["title"] = json!(t);
+        }
+        o
+    };
+    let mut links = vec![link("self", params.offset, None)];
+    if result.has_next {
+        links.push(link("next", result.next_offset, Some("Next page")));
+    }
+    if result.has_prev {
+        links.push(link("prev", result.prev_offset, Some("Previous page")));
+    }
+
+    Ok(Json(json!({
         "collections": collections,
-        "links": [
-            {
-                "href": format!("{base}/features/collections"),
-                "rel": "self",
-                "type": "application/json"
-            }
-        ]
-    }))
+        "numberMatched": result.number_matched,
+        "numberReturned": number_returned,
+        "links": links
+    })))
 }
 
 pub async fn collection(

--- a/crates/api-features/src/handlers.rs
+++ b/crates/api-features/src/handlers.rs
@@ -396,7 +396,13 @@ pub async fn collections(
         .collections
         .values()
         .filter_map(|config| {
-            let engine = state.engines.get(&config.id)?;
+            let Some(engine) = state.engines.get(&config.id) else {
+                tracing::warn!(
+                    collection = %config.id,
+                    "collection has no registered feature engine; omitting from /collections"
+                );
+                return None;
+            };
             let value = build_collection_metadata(engine.as_ref(), config, base);
             Some((
                 config.id.clone(),

--- a/crates/api-features/src/handlers.rs
+++ b/crates/api-features/src/handlers.rs
@@ -420,7 +420,6 @@ pub async fn collections(
         .map(|r| CollectionMatch {
             title: &r.1,
             description: &r.2,
-            keywords: &[],
             bbox: r.3,
             time: None,
         })

--- a/crates/api-features/src/handlers.rs
+++ b/crates/api-features/src/handlers.rs
@@ -388,9 +388,10 @@ pub async fn collections(
     let base = &state.base_url;
 
     // (id, title, description, bbox, metadata) per collection. Features carry
-    // no temporal extent today, so a `datetime` filter excludes them (per the
-    // Part 4 draft: a collection with no temporal extent doesn't match a
-    // datetime query); tuple element types are inferred.
+    // no temporal extent today (`time: None`), so per OGC API – Common – Part 4
+    // §7.14.3 ("unknown extent ≡ unbounded") they *match* any `datetime`
+    // filter rather than being excluded — see `collection_search::matches`.
+    // Tuple element types are inferred.
     let mut rows: Vec<_> = state
         .collections
         .values()

--- a/crates/api-features/src/handlers.rs
+++ b/crates/api-features/src/handlers.rs
@@ -425,7 +425,7 @@ pub async fn collections(
 
     let link = |rel: &str, offset: usize, title: Option<&str>| {
         let mut o = json!({
-            "href": format!("{base}/features/collections{}", sp.query_string(offset)),
+            "href": format!("{base}/features/collections{}", sp.query_string(params.limit, offset)),
             "rel": rel,
             "type": "application/json"
         });

--- a/crates/api-features/tests/ogc_features_api_tests.rs
+++ b/crates/api-features/tests/ogc_features_api_tests.rs
@@ -757,3 +757,35 @@ mod errors {
         assert!(json["code"].is_string());
     }
 }
+
+// ---------------------------------------------------------------------------
+// OGC API - Common - Part 4: Searchable Collections — handler wiring smoke
+// ---------------------------------------------------------------------------
+
+mod part4_searchable {
+    use super::*;
+
+    #[tokio::test]
+    async fn conformance_declares_searchable_collections() {
+        let (_, json) = get("/conformance").await;
+        let classes = json["conformsTo"].as_array().unwrap();
+        assert!(classes.iter().any(|c| c
+            .as_str()
+            .unwrap()
+            .contains("common-4/1.0/conf/searchable-collections")));
+    }
+
+    #[tokio::test]
+    async fn collections_has_match_counts() {
+        let (status, json) = get("/collections").await;
+        assert_eq!(status, StatusCode::OK);
+        assert!(json["numberMatched"].is_number());
+        assert!(json["numberReturned"].is_number());
+    }
+
+    #[tokio::test]
+    async fn invalid_bbox_is_400() {
+        let (status, _) = get("/collections?bbox=1,2,3").await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+    }
+}

--- a/crates/api-maps/src/handlers.rs
+++ b/crates/api-maps/src/handlers.rs
@@ -625,7 +625,13 @@ pub async fn collections(
         .collections
         .values()
         .filter_map(|config| {
-            let engine = state.engines.get(&config.id)?;
+            let Some(engine) = state.engines.get(&config.id) else {
+                tracing::warn!(
+                    collection = %config.id,
+                    "collection has no registered map engine; omitting from /collections"
+                );
+                return None;
+            };
             let info = engine.raster_info();
             let styles = state.styles.get(&config.id);
             let value = build_collection_metadata(config, &info, styles, base);

--- a/crates/api-maps/src/handlers.rs
+++ b/crates/api-maps/src/handlers.rs
@@ -653,7 +653,6 @@ pub async fn collections(
         .map(|r| CollectionMatch {
             title: &r.1,
             description: &r.2,
-            keywords: &[],
             bbox: r.3,
             time: r.4,
         })

--- a/crates/api-maps/src/handlers.rs
+++ b/crates/api-maps/src/handlers.rs
@@ -658,7 +658,7 @@ pub async fn collections(
 
     let link = |rel: &str, offset: usize, title: Option<&str>| {
         let mut o = json!({
-            "href": format!("{base}/maps/collections{}", sp.query_string(offset)),
+            "href": format!("{base}/maps/collections{}", sp.query_string(params.limit, offset)),
             "rel": rel,
             "type": "application/json"
         });

--- a/crates/api-maps/src/handlers.rs
+++ b/crates/api-maps/src/handlers.rs
@@ -241,6 +241,25 @@ pub async fn landing_page(State(state): State<AppState>) -> impl IntoResponse {
     }))
 }
 
+/// OpenAPI `parameters` array for the OGC API – Common – Part 4 searchable
+/// `/collections` query parameters.
+fn searchable_collections_parameters() -> serde_json::Value {
+    json!([
+        {"name": "bbox", "in": "query", "required": false, "schema": {"type": "string"},
+         "description": "Filter to collections intersecting this CRS84 bbox: 4 (or 6) comma-separated numbers west,south,east,north."},
+        {"name": "bbox-crs", "in": "query", "required": false, "schema": {"type": "string"},
+         "description": "CRS of the bbox values. Only CRS84 is supported."},
+        {"name": "datetime", "in": "query", "required": false, "schema": {"type": "string"},
+         "description": "Filter to collections whose temporal extent intersects this RFC 3339 instant or interval (start/end, ../end, start/..)."},
+        {"name": "q", "in": "query", "required": false, "schema": {"type": "string"},
+         "description": "Free-text search (comma-separated terms, OR) over collection title and description."},
+        {"name": "limit", "in": "query", "required": false, "schema": {"type": "integer", "minimum": 1, "maximum": 1000},
+         "description": "Maximum number of collections per page (default 1000)."},
+        {"name": "offset", "in": "query", "required": false, "schema": {"type": "integer", "minimum": 0},
+         "description": "Number of matching collections to skip (pagination cursor)."}
+    ])
+}
+
 /// GET /maps/api — OpenAPI 3.0.3 definition
 pub async fn api_definition(State(state): State<AppState>) -> impl IntoResponse {
     let state = state.load_full();
@@ -395,6 +414,7 @@ pub async fn api_definition(State(state): State<AppState>) -> impl IntoResponse 
             "get": {
                 "summary": "List collections",
                 "operationId": "getCollections",
+                "parameters": searchable_collections_parameters(),
                 "responses": {
                     "200": {"description": "List of collections"}
                 }
@@ -561,6 +581,10 @@ pub async fn conformance() -> impl IntoResponse {
             "http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/oas30",
             "http://www.opengis.net/spec/ogcapi-common-2/1.0/conf/collections",
             "http://www.opengis.net/spec/ogcapi-common-2/1.0/conf/json",
+            // OGC API - Common - Part 4 (Discovery within many collections,
+            // draft 25-046): /collections supports bbox/bbox-crs/datetime/q/
+            // limit filtering + offset pagination.
+            "http://www.opengis.net/spec/ogcapi-common-4/1.0/conf/searchable-collections",
             "http://www.opengis.net/spec/ogcapi-maps-1/1.0/conf/core",
             "http://www.opengis.net/spec/ogcapi-maps-1/1.0/conf/collection-map",
             "http://www.opengis.net/spec/ogcapi-maps-1/1.0/conf/styled-map",
@@ -583,37 +607,80 @@ pub async fn conformance() -> impl IntoResponse {
 }
 
 /// GET /maps/collections
-pub async fn collections(State(state): State<AppState>) -> impl IntoResponse {
+pub async fn collections(
+    State(state): State<AppState>,
+    Query(sp): Query<ds_core::collection_search::SearchQueryParams>,
+) -> Result<Json<serde_json::Value>, MapsError> {
+    use ds_core::collection_search::{search, CollectionMatch};
+
+    let params = sp
+        .parse()
+        .map_err(|e| MapsError::BadRequest(e.to_string()))?;
     let state = state.load_full();
     let base = &state.base_url;
-    let mut colls: Vec<serde_json::Value> = state
+
+    // (id, title, description, bbox, time, metadata) per collection; tuple
+    // element types are inferred (no extra chrono import).
+    let mut rows: Vec<_> = state
         .collections
         .values()
         .filter_map(|config| {
             let engine = state.engines.get(&config.id)?;
             let info = engine.raster_info();
             let styles = state.styles.get(&config.id);
-            Some(build_collection_metadata(config, &info, styles, base))
+            let value = build_collection_metadata(config, &info, styles, base);
+            let time = info.times.first().copied().zip(info.times.last().copied());
+            Some((
+                config.id.clone(),
+                config.title.clone(),
+                config.description.clone(),
+                info.spatial_extent,
+                time,
+                value,
+            ))
         })
         .collect();
+    rows.sort_by(|a, b| a.0.cmp(&b.0));
 
-    colls.sort_by(|a, b| {
-        a["id"]
-            .as_str()
-            .unwrap_or("")
-            .cmp(b["id"].as_str().unwrap_or(""))
-    });
+    let matches: Vec<CollectionMatch> = rows
+        .iter()
+        .map(|r| CollectionMatch {
+            title: &r.1,
+            description: &r.2,
+            keywords: &[],
+            bbox: r.3,
+            time: r.4,
+        })
+        .collect();
+    let result = search(&matches, &params);
+    let colls: Vec<serde_json::Value> = result.page.iter().map(|&i| rows[i].5.clone()).collect();
+    let number_returned = colls.len();
 
-    Json(json!({
+    let link = |rel: &str, offset: usize, title: Option<&str>| {
+        let mut o = json!({
+            "href": format!("{base}/maps/collections{}", sp.query_string(offset)),
+            "rel": rel,
+            "type": "application/json"
+        });
+        if let Some(t) = title {
+            o["title"] = json!(t);
+        }
+        o
+    };
+    let mut links = vec![link("self", params.offset, None)];
+    if result.has_next {
+        links.push(link("next", result.next_offset, Some("Next page")));
+    }
+    if result.has_prev {
+        links.push(link("prev", result.prev_offset, Some("Previous page")));
+    }
+
+    Ok(Json(json!({
         "collections": colls,
-        "links": [
-            {
-                "href": format!("{base}/maps/collections"),
-                "rel": "self",
-                "type": "application/json"
-            }
-        ]
-    }))
+        "numberMatched": result.number_matched,
+        "numberReturned": number_returned,
+        "links": links
+    })))
 }
 
 /// GET /maps/collections/{id}

--- a/crates/api-maps/tests/integration.rs
+++ b/crates/api-maps/tests/integration.rs
@@ -1583,3 +1583,163 @@ mod extent_edge_cases {
         assert!((lon_res - 0.01).abs() < 1e-9);
     }
 }
+
+// ---------------------------------------------------------------------------
+// OGC API - Common - Part 4: Searchable Collections (?bbox/datetime/q/limit)
+// ---------------------------------------------------------------------------
+
+mod searchable {
+    use super::*;
+
+    /// Build a Maps router with two collections so pagination links can be
+    /// exercised end-to-end. Both are backed by the same mock engine
+    /// (bbox [10,55,30,70], times 2024-01-01T00..01Z, title "Test Radar").
+    fn build_router_two() -> axum::Router {
+        let mut engines: HashMap<String, Arc<dyn MapEngine>> = HashMap::new();
+        let mut collections = HashMap::new();
+        for id in ["radar-a", "radar-b"] {
+            engines.insert(id.to_string(), Arc::new(MockMapEngine::new()));
+            collections.insert(
+                id.to_string(),
+                CollectionConfig {
+                    id: id.to_string(),
+                    title: "Test Radar".to_string(),
+                    description: "Test radar data".to_string(),
+                    data_path: None,
+                    apis: vec!["maps".to_string()],
+                    engine_type: "geotiff".to_string(),
+                    geotiff: None,
+                    querydata: None,
+                    wms: None,
+                    grib: None,
+                    odim: None,
+                    postgis: None,
+                    preview: None,
+                },
+            );
+        }
+        let state = Arc::new(ArcSwap::from_pointee(MapsState {
+            engines,
+            collections,
+            styles: HashMap::new(),
+            render_semaphore: Arc::new(tokio::sync::Semaphore::new(4)),
+            rendered_cache: Arc::new(RenderedCache::new(16)),
+            base_url: String::new(),
+        }));
+        api_maps::router(state)
+    }
+
+    #[tokio::test]
+    async fn conformance_declares_searchable_collections() {
+        let (_, json) = get("/conformance").await;
+        let classes = json["conformsTo"].as_array().unwrap();
+        assert!(classes.iter().any(|c| c
+            .as_str()
+            .unwrap()
+            .contains("common-4/1.0/conf/searchable-collections")));
+    }
+
+    #[tokio::test]
+    async fn unfiltered_has_match_counts() {
+        let (status, json) = get("/collections").await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(json["numberMatched"], 1);
+        assert_eq!(json["numberReturned"], 1);
+        assert_eq!(json["collections"].as_array().unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn q_matches_title_word() {
+        let (_, json) = get("/collections?q=radar").await;
+        assert_eq!(json["numberMatched"], 1);
+    }
+
+    #[tokio::test]
+    async fn q_no_match_excludes() {
+        let (_, json) = get("/collections?q=zzznotaword").await;
+        assert_eq!(json["numberMatched"], 0);
+        assert_eq!(json["numberReturned"], 0);
+        assert!(json["collections"].as_array().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn bbox_intersecting_includes() {
+        let (_, json) = get("/collections?bbox=0,50,15,60").await;
+        assert_eq!(json["numberMatched"], 1);
+    }
+
+    #[tokio::test]
+    async fn bbox_disjoint_excludes() {
+        let (_, json) = get("/collections?bbox=-50,-50,-40,-40").await;
+        assert_eq!(json["numberMatched"], 0);
+    }
+
+    #[tokio::test]
+    async fn datetime_within_extent_includes() {
+        let (_, json) = get("/collections?datetime=2024-01-01T00:30:00Z").await;
+        assert_eq!(json["numberMatched"], 1);
+    }
+
+    #[tokio::test]
+    async fn datetime_outside_extent_excludes() {
+        let (_, json) = get("/collections?datetime=2025-06-01T00:00:00Z").await;
+        assert_eq!(json["numberMatched"], 0);
+    }
+
+    #[tokio::test]
+    async fn invalid_limit_is_400() {
+        let (status, _) = get("/collections?limit=0").await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn invalid_bbox_is_400() {
+        let (status, _) = get("/collections?bbox=1,2,3").await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn non_crs84_bbox_crs_is_400() {
+        let (status, _) = get("/collections?bbox=0,0,1,1&bbox-crs=EPSG:3857").await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn pagination_first_page_has_next_not_prev() {
+        let app = build_router_two();
+        let (_, json) = get_on(app, "/collections?limit=1").await;
+        assert_eq!(json["numberMatched"], 2);
+        assert_eq!(json["numberReturned"], 1);
+        let links = json["links"].as_array().unwrap();
+        let next = links
+            .iter()
+            .find(|l| l["rel"] == "next")
+            .expect("next link");
+        assert!(next["href"].as_str().unwrap().contains("offset=1"));
+        assert!(!links.iter().any(|l| l["rel"] == "prev"));
+    }
+
+    #[tokio::test]
+    async fn pagination_second_page_has_prev_not_next() {
+        let app = build_router_two();
+        let (_, json) = get_on(app, "/collections?limit=1&offset=1").await;
+        assert_eq!(json["numberReturned"], 1);
+        let links = json["links"].as_array().unwrap();
+        assert!(links.iter().any(|l| l["rel"] == "prev"));
+        assert!(!links.iter().any(|l| l["rel"] == "next"));
+    }
+
+    #[tokio::test]
+    async fn self_link_preserves_query() {
+        let app = build_router_two();
+        let (_, json) = get_on(app, "/collections?q=radar&limit=1").await;
+        let links = json["links"].as_array().unwrap();
+        let self_link = links
+            .iter()
+            .find(|l| l["rel"] == "self")
+            .expect("self link");
+        let href = self_link["href"].as_str().unwrap();
+        assert!(href.contains("q=radar"));
+        assert!(href.contains("limit=1"));
+    }
+}

--- a/crates/api-tiles/src/handlers.rs
+++ b/crates/api-tiles/src/handlers.rs
@@ -302,6 +302,25 @@ pub async fn landing_page(State(state): State<AppState>) -> impl IntoResponse {
     }))
 }
 
+/// OpenAPI `parameters` array for the OGC API – Common – Part 4 searchable
+/// `/collections` query parameters.
+fn searchable_collections_parameters() -> serde_json::Value {
+    json!([
+        {"name": "bbox", "in": "query", "required": false, "schema": {"type": "string"},
+         "description": "Filter to collections intersecting this CRS84 bbox: 4 (or 6) comma-separated numbers west,south,east,north."},
+        {"name": "bbox-crs", "in": "query", "required": false, "schema": {"type": "string"},
+         "description": "CRS of the bbox values. Only CRS84 is supported."},
+        {"name": "datetime", "in": "query", "required": false, "schema": {"type": "string"},
+         "description": "Filter to collections whose temporal extent intersects this RFC 3339 instant or interval (start/end, ../end, start/..)."},
+        {"name": "q", "in": "query", "required": false, "schema": {"type": "string"},
+         "description": "Free-text search (comma-separated terms, OR) over collection title and description."},
+        {"name": "limit", "in": "query", "required": false, "schema": {"type": "integer", "minimum": 1, "maximum": 1000},
+         "description": "Maximum number of collections per page (default 1000)."},
+        {"name": "offset", "in": "query", "required": false, "schema": {"type": "integer", "minimum": 0},
+         "description": "Number of matching collections to skip (pagination cursor)."}
+    ])
+}
+
 /// GET /tiles/api — OpenAPI 3.0.3 definition
 pub async fn api_definition(State(state): State<AppState>) -> impl IntoResponse {
     let state = state.load_full();
@@ -441,6 +460,7 @@ pub async fn api_definition(State(state): State<AppState>) -> impl IntoResponse 
             "get": {
                 "summary": "List tile-enabled collections",
                 "operationId": "getCollections",
+                "parameters": searchable_collections_parameters(),
                 "responses": { "200": {"description": "List of collections"} }
             }
         },
@@ -548,6 +568,10 @@ pub async fn conformance() -> impl IntoResponse {
             "http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/oas30",
             "http://www.opengis.net/spec/ogcapi-common-2/1.0/conf/collections",
             "http://www.opengis.net/spec/ogcapi-common-2/1.0/conf/json",
+            // OGC API - Common - Part 4 (Discovery within many collections,
+            // draft 25-046): /collections supports bbox/bbox-crs/datetime/q/
+            // limit filtering + offset pagination.
+            "http://www.opengis.net/spec/ogcapi-common-4/1.0/conf/searchable-collections",
             "http://www.opengis.net/spec/ogcapi-tiles-1/1.0/conf/core",
             "http://www.opengis.net/spec/ogcapi-tiles-1/1.0/conf/tileset",
             "http://www.opengis.net/spec/ogcapi-tiles-1/1.0/conf/tilesets-list",
@@ -605,14 +629,24 @@ pub async fn tile_matrix_set(Path(tms_id): Path<String>) -> Result<impl IntoResp
 }
 
 /// GET /tiles/collections — List tile-enabled collections
-pub async fn collections(State(state): State<AppState>) -> impl IntoResponse {
+pub async fn collections(
+    State(state): State<AppState>,
+    Query(sp): Query<ds_core::collection_search::SearchQueryParams>,
+) -> Result<Json<serde_json::Value>, TilesError> {
+    use ds_core::collection_search::{search, CollectionMatch};
+
+    let params = sp
+        .parse()
+        .map_err(|e| TilesError::BadRequest(e.to_string()))?;
     let state = state.load_full();
     let base = &state.base_url;
-    // Surface every tile-enabled collection, regardless of which engine
-    // backs it — a vector-only collection that lives in `feature_collections`
-    // would otherwise be invisible at the discovery endpoint.
+
+    // Surface every tile-enabled collection, regardless of which engine backs
+    // it — a vector-only collection that lives in `feature_collections` would
+    // otherwise be invisible. Rows are (id, title, description, bbox, time,
+    // metadata); tuple element types are inferred (no extra chrono import).
     let mut seen = std::collections::HashSet::new();
-    let mut colls: Vec<serde_json::Value> = Vec::new();
+    let mut rows: Vec<_> = Vec::new();
     for config in state
         .collections
         .values()
@@ -627,30 +661,65 @@ pub async fn collections(State(state): State<AppState>) -> impl IntoResponse {
             .get(&config.id)
             .and_then(|e| e.spatial_extent());
         let styles = state.styles.get(&config.id);
-        colls.push(build_collection_metadata(
-            config,
-            raster_info.as_ref(),
-            feature_extent,
-            styles,
-            base,
+        let value =
+            build_collection_metadata(config, raster_info.as_ref(), feature_extent, styles, base);
+        let bbox = raster_info
+            .as_ref()
+            .and_then(|i| i.spatial_extent)
+            .or(feature_extent);
+        let time = raster_info
+            .as_ref()
+            .and_then(|i| i.times.first().copied().zip(i.times.last().copied()));
+        rows.push((
+            config.id.clone(),
+            config.title.clone(),
+            config.description.clone(),
+            bbox,
+            time,
+            value,
         ));
     }
+    rows.sort_by(|a, b| a.0.cmp(&b.0));
 
-    colls.sort_by(|a, b| {
-        a["id"]
-            .as_str()
-            .unwrap_or("")
-            .cmp(b["id"].as_str().unwrap_or(""))
-    });
+    let matches: Vec<CollectionMatch> = rows
+        .iter()
+        .map(|r| CollectionMatch {
+            title: &r.1,
+            description: &r.2,
+            keywords: &[],
+            bbox: r.3,
+            time: r.4,
+        })
+        .collect();
+    let result = search(&matches, &params);
+    let colls: Vec<serde_json::Value> = result.page.iter().map(|&i| rows[i].5.clone()).collect();
+    let number_returned = colls.len();
 
-    Json(json!({
-        "collections": colls,
-        "links": [{
-            "href": format!("{base}/tiles/collections"),
-            "rel": "self",
+    let link = |rel: &str, offset: usize, title: Option<&str>| {
+        let mut o = json!({
+            "href": format!("{base}/tiles/collections{}", sp.query_string(offset)),
+            "rel": rel,
             "type": "application/json"
-        }]
-    }))
+        });
+        if let Some(t) = title {
+            o["title"] = json!(t);
+        }
+        o
+    };
+    let mut links = vec![link("self", params.offset, None)];
+    if result.has_next {
+        links.push(link("next", result.next_offset, Some("Next page")));
+    }
+    if result.has_prev {
+        links.push(link("prev", result.prev_offset, Some("Previous page")));
+    }
+
+    Ok(Json(json!({
+        "collections": colls,
+        "numberMatched": result.number_matched,
+        "numberReturned": number_returned,
+        "links": links
+    })))
 }
 
 /// GET /tiles/collections/{id} — Collection detail

--- a/crates/api-tiles/src/handlers.rs
+++ b/crates/api-tiles/src/handlers.rs
@@ -686,7 +686,6 @@ pub async fn collections(
         .map(|r| CollectionMatch {
             title: &r.1,
             description: &r.2,
-            keywords: &[],
             bbox: r.3,
             time: r.4,
         })

--- a/crates/api-tiles/src/handlers.rs
+++ b/crates/api-tiles/src/handlers.rs
@@ -697,7 +697,7 @@ pub async fn collections(
 
     let link = |rel: &str, offset: usize, title: Option<&str>| {
         let mut o = json!({
-            "href": format!("{base}/tiles/collections{}", sp.query_string(offset)),
+            "href": format!("{base}/tiles/collections{}", sp.query_string(params.limit, offset)),
             "rel": rel,
             "type": "application/json"
         });

--- a/crates/api-tiles/tests/integration.rs
+++ b/crates/api-tiles/tests/integration.rs
@@ -1761,3 +1761,35 @@ mod temporal_grid_jitter {
         assert!(grid.get("coordinates").is_none());
     }
 }
+
+// ---------------------------------------------------------------------------
+// OGC API - Common - Part 4: Searchable Collections — handler wiring smoke
+// ---------------------------------------------------------------------------
+
+mod part4_searchable {
+    use super::*;
+
+    #[tokio::test]
+    async fn conformance_declares_searchable_collections() {
+        let (_, json) = get("/conformance").await;
+        let classes = json["conformsTo"].as_array().unwrap();
+        assert!(classes.iter().any(|c| c
+            .as_str()
+            .unwrap()
+            .contains("common-4/1.0/conf/searchable-collections")));
+    }
+
+    #[tokio::test]
+    async fn collections_has_match_counts() {
+        let (status, json) = get("/collections").await;
+        assert_eq!(status, StatusCode::OK);
+        assert!(json["numberMatched"].is_number());
+        assert!(json["numberReturned"].is_number());
+    }
+
+    #[tokio::test]
+    async fn invalid_limit_is_400() {
+        let (status, _) = get("/collections?limit=-1").await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+    }
+}

--- a/crates/core/src/collection_search.rs
+++ b/crates/core/src/collection_search.rs
@@ -1,0 +1,557 @@
+//! OGC API – Common – Part 4 ("Discovery within many collections", draft
+//! [25-046]) — the **Searchable Collections** requirements class.
+//!
+//! Filtering and pagination for the `/collections` resource: `bbox` /
+//! `bbox-crs`, `datetime`, `q`, and `limit` + `offset`. The logic lives here
+//! (not in the API crates) so EDR, Maps, Tiles, and Features share one
+//! implementation — ds-core never builds `serde_json::Value`, so the crates
+//! call [`parse_search_params`] + [`search`] and assemble the JSON response
+//! themselves (and build `next`/`prev` link hrefs with [`page_query_string`]).
+//!
+//! Only CRS84 is supported for `bbox` / `bbox-crs` (every collection bbox is
+//! advertised in CRS84). Sortable / Filterable (CQL2) / Hierarchical classes
+//! are intentionally not implemented.
+//!
+//! [25-046]: https://docs.ogc.org/DRAFTS/25-046.html
+
+use crate::datetime::parse_datetime_interval;
+use chrono::{DateTime, Utc};
+
+/// Server default page size when `limit` is absent. Sized so realistic
+/// catalogs (including a full OPERA radar network) come back in one page and
+/// existing single-page clients see no behaviour change.
+pub const DEFAULT_LIMIT: usize = 1000;
+/// Maximum honoured `limit`. A larger requested value is clamped to this (per
+/// the draft, an over-large `limit` is not an error).
+pub const MAX_LIMIT: usize = 1000;
+
+/// `bbox-crs` values accepted as CRS84 (URI, CURIE, and short forms).
+const ACCEPTED_BBOX_CRS: &[&str] = &[
+    "http://www.opengis.net/def/crs/OGC/1.3/CRS84",
+    "https://www.opengis.net/def/crs/OGC/1.3/CRS84",
+    "[OGC:CRS84]",
+    "OGC:CRS84",
+    "CRS84",
+    "CRS:84",
+];
+
+/// A bad `/collections` query parameter. The API crates map this to HTTP 400.
+#[derive(Debug, Clone, thiserror::Error)]
+#[error("{0}")]
+pub struct SearchError(pub String);
+
+impl SearchError {
+    fn new(msg: impl Into<String>) -> Self {
+        SearchError(msg.into())
+    }
+}
+
+/// The searchable facets of one collection. Borrows from the caller's config /
+/// engine snapshot; build one per collection in the same order as the response
+/// list, then pass the slice to [`search`].
+#[derive(Debug, Clone)]
+pub struct CollectionMatch<'a> {
+    pub title: &'a str,
+    pub description: &'a str,
+    pub keywords: &'a [String],
+    /// CRS84 bbox `[west, south, east, north]`, if the collection has one.
+    pub bbox: Option<[f64; 4]>,
+    /// Temporal interval `(start, end)`, if the collection has one.
+    pub time: Option<(DateTime<Utc>, DateTime<Utc>)>,
+}
+
+/// Validated, parsed search parameters.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SearchParams {
+    /// CRS84 query bbox `[west, south, east, north]`.
+    pub bbox: Option<[f64; 4]>,
+    /// Query interval `(start, end)`.
+    pub datetime: Option<(DateTime<Utc>, DateTime<Utc>)>,
+    /// Lower-cased, non-empty free-text terms (OR semantics). Empty = no `q`.
+    pub q: Vec<String>,
+    pub limit: usize,
+    pub offset: usize,
+}
+
+/// The outcome of a [`search`]: the total match count and the indices of the
+/// items on the requested page, plus pagination cursors.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SearchResult {
+    /// Total collections matching the filters (before pagination).
+    pub number_matched: usize,
+    /// Indices into the `items` slice for this page, in input order.
+    pub page: Vec<usize>,
+    pub has_next: bool,
+    pub next_offset: usize,
+    pub has_prev: bool,
+    pub prev_offset: usize,
+}
+
+/// Parse and validate the raw `/collections` query parameters. Returns
+/// [`SearchError`] (→ HTTP 400) for malformed input.
+pub fn parse_search_params(
+    bbox: Option<&str>,
+    bbox_crs: Option<&str>,
+    datetime: Option<&str>,
+    q: Option<&str>,
+    limit: Option<&str>,
+    offset: Option<&str>,
+) -> Result<SearchParams, SearchError> {
+    // bbox-crs is only meaningful with a bbox, but validate it whenever present.
+    if let Some(crs) = bbox_crs.map(str::trim).filter(|s| !s.is_empty()) {
+        if !ACCEPTED_BBOX_CRS
+            .iter()
+            .any(|c| c.eq_ignore_ascii_case(crs))
+        {
+            return Err(SearchError::new(
+                "Only CRS84 is supported for bbox-crs (e.g. \
+                 http://www.opengis.net/def/crs/OGC/1.3/CRS84)",
+            ));
+        }
+    }
+
+    let bbox = match bbox.map(str::trim).filter(|s| !s.is_empty()) {
+        Some(s) => Some(parse_bbox(s)?),
+        None => None,
+    };
+
+    let datetime = match datetime.map(str::trim).filter(|s| !s.is_empty()) {
+        Some(s) => Some(
+            parse_datetime_interval(s)
+                .map_err(|e| SearchError::new(format!("Invalid datetime: {e}")))?,
+        ),
+        None => None,
+    };
+
+    let q = match q.map(str::trim).filter(|s| !s.is_empty()) {
+        Some(s) => s
+            .split(',')
+            .map(|t| t.trim().to_lowercase())
+            .filter(|t| !t.is_empty())
+            .collect(),
+        None => Vec::new(),
+    };
+
+    let limit = match limit.map(str::trim).filter(|s| !s.is_empty()) {
+        Some(s) => {
+            let n: usize = s.parse().map_err(|_| {
+                SearchError::new(format!("Invalid limit: '{s}' is not a positive integer"))
+            })?;
+            if n < 1 {
+                return Err(SearchError::new("limit must be >= 1"));
+            }
+            n.min(MAX_LIMIT)
+        }
+        None => DEFAULT_LIMIT,
+    };
+
+    let offset = match offset.map(str::trim).filter(|s| !s.is_empty()) {
+        Some(s) => s.parse().map_err(|_| {
+            SearchError::new(format!(
+                "Invalid offset: '{s}' is not a non-negative integer"
+            ))
+        })?,
+        None => 0,
+    };
+
+    Ok(SearchParams {
+        bbox,
+        datetime,
+        q,
+        limit,
+        offset,
+    })
+}
+
+/// Parse a `bbox` query value: 4 numbers (2D) or 6 (3D, vertical axis dropped).
+fn parse_bbox(s: &str) -> Result<[f64; 4], SearchError> {
+    let nums: Result<Vec<f64>, _> = s.split(',').map(|p| p.trim().parse::<f64>()).collect();
+    let nums =
+        nums.map_err(|_| SearchError::new("bbox must be a comma-separated list of numbers"))?;
+    match nums.len() {
+        // 2D: minx,miny,maxx,maxy
+        4 => Ok([nums[0], nums[1], nums[2], nums[3]]),
+        // 3D: minx,miny,minz,maxx,maxy,maxz — drop the vertical axis.
+        6 => Ok([nums[0], nums[1], nums[3], nums[4]]),
+        _ => Err(SearchError::new("bbox must have 4 or 6 numbers")),
+    }
+}
+
+/// Filter `items` by the parameters and apply `offset`/`limit` pagination.
+pub fn search(items: &[CollectionMatch], p: &SearchParams) -> SearchResult {
+    let matched: Vec<usize> = items
+        .iter()
+        .enumerate()
+        .filter(|(_, it)| matches(it, p))
+        .map(|(i, _)| i)
+        .collect();
+
+    let number_matched = matched.len();
+    let end = p.offset.saturating_add(p.limit).min(number_matched);
+    let page: Vec<usize> = if p.offset < number_matched {
+        matched[p.offset..end].to_vec()
+    } else {
+        Vec::new()
+    };
+
+    SearchResult {
+        number_matched,
+        page,
+        has_next: end < number_matched,
+        next_offset: p.offset.saturating_add(p.limit),
+        has_prev: p.offset > 0,
+        prev_offset: p.offset.saturating_sub(p.limit),
+    }
+}
+
+fn matches(it: &CollectionMatch, p: &SearchParams) -> bool {
+    if let Some(qbox) = p.bbox {
+        match it.bbox {
+            Some(cbox) if bbox_intersects(qbox, cbox) => {}
+            _ => return false,
+        }
+    }
+    if let Some((qs, qe)) = p.datetime {
+        match it.time {
+            Some((cs, ce)) if qs <= ce && cs <= qe => {}
+            _ => return false,
+        }
+    }
+    if !p.q.is_empty() && !q_matches(&p.q, it.title, it.description, it.keywords) {
+        return false;
+    }
+    true
+}
+
+/// CRS84 bbox intersection, anti-meridian aware.
+fn bbox_intersects(q: [f64; 4], c: [f64; 4]) -> bool {
+    // Latitude (no wrap).
+    let lat = q[1] <= c[3] && c[1] <= q[3];
+    lat && lon_overlaps(q[0], q[2], c[0], c[2])
+}
+
+/// Longitude overlap where a box with `west > east` wraps the anti-meridian.
+fn lon_overlaps(qw: f64, qe: f64, cw: f64, ce: f64) -> bool {
+    match (qw > qe, cw > ce) {
+        (false, false) => qw <= ce && cw <= qe,
+        // Exactly one wraps: it covers [w, 180] ∪ [-180, e].
+        (true, false) | (false, true) => qw <= ce || cw <= qe,
+        // Both wrap: each spans the anti-meridian, so they always overlap.
+        (true, true) => true,
+    }
+}
+
+/// Whole-word (or, for terms containing whitespace, phrase) match of any `q`
+/// term against the collection's title, description, or keywords. Terms are
+/// pre-lowercased; comparison is Unicode-case-insensitive (Finnish ä/ö etc.).
+fn q_matches(terms: &[String], title: &str, description: &str, keywords: &[String]) -> bool {
+    terms.iter().any(|term| {
+        if term.chars().any(char::is_whitespace) {
+            // Phrase: case-insensitive substring across the combined text.
+            let hay = format!("{title} {description} {}", keywords.join(" ")).to_lowercase();
+            hay.contains(term.as_str())
+        } else {
+            word_match(title, term)
+                || word_match(description, term)
+                || keywords.iter().any(|k| word_match(k, term))
+        }
+    })
+}
+
+/// True if `term` (already lower-cased) equals a whole word of `text`. Words
+/// are maximal runs of alphanumeric characters (Unicode-aware).
+fn word_match(text: &str, term: &str) -> bool {
+    text.split(|c: char| !c.is_alphanumeric())
+        .filter(|w| !w.is_empty())
+        .any(|w| w.to_lowercase() == term)
+}
+
+/// Raw `/collections` query parameters, deserialized by the API crates'
+/// handlers (`Query<SearchQueryParams>`). Defined here so all four surfaces
+/// share one extractor; [`parse`](Self::parse) validates it into
+/// [`SearchParams`] and [`query_string`](Self::query_string) rebuilds a
+/// link href for the same request at a different offset.
+#[derive(Debug, Clone, Default, serde::Deserialize)]
+pub struct SearchQueryParams {
+    pub bbox: Option<String>,
+    #[serde(rename = "bbox-crs")]
+    pub bbox_crs: Option<String>,
+    pub datetime: Option<String>,
+    pub q: Option<String>,
+    pub limit: Option<String>,
+    pub offset: Option<String>,
+}
+
+impl SearchQueryParams {
+    /// Validate into [`SearchParams`] (→ HTTP 400 on bad input).
+    pub fn parse(&self) -> Result<SearchParams, SearchError> {
+        parse_search_params(
+            self.bbox.as_deref(),
+            self.bbox_crs.as_deref(),
+            self.datetime.as_deref(),
+            self.q.as_deref(),
+            self.limit.as_deref(),
+            self.offset.as_deref(),
+        )
+    }
+
+    /// The query string (leading `?`, or empty) for this request at `offset`,
+    /// for building `self`/`next`/`prev` link hrefs.
+    pub fn query_string(&self, offset: usize) -> String {
+        page_query_string(
+            self.bbox.as_deref(),
+            self.bbox_crs.as_deref(),
+            self.datetime.as_deref(),
+            self.q.as_deref(),
+            self.limit.as_deref(),
+            offset,
+        )
+    }
+}
+
+/// Reconstruct the `/collections` query string (leading `?`, or empty) for a
+/// `self`/`next`/`prev` link: the original raw filter values plus the given
+/// `offset` (omitted when 0). Percent-encodes values; keeps `,` `:` `/`
+/// readable (all valid in a query component per RFC 3986).
+pub fn page_query_string(
+    bbox: Option<&str>,
+    bbox_crs: Option<&str>,
+    datetime: Option<&str>,
+    q: Option<&str>,
+    limit: Option<&str>,
+    offset: usize,
+) -> String {
+    let mut parts: Vec<String> = Vec::new();
+    let mut push = |key: &str, val: Option<&str>| {
+        if let Some(v) = val.map(str::trim).filter(|s| !s.is_empty()) {
+            parts.push(format!("{key}={}", encode_qval(v)));
+        }
+    };
+    push("bbox", bbox);
+    push("bbox-crs", bbox_crs);
+    push("datetime", datetime);
+    push("q", q);
+    push("limit", limit);
+    if offset > 0 {
+        parts.push(format!("offset={offset}"));
+    }
+    if parts.is_empty() {
+        String::new()
+    } else {
+        format!("?{}", parts.join("&"))
+    }
+}
+
+/// Percent-encode a query-parameter value, leaving unreserved characters and
+/// the query-safe sub-delims `,` `:` `/` intact for readability.
+fn encode_qval(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for b in s.bytes() {
+        match b {
+            b'A'..=b'Z'
+            | b'a'..=b'z'
+            | b'0'..=b'9'
+            | b'-'
+            | b'.'
+            | b'_'
+            | b'~'
+            | b','
+            | b':'
+            | b'/' => out.push(b as char),
+            _ => out.push_str(&format!("%{b:02X}")),
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn t(s: &str) -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339(s).unwrap().with_timezone(&Utc)
+    }
+
+    fn cm<'a>(
+        title: &'a str,
+        description: &'a str,
+        keywords: &'a [String],
+        bbox: Option<[f64; 4]>,
+        time: Option<(DateTime<Utc>, DateTime<Utc>)>,
+    ) -> CollectionMatch<'a> {
+        CollectionMatch {
+            title,
+            description,
+            keywords,
+            bbox,
+            time,
+        }
+    }
+
+    #[test]
+    fn parse_defaults() {
+        let p = parse_search_params(None, None, None, None, None, None).unwrap();
+        assert_eq!(p.limit, DEFAULT_LIMIT);
+        assert_eq!(p.offset, 0);
+        assert!(p.bbox.is_none() && p.datetime.is_none() && p.q.is_empty());
+    }
+
+    #[test]
+    fn parse_bbox_4_and_6() {
+        let p = parse_search_params(Some("20,60,30,70"), None, None, None, None, None).unwrap();
+        assert_eq!(p.bbox, Some([20.0, 60.0, 30.0, 70.0]));
+        // 6-number form drops the vertical axis.
+        let p6 =
+            parse_search_params(Some("20,60,0,30,70,5000"), None, None, None, None, None).unwrap();
+        assert_eq!(p6.bbox, Some([20.0, 60.0, 30.0, 70.0]));
+    }
+
+    #[test]
+    fn parse_rejects_bad_bbox_and_limit_and_crs() {
+        assert!(parse_search_params(Some("1,2,3"), None, None, None, None, None).is_err());
+        assert!(parse_search_params(Some("a,b,c,d"), None, None, None, None, None).is_err());
+        assert!(parse_search_params(None, None, None, None, Some("0"), None).is_err());
+        assert!(parse_search_params(None, None, None, None, Some("-3"), None).is_err());
+        assert!(
+            parse_search_params(Some("0,0,1,1"), Some("EPSG:3857"), None, None, None, None)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn parse_accepts_crs84_bbox_crs_forms() {
+        for crs in [
+            "CRS84",
+            "OGC:CRS84",
+            "http://www.opengis.net/def/crs/OGC/1.3/CRS84",
+        ] {
+            assert!(
+                parse_search_params(Some("0,0,1,1"), Some(crs), None, None, None, None).is_ok()
+            );
+        }
+    }
+
+    #[test]
+    fn limit_clamped_to_max() {
+        let p = parse_search_params(None, None, None, None, Some("99999"), None).unwrap();
+        assert_eq!(p.limit, MAX_LIMIT);
+    }
+
+    #[test]
+    fn bbox_filter_includes_and_excludes() {
+        let kw: Vec<String> = vec![];
+        let inside = cm("a", "", &kw, Some([20.0, 60.0, 25.0, 65.0]), None);
+        let outside = cm("b", "", &kw, Some([-10.0, -10.0, -5.0, -5.0]), None);
+        let no_bbox = cm("c", "", &kw, None, None);
+        let items = [inside, outside, no_bbox];
+        let p = parse_search_params(Some("0,50,30,70"), None, None, None, None, None).unwrap();
+        let r = search(&items, &p);
+        assert_eq!(r.page, vec![0]); // only the intersecting one; no-bbox excluded
+        assert_eq!(r.number_matched, 1);
+    }
+
+    #[test]
+    fn antimeridian_bbox_overlaps() {
+        // Query wraps the anti-meridian: [170, -170] covers 170..180 and -180..-170.
+        assert!(lon_overlaps(170.0, -170.0, 175.0, 178.0));
+        assert!(lon_overlaps(170.0, -170.0, -179.0, -171.0));
+        assert!(!lon_overlaps(170.0, -170.0, 0.0, 10.0));
+    }
+
+    #[test]
+    fn datetime_overlap_filter() {
+        let kw: Vec<String> = vec![];
+        let c = cm(
+            "a",
+            "",
+            &kw,
+            None,
+            Some((t("2026-06-01T00:00:00Z"), t("2026-06-03T00:00:00Z"))),
+        );
+        let items = [c];
+        let hit = parse_search_params(None, None, Some("2026-06-02T12:00:00Z"), None, None, None)
+            .unwrap();
+        assert_eq!(search(&items, &hit).number_matched, 1);
+        let miss = parse_search_params(None, None, Some("2026-07-01T00:00:00Z"), None, None, None)
+            .unwrap();
+        assert_eq!(search(&items, &miss).number_matched, 0);
+    }
+
+    #[test]
+    fn q_whole_word_and_keywords_and_unicode() {
+        let kw = vec!["sää".to_string(), "tutka".to_string()];
+        let c = cm("Helsinki Radar", "Reflectivity composite", &kw, None, None);
+        let items = [c];
+        // whole word, case-insensitive
+        assert_eq!(
+            search(
+                &items,
+                &parse_search_params(None, None, None, Some("radar"), None, None).unwrap()
+            )
+            .number_matched,
+            1
+        );
+        // keyword match, Unicode case-insensitive (SÄÄ -> sää)
+        assert_eq!(
+            search(
+                &items,
+                &parse_search_params(None, None, None, Some("SÄÄ"), None, None).unwrap()
+            )
+            .number_matched,
+            1
+        );
+        // partial word does NOT match whole-word term
+        assert_eq!(
+            search(
+                &items,
+                &parse_search_params(None, None, None, Some("rada"), None, None).unwrap()
+            )
+            .number_matched,
+            0
+        );
+        // phrase (whitespace) → substring
+        assert_eq!(
+            search(
+                &items,
+                &parse_search_params(None, None, None, Some("helsinki radar"), None, None).unwrap()
+            )
+            .number_matched,
+            1
+        );
+    }
+
+    #[test]
+    fn pagination_cursors() {
+        let kw: Vec<String> = vec![];
+        let items: Vec<CollectionMatch> = (0..5).map(|_| cm("a", "", &kw, None, None)).collect();
+        let p = parse_search_params(None, None, None, None, Some("2"), Some("2")).unwrap();
+        let r = search(&items, &p);
+        assert_eq!(r.number_matched, 5);
+        assert_eq!(r.page, vec![2, 3]);
+        assert!(r.has_next && r.next_offset == 4);
+        assert!(r.has_prev && r.prev_offset == 0);
+    }
+
+    #[test]
+    fn query_string_roundtrip() {
+        let qs = page_query_string(
+            Some("20,60,30,70"),
+            None,
+            Some("2026-06-02T00:00:00Z"),
+            Some("radar"),
+            Some("10"),
+            10,
+        );
+        assert_eq!(
+            qs,
+            "?bbox=20,60,30,70&datetime=2026-06-02T00:00:00Z&q=radar&limit=10&offset=10"
+        );
+        // No params, offset 0 → empty (backward compatible self link).
+        assert_eq!(page_query_string(None, None, None, None, None, 0), "");
+        // Spaces get percent-encoded.
+        assert_eq!(
+            page_query_string(None, None, None, Some("heavy rain"), None, 0),
+            "?q=heavy%20rain"
+        );
+    }
+}

--- a/crates/core/src/collection_search.rs
+++ b/crates/core/src/collection_search.rs
@@ -192,6 +192,19 @@ fn parse_bbox(s: &str) -> Result<[f64; 4], SearchError> {
     if bbox[1] > bbox[3] {
         return Err(SearchError::new("bbox: south must be <= north"));
     }
+    // CRS84 range. Out-of-range coordinates would otherwise pass through and
+    // silently match nothing (HTTP 200, numberMatched 0) instead of a 400.
+    if bbox[1] < -90.0 || bbox[3] > 90.0 {
+        return Err(SearchError::new(
+            "bbox: latitude values must be within [-90, 90]",
+        ));
+    }
+    // Anti-meridian (west > east) is allowed, but both must be in range.
+    if !(-180.0..=180.0).contains(&bbox[0]) || !(-180.0..=180.0).contains(&bbox[2]) {
+        return Err(SearchError::new(
+            "bbox: longitude values must be within [-180, 180]",
+        ));
+    }
     Ok(bbox)
 }
 
@@ -217,10 +230,12 @@ pub fn search(items: &[CollectionMatch], p: &SearchParams) -> SearchResult {
         page,
         has_next: end < number_matched,
         next_offset: p.offset.saturating_add(p.limit),
-        // Only offer `prev` from a page at or before the data: an out-of-range
-        // `offset` (> number_matched) must not chain to further empty `prev`
-        // pages that never reach data.
-        has_prev: p.offset > 0 && p.offset <= number_matched,
+        // Offer `prev` only from a non-empty result page (`offset < number_matched`,
+        // matching the page-population guard above). An out-of-range or
+        // exactly-off-the-end `offset` yields an empty page with no `prev`,
+        // since `prev` implies a preceding result page. A `next` link never
+        // produces `offset == number_matched`, so normal paging is unaffected.
+        has_prev: p.offset > 0 && p.offset < number_matched,
         prev_offset: p.offset.saturating_sub(p.limit),
     }
 }
@@ -275,9 +290,14 @@ fn lon_overlaps(qw: f64, qe: f64, cw: f64, ce: f64) -> bool {
 fn q_matches(terms: &[String], title: &str, description: &str, keywords: &[String]) -> bool {
     terms.iter().any(|term| {
         if term.chars().any(char::is_whitespace) {
-            // Phrase: case-insensitive substring across the combined text.
-            let hay = format!("{title} {description} {}", keywords.join(" ")).to_lowercase();
-            hay.contains(term.as_str())
+            // Phrase: case-insensitive substring within a *single* field, so the
+            // boundary between two fields can't form a phantom match (e.g. title
+            // "Finnish Weather" + keyword "Helsinki" must not match "weather
+            // helsinki"). Each keyword is checked individually for the same reason.
+            let t = term.as_str();
+            title.to_lowercase().contains(t)
+                || description.to_lowercase().contains(t)
+                || keywords.iter().any(|k| k.to_lowercase().contains(t))
         } else {
             word_match(title, term)
                 || word_match(description, term)
@@ -459,6 +479,34 @@ mod tests {
         // south > north is always invalid (longitude inversion stays allowed).
         assert!(parse_search_params(Some("0,70,30,60"), None, None, None, None, None).is_err());
         assert!(parse_search_params(Some("170,50,-170,60"), None, None, None, None, None).is_ok());
+        // out-of-range latitude / longitude rejected.
+        assert!(parse_search_params(Some("0,200,10,300"), None, None, None, None, None).is_err());
+        assert!(parse_search_params(Some("200,0,300,10"), None, None, None, None, None).is_err());
+    }
+
+    #[test]
+    fn phrase_q_does_not_match_across_fields() {
+        let kw = vec!["Helsinki".to_string(), "radar".to_string()];
+        let items = [cm("Finnish Weather", "", &kw, None, None)];
+        // "weather helsinki" spans the title→keyword boundary — must NOT match.
+        let across =
+            parse_search_params(None, None, None, Some("weather helsinki"), None, None).unwrap();
+        assert_eq!(search(&items, &across).number_matched, 0);
+        // a phrase within a single field still matches.
+        let within =
+            parse_search_params(None, None, None, Some("finnish weather"), None, None).unwrap();
+        assert_eq!(search(&items, &within).number_matched, 1);
+    }
+
+    #[test]
+    fn no_prev_exactly_off_the_end() {
+        let kw: Vec<String> = vec![];
+        let items: Vec<CollectionMatch> = (0..4).map(|_| cm("a", "", &kw, None, None)).collect();
+        // offset == number_matched: empty page, no prev (prev implies a result page).
+        let p = parse_search_params(None, None, None, None, Some("2"), Some("4")).unwrap();
+        let r = search(&items, &p);
+        assert!(r.page.is_empty());
+        assert!(!r.has_prev);
     }
 
     #[test]

--- a/crates/core/src/collection_search.rs
+++ b/crates/core/src/collection_search.rs
@@ -199,22 +199,32 @@ pub fn search(items: &[CollectionMatch], p: &SearchParams) -> SearchResult {
         page,
         has_next: end < number_matched,
         next_offset: p.offset.saturating_add(p.limit),
-        has_prev: p.offset > 0,
+        // Only offer `prev` from a page at or before the data: an out-of-range
+        // `offset` (> number_matched) must not chain to further empty `prev`
+        // pages that never reach data.
+        has_prev: p.offset > 0 && p.offset <= number_matched,
         prev_offset: p.offset.saturating_sub(p.limit),
     }
 }
 
 fn matches(it: &CollectionMatch, p: &SearchParams) -> bool {
+    // "Unknown extent ≡ unbounded" (OGC API – Common – Part 4 §7.14.2/§7.14.3):
+    // a collection that declares no spatial/temporal extent matches any
+    // bbox/datetime filter, rather than being excluded — otherwise cold-start
+    // engines (bbox/time still None) and extent-less collections silently
+    // vanish from filtered /collections responses.
     if let Some(qbox) = p.bbox {
         match it.bbox {
             Some(cbox) if bbox_intersects(qbox, cbox) => {}
-            _ => return false,
+            None => {}
+            Some(_) => return false,
         }
     }
     if let Some((qs, qe)) = p.datetime {
         match it.time {
             Some((cs, ce)) if qs <= ce && cs <= qe => {}
-            _ => return false,
+            None => {}
+            Some(_) => return false,
         }
     }
     if !p.q.is_empty() && !q_matches(&p.q, it.title, it.description, it.keywords) {
@@ -296,14 +306,19 @@ impl SearchQueryParams {
     }
 
     /// The query string (leading `?`, or empty) for this request at `offset`,
-    /// for building `self`/`next`/`prev` link hrefs.
-    pub fn query_string(&self, offset: usize) -> String {
+    /// for building `self`/`next`/`prev` link hrefs. `limit` is the *resolved*
+    /// (clamped) value — when the client supplied a `limit`, links reflect the
+    /// honoured value, not the raw request (a `limit=9999` clamped to 1000 must
+    /// not leak `9999` into links). When the client supplied none, links omit
+    /// `limit` so default-page URLs stay clean.
+    pub fn query_string(&self, limit: usize, offset: usize) -> String {
+        let limit_str = self.limit.as_ref().map(|_| limit.to_string());
         page_query_string(
             self.bbox.as_deref(),
             self.bbox_crs.as_deref(),
             self.datetime.as_deref(),
             self.q.as_deref(),
-            self.limit.as_deref(),
+            limit_str.as_deref(),
             offset,
         )
     }
@@ -442,12 +457,38 @@ mod tests {
         let kw: Vec<String> = vec![];
         let inside = cm("a", "", &kw, Some([20.0, 60.0, 25.0, 65.0]), None);
         let outside = cm("b", "", &kw, Some([-10.0, -10.0, -5.0, -5.0]), None);
+        // "unknown extent ≡ unbounded": a collection with no bbox matches.
         let no_bbox = cm("c", "", &kw, None, None);
         let items = [inside, outside, no_bbox];
         let p = parse_search_params(Some("0,50,30,70"), None, None, None, None, None).unwrap();
         let r = search(&items, &p);
-        assert_eq!(r.page, vec![0]); // only the intersecting one; no-bbox excluded
-        assert_eq!(r.number_matched, 1);
+        // intersecting (0) + unbounded no-bbox (2); the disjoint one (1) is out.
+        assert_eq!(r.page, vec![0, 2]);
+        assert_eq!(r.number_matched, 2);
+    }
+
+    #[test]
+    fn unknown_extent_is_unbounded() {
+        let kw: Vec<String> = vec![];
+        // No spatial and no temporal extent → matches both bbox and datetime
+        // filters (OGC API – Common – Part 4 §7.14.2 / §7.14.3).
+        let items = [cm("a", "", &kw, None, None)];
+        let bbox = parse_search_params(Some("0,0,1,1"), None, None, None, None, None).unwrap();
+        assert_eq!(search(&items, &bbox).number_matched, 1);
+        let dt = parse_search_params(None, None, Some("2026-06-02T00:00:00Z"), None, None, None)
+            .unwrap();
+        assert_eq!(search(&items, &dt).number_matched, 1);
+    }
+
+    #[test]
+    fn prev_suppressed_when_offset_out_of_range() {
+        let kw: Vec<String> = vec![];
+        let items: Vec<CollectionMatch> = (0..3).map(|_| cm("a", "", &kw, None, None)).collect();
+        // offset far beyond the 3 matches: empty page, and no `prev` chain.
+        let p = parse_search_params(None, None, None, None, Some("2"), Some("5000")).unwrap();
+        let r = search(&items, &p);
+        assert!(r.page.is_empty());
+        assert!(!r.has_prev, "out-of-range offset must not offer prev");
     }
 
     #[test]
@@ -553,5 +594,21 @@ mod tests {
             page_query_string(None, None, None, Some("heavy rain"), None, 0),
             "?q=heavy%20rain"
         );
+    }
+
+    #[test]
+    fn query_string_reflects_clamped_limit() {
+        // Client asked for an over-large limit; links must carry the resolved
+        // (clamped) value, not the raw request.
+        let sp = SearchQueryParams {
+            limit: Some("99999".to_string()),
+            ..Default::default()
+        };
+        let resolved = sp.parse().unwrap().limit; // == MAX_LIMIT
+        assert_eq!(resolved, MAX_LIMIT);
+        assert_eq!(sp.query_string(resolved, 0), format!("?limit={MAX_LIMIT}"));
+        // Client supplied no limit → links omit it (clean default-page URL).
+        let none = SearchQueryParams::default();
+        assert_eq!(none.query_string(DEFAULT_LIMIT, 0), "");
     }
 }

--- a/crates/core/src/collection_search.rs
+++ b/crates/core/src/collection_search.rs
@@ -53,7 +53,6 @@ impl SearchError {
 pub struct CollectionMatch<'a> {
     pub title: &'a str,
     pub description: &'a str,
-    pub keywords: &'a [String],
     /// CRS84 bbox `[west, south, east, north]`, if the collection has one.
     pub bbox: Option<[f64; 4]>,
     /// Temporal interval `(start, end)`, if the collection has one.
@@ -260,7 +259,7 @@ fn matches(it: &CollectionMatch, p: &SearchParams) -> bool {
             Some(_) => return false,
         }
     }
-    if !p.q.is_empty() && !q_matches(&p.q, it.title, it.description, it.keywords) {
+    if !p.q.is_empty() && !q_matches(&p.q, it.title, it.description) {
         return false;
     }
     true
@@ -285,23 +284,23 @@ fn lon_overlaps(qw: f64, qe: f64, cw: f64, ce: f64) -> bool {
 }
 
 /// Whole-word (or, for terms containing whitespace, phrase) match of any `q`
-/// term against the collection's title, description, or keywords. Terms are
-/// pre-lowercased; comparison is Unicode-case-insensitive (Finnish ä/ö etc.).
-fn q_matches(terms: &[String], title: &str, description: &str, keywords: &[String]) -> bool {
+/// term against the collection's title or description. Terms are pre-lowercased;
+/// comparison is Unicode-case-insensitive (Finnish ä/ö etc.).
+///
+/// Keyword search is intentionally not included: `CollectionConfig` has no
+/// `keywords` field yet (tracked as a follow-up), so matching only the fields
+/// that actually exist avoids carrying dead code.
+fn q_matches(terms: &[String], title: &str, description: &str) -> bool {
     terms.iter().any(|term| {
         if term.chars().any(char::is_whitespace) {
             // Phrase: case-insensitive substring within a *single* field, so the
             // boundary between two fields can't form a phantom match (e.g. title
-            // "Finnish Weather" + keyword "Helsinki" must not match "weather
-            // helsinki"). Each keyword is checked individually for the same reason.
+            // "Finnish Weather" + description "Helsinki …" must not match
+            // "weather helsinki").
             let t = term.as_str();
-            title.to_lowercase().contains(t)
-                || description.to_lowercase().contains(t)
-                || keywords.iter().any(|k| k.to_lowercase().contains(t))
+            title.to_lowercase().contains(t) || description.to_lowercase().contains(t)
         } else {
-            word_match(title, term)
-                || word_match(description, term)
-                || keywords.iter().any(|k| word_match(k, term))
+            word_match(title, term) || word_match(description, term)
         }
     })
 }
@@ -428,14 +427,12 @@ mod tests {
     fn cm<'a>(
         title: &'a str,
         description: &'a str,
-        keywords: &'a [String],
         bbox: Option<[f64; 4]>,
         time: Option<(DateTime<Utc>, DateTime<Utc>)>,
     ) -> CollectionMatch<'a> {
         CollectionMatch {
             title,
             description,
-            keywords,
             bbox,
             time,
         }
@@ -486,9 +483,8 @@ mod tests {
 
     #[test]
     fn phrase_q_does_not_match_across_fields() {
-        let kw = vec!["Helsinki".to_string(), "radar".to_string()];
-        let items = [cm("Finnish Weather", "", &kw, None, None)];
-        // "weather helsinki" spans the title→keyword boundary — must NOT match.
+        let items = [cm("Finnish Weather", "Helsinki radar", None, None)];
+        // "weather helsinki" spans the title→description boundary — must NOT match.
         let across =
             parse_search_params(None, None, None, Some("weather helsinki"), None, None).unwrap();
         assert_eq!(search(&items, &across).number_matched, 0);
@@ -500,8 +496,7 @@ mod tests {
 
     #[test]
     fn no_prev_exactly_off_the_end() {
-        let kw: Vec<String> = vec![];
-        let items: Vec<CollectionMatch> = (0..4).map(|_| cm("a", "", &kw, None, None)).collect();
+        let items: Vec<CollectionMatch> = (0..4).map(|_| cm("a", "", None, None)).collect();
         // offset == number_matched: empty page, no prev (prev implies a result page).
         let p = parse_search_params(None, None, None, None, Some("2"), Some("4")).unwrap();
         let r = search(&items, &p);
@@ -543,11 +538,10 @@ mod tests {
 
     #[test]
     fn bbox_filter_includes_and_excludes() {
-        let kw: Vec<String> = vec![];
-        let inside = cm("a", "", &kw, Some([20.0, 60.0, 25.0, 65.0]), None);
-        let outside = cm("b", "", &kw, Some([-10.0, -10.0, -5.0, -5.0]), None);
+        let inside = cm("a", "", Some([20.0, 60.0, 25.0, 65.0]), None);
+        let outside = cm("b", "", Some([-10.0, -10.0, -5.0, -5.0]), None);
         // "unknown extent ≡ unbounded": a collection with no bbox matches.
-        let no_bbox = cm("c", "", &kw, None, None);
+        let no_bbox = cm("c", "", None, None);
         let items = [inside, outside, no_bbox];
         let p = parse_search_params(Some("0,50,30,70"), None, None, None, None, None).unwrap();
         let r = search(&items, &p);
@@ -558,10 +552,9 @@ mod tests {
 
     #[test]
     fn unknown_extent_is_unbounded() {
-        let kw: Vec<String> = vec![];
         // No spatial and no temporal extent → matches both bbox and datetime
         // filters (OGC API – Common – Part 4 §7.14.2 / §7.14.3).
-        let items = [cm("a", "", &kw, None, None)];
+        let items = [cm("a", "", None, None)];
         let bbox = parse_search_params(Some("0,0,1,1"), None, None, None, None, None).unwrap();
         assert_eq!(search(&items, &bbox).number_matched, 1);
         let dt = parse_search_params(None, None, Some("2026-06-02T00:00:00Z"), None, None, None)
@@ -571,8 +564,7 @@ mod tests {
 
     #[test]
     fn prev_suppressed_when_offset_out_of_range() {
-        let kw: Vec<String> = vec![];
-        let items: Vec<CollectionMatch> = (0..3).map(|_| cm("a", "", &kw, None, None)).collect();
+        let items: Vec<CollectionMatch> = (0..3).map(|_| cm("a", "", None, None)).collect();
         // offset far beyond the 3 matches: empty page, and no `prev` chain.
         let p = parse_search_params(None, None, None, None, Some("2"), Some("5000")).unwrap();
         let r = search(&items, &p);
@@ -590,11 +582,9 @@ mod tests {
 
     #[test]
     fn datetime_overlap_filter() {
-        let kw: Vec<String> = vec![];
         let c = cm(
             "a",
             "",
-            &kw,
             None,
             Some((t("2026-06-01T00:00:00Z"), t("2026-06-03T00:00:00Z"))),
         );
@@ -608,9 +598,8 @@ mod tests {
     }
 
     #[test]
-    fn q_whole_word_and_keywords_and_unicode() {
-        let kw = vec!["sää".to_string(), "tutka".to_string()];
-        let c = cm("Helsinki Radar", "Reflectivity composite", &kw, None, None);
+    fn q_whole_word_and_unicode() {
+        let c = cm("Helsinki Radar", "Reflectivity composite sää", None, None);
         let items = [c];
         // whole word, case-insensitive
         assert_eq!(
@@ -621,7 +610,7 @@ mod tests {
             .number_matched,
             1
         );
-        // keyword match, Unicode case-insensitive (SÄÄ -> sää)
+        // whole word in description, Unicode case-insensitive (SÄÄ -> sää)
         assert_eq!(
             search(
                 &items,
@@ -652,8 +641,7 @@ mod tests {
 
     #[test]
     fn pagination_cursors() {
-        let kw: Vec<String> = vec![];
-        let items: Vec<CollectionMatch> = (0..5).map(|_| cm("a", "", &kw, None, None)).collect();
+        let items: Vec<CollectionMatch> = (0..5).map(|_| cm("a", "", None, None)).collect();
         let p = parse_search_params(None, None, None, None, Some("2"), Some("2")).unwrap();
         let r = search(&items, &p);
         assert_eq!(r.number_matched, 5);

--- a/crates/core/src/collection_search.rs
+++ b/crates/core/src/collection_search.rs
@@ -116,10 +116,16 @@ pub fn parse_search_params(
     };
 
     let datetime = match datetime.map(str::trim).filter(|s| !s.is_empty()) {
-        Some(s) => Some(
-            parse_datetime_interval(s)
-                .map_err(|e| SearchError::new(format!("Invalid datetime: {e}")))?,
-        ),
+        Some(s) => {
+            let (start, end) = parse_datetime_interval(s)
+                .map_err(|e| SearchError::new(format!("Invalid datetime: {e}")))?;
+            // An inverted interval (end before start) would silently exclude
+            // every overlapping collection; reject it as a 400.
+            if start > end {
+                return Err(SearchError::new("datetime: start must be <= end"));
+            }
+            Some((start, end))
+        }
         None => None,
     };
 
@@ -168,13 +174,25 @@ fn parse_bbox(s: &str) -> Result<[f64; 4], SearchError> {
     let nums: Result<Vec<f64>, _> = s.split(',').map(|p| p.trim().parse::<f64>()).collect();
     let nums =
         nums.map_err(|_| SearchError::new("bbox must be a comma-separated list of numbers"))?;
-    match nums.len() {
-        // 2D: minx,miny,maxx,maxy
-        4 => Ok([nums[0], nums[1], nums[2], nums[3]]),
-        // 3D: minx,miny,minz,maxx,maxy,maxz — drop the vertical axis.
-        6 => Ok([nums[0], nums[1], nums[3], nums[4]]),
-        _ => Err(SearchError::new("bbox must have 4 or 6 numbers")),
+    // `f64::parse` accepts "NaN"/"Inf"/"-Inf"; those would slip past the
+    // intersection test (NaN compares false → silent empty result) and must be
+    // rejected as a 400.
+    if nums.iter().any(|n| !n.is_finite()) {
+        return Err(SearchError::new("bbox values must be finite numbers"));
     }
+    let bbox = match nums.len() {
+        // 2D: west,south,east,north
+        4 => [nums[0], nums[1], nums[2], nums[3]],
+        // 3D: west,south,minz,east,north,maxz — drop the vertical axis.
+        6 => [nums[0], nums[1], nums[3], nums[4]],
+        _ => return Err(SearchError::new("bbox must have 4 or 6 numbers")),
+    };
+    // Latitude must not be inverted (south <= north). Longitude inversion is
+    // legitimate — `west > east` represents an anti-meridian-crossing bbox.
+    if bbox[1] > bbox[3] {
+        return Err(SearchError::new("bbox: south must be <= north"));
+    }
+    Ok(bbox)
 }
 
 /// Filter `items` by the parameters and apply `offset`/`limit` pagination.
@@ -431,6 +449,29 @@ mod tests {
             parse_search_params(Some("0,0,1,1"), Some("EPSG:3857"), None, None, None, None)
                 .is_err()
         );
+    }
+
+    #[test]
+    fn parse_rejects_nonfinite_and_inverted_bbox() {
+        // NaN / Inf must not slip through as a silent empty result.
+        assert!(parse_search_params(Some("NaN,60,30,70"), None, None, None, None, None).is_err());
+        assert!(parse_search_params(Some("0,60,Inf,70"), None, None, None, None, None).is_err());
+        // south > north is always invalid (longitude inversion stays allowed).
+        assert!(parse_search_params(Some("0,70,30,60"), None, None, None, None, None).is_err());
+        assert!(parse_search_params(Some("170,50,-170,60"), None, None, None, None, None).is_ok());
+    }
+
+    #[test]
+    fn parse_rejects_inverted_datetime() {
+        assert!(parse_search_params(
+            None,
+            None,
+            Some("2024-12-01T00:00:00Z/2024-01-01T00:00:00Z"),
+            None,
+            None,
+            None
+        )
+        .is_err());
     }
 
     #[test]

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod collection_search;
 pub mod config;
 pub mod datetime;
 pub mod edr_engine;


### PR DESCRIPTION
Implements the **Searchable Collections** requirements class of [OGC API – Common – Part 4](https://docs.ogc.org/DRAFTS/25-046.html) ("Discovery within many collections") on **EDR, Maps, Tiles, and Features**.

This server routinely exposes *many* collections — the ODIM PVOL model-B auto-split fans one source into N per-site collections — so `/collections` needs server-side discovery rather than always returning the full list.

## What

`GET /collections` now accepts:

| Param | Behaviour |
|---|---|
| `bbox` (+ `bbox-crs`) | Keep collections whose CRS84 footprint intersects. 4- or 6-number bbox, anti-meridian aware. CRS84 only (else 400). |
| `datetime` | Keep collections whose temporal extent intersects this RFC 3339 instant or interval (open ends via `..`). |
| `q` | Free-text, comma-separated OR terms, whole-word & Unicode-case-insensitive, over title + description. |
| `limit` + `offset` | Pagination. |

The response gains `numberMatched`, `numberReturned`, and `self`/`next`/`prev` links. Default/max `limit` is 1000, so realistic catalogs still come back in one page — **no behaviour change** for small deployments, just the extra count fields.

All four `/conformance` lists now declare `ogcapi-common-4/1.0/conf/searchable-collections`, and each `/collections` OpenAPI operation documents the parameters.

## Design

Filtering + pagination + link-query rebuilding lives once in the new **`ds_core::collection_search`** module (chrono + serde only — no `serde_json::Value`, per the ds-core architecture rule). Each crate's `collections()` handler builds lightweight `CollectionMatch` descriptors, calls `search()`, and assembles the JSON; a shared `SearchQueryParams` extractor centralises parse + link rebuilding. Invalid `bbox`/`bbox-crs`/`limit`/`datetime` → HTTP 400.

Resolves EDR spec-compliance **FINDING 17** (collections list missing `numberMatched`/`numberReturned`) — that test is flipped to assert the fix.

**Out of scope (deliberate):** CQL2 and Part 3 → the Sortable, Filterable, and Hierarchical classes are not implemented.

## Tests

- `ds_core::collection_search`: 11 unit tests (bbox incl. anti-meridian, datetime overlap, `q` whole-word + Unicode, pagination cursors, query-string round-trip, parse/validation).
- api-maps: 14 integration tests (counts, `q`, `bbox`, `datetime`, 400s, next/prev links, self-link query preservation).
- api-edr / api-tiles / api-features: handler-wiring smoke tests (conformance class, count fields, 400).
- Full workspace incl. `server` green; `clippy -D warnings` clean.

## Merge order

Part 4 builds on Common Part 2 "collections". EDR/Maps/Tiles already declare it (#292); **Features declares it in #298** (the companion #296 PR) — land #298 first so the Features Part 4 declaration isn't dangling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)