### PR TITLE
feat(api): HTML representation + ?f=json|html content negotiation (#296)

### DIFF
--- a/crates/api-edr/src/handlers.rs
+++ b/crates/api-edr/src/handlers.rs
@@ -208,10 +208,18 @@ pub async fn landing_page(
                 .into_response()
         }
         Wanted::Html => {
-            let views: Vec<LinkView> = links
+            let mut views: Vec<LinkView> = links
                 .iter()
                 .map(|(h, r, _, ti)| LinkView::new(h.clone(), *r, Some(ti)))
                 .collect();
+            // rel="alternate" to the JSON representation (parity with the
+            // collection-detail HTML page), so the HTML landing page links to
+            // its machine-readable twin.
+            views.push(LinkView::new(
+                format!("{base}/edr/?f=json"),
+                "alternate",
+                Some("This document as JSON"),
+            ));
             Html(ds_core::html::landing_html(title, description, &views)).into_response()
         }
     }))
@@ -595,11 +603,14 @@ pub async fn api_docs(State(state): State<AppState>) -> impl IntoResponse {
 }
 
 pub async fn conformance(
+    State(state): State<AppState>,
     Query(fp): Query<ds_core::html::FormatParams>,
     headers: HeaderMap,
 ) -> Result<Response, HandlerError> {
-    use ds_core::html::Wanted;
+    use ds_core::html::{LinkView, Wanted};
     let wanted = negotiate(fp.f.as_deref(), &headers)?;
+    let state = state.load_full();
+    let base = &state.base_url;
     let classes = [
         "http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/core",
         "http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/landing-page",
@@ -622,7 +633,17 @@ pub async fn conformance(
     ];
     Ok(with_vary(match wanted {
         Wanted::Json => Json(json!({ "conformsTo": classes })).into_response(),
-        Wanted::Html => Html(ds_core::html::conformance_html(&classes)).into_response(),
+        Wanted::Html => {
+            let nav = [
+                LinkView::new(format!("{base}/edr/"), "up", Some("Landing page")),
+                LinkView::new(
+                    format!("{base}/edr/conformance?f=json"),
+                    "alternate",
+                    Some("This document as JSON"),
+                ),
+            ];
+            Html(ds_core::html::conformance_html(&classes, &nav)).into_response()
+        }
     }))
 }
 

--- a/crates/api-edr/src/handlers.rs
+++ b/crates/api-edr/src/handlers.rs
@@ -3,8 +3,8 @@ use std::sync::Arc;
 
 use arc_swap::ArcSwap;
 use axum::extract::{Path, Query, State};
-use axum::http::{header, StatusCode};
-use axum::response::{IntoResponse, Response};
+use axum::http::{header, HeaderMap, StatusCode};
+use axum::response::{Html, IntoResponse, Response};
 use axum::Json;
 use serde_json::json;
 
@@ -74,6 +74,20 @@ fn server_error() -> HandlerError {
     )
 }
 
+/// A 400 from a plain message (used for `?f=` content negotiation errors).
+fn bad_request_msg(msg: &str) -> HandlerError {
+    (
+        StatusCode::BAD_REQUEST,
+        Json(json!({ "code": "BadRequest", "description": msg })),
+    )
+}
+
+/// Resolve the requested representation from `?f=` + the `Accept` header.
+fn negotiate(f: Option<&str>, headers: &HeaderMap) -> Result<ds_core::html::Wanted, HandlerError> {
+    let accept = headers.get(header::ACCEPT).and_then(|v| v.to_str().ok());
+    ds_core::html::negotiate(f, accept).map_err(|e| bad_request_msg(&e.to_string()))
+}
+
 /// Shared state for the EDR API: a registry of collection engines + metadata.
 #[derive(Clone)]
 pub struct EdrState {
@@ -130,45 +144,67 @@ fn resolve_request_z(
     Ok(Some(levels))
 }
 
-pub async fn landing_page(State(state): State<AppState>) -> impl IntoResponse {
+pub async fn landing_page(
+    State(state): State<AppState>,
+    Query(fp): Query<ds_core::html::FormatParams>,
+    headers: HeaderMap,
+) -> Result<Response, HandlerError> {
+    use ds_core::html::{LinkView, Wanted};
+    let wanted = negotiate(fp.f.as_deref(), &headers)?;
     let state = state.load_full();
     let base = &state.base_url;
-    Json(json!({
-        "title": "MeteoCore - EDR",
-        "description": "Metocean Data Server — OGC API EDR",
-        "links": [
-            {
-                "href": format!("{base}/edr/"),
-                "rel": "self",
-                "type": "application/json",
-                "title": "This document"
-            },
-            {
-                "href": format!("{base}/edr/api"),
-                "rel": "service-desc",
-                "type": "application/vnd.oai.openapi+json;version=3.0",
-                "title": "API definition"
-            },
-            {
-                "href": format!("{base}/edr/api/docs"),
-                "rel": "service-doc",
-                "type": "text/html",
-                "title": "API documentation"
-            },
-            {
-                "href": format!("{base}/edr/conformance"),
-                "rel": "conformance",
-                "type": "application/json",
-                "title": "Conformance classes"
-            },
-            {
-                "href": format!("{base}/edr/collections"),
-                "rel": "data",
-                "type": "application/json",
-                "title": "Collections"
-            }
-        ]
-    }))
+    let title = "MeteoCore - EDR";
+    let description = "Metocean Data Server — OGC API EDR";
+    // (href, rel, type, title) — one source for both representations.
+    let links = [
+        (
+            format!("{base}/edr/"),
+            "self",
+            "application/json",
+            "This document",
+        ),
+        (
+            format!("{base}/edr/api"),
+            "service-desc",
+            "application/vnd.oai.openapi+json;version=3.0",
+            "API definition",
+        ),
+        (
+            format!("{base}/edr/api/docs"),
+            "service-doc",
+            "text/html",
+            "API documentation",
+        ),
+        (
+            format!("{base}/edr/conformance"),
+            "conformance",
+            "application/json",
+            "Conformance classes",
+        ),
+        (
+            format!("{base}/edr/collections"),
+            "data",
+            "application/json",
+            "Collections",
+        ),
+    ];
+    Ok(match wanted {
+        Wanted::Json => {
+            let json_links: Vec<_> = links
+                .iter()
+                .map(|(h, r, t, ti)| json!({ "href": h, "rel": r, "type": t, "title": ti }))
+                .collect();
+            Json(json!({ "title": title, "description": description, "links": json_links }))
+                .into_response()
+        }
+        Wanted::Html => {
+            let views: Vec<LinkView> = links
+                .iter()
+                .map(|(h, r, _, ti)| LinkView::new(h.clone(), *r, Some(ti)))
+                .collect();
+            Html(ds_core::html::landing_html(title, description, &views)).into_response()
+        }
+    })
 }
 
 /// OpenAPI `parameters` array for the OGC API – Common – Part 4 searchable
@@ -187,7 +223,9 @@ fn searchable_collections_parameters() -> serde_json::Value {
         {"name": "limit", "in": "query", "required": false, "schema": {"type": "integer", "minimum": 1, "maximum": 1000},
          "description": "Maximum number of collections per page (default 1000)."},
         {"name": "offset", "in": "query", "required": false, "schema": {"type": "integer", "minimum": 0},
-         "description": "Number of matching collections to skip (pagination cursor)."}
+         "description": "Number of matching collections to skip (pagination cursor)."},
+        {"name": "f", "in": "query", "required": false, "schema": {"type": "string", "enum": ["json", "html"]},
+         "description": "Output format. 'json' (default) or 'html'; overrides the Accept header."}
     ])
 }
 
@@ -533,44 +571,48 @@ pub async fn api_docs(State(state): State<AppState>) -> impl IntoResponse {
     ))
 }
 
-pub async fn conformance() -> impl IntoResponse {
-    Json(json!({
-        "conformsTo": [
-            "http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/core",
-            "http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/landing-page",
-            "http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/oas30",
-            // OGC API - Common - Part 2: Geospatial Data (20-024). Our
-            // /collections + /collections/{id} already satisfy the Collections
-            // and JSON classes structurally; declaring them makes that
-            // discoverable. The HTML class (.../conf/html) is intentionally
-            // omitted — there is no HTML representation of /collections.
-            "http://www.opengis.net/spec/ogcapi-common-2/1.0/conf/collections",
-            "http://www.opengis.net/spec/ogcapi-common-2/1.0/conf/json",
-            // OGC API - Common - Part 4 (Discovery within many collections,
-            // draft 25-046): /collections supports bbox/bbox-crs/datetime/q/
-            // limit filtering + offset pagination (numberMatched/Returned +
-            // next/prev links). Sortable/Filterable/Hierarchical not declared.
-            "http://www.opengis.net/spec/ogcapi-common-4/1.0/conf/searchable-collections",
-            "http://www.opengis.net/spec/ogcapi-edr-1/1.1/conf/core",
-            "http://www.opengis.net/spec/ogcapi-edr-1/1.1/conf/collections",
-            "http://www.opengis.net/spec/ogcapi-edr-1/1.1/conf/json",
-            "http://www.opengis.net/spec/ogcapi-edr-1/1.1/conf/covjson"
-        ]
-    }))
+pub async fn conformance(
+    Query(fp): Query<ds_core::html::FormatParams>,
+    headers: HeaderMap,
+) -> Result<Response, HandlerError> {
+    use ds_core::html::Wanted;
+    let wanted = negotiate(fp.f.as_deref(), &headers)?;
+    let classes = [
+        "http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/core",
+        "http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/landing-page",
+        "http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/oas30",
+        // OGC API - Common - Part 2: Geospatial Data (20-024). /collections +
+        // /collections/{id} satisfy the Collections, JSON, and (now) HTML
+        // classes — the HTML representation is served via `?f=html` / Accept.
+        "http://www.opengis.net/spec/ogcapi-common-2/1.0/conf/collections",
+        "http://www.opengis.net/spec/ogcapi-common-2/1.0/conf/json",
+        "http://www.opengis.net/spec/ogcapi-common-2/1.0/conf/html",
+        // OGC API - Common - Part 4 (Discovery within many collections,
+        // draft 25-046): /collections supports bbox/bbox-crs/datetime/q/
+        // limit filtering + offset pagination (numberMatched/Returned +
+        // next/prev links). Sortable/Filterable/Hierarchical not declared.
+        "http://www.opengis.net/spec/ogcapi-common-4/1.0/conf/searchable-collections",
+        "http://www.opengis.net/spec/ogcapi-edr-1/1.1/conf/core",
+        "http://www.opengis.net/spec/ogcapi-edr-1/1.1/conf/collections",
+        "http://www.opengis.net/spec/ogcapi-edr-1/1.1/conf/json",
+        "http://www.opengis.net/spec/ogcapi-edr-1/1.1/conf/covjson",
+    ];
+    Ok(match wanted {
+        Wanted::Json => Json(json!({ "conformsTo": classes })).into_response(),
+        Wanted::Html => Html(ds_core::html::conformance_html(&classes)).into_response(),
+    })
 }
 
 pub async fn collections(
     State(state): State<AppState>,
     Query(sp): Query<ds_core::collection_search::SearchQueryParams>,
-) -> Result<Json<serde_json::Value>, HandlerError> {
+    headers: HeaderMap,
+) -> Result<Response, HandlerError> {
     use ds_core::collection_search::{search, CollectionMatch};
+    use ds_core::html::Wanted;
 
-    let params = sp.parse().map_err(|e| {
-        (
-            StatusCode::BAD_REQUEST,
-            Json(json!({ "code": "BadRequest", "description": e.to_string() })),
-        )
-    })?;
+    let wanted = negotiate(sp.f.as_deref(), &headers)?;
+    let params = sp.parse().map_err(|e| bad_request_msg(&e.to_string()))?;
     let state = state.load_full();
     let base = &state.base_url;
 
@@ -612,48 +654,113 @@ pub async fn collections(
         })
         .collect();
     let result = search(&matches, &params);
-    let collections: Vec<serde_json::Value> =
-        result.page.iter().map(|&i| rows[i].5.clone()).collect();
-    let number_returned = collections.len();
-
-    let link = |rel: &str, offset: usize, title: Option<&str>| {
-        let mut o = json!({
-            "href": format!("{base}/edr/collections{}", sp.query_string(params.limit, offset)),
-            "rel": rel,
-            "type": "application/json"
-        });
-        if let Some(t) = title {
-            o["title"] = json!(t);
-        }
-        o
+    let href = |offset| {
+        format!(
+            "{base}/edr/collections{}",
+            sp.query_string(params.limit, offset)
+        )
     };
-    let mut links = vec![link("self", params.offset, None)];
-    if result.has_next {
-        links.push(link("next", result.next_offset, Some("Next page")));
-    }
-    if result.has_prev {
-        links.push(link("prev", result.prev_offset, Some("Previous page")));
-    }
 
-    Ok(Json(json!({
-        "collections": collections,
-        "numberMatched": result.number_matched,
-        "numberReturned": number_returned,
-        "links": links
-    })))
+    Ok(match wanted {
+        Wanted::Json => {
+            let collections: Vec<serde_json::Value> =
+                result.page.iter().map(|&i| rows[i].5.clone()).collect();
+            let number_returned = collections.len();
+            let link = |rel: &str, offset: usize, title: Option<&str>| {
+                let mut o = json!({ "href": href(offset), "rel": rel, "type": "application/json" });
+                if let Some(t) = title {
+                    o["title"] = json!(t);
+                }
+                o
+            };
+            let mut links = vec![link("self", params.offset, None)];
+            if result.has_next {
+                links.push(link("next", result.next_offset, Some("Next page")));
+            }
+            if result.has_prev {
+                links.push(link("prev", result.prev_offset, Some("Previous page")));
+            }
+            Json(json!({
+                "collections": collections,
+                "numberMatched": result.number_matched,
+                "numberReturned": number_returned,
+                "links": links
+            }))
+            .into_response()
+        }
+        Wanted::Html => {
+            use ds_core::html::{CollectionCard, LinkView};
+            let cards: Vec<CollectionCard> = result
+                .page
+                .iter()
+                .map(|&i| CollectionCard {
+                    id: rows[i].0.clone(),
+                    title: rows[i].1.clone(),
+                    description: rows[i].2.clone(),
+                    self_href: format!("{base}/edr/collections/{}", rows[i].0),
+                })
+                .collect();
+            let mut nav = vec![LinkView::new(
+                href(params.offset),
+                "self",
+                Some("This page"),
+            )];
+            if result.has_next {
+                nav.push(LinkView::new(
+                    href(result.next_offset),
+                    "next",
+                    Some("Next page"),
+                ));
+            }
+            if result.has_prev {
+                nav.push(LinkView::new(
+                    href(result.prev_offset),
+                    "prev",
+                    Some("Previous page"),
+                ));
+            }
+            Html(ds_core::html::collections_html("Collections", &cards, &nav)).into_response()
+        }
+    })
 }
 
 pub async fn collection(
     Path(id): Path<String>,
     State(state): State<AppState>,
-) -> Result<impl IntoResponse, (StatusCode, Json<serde_json::Value>)> {
+    Query(fp): Query<ds_core::html::FormatParams>,
+    headers: HeaderMap,
+) -> Result<Response, HandlerError> {
+    use ds_core::html::{CollectionCard, LinkView, Wanted};
+    let wanted = negotiate(fp.f.as_deref(), &headers)?;
     let state = state.load_full();
     let (engine, config) = lookup_collection(&state, &id)?;
-    Ok(Json(build_collection_metadata(
-        engine.as_ref(),
-        config,
-        &state.base_url,
-    )))
+    let base = &state.base_url;
+    Ok(match wanted {
+        Wanted::Json => {
+            Json(build_collection_metadata(engine.as_ref(), config, base)).into_response()
+        }
+        Wanted::Html => {
+            let card = CollectionCard {
+                id: config.id.clone(),
+                title: config.title.clone(),
+                description: config.description.clone(),
+                self_href: format!("{base}/edr/collections/{}", config.id),
+            };
+            let links = [
+                LinkView::new(
+                    format!("{base}/edr/collections/{}?f=json", config.id),
+                    "alternate",
+                    Some("JSON"),
+                ),
+                LinkView::new(
+                    format!("{base}/edr/collections"),
+                    "collection",
+                    Some("All collections"),
+                ),
+            ];
+            Html(ds_core::html::collection_html(&card, &links)).into_response()
+        }
+    })
 }
 
 pub async fn locations(

--- a/crates/api-edr/src/handlers.rs
+++ b/crates/api-edr/src/handlers.rs
@@ -215,11 +215,18 @@ pub async fn landing_page(
     }))
 }
 
+/// OpenAPI `f` (output-format) query parameter, shared by the content-negotiated
+/// metadata endpoints (landing, conformance, collections, collection detail).
+fn format_parameter() -> serde_json::Value {
+    json!({"name": "f", "in": "query", "required": false, "schema": {"type": "string", "enum": ["json", "html"]},
+           "description": "Output format. 'json' (default) or 'html'; overrides the Accept header."})
+}
+
 /// OpenAPI `parameters` array for the OGC API – Common – Part 4 searchable
-/// `/collections` query parameters. Documented per the CLAUDE.md rule and
-/// Part 4 §5.5.
+/// `/collections` query parameters (plus the shared `f` format selector).
+/// Documented per the CLAUDE.md rule and Part 4 §5.5.
 fn searchable_collections_parameters() -> serde_json::Value {
-    json!([
+    let mut params = json!([
         {"name": "bbox", "in": "query", "required": false, "schema": {"type": "string"},
          "description": "Filter to collections intersecting this CRS84 bbox: 4 (or 6) comma-separated numbers west,south,east,north."},
         {"name": "bbox-crs", "in": "query", "required": false, "schema": {"type": "string"},
@@ -231,10 +238,13 @@ fn searchable_collections_parameters() -> serde_json::Value {
         {"name": "limit", "in": "query", "required": false, "schema": {"type": "integer", "minimum": 1, "maximum": 1000},
          "description": "Maximum number of collections per page (default 1000)."},
         {"name": "offset", "in": "query", "required": false, "schema": {"type": "integer", "minimum": 0},
-         "description": "Number of matching collections to skip (pagination cursor)."},
-        {"name": "f", "in": "query", "required": false, "schema": {"type": "string", "enum": ["json", "html"]},
-         "description": "Output format. 'json' (default) or 'html'; overrides the Accept header."}
-    ])
+         "description": "Number of matching collections to skip (pagination cursor)."}
+    ]);
+    params
+        .as_array_mut()
+        .expect("searchable params is a JSON array")
+        .push(format_parameter());
+    params
 }
 
 pub async fn api_definition(State(state): State<AppState>) -> impl IntoResponse {
@@ -264,6 +274,7 @@ pub async fn api_definition(State(state): State<AppState>) -> impl IntoResponse 
                 "summary": format!("Get {} collection metadata", config.title),
                 "operationId": format!("getCollection_{id}"),
                 "tags": [id],
+                "parameters": [format_parameter()],
                 "responses": {
                     "200": {"description": "Collection metadata"},
                     "404": {"description": "Collection not found"}
@@ -457,6 +468,7 @@ pub async fn api_definition(State(state): State<AppState>) -> impl IntoResponse 
             "get": {
                 "summary": "Landing page",
                 "operationId": "getLandingPage",
+                "parameters": [format_parameter()],
                 "responses": {
                     "200": {"description": "Landing page"}
                 }
@@ -466,6 +478,7 @@ pub async fn api_definition(State(state): State<AppState>) -> impl IntoResponse 
             "get": {
                 "summary": "Conformance classes",
                 "operationId": "getConformance",
+                "parameters": [format_parameter()],
                 "responses": {
                     "200": {"description": "Conformance classes"}
                 }

--- a/crates/api-edr/src/handlers.rs
+++ b/crates/api-edr/src/handlers.rs
@@ -90,9 +90,11 @@ fn negotiate(f: Option<&str>, headers: &HeaderMap) -> Result<ds_core::html::Want
 
 /// Tag a content-negotiated response with `Vary: Accept` so shared caches
 /// don't serve the JSON body to a client that asked for HTML (or vice versa).
+/// Uses `append` (not `insert`) so it never clobbers a `Vary` an upstream layer
+/// may have set (e.g. compression's `Vary: Accept-Encoding`).
 fn with_vary(mut resp: Response) -> Response {
     resp.headers_mut()
-        .insert(header::VARY, axum::http::HeaderValue::from_static("accept"));
+        .append(header::VARY, axum::http::HeaderValue::from_static("accept"));
     resp
 }
 

--- a/crates/api-edr/src/handlers.rs
+++ b/crates/api-edr/src/handlers.rs
@@ -763,6 +763,17 @@ pub async fn collections(
                     Some("Previous page"),
                 ));
             }
+            // rel="alternate" to the JSON representation, preserving the current
+            // bbox/datetime/q/limit/offset filters (parity with the other HTML
+            // metadata pages).
+            nav.push(LinkView::new(
+                format!(
+                    "{base}/edr/collections{}",
+                    sp.query_string_with_format(params.limit, params.offset, "json")
+                ),
+                "alternate",
+                Some("This page as JSON"),
+            ));
             Html(ds_core::html::collections_html("Collections", &cards, &nav)).into_response()
         }
     }))

--- a/crates/api-edr/src/handlers.rs
+++ b/crates/api-edr/src/handlers.rs
@@ -88,6 +88,14 @@ fn negotiate(f: Option<&str>, headers: &HeaderMap) -> Result<ds_core::html::Want
     ds_core::html::negotiate(f, accept).map_err(|e| bad_request_msg(&e.to_string()))
 }
 
+/// Tag a content-negotiated response with `Vary: Accept` so shared caches
+/// don't serve the JSON body to a client that asked for HTML (or vice versa).
+fn with_vary(mut resp: Response) -> Response {
+    resp.headers_mut()
+        .insert(header::VARY, axum::http::HeaderValue::from_static("accept"));
+    resp
+}
+
 /// Shared state for the EDR API: a registry of collection engines + metadata.
 #[derive(Clone)]
 pub struct EdrState {
@@ -188,7 +196,7 @@ pub async fn landing_page(
             "Collections",
         ),
     ];
-    Ok(match wanted {
+    Ok(with_vary(match wanted {
         Wanted::Json => {
             let json_links: Vec<_> = links
                 .iter()
@@ -204,7 +212,7 @@ pub async fn landing_page(
                 .collect();
             Html(ds_core::html::landing_html(title, description, &views)).into_response()
         }
-    })
+    }))
 }
 
 /// OpenAPI `parameters` array for the OGC API – Common – Part 4 searchable
@@ -597,10 +605,10 @@ pub async fn conformance(
         "http://www.opengis.net/spec/ogcapi-edr-1/1.1/conf/json",
         "http://www.opengis.net/spec/ogcapi-edr-1/1.1/conf/covjson",
     ];
-    Ok(match wanted {
+    Ok(with_vary(match wanted {
         Wanted::Json => Json(json!({ "conformsTo": classes })).into_response(),
         Wanted::Html => Html(ds_core::html::conformance_html(&classes)).into_response(),
-    })
+    }))
 }
 
 pub async fn collections(
@@ -661,7 +669,7 @@ pub async fn collections(
         )
     };
 
-    Ok(match wanted {
+    Ok(with_vary(match wanted {
         Wanted::Json => {
             let collections: Vec<serde_json::Value> =
                 result.page.iter().map(|&i| rows[i].5.clone()).collect();
@@ -721,7 +729,7 @@ pub async fn collections(
             }
             Html(ds_core::html::collections_html("Collections", &cards, &nav)).into_response()
         }
-    })
+    }))
 }
 
 pub async fn collection(
@@ -735,7 +743,7 @@ pub async fn collection(
     let state = state.load_full();
     let (engine, config) = lookup_collection(&state, &id)?;
     let base = &state.base_url;
-    Ok(match wanted {
+    Ok(with_vary(match wanted {
         Wanted::Json => {
             Json(build_collection_metadata(engine.as_ref(), config, base)).into_response()
         }
@@ -760,7 +768,7 @@ pub async fn collection(
             ];
             Html(ds_core::html::collection_html(&card, &links)).into_response()
         }
-    })
+    }))
 }
 
 pub async fn locations(

--- a/crates/api-edr/tests/spec_compliance_tests.rs
+++ b/crates/api-edr/tests/spec_compliance_tests.rs
@@ -288,11 +288,9 @@ async fn finding_05_collections_bbox_filtering() {
 // ===========================================================================
 // Spec: All endpoints should support `f` query parameter for content
 //   negotiation (e.g., f=json, f=html).
-// Implementation: No endpoint accepts or processes the `f` parameter.
-// Impact: Clients requesting specific output format via query param get
-//   no format negotiation.
-// Fix: Add `f` parameter support to all handlers, or at minimum accept
-//   and ignore it without returning an error.
+// RESOLVED (#296): the metadata endpoints (landing, /conformance, /collections,
+//   /collections/{id}) now negotiate `?f=json|html` + the Accept header and
+//   serve an HTML representation. See the `content_negotiation` tests below.
 
 #[tokio::test]
 async fn finding_06_landing_page_accepts_f_param() {
@@ -714,9 +712,9 @@ async fn finding_18_conformance_has_ogc_common_classes() {
     );
 }
 
-// OGC API - Common - Part 2: Geospatial Data (20-024). #291: /collections +
-// /collections/{id} satisfy the Collections + JSON classes structurally, so
-// they are advertised for discovery. The HTML class is intentionally omitted.
+// OGC API - Common - Part 2: Geospatial Data (20-024). /collections +
+// /collections/{id} satisfy the Collections + JSON classes; the HTML class is
+// now also declared (HTML representation served via ?f=html / Accept, #296).
 #[tokio::test]
 async fn declares_ogcapi_common_part2_classes() {
     let (_status, json) = get_json("/conformance").await;
@@ -733,8 +731,8 @@ async fn declares_ogcapi_common_part2_classes() {
         "must declare OGC API Common Part 2 JSON class"
     );
     assert!(
-        !has("ogcapi-common-2/1.0/conf/html"),
-        "must NOT declare the HTML class (no HTML /collections representation)"
+        has("ogcapi-common-2/1.0/conf/html"),
+        "must declare the HTML class (HTML representation served via ?f=html)"
     );
 }
 
@@ -1061,5 +1059,75 @@ mod part4_searchable {
         let (_, json) = get_json("/collections?q=zzznotaword").await;
         assert_eq!(json["numberReturned"], 0);
         assert!(json["collections"].as_array().unwrap().is_empty());
+    }
+}
+
+// ===========================================================================
+// Content negotiation — ?f=json|html + Accept (OGC API Common Part 2 conf/html)
+// ===========================================================================
+
+mod content_negotiation {
+    use super::*;
+
+    /// Raw request returning (status, content-type, body string).
+    async fn get_raw(uri: &str, accept: Option<&str>) -> (StatusCode, String, String) {
+        let mut builder = Request::builder().uri(uri);
+        if let Some(a) = accept {
+            builder = builder.header("accept", a);
+        }
+        let resp = app()
+            .oneshot(builder.body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        let status = resp.status();
+        let ct = resp
+            .headers()
+            .get("content-type")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("")
+            .to_string();
+        let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+        (status, ct, String::from_utf8_lossy(&bytes).to_string())
+    }
+
+    #[tokio::test]
+    async fn f_html_serves_html_on_all_metadata_endpoints() {
+        for uri in [
+            "/?f=html",
+            "/conformance?f=html",
+            "/collections?f=html",
+            "/collections/weather?f=html",
+        ] {
+            let (status, ct, body) = get_raw(uri, None).await;
+            assert_eq!(status, StatusCode::OK, "{uri}");
+            assert!(ct.starts_with("text/html"), "{uri}: content-type was {ct}");
+            assert!(body.contains("<!DOCTYPE html>"), "{uri}: not HTML");
+        }
+    }
+
+    #[tokio::test]
+    async fn f_json_serves_json() {
+        let (status, ct, _) = get_raw("/collections?f=json", None).await;
+        assert_eq!(status, StatusCode::OK);
+        assert!(ct.starts_with("application/json"), "content-type was {ct}");
+    }
+
+    #[tokio::test]
+    async fn accept_header_selects_html() {
+        let (status, ct, _) = get_raw("/collections", Some("text/html")).await;
+        assert_eq!(status, StatusCode::OK);
+        assert!(ct.starts_with("text/html"), "content-type was {ct}");
+    }
+
+    #[tokio::test]
+    async fn no_accept_defaults_to_json() {
+        let (_status, ct, _) = get_raw("/collections", None).await;
+        assert!(ct.starts_with("application/json"), "content-type was {ct}");
+    }
+
+    #[tokio::test]
+    async fn unknown_f_is_400() {
+        let (status, _, _) = get_raw("/collections?f=xml", None).await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
     }
 }

--- a/crates/api-edr/tests/spec_compliance_tests.rs
+++ b/crates/api-edr/tests/spec_compliance_tests.rs
@@ -1130,4 +1130,25 @@ mod content_negotiation {
         let (status, _, _) = get_raw("/collections?f=xml", None).await;
         assert_eq!(status, StatusCode::BAD_REQUEST);
     }
+
+    /// Negotiated responses carry `Vary: Accept` so shared caches don't serve
+    /// the wrong representation.
+    #[tokio::test]
+    async fn negotiated_responses_set_vary_accept() {
+        for uri in ["/collections", "/collections?f=html", "/conformance", "/"] {
+            let resp = app()
+                .oneshot(Request::builder().uri(uri).body(Body::empty()).unwrap())
+                .await
+                .unwrap();
+            let vary = resp
+                .headers()
+                .get("vary")
+                .and_then(|v| v.to_str().ok())
+                .unwrap_or("");
+            assert!(
+                vary.to_ascii_lowercase().contains("accept"),
+                "{uri}: missing Vary: Accept (got {vary:?})"
+            );
+        }
+    }
 }

--- a/crates/api-edr/tests/spec_compliance_tests.rs
+++ b/crates/api-edr/tests/spec_compliance_tests.rs
@@ -1135,7 +1135,13 @@ mod content_negotiation {
     /// the wrong representation.
     #[tokio::test]
     async fn negotiated_responses_set_vary_accept() {
-        for uri in ["/collections", "/collections?f=html", "/conformance", "/"] {
+        for uri in [
+            "/collections",
+            "/collections?f=html",
+            "/collections/weather",
+            "/conformance",
+            "/",
+        ] {
             let resp = app()
                 .oneshot(Request::builder().uri(uri).body(Body::empty()).unwrap())
                 .await

--- a/crates/api-features/src/handlers.rs
+++ b/crates/api-features/src/handlers.rs
@@ -78,6 +78,14 @@ fn negotiate(f: Option<&str>, headers: &HeaderMap) -> Result<ds_core::html::Want
     ds_core::html::negotiate(f, accept).map_err(|e| bad_request_msg(&e.to_string()))
 }
 
+/// Tag a content-negotiated response with `Vary: Accept` so shared caches
+/// don't serve the JSON body to a client that asked for HTML (or vice versa).
+fn with_vary(mut resp: Response) -> Response {
+    resp.headers_mut()
+        .insert(header::VARY, HeaderValue::from_static("accept"));
+    resp
+}
+
 pub async fn landing_page(
     State(state): State<AppState>,
     Query(fp): Query<ds_core::html::FormatParams>,
@@ -122,7 +130,7 @@ pub async fn landing_page(
             "Collections",
         ),
     ];
-    Ok(match wanted {
+    Ok(with_vary(match wanted {
         Wanted::Json => {
             let json_links: Vec<_> = links
                 .iter()
@@ -138,7 +146,7 @@ pub async fn landing_page(
                 .collect();
             Html(ds_core::html::landing_html(title, description, &views)).into_response()
         }
-    })
+    }))
 }
 
 pub async fn conformance(
@@ -169,10 +177,10 @@ pub async fn conformance(
         "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/oas30",
         "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/geojson",
     ];
-    Ok(match wanted {
+    Ok(with_vary(match wanted {
         Wanted::Json => Json(json!({ "conformsTo": classes })).into_response(),
         Wanted::Html => Html(ds_core::html::conformance_html(&classes)).into_response(),
-    })
+    }))
 }
 
 /// OpenAPI `parameters` array for the OGC API – Common – Part 4 searchable
@@ -478,7 +486,7 @@ pub async fn collections(
         )
     };
 
-    Ok(match wanted {
+    Ok(with_vary(match wanted {
         Wanted::Json => {
             let collections: Vec<serde_json::Value> =
                 result.page.iter().map(|&i| rows[i].4.clone()).collect();
@@ -540,7 +548,7 @@ pub async fn collections(
             }
             Html(ds_core::html::collections_html("Collections", &cards, &nav)).into_response()
         }
-    })
+    }))
 }
 
 pub async fn collection(
@@ -554,7 +562,7 @@ pub async fn collection(
     let state = state.load_full();
     let (engine, config) = lookup_collection(&state, &id)?;
     let base = &state.base_url;
-    Ok(match wanted {
+    Ok(with_vary(match wanted {
         Wanted::Json => {
             Json(build_collection_metadata(engine.as_ref(), config, base)).into_response()
         }
@@ -579,7 +587,7 @@ pub async fn collection(
             ];
             Html(ds_core::html::collection_html(&card, &links)).into_response()
         }
-    })
+    }))
 }
 
 pub async fn items(

--- a/crates/api-features/src/handlers.rs
+++ b/crates/api-features/src/handlers.rs
@@ -183,10 +183,17 @@ pub async fn conformance(
     }))
 }
 
+/// OpenAPI `f` (output-format) query parameter, shared by the content-negotiated
+/// metadata endpoints (landing, conformance, collections, collection detail).
+fn format_parameter() -> serde_json::Value {
+    json!({"name": "f", "in": "query", "required": false, "schema": {"type": "string", "enum": ["json", "html"]},
+           "description": "Output format. 'json' (default) or 'html'; overrides the Accept header."})
+}
+
 /// OpenAPI `parameters` array for the OGC API – Common – Part 4 searchable
-/// `/collections` query parameters.
+/// `/collections` query parameters (plus the shared `f` format selector).
 fn searchable_collections_parameters() -> serde_json::Value {
-    json!([
+    let mut params = json!([
         {"name": "bbox", "in": "query", "required": false, "schema": {"type": "string"},
          "description": "Filter to collections intersecting this CRS84 bbox: 4 (or 6) comma-separated numbers west,south,east,north."},
         {"name": "bbox-crs", "in": "query", "required": false, "schema": {"type": "string"},
@@ -198,10 +205,13 @@ fn searchable_collections_parameters() -> serde_json::Value {
         {"name": "limit", "in": "query", "required": false, "schema": {"type": "integer", "minimum": 1, "maximum": 1000},
          "description": "Maximum number of collections per page (default 1000)."},
         {"name": "offset", "in": "query", "required": false, "schema": {"type": "integer", "minimum": 0},
-         "description": "Number of matching collections to skip (pagination cursor)."},
-        {"name": "f", "in": "query", "required": false, "schema": {"type": "string", "enum": ["json", "html"]},
-         "description": "Output format. 'json' (default) or 'html'; overrides the Accept header."}
-    ])
+         "description": "Number of matching collections to skip (pagination cursor)."}
+    ]);
+    params
+        .as_array_mut()
+        .expect("searchable params is a JSON array")
+        .push(format_parameter());
+    params
 }
 
 pub async fn api_definition(State(state): State<AppState>) -> impl IntoResponse {
@@ -222,6 +232,7 @@ pub async fn api_definition(State(state): State<AppState>) -> impl IntoResponse 
                 "summary": format!("Get {} collection metadata", config.title),
                 "operationId": format!("getCollection_{id}"),
                 "tags": [id],
+                "parameters": [format_parameter()],
                 "responses": {
                     "200": {
                         "description": "Collection metadata",
@@ -292,6 +303,7 @@ pub async fn api_definition(State(state): State<AppState>) -> impl IntoResponse 
             "get": {
                 "summary": "Landing page",
                 "operationId": "getLandingPage",
+                "parameters": [format_parameter()],
                 "responses": {
                     "200": {"description": "Landing page"}
                 }
@@ -301,6 +313,7 @@ pub async fn api_definition(State(state): State<AppState>) -> impl IntoResponse 
             "get": {
                 "summary": "Conformance classes",
                 "operationId": "getConformance",
+                "parameters": [format_parameter()],
                 "responses": {
                     "200": {"description": "Conformance classes"}
                 }

--- a/crates/api-features/src/handlers.rs
+++ b/crates/api-features/src/handlers.rs
@@ -142,21 +142,31 @@ pub async fn landing_page(
                 .into_response()
         }
         Wanted::Html => {
-            let views: Vec<LinkView> = links
+            let mut views: Vec<LinkView> = links
                 .iter()
                 .map(|(h, r, _, ti)| LinkView::new(h.clone(), *r, Some(ti)))
                 .collect();
+            // rel="alternate" to the JSON representation (parity with the
+            // collection-detail HTML page).
+            views.push(LinkView::new(
+                format!("{base}/features/?f=json"),
+                "alternate",
+                Some("This document as JSON"),
+            ));
             Html(ds_core::html::landing_html(title, description, &views)).into_response()
         }
     }))
 }
 
 pub async fn conformance(
+    State(state): State<AppState>,
     Query(fp): Query<ds_core::html::FormatParams>,
     headers: HeaderMap,
 ) -> Result<Response, HandlerError> {
-    use ds_core::html::Wanted;
+    use ds_core::html::{LinkView, Wanted};
     let wanted = negotiate(fp.f.as_deref(), &headers)?;
+    let state = state.load_full();
+    let base = &state.base_url;
     let classes = [
         // OGC API – Common – Part 1: Core and Part 2: Geospatial Data. The
         // Features landing page, /conformance, /api, and
@@ -181,7 +191,17 @@ pub async fn conformance(
     ];
     Ok(with_vary(match wanted {
         Wanted::Json => Json(json!({ "conformsTo": classes })).into_response(),
-        Wanted::Html => Html(ds_core::html::conformance_html(&classes)).into_response(),
+        Wanted::Html => {
+            let nav = [
+                LinkView::new(format!("{base}/features/"), "up", Some("Landing page")),
+                LinkView::new(
+                    format!("{base}/features/conformance?f=json"),
+                    "alternate",
+                    Some("This document as JSON"),
+                ),
+            ];
+            Html(ds_core::html::conformance_html(&classes, &nav)).into_response()
+        }
     }))
 }
 

--- a/crates/api-features/src/handlers.rs
+++ b/crates/api-features/src/handlers.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use arc_swap::ArcSwap;
 use axum::extract::{Path, Query, State};
 use axum::http::{header, HeaderMap, HeaderValue, StatusCode};
-use axum::response::IntoResponse;
+use axum::response::{Html, IntoResponse, Response};
 use axum::Json;
 use chrono::Utc;
 use serde_json::json;
@@ -62,71 +62,117 @@ fn lookup_collection<'a>(
     Ok((engine, config))
 }
 
-pub async fn landing_page(State(state): State<AppState>) -> impl IntoResponse {
-    let state = state.load_full();
-    let base = &state.base_url;
-    Json(json!({
-        "title": "MeteoCore - Features",
-        "description": "Metocean Data Server — OGC API Features",
-        "links": [
-            {
-                "href": format!("{base}/features/"),
-                "rel": "self",
-                "type": "application/json",
-                "title": "This document"
-            },
-            {
-                "href": format!("{base}/features/api"),
-                "rel": "service-desc",
-                "type": "application/vnd.oai.openapi+json;version=3.0",
-                "title": "API definition"
-            },
-            {
-                "href": format!("{base}/features/api/docs"),
-                "rel": "service-doc",
-                "type": "text/html",
-                "title": "API documentation"
-            },
-            {
-                "href": format!("{base}/features/conformance"),
-                "rel": "conformance",
-                "type": "application/json",
-                "title": "Conformance classes"
-            },
-            {
-                "href": format!("{base}/features/collections"),
-                "rel": "data",
-                "type": "application/json",
-                "title": "Collections"
-            }
-        ]
-    }))
+type HandlerError = (StatusCode, Json<serde_json::Value>);
+
+/// A 400 from a plain message (used for `?f=` content negotiation errors).
+fn bad_request_msg(msg: &str) -> HandlerError {
+    (
+        StatusCode::BAD_REQUEST,
+        Json(json!({ "code": "BadRequest", "description": msg })),
+    )
 }
 
-pub async fn conformance() -> impl IntoResponse {
-    Json(json!({
-        "conformsTo": [
-            // OGC API – Common – Part 1: Core and Part 2: Geospatial Data. The
-            // Features landing page, /conformance, /api, and
-            // /collections{,/{id}} satisfy these structurally — the same
-            // declaration #292 added for Maps and Tiles. The HTML class
-            // (.../conf/html) is omitted — there is no HTML representation of
-            // /collections yet.
-            "http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/core",
-            "http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/landing-page",
-            "http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/oas30",
-            "http://www.opengis.net/spec/ogcapi-common-2/1.0/conf/collections",
-            "http://www.opengis.net/spec/ogcapi-common-2/1.0/conf/json",
-            // OGC API - Common - Part 4 (Discovery within many collections,
-            // draft 25-046): /collections supports bbox/bbox-crs/datetime/q/
-            // limit filtering + offset pagination. Builds on the Common Part 2
-            // "collections" class declared just above.
-            "http://www.opengis.net/spec/ogcapi-common-4/1.0/conf/searchable-collections",
-            "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/core",
-            "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/oas30",
-            "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/geojson"
-        ]
-    }))
+/// Resolve the requested representation from `?f=` + the `Accept` header.
+fn negotiate(f: Option<&str>, headers: &HeaderMap) -> Result<ds_core::html::Wanted, HandlerError> {
+    let accept = headers.get(header::ACCEPT).and_then(|v| v.to_str().ok());
+    ds_core::html::negotiate(f, accept).map_err(|e| bad_request_msg(&e.to_string()))
+}
+
+pub async fn landing_page(
+    State(state): State<AppState>,
+    Query(fp): Query<ds_core::html::FormatParams>,
+    headers: HeaderMap,
+) -> Result<Response, HandlerError> {
+    use ds_core::html::{LinkView, Wanted};
+    let wanted = negotiate(fp.f.as_deref(), &headers)?;
+    let state = state.load_full();
+    let base = &state.base_url;
+    let title = "MeteoCore - Features";
+    let description = "Metocean Data Server — OGC API Features";
+    // (href, rel, type, title) — one source for both representations.
+    let links = [
+        (
+            format!("{base}/features/"),
+            "self",
+            "application/json",
+            "This document",
+        ),
+        (
+            format!("{base}/features/api"),
+            "service-desc",
+            "application/vnd.oai.openapi+json;version=3.0",
+            "API definition",
+        ),
+        (
+            format!("{base}/features/api/docs"),
+            "service-doc",
+            "text/html",
+            "API documentation",
+        ),
+        (
+            format!("{base}/features/conformance"),
+            "conformance",
+            "application/json",
+            "Conformance classes",
+        ),
+        (
+            format!("{base}/features/collections"),
+            "data",
+            "application/json",
+            "Collections",
+        ),
+    ];
+    Ok(match wanted {
+        Wanted::Json => {
+            let json_links: Vec<_> = links
+                .iter()
+                .map(|(h, r, t, ti)| json!({ "href": h, "rel": r, "type": t, "title": ti }))
+                .collect();
+            Json(json!({ "title": title, "description": description, "links": json_links }))
+                .into_response()
+        }
+        Wanted::Html => {
+            let views: Vec<LinkView> = links
+                .iter()
+                .map(|(h, r, _, ti)| LinkView::new(h.clone(), *r, Some(ti)))
+                .collect();
+            Html(ds_core::html::landing_html(title, description, &views)).into_response()
+        }
+    })
+}
+
+pub async fn conformance(
+    Query(fp): Query<ds_core::html::FormatParams>,
+    headers: HeaderMap,
+) -> Result<Response, HandlerError> {
+    use ds_core::html::Wanted;
+    let wanted = negotiate(fp.f.as_deref(), &headers)?;
+    let classes = [
+        // OGC API – Common – Part 1: Core and Part 2: Geospatial Data. The
+        // Features landing page, /conformance, /api, and
+        // /collections{,/{id}} satisfy these structurally — the same
+        // declaration #292 added for Maps and Tiles. The HTML class
+        // (.../conf/html) is now declared — the HTML representation of the
+        // metadata endpoints is served via `?f=html` / Accept.
+        "http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/core",
+        "http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/landing-page",
+        "http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/oas30",
+        "http://www.opengis.net/spec/ogcapi-common-2/1.0/conf/collections",
+        "http://www.opengis.net/spec/ogcapi-common-2/1.0/conf/json",
+        "http://www.opengis.net/spec/ogcapi-common-2/1.0/conf/html",
+        // OGC API - Common - Part 4 (Discovery within many collections,
+        // draft 25-046): /collections supports bbox/bbox-crs/datetime/q/
+        // limit filtering + offset pagination. Builds on the Common Part 2
+        // "collections" class declared just above.
+        "http://www.opengis.net/spec/ogcapi-common-4/1.0/conf/searchable-collections",
+        "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/core",
+        "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/oas30",
+        "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/geojson",
+    ];
+    Ok(match wanted {
+        Wanted::Json => Json(json!({ "conformsTo": classes })).into_response(),
+        Wanted::Html => Html(ds_core::html::conformance_html(&classes)).into_response(),
+    })
 }
 
 /// OpenAPI `parameters` array for the OGC API – Common – Part 4 searchable
@@ -144,7 +190,9 @@ fn searchable_collections_parameters() -> serde_json::Value {
         {"name": "limit", "in": "query", "required": false, "schema": {"type": "integer", "minimum": 1, "maximum": 1000},
          "description": "Maximum number of collections per page (default 1000)."},
         {"name": "offset", "in": "query", "required": false, "schema": {"type": "integer", "minimum": 0},
-         "description": "Number of matching collections to skip (pagination cursor)."}
+         "description": "Number of matching collections to skip (pagination cursor)."},
+        {"name": "f", "in": "query", "required": false, "schema": {"type": "string", "enum": ["json", "html"]},
+         "description": "Output format. 'json' (default) or 'html'; overrides the Accept header."}
     ])
 }
 
@@ -375,15 +423,13 @@ pub async fn api_docs(State(state): State<AppState>) -> impl IntoResponse {
 pub async fn collections(
     State(state): State<AppState>,
     Query(sp): Query<ds_core::collection_search::SearchQueryParams>,
-) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
+    headers: HeaderMap,
+) -> Result<Response, HandlerError> {
     use ds_core::collection_search::{search, CollectionMatch};
+    use ds_core::html::Wanted;
 
-    let params = sp.parse().map_err(|e| {
-        (
-            StatusCode::BAD_REQUEST,
-            Json(json!({ "code": "BadRequest", "description": e.to_string() })),
-        )
-    })?;
+    let wanted = negotiate(sp.f.as_deref(), &headers)?;
+    let params = sp.parse().map_err(|e| bad_request_msg(&e.to_string()))?;
     let state = state.load_full();
     let base = &state.base_url;
 
@@ -425,48 +471,115 @@ pub async fn collections(
         })
         .collect();
     let result = search(&matches, &params);
-    let collections: Vec<serde_json::Value> =
-        result.page.iter().map(|&i| rows[i].4.clone()).collect();
-    let number_returned = collections.len();
-
-    let link = |rel: &str, offset: usize, title: Option<&str>| {
-        let mut o = json!({
-            "href": format!("{base}/features/collections{}", sp.query_string(params.limit, offset)),
-            "rel": rel,
-            "type": "application/json"
-        });
-        if let Some(t) = title {
-            o["title"] = json!(t);
-        }
-        o
+    let href = |offset| {
+        format!(
+            "{base}/features/collections{}",
+            sp.query_string(params.limit, offset)
+        )
     };
-    let mut links = vec![link("self", params.offset, None)];
-    if result.has_next {
-        links.push(link("next", result.next_offset, Some("Next page")));
-    }
-    if result.has_prev {
-        links.push(link("prev", result.prev_offset, Some("Previous page")));
-    }
 
-    Ok(Json(json!({
-        "collections": collections,
-        "numberMatched": result.number_matched,
-        "numberReturned": number_returned,
-        "links": links
-    })))
+    Ok(match wanted {
+        Wanted::Json => {
+            let collections: Vec<serde_json::Value> =
+                result.page.iter().map(|&i| rows[i].4.clone()).collect();
+            let number_returned = collections.len();
+
+            let link = |rel: &str, offset: usize, title: Option<&str>| {
+                let mut o = json!({ "href": href(offset), "rel": rel, "type": "application/json" });
+                if let Some(t) = title {
+                    o["title"] = json!(t);
+                }
+                o
+            };
+            let mut links = vec![link("self", params.offset, None)];
+            if result.has_next {
+                links.push(link("next", result.next_offset, Some("Next page")));
+            }
+            if result.has_prev {
+                links.push(link("prev", result.prev_offset, Some("Previous page")));
+            }
+
+            Json(json!({
+                "collections": collections,
+                "numberMatched": result.number_matched,
+                "numberReturned": number_returned,
+                "links": links
+            }))
+            .into_response()
+        }
+        Wanted::Html => {
+            use ds_core::html::{CollectionCard, LinkView};
+            let cards: Vec<CollectionCard> = result
+                .page
+                .iter()
+                .map(|&i| CollectionCard {
+                    id: rows[i].0.clone(),
+                    title: rows[i].1.clone(),
+                    description: rows[i].2.clone(),
+                    self_href: format!("{base}/features/collections/{}", rows[i].0),
+                })
+                .collect();
+            let mut nav = vec![LinkView::new(
+                href(params.offset),
+                "self",
+                Some("This page"),
+            )];
+            if result.has_next {
+                nav.push(LinkView::new(
+                    href(result.next_offset),
+                    "next",
+                    Some("Next page"),
+                ));
+            }
+            if result.has_prev {
+                nav.push(LinkView::new(
+                    href(result.prev_offset),
+                    "prev",
+                    Some("Previous page"),
+                ));
+            }
+            Html(ds_core::html::collections_html("Collections", &cards, &nav)).into_response()
+        }
+    })
 }
 
 pub async fn collection(
     Path(id): Path<String>,
     State(state): State<AppState>,
-) -> Result<impl IntoResponse, (StatusCode, Json<serde_json::Value>)> {
+    Query(fp): Query<ds_core::html::FormatParams>,
+    headers: HeaderMap,
+) -> Result<Response, HandlerError> {
+    use ds_core::html::{CollectionCard, LinkView, Wanted};
+    let wanted = negotiate(fp.f.as_deref(), &headers)?;
     let state = state.load_full();
     let (engine, config) = lookup_collection(&state, &id)?;
-    Ok(Json(build_collection_metadata(
-        engine.as_ref(),
-        config,
-        &state.base_url,
-    )))
+    let base = &state.base_url;
+    Ok(match wanted {
+        Wanted::Json => {
+            Json(build_collection_metadata(engine.as_ref(), config, base)).into_response()
+        }
+        Wanted::Html => {
+            let card = CollectionCard {
+                id: config.id.clone(),
+                title: config.title.clone(),
+                description: config.description.clone(),
+                self_href: format!("{base}/features/collections/{}", config.id),
+            };
+            let links = [
+                LinkView::new(
+                    format!("{base}/features/collections/{}?f=json", config.id),
+                    "alternate",
+                    Some("JSON"),
+                ),
+                LinkView::new(
+                    format!("{base}/features/collections"),
+                    "collection",
+                    Some("All collections"),
+                ),
+            ];
+            Html(ds_core::html::collection_html(&card, &links)).into_response()
+        }
+    })
 }
 
 pub async fn items(

--- a/crates/api-features/src/handlers.rs
+++ b/crates/api-features/src/handlers.rs
@@ -81,8 +81,10 @@ fn negotiate(f: Option<&str>, headers: &HeaderMap) -> Result<ds_core::html::Want
 /// Tag a content-negotiated response with `Vary: Accept` so shared caches
 /// don't serve the JSON body to a client that asked for HTML (or vice versa).
 fn with_vary(mut resp: Response) -> Response {
+    // `append` (not `insert`) so a `Vary` set upstream (e.g. compression's
+    // `Vary: Accept-Encoding`) isn't clobbered.
     resp.headers_mut()
-        .insert(header::VARY, HeaderValue::from_static("accept"));
+        .append(header::VARY, HeaderValue::from_static("accept"));
     resp
 }
 

--- a/crates/api-features/src/handlers.rs
+++ b/crates/api-features/src/handlers.rs
@@ -581,6 +581,17 @@ pub async fn collections(
                     Some("Previous page"),
                 ));
             }
+            // rel="alternate" to the JSON representation, preserving the current
+            // bbox/datetime/q/limit/offset filters (parity with the other HTML
+            // metadata pages).
+            nav.push(LinkView::new(
+                format!(
+                    "{base}/features/collections{}",
+                    sp.query_string_with_format(params.limit, params.offset, "json")
+                ),
+                "alternate",
+                Some("This page as JSON"),
+            ));
             Html(ds_core::html::collections_html("Collections", &cards, &nav)).into_response()
         }
     }))

--- a/crates/api-features/tests/ogc_features_api_tests.rs
+++ b/crates/api-features/tests/ogc_features_api_tests.rs
@@ -796,9 +796,13 @@ mod part4_searchable {
 mod content_negotiation {
     use super::*;
 
-    async fn get_raw(uri: &str) -> (StatusCode, String, String) {
+    async fn get_raw(uri: &str, accept: Option<&str>) -> (StatusCode, String, String) {
+        let mut builder = Request::builder().uri(uri);
+        if let Some(a) = accept {
+            builder = builder.header("accept", a);
+        }
         let resp = build_router()
-            .oneshot(Request::builder().uri(uri).body(Body::empty()).unwrap())
+            .oneshot(builder.body(Body::empty()).unwrap())
             .await
             .unwrap();
         let status = resp.status();
@@ -814,7 +818,7 @@ mod content_negotiation {
 
     #[tokio::test]
     async fn f_html_serves_html() {
-        let (status, ct, body) = get_raw("/collections?f=html").await;
+        let (status, ct, body) = get_raw("/collections?f=html", None).await;
         assert_eq!(status, StatusCode::OK);
         assert!(ct.starts_with("text/html"), "content-type was {ct}");
         assert!(body.contains("<!DOCTYPE html>"));
@@ -822,14 +826,42 @@ mod content_negotiation {
 
     #[tokio::test]
     async fn collection_detail_serves_html() {
-        let (status, ct, _) = get_raw("/collections/cities?f=html").await;
+        let (status, ct, _) = get_raw("/collections/cities?f=html", None).await;
         assert_eq!(status, StatusCode::OK);
         assert!(ct.starts_with("text/html"), "content-type was {ct}");
     }
 
     #[tokio::test]
     async fn unknown_f_is_400() {
-        let (status, _, _) = get_raw("/collections?f=xml").await;
+        let (status, _, _) = get_raw("/collections?f=xml", None).await;
         assert_eq!(status, StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn accept_header_selects_html() {
+        let (status, ct, _) = get_raw("/collections", Some("text/html")).await;
+        assert_eq!(status, StatusCode::OK);
+        assert!(ct.starts_with("text/html"), "content-type was {ct}");
+    }
+
+    /// Negotiated responses carry `Vary: Accept` so shared caches don't serve
+    /// the wrong representation.
+    #[tokio::test]
+    async fn negotiated_responses_set_vary_accept() {
+        for uri in ["/collections", "/collections?f=html", "/conformance", "/"] {
+            let resp = build_router()
+                .oneshot(Request::builder().uri(uri).body(Body::empty()).unwrap())
+                .await
+                .unwrap();
+            let vary = resp
+                .headers()
+                .get("vary")
+                .and_then(|v| v.to_str().ok())
+                .unwrap_or("");
+            assert!(
+                vary.to_ascii_lowercase().contains("accept"),
+                "{uri}: missing Vary: Accept (got {vary:?})"
+            );
+        }
     }
 }

--- a/crates/api-features/tests/ogc_features_api_tests.rs
+++ b/crates/api-features/tests/ogc_features_api_tests.rs
@@ -789,3 +789,47 @@ mod part4_searchable {
         assert_eq!(status, StatusCode::BAD_REQUEST);
     }
 }
+
+// ---------------------------------------------------------------------------
+// Content negotiation — ?f=json|html (OGC API Common Part 2 conf/html, #296)
+// ---------------------------------------------------------------------------
+mod content_negotiation {
+    use super::*;
+
+    async fn get_raw(uri: &str) -> (StatusCode, String, String) {
+        let resp = build_router()
+            .oneshot(Request::builder().uri(uri).body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        let status = resp.status();
+        let ct = resp
+            .headers()
+            .get("content-type")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("")
+            .to_string();
+        let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+        (status, ct, String::from_utf8_lossy(&bytes).to_string())
+    }
+
+    #[tokio::test]
+    async fn f_html_serves_html() {
+        let (status, ct, body) = get_raw("/collections?f=html").await;
+        assert_eq!(status, StatusCode::OK);
+        assert!(ct.starts_with("text/html"), "content-type was {ct}");
+        assert!(body.contains("<!DOCTYPE html>"));
+    }
+
+    #[tokio::test]
+    async fn collection_detail_serves_html() {
+        let (status, ct, _) = get_raw("/collections/cities?f=html").await;
+        assert_eq!(status, StatusCode::OK);
+        assert!(ct.starts_with("text/html"), "content-type was {ct}");
+    }
+
+    #[tokio::test]
+    async fn unknown_f_is_400() {
+        let (status, _, _) = get_raw("/collections?f=xml").await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+    }
+}

--- a/crates/api-features/tests/ogc_features_api_tests.rs
+++ b/crates/api-features/tests/ogc_features_api_tests.rs
@@ -848,7 +848,13 @@ mod content_negotiation {
     /// the wrong representation.
     #[tokio::test]
     async fn negotiated_responses_set_vary_accept() {
-        for uri in ["/collections", "/collections?f=html", "/conformance", "/"] {
+        for uri in [
+            "/collections",
+            "/collections?f=html",
+            "/collections/cities",
+            "/conformance",
+            "/",
+        ] {
             let resp = build_router()
                 .oneshot(Request::builder().uri(uri).body(Body::empty()).unwrap())
                 .await

--- a/crates/api-maps/src/handlers.rs
+++ b/crates/api-maps/src/handlers.rs
@@ -274,10 +274,17 @@ pub async fn landing_page(
                 .into_response()
         }
         Wanted::Html => {
-            let views: Vec<LinkView> = links
+            let mut views: Vec<LinkView> = links
                 .iter()
                 .map(|(h, r, _, ti)| LinkView::new(h.clone(), *r, Some(ti)))
                 .collect();
+            // rel="alternate" to the JSON representation (parity with the
+            // collection-detail HTML page).
+            views.push(LinkView::new(
+                format!("{base}/maps/?f=json"),
+                "alternate",
+                Some("This document as JSON"),
+            ));
             Html(ds_core::html::landing_html(title, description, &views)).into_response()
         }
     }))
@@ -627,11 +634,14 @@ pub async fn api_docs(State(state): State<AppState>) -> impl IntoResponse {
 
 /// GET /maps/conformance
 pub async fn conformance(
+    State(state): State<AppState>,
     Query(fp): Query<ds_core::html::FormatParams>,
     headers: HeaderMap,
 ) -> Result<Response, MapsError> {
-    use ds_core::html::Wanted;
+    use ds_core::html::{LinkView, Wanted};
     let wanted = negotiate(fp.f.as_deref(), &headers)?;
+    let state = state.load_full();
+    let base = &state.base_url;
     let classes = [
         // OGC API - Common - Part 1: Core (landing page, /conformance,
         // /api) and Part 2: Geospatial Data (/collections + /collections/
@@ -668,7 +678,17 @@ pub async fn conformance(
     ];
     Ok(with_vary(match wanted {
         Wanted::Json => Json(json!({ "conformsTo": classes })).into_response(),
-        Wanted::Html => Html(ds_core::html::conformance_html(&classes)).into_response(),
+        Wanted::Html => {
+            let nav = [
+                LinkView::new(format!("{base}/maps/"), "up", Some("Landing page")),
+                LinkView::new(
+                    format!("{base}/maps/conformance?f=json"),
+                    "alternate",
+                    Some("This document as JSON"),
+                ),
+            ];
+            Html(ds_core::html::conformance_html(&classes, &nav)).into_response()
+        }
     }))
 }
 

--- a/crates/api-maps/src/handlers.rs
+++ b/crates/api-maps/src/handlers.rs
@@ -80,7 +80,9 @@ fn negotiate(f: Option<&str>, headers: &HeaderMap) -> Result<ds_core::html::Want
 /// Tag a content-negotiated response with `Vary: Accept` so shared caches
 /// don't serve the JSON body to a client that asked for HTML (or vice versa).
 fn with_vary(mut resp: Response) -> Response {
-    resp.headers_mut().insert(
+    // `append` (not `insert`) so a `Vary` set upstream (e.g. compression's
+    // `Vary: Accept-Encoding`) isn't clobbered.
+    resp.headers_mut().append(
         axum::http::header::VARY,
         axum::http::HeaderValue::from_static("accept"),
     );

--- a/crates/api-maps/src/handlers.rs
+++ b/crates/api-maps/src/handlers.rs
@@ -814,6 +814,17 @@ pub async fn collections(
                     Some("Previous page"),
                 ));
             }
+            // rel="alternate" to the JSON representation, preserving the current
+            // bbox/datetime/q/limit/offset filters (parity with the other HTML
+            // metadata pages).
+            nav.push(LinkView::new(
+                format!(
+                    "{base}/maps/collections{}",
+                    sp.query_string_with_format(params.limit, params.offset, "json")
+                ),
+                "alternate",
+                Some("This page as JSON"),
+            ));
             Html(ds_core::html::collections_html("Collections", &cards, &nav)).into_response()
         }
     }))

--- a/crates/api-maps/src/handlers.rs
+++ b/crates/api-maps/src/handlers.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use arc_swap::ArcSwap;
 use axum::extract::{Path, Query, State};
 use axum::http::{header, HeaderMap, StatusCode};
-use axum::response::IntoResponse;
+use axum::response::{Html, IntoResponse, Response};
 use axum::Json;
 use serde_json::json;
 
@@ -67,6 +67,14 @@ fn cache_control_value(has_explicit_time: bool) -> &'static str {
     } else {
         "public, max-age=60, must-revalidate"
     }
+}
+
+/// Resolve the requested representation from `?f=` + the `Accept` header.
+fn negotiate(f: Option<&str>, headers: &HeaderMap) -> Result<ds_core::html::Wanted, MapsError> {
+    let accept = headers
+        .get(axum::http::header::ACCEPT)
+        .and_then(|v| v.to_str().ok());
+    ds_core::html::negotiate(f, accept).map_err(|e| MapsError::BadRequest(e.to_string()))
 }
 
 fn build_collection_metadata(
@@ -200,45 +208,67 @@ fn build_extent(info: &ds_core::map_engine::RasterInfo) -> Option<serde_json::Va
 // ---------------------------------------------------------------------------
 
 /// GET /maps/ — Landing page
-pub async fn landing_page(State(state): State<AppState>) -> impl IntoResponse {
+pub async fn landing_page(
+    State(state): State<AppState>,
+    Query(fp): Query<ds_core::html::FormatParams>,
+    headers: HeaderMap,
+) -> Result<Response, MapsError> {
+    use ds_core::html::{LinkView, Wanted};
+    let wanted = negotiate(fp.f.as_deref(), &headers)?;
     let state = state.load_full();
     let base = &state.base_url;
-    Json(json!({
-        "title": "MeteoCore - Maps",
-        "description": "Metocean Data Server — OGC API Maps",
-        "links": [
-            {
-                "href": format!("{base}/maps/"),
-                "rel": "self",
-                "type": "application/json",
-                "title": "This document"
-            },
-            {
-                "href": format!("{base}/maps/api"),
-                "rel": "service-desc",
-                "type": "application/vnd.oai.openapi+json;version=3.0",
-                "title": "API definition"
-            },
-            {
-                "href": format!("{base}/maps/api/docs"),
-                "rel": "service-doc",
-                "type": "text/html",
-                "title": "API documentation"
-            },
-            {
-                "href": format!("{base}/maps/conformance"),
-                "rel": "conformance",
-                "type": "application/json",
-                "title": "Conformance classes"
-            },
-            {
-                "href": format!("{base}/maps/collections"),
-                "rel": "data",
-                "type": "application/json",
-                "title": "Collections"
-            }
-        ]
-    }))
+    let title = "MeteoCore - Maps";
+    let description = "Metocean Data Server — OGC API Maps";
+    // (href, rel, type, title) — one source for both representations.
+    let links = [
+        (
+            format!("{base}/maps/"),
+            "self",
+            "application/json",
+            "This document",
+        ),
+        (
+            format!("{base}/maps/api"),
+            "service-desc",
+            "application/vnd.oai.openapi+json;version=3.0",
+            "API definition",
+        ),
+        (
+            format!("{base}/maps/api/docs"),
+            "service-doc",
+            "text/html",
+            "API documentation",
+        ),
+        (
+            format!("{base}/maps/conformance"),
+            "conformance",
+            "application/json",
+            "Conformance classes",
+        ),
+        (
+            format!("{base}/maps/collections"),
+            "data",
+            "application/json",
+            "Collections",
+        ),
+    ];
+    Ok(match wanted {
+        Wanted::Json => {
+            let json_links: Vec<_> = links
+                .iter()
+                .map(|(h, r, t, ti)| json!({ "href": h, "rel": r, "type": t, "title": ti }))
+                .collect();
+            Json(json!({ "title": title, "description": description, "links": json_links }))
+                .into_response()
+        }
+        Wanted::Html => {
+            let views: Vec<LinkView> = links
+                .iter()
+                .map(|(h, r, _, ti)| LinkView::new(h.clone(), *r, Some(ti)))
+                .collect();
+            Html(ds_core::html::landing_html(title, description, &views)).into_response()
+        }
+    })
 }
 
 /// OpenAPI `parameters` array for the OGC API – Common – Part 4 searchable
@@ -256,7 +286,9 @@ fn searchable_collections_parameters() -> serde_json::Value {
         {"name": "limit", "in": "query", "required": false, "schema": {"type": "integer", "minimum": 1, "maximum": 1000},
          "description": "Maximum number of collections per page (default 1000)."},
         {"name": "offset", "in": "query", "required": false, "schema": {"type": "integer", "minimum": 0},
-         "description": "Number of matching collections to skip (pagination cursor)."}
+         "description": "Number of matching collections to skip (pagination cursor)."},
+        {"name": "f", "in": "query", "required": false, "schema": {"type": "string", "enum": ["json", "html"]},
+         "description": "Output format. 'json' (default) or 'html'; overrides the Accept header."}
     ])
 }
 
@@ -569,50 +601,62 @@ pub async fn api_docs(State(state): State<AppState>) -> impl IntoResponse {
 }
 
 /// GET /maps/conformance
-pub async fn conformance() -> impl IntoResponse {
-    Json(json!({
-        "conformsTo": [
-            // OGC API - Common - Part 1: Core (landing page, /conformance,
-            // /api) and Part 2: Geospatial Data (/collections + /collections/
-            // {id}, JSON). Both are satisfied structurally; the HTML class
-            // (.../common-2/.../conf/html) is omitted — no HTML /collections.
-            "http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/core",
-            "http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/landing-page",
-            "http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/oas30",
-            "http://www.opengis.net/spec/ogcapi-common-2/1.0/conf/collections",
-            "http://www.opengis.net/spec/ogcapi-common-2/1.0/conf/json",
-            // OGC API - Common - Part 4 (Discovery within many collections,
-            // draft 25-046): /collections supports bbox/bbox-crs/datetime/q/
-            // limit filtering + offset pagination.
-            "http://www.opengis.net/spec/ogcapi-common-4/1.0/conf/searchable-collections",
-            "http://www.opengis.net/spec/ogcapi-maps-1/1.0/conf/core",
-            "http://www.opengis.net/spec/ogcapi-maps-1/1.0/conf/collection-map",
-            "http://www.opengis.net/spec/ogcapi-maps-1/1.0/conf/styled-map",
-            "http://www.opengis.net/spec/ogcapi-maps-1/1.0/conf/spatial-subsetting",
-            "http://www.opengis.net/spec/ogcapi-maps-1/1.0/conf/scaling",
-            "http://www.opengis.net/spec/ogcapi-maps-1/1.0/conf/datetime",
-            "http://www.opengis.net/spec/ogcapi-maps-1/1.0/conf/crs",
-            "http://www.opengis.net/spec/ogcapi-maps-1/1.0/conf/png",
-            "http://www.opengis.net/spec/ogcapi-maps-1/1.0/conf/jpeg"
-            // NOTE: the OGC API Maps "Map Tilesets" class
-            // (.../conf/tilesets) is intentionally NOT declared. Its abstract
-            // tests require maps-native /collections/{id}/map/tiles endpoints,
-            // which we don't implement — raster tiles are served by the
-            // standalone OGC API Tiles service and merely *discovered* from a
-            // maps collection via the `tilesets-map` link relation. Declaring
-            // the class without the endpoints would be a false conformance
-            // claim.
-        ]
-    }))
+pub async fn conformance(
+    Query(fp): Query<ds_core::html::FormatParams>,
+    headers: HeaderMap,
+) -> Result<Response, MapsError> {
+    use ds_core::html::Wanted;
+    let wanted = negotiate(fp.f.as_deref(), &headers)?;
+    let classes = [
+        // OGC API - Common - Part 1: Core (landing page, /conformance,
+        // /api) and Part 2: Geospatial Data (/collections + /collections/
+        // {id}, JSON). Both are satisfied structurally; the HTML class
+        // (.../common-2/.../conf/html) is now declared — the HTML
+        // representation is served via `?f=html` / Accept.
+        "http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/core",
+        "http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/landing-page",
+        "http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/oas30",
+        "http://www.opengis.net/spec/ogcapi-common-2/1.0/conf/collections",
+        "http://www.opengis.net/spec/ogcapi-common-2/1.0/conf/json",
+        "http://www.opengis.net/spec/ogcapi-common-2/1.0/conf/html",
+        // OGC API - Common - Part 4 (Discovery within many collections,
+        // draft 25-046): /collections supports bbox/bbox-crs/datetime/q/
+        // limit filtering + offset pagination.
+        "http://www.opengis.net/spec/ogcapi-common-4/1.0/conf/searchable-collections",
+        "http://www.opengis.net/spec/ogcapi-maps-1/1.0/conf/core",
+        "http://www.opengis.net/spec/ogcapi-maps-1/1.0/conf/collection-map",
+        "http://www.opengis.net/spec/ogcapi-maps-1/1.0/conf/styled-map",
+        "http://www.opengis.net/spec/ogcapi-maps-1/1.0/conf/spatial-subsetting",
+        "http://www.opengis.net/spec/ogcapi-maps-1/1.0/conf/scaling",
+        "http://www.opengis.net/spec/ogcapi-maps-1/1.0/conf/datetime",
+        "http://www.opengis.net/spec/ogcapi-maps-1/1.0/conf/crs",
+        "http://www.opengis.net/spec/ogcapi-maps-1/1.0/conf/png",
+        "http://www.opengis.net/spec/ogcapi-maps-1/1.0/conf/jpeg",
+        // NOTE: the OGC API Maps "Map Tilesets" class
+        // (.../conf/tilesets) is intentionally NOT declared. Its abstract
+        // tests require maps-native /collections/{id}/map/tiles endpoints,
+        // which we don't implement — raster tiles are served by the
+        // standalone OGC API Tiles service and merely *discovered* from a
+        // maps collection via the `tilesets-map` link relation. Declaring
+        // the class without the endpoints would be a false conformance
+        // claim.
+    ];
+    Ok(match wanted {
+        Wanted::Json => Json(json!({ "conformsTo": classes })).into_response(),
+        Wanted::Html => Html(ds_core::html::conformance_html(&classes)).into_response(),
+    })
 }
 
 /// GET /maps/collections
 pub async fn collections(
     State(state): State<AppState>,
     Query(sp): Query<ds_core::collection_search::SearchQueryParams>,
-) -> Result<Json<serde_json::Value>, MapsError> {
+    headers: HeaderMap,
+) -> Result<Response, MapsError> {
     use ds_core::collection_search::{search, CollectionMatch};
+    use ds_core::html::Wanted;
 
+    let wanted = negotiate(sp.f.as_deref(), &headers)?;
     let params = sp
         .parse()
         .map_err(|e| MapsError::BadRequest(e.to_string()))?;
@@ -658,51 +702,118 @@ pub async fn collections(
         })
         .collect();
     let result = search(&matches, &params);
-    let colls: Vec<serde_json::Value> = result.page.iter().map(|&i| rows[i].5.clone()).collect();
-    let number_returned = colls.len();
-
-    let link = |rel: &str, offset: usize, title: Option<&str>| {
-        let mut o = json!({
-            "href": format!("{base}/maps/collections{}", sp.query_string(params.limit, offset)),
-            "rel": rel,
-            "type": "application/json"
-        });
-        if let Some(t) = title {
-            o["title"] = json!(t);
-        }
-        o
+    let href = |offset| {
+        format!(
+            "{base}/maps/collections{}",
+            sp.query_string(params.limit, offset)
+        )
     };
-    let mut links = vec![link("self", params.offset, None)];
-    if result.has_next {
-        links.push(link("next", result.next_offset, Some("Next page")));
-    }
-    if result.has_prev {
-        links.push(link("prev", result.prev_offset, Some("Previous page")));
-    }
 
-    Ok(Json(json!({
-        "collections": colls,
-        "numberMatched": result.number_matched,
-        "numberReturned": number_returned,
-        "links": links
-    })))
+    Ok(match wanted {
+        Wanted::Json => {
+            let colls: Vec<serde_json::Value> =
+                result.page.iter().map(|&i| rows[i].5.clone()).collect();
+            let number_returned = colls.len();
+
+            let link = |rel: &str, offset: usize, title: Option<&str>| {
+                let mut o = json!({ "href": href(offset), "rel": rel, "type": "application/json" });
+                if let Some(t) = title {
+                    o["title"] = json!(t);
+                }
+                o
+            };
+            let mut links = vec![link("self", params.offset, None)];
+            if result.has_next {
+                links.push(link("next", result.next_offset, Some("Next page")));
+            }
+            if result.has_prev {
+                links.push(link("prev", result.prev_offset, Some("Previous page")));
+            }
+
+            Json(json!({
+                "collections": colls,
+                "numberMatched": result.number_matched,
+                "numberReturned": number_returned,
+                "links": links
+            }))
+            .into_response()
+        }
+        Wanted::Html => {
+            use ds_core::html::{CollectionCard, LinkView};
+            let cards: Vec<CollectionCard> = result
+                .page
+                .iter()
+                .map(|&i| CollectionCard {
+                    id: rows[i].0.clone(),
+                    title: rows[i].1.clone(),
+                    description: rows[i].2.clone(),
+                    self_href: format!("{base}/maps/collections/{}", rows[i].0),
+                })
+                .collect();
+            let mut nav = vec![LinkView::new(
+                href(params.offset),
+                "self",
+                Some("This page"),
+            )];
+            if result.has_next {
+                nav.push(LinkView::new(
+                    href(result.next_offset),
+                    "next",
+                    Some("Next page"),
+                ));
+            }
+            if result.has_prev {
+                nav.push(LinkView::new(
+                    href(result.prev_offset),
+                    "prev",
+                    Some("Previous page"),
+                ));
+            }
+            Html(ds_core::html::collections_html("Collections", &cards, &nav)).into_response()
+        }
+    })
 }
 
 /// GET /maps/collections/{id}
 pub async fn collection(
     Path(id): Path<String>,
     State(state): State<AppState>,
-) -> Result<impl IntoResponse, MapsError> {
+    Query(fp): Query<ds_core::html::FormatParams>,
+    headers: HeaderMap,
+) -> Result<Response, MapsError> {
+    use ds_core::html::{CollectionCard, LinkView, Wanted};
+    let wanted = negotiate(fp.f.as_deref(), &headers)?;
     let state = state.load_full();
     let (engine, config) = lookup_engine(&state, &id)?;
-    let info = engine.raster_info();
-    let styles = state.styles.get(&id);
-    Ok(Json(build_collection_metadata(
-        config,
-        &info,
-        styles,
-        &state.base_url,
-    )))
+    let base = &state.base_url;
+    Ok(match wanted {
+        Wanted::Json => {
+            let info = engine.raster_info();
+            let styles = state.styles.get(&id);
+            Json(build_collection_metadata(config, &info, styles, base)).into_response()
+        }
+        Wanted::Html => {
+            let card = CollectionCard {
+                id: config.id.clone(),
+                title: config.title.clone(),
+                description: config.description.clone(),
+                self_href: format!("{base}/maps/collections/{}", config.id),
+            };
+            let links = [
+                LinkView::new(
+                    format!("{base}/maps/collections/{}?f=json", config.id),
+                    "alternate",
+                    Some("JSON"),
+                ),
+                LinkView::new(
+                    format!("{base}/maps/collections"),
+                    "collection",
+                    Some("All collections"),
+                ),
+            ];
+            Html(ds_core::html::collection_html(&card, &links)).into_response()
+        }
+    })
 }
 
 /// GET /maps/collections/{id}/styles

--- a/crates/api-maps/src/handlers.rs
+++ b/crates/api-maps/src/handlers.rs
@@ -77,6 +77,16 @@ fn negotiate(f: Option<&str>, headers: &HeaderMap) -> Result<ds_core::html::Want
     ds_core::html::negotiate(f, accept).map_err(|e| MapsError::BadRequest(e.to_string()))
 }
 
+/// Tag a content-negotiated response with `Vary: Accept` so shared caches
+/// don't serve the JSON body to a client that asked for HTML (or vice versa).
+fn with_vary(mut resp: Response) -> Response {
+    resp.headers_mut().insert(
+        axum::http::header::VARY,
+        axum::http::HeaderValue::from_static("accept"),
+    );
+    resp
+}
+
 fn build_collection_metadata(
     config: &CollectionConfig,
     info: &ds_core::map_engine::RasterInfo,
@@ -252,7 +262,7 @@ pub async fn landing_page(
             "Collections",
         ),
     ];
-    Ok(match wanted {
+    Ok(with_vary(match wanted {
         Wanted::Json => {
             let json_links: Vec<_> = links
                 .iter()
@@ -268,7 +278,7 @@ pub async fn landing_page(
                 .collect();
             Html(ds_core::html::landing_html(title, description, &views)).into_response()
         }
-    })
+    }))
 }
 
 /// OpenAPI `parameters` array for the OGC API – Common – Part 4 searchable
@@ -641,10 +651,10 @@ pub async fn conformance(
         // the class without the endpoints would be a false conformance
         // claim.
     ];
-    Ok(match wanted {
+    Ok(with_vary(match wanted {
         Wanted::Json => Json(json!({ "conformsTo": classes })).into_response(),
         Wanted::Html => Html(ds_core::html::conformance_html(&classes)).into_response(),
-    })
+    }))
 }
 
 /// GET /maps/collections
@@ -709,7 +719,7 @@ pub async fn collections(
         )
     };
 
-    Ok(match wanted {
+    Ok(with_vary(match wanted {
         Wanted::Json => {
             let colls: Vec<serde_json::Value> =
                 result.page.iter().map(|&i| rows[i].5.clone()).collect();
@@ -771,7 +781,7 @@ pub async fn collections(
             }
             Html(ds_core::html::collections_html("Collections", &cards, &nav)).into_response()
         }
-    })
+    }))
 }
 
 /// GET /maps/collections/{id}
@@ -786,7 +796,7 @@ pub async fn collection(
     let state = state.load_full();
     let (engine, config) = lookup_engine(&state, &id)?;
     let base = &state.base_url;
-    Ok(match wanted {
+    Ok(with_vary(match wanted {
         Wanted::Json => {
             let info = engine.raster_info();
             let styles = state.styles.get(&id);
@@ -813,7 +823,7 @@ pub async fn collection(
             ];
             Html(ds_core::html::collection_html(&card, &links)).into_response()
         }
-    })
+    }))
 }
 
 /// GET /maps/collections/{id}/styles

--- a/crates/api-maps/src/handlers.rs
+++ b/crates/api-maps/src/handlers.rs
@@ -281,10 +281,17 @@ pub async fn landing_page(
     }))
 }
 
+/// OpenAPI `f` (output-format) query parameter, shared by the content-negotiated
+/// metadata endpoints (landing, conformance, collections, collection detail).
+fn format_parameter() -> serde_json::Value {
+    json!({"name": "f", "in": "query", "required": false, "schema": {"type": "string", "enum": ["json", "html"]},
+           "description": "Output format. 'json' (default) or 'html'; overrides the Accept header."})
+}
+
 /// OpenAPI `parameters` array for the OGC API – Common – Part 4 searchable
-/// `/collections` query parameters.
+/// `/collections` query parameters (plus the shared `f` format selector).
 fn searchable_collections_parameters() -> serde_json::Value {
-    json!([
+    let mut params = json!([
         {"name": "bbox", "in": "query", "required": false, "schema": {"type": "string"},
          "description": "Filter to collections intersecting this CRS84 bbox: 4 (or 6) comma-separated numbers west,south,east,north."},
         {"name": "bbox-crs", "in": "query", "required": false, "schema": {"type": "string"},
@@ -296,10 +303,13 @@ fn searchable_collections_parameters() -> serde_json::Value {
         {"name": "limit", "in": "query", "required": false, "schema": {"type": "integer", "minimum": 1, "maximum": 1000},
          "description": "Maximum number of collections per page (default 1000)."},
         {"name": "offset", "in": "query", "required": false, "schema": {"type": "integer", "minimum": 0},
-         "description": "Number of matching collections to skip (pagination cursor)."},
-        {"name": "f", "in": "query", "required": false, "schema": {"type": "string", "enum": ["json", "html"]},
-         "description": "Output format. 'json' (default) or 'html'; overrides the Accept header."}
-    ])
+         "description": "Number of matching collections to skip (pagination cursor)."}
+    ]);
+    params
+        .as_array_mut()
+        .expect("searchable params is a JSON array")
+        .push(format_parameter());
+    params
 }
 
 /// GET /maps/api — OpenAPI 3.0.3 definition
@@ -316,6 +326,7 @@ pub async fn api_definition(State(state): State<AppState>) -> impl IntoResponse 
                 "summary": format!("Get {} collection metadata", config.title),
                 "operationId": format!("getCollection_{id}"),
                 "tags": [id],
+                "parameters": [format_parameter()],
                 "responses": {
                     "200": {"description": "Collection metadata"},
                     "404": {"description": "Collection not found"}
@@ -438,6 +449,7 @@ pub async fn api_definition(State(state): State<AppState>) -> impl IntoResponse 
             "get": {
                 "summary": "Landing page",
                 "operationId": "getLandingPage",
+                "parameters": [format_parameter()],
                 "responses": {
                     "200": {"description": "Landing page"}
                 }
@@ -447,6 +459,7 @@ pub async fn api_definition(State(state): State<AppState>) -> impl IntoResponse 
             "get": {
                 "summary": "Conformance classes",
                 "operationId": "getConformance",
+                "parameters": [format_parameter()],
                 "responses": {
                     "200": {"description": "Conformance classes"}
                 }

--- a/crates/api-maps/tests/integration.rs
+++ b/crates/api-maps/tests/integration.rs
@@ -1799,7 +1799,13 @@ mod content_negotiation {
     /// the wrong representation.
     #[tokio::test]
     async fn negotiated_responses_set_vary_accept() {
-        for uri in ["/collections", "/collections?f=html", "/conformance", "/"] {
+        for uri in [
+            "/collections",
+            "/collections?f=html",
+            "/collections/radar",
+            "/conformance",
+            "/",
+        ] {
             let (_, headers, _) = get_raw(uri).await;
             let vary = headers
                 .get("vary")

--- a/crates/api-maps/tests/integration.rs
+++ b/crates/api-maps/tests/integration.rs
@@ -418,12 +418,12 @@ mod conformance {
     }
 
     #[tokio::test]
-    async fn omits_common_html_class() {
-        // No HTML representation of /collections — declaring the HTML class
-        // would be a false conformance claim (#291).
+    async fn declares_common_html_class() {
+        // HTML representation of the metadata endpoints is now served via
+        // `?f=html` / Accept, so the Common Part 2 HTML class is declared (#296).
         let (_, json) = get("/conformance").await;
         let classes = json["conformsTo"].as_array().unwrap();
-        assert!(!classes
+        assert!(classes
             .iter()
             .any(|c| c.as_str().unwrap().contains("common-2/1.0/conf/html")));
     }
@@ -1741,5 +1741,39 @@ mod searchable {
         let href = self_link["href"].as_str().unwrap();
         assert!(href.contains("q=radar"));
         assert!(href.contains("limit=1"));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Content negotiation — ?f=json|html (OGC API Common Part 2 conf/html, #296)
+// ---------------------------------------------------------------------------
+mod content_negotiation {
+    use super::*;
+
+    #[tokio::test]
+    async fn f_html_serves_html() {
+        let (status, headers, body) = get_raw("/collections?f=html").await;
+        assert_eq!(status, StatusCode::OK);
+        let ct = headers.get("content-type").unwrap().to_str().unwrap();
+        assert!(ct.starts_with("text/html"), "content-type was {ct}");
+        assert!(String::from_utf8_lossy(&body).contains("<!DOCTYPE html>"));
+    }
+
+    #[tokio::test]
+    async fn collection_detail_serves_html() {
+        let (status, headers, _) = get_raw("/collections/radar?f=html").await;
+        assert_eq!(status, StatusCode::OK);
+        assert!(headers
+            .get("content-type")
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .starts_with("text/html"));
+    }
+
+    #[tokio::test]
+    async fn unknown_f_is_400() {
+        let (status, _, _) = get_raw("/collections?f=xml").await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
     }
 }

--- a/crates/api-maps/tests/integration.rs
+++ b/crates/api-maps/tests/integration.rs
@@ -1776,4 +1776,39 @@ mod content_negotiation {
         let (status, _, _) = get_raw("/collections?f=xml").await;
         assert_eq!(status, StatusCode::BAD_REQUEST);
     }
+
+    #[tokio::test]
+    async fn accept_header_selects_html() {
+        let app = build_router();
+        let req = Request::builder()
+            .uri("/collections")
+            .header("accept", "text/html")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let ct = resp
+            .headers()
+            .get("content-type")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+        assert!(ct.starts_with("text/html"), "content-type was {ct}");
+    }
+
+    /// Negotiated responses carry `Vary: Accept` so shared caches don't serve
+    /// the wrong representation.
+    #[tokio::test]
+    async fn negotiated_responses_set_vary_accept() {
+        for uri in ["/collections", "/collections?f=html", "/conformance", "/"] {
+            let (_, headers, _) = get_raw(uri).await;
+            let vary = headers
+                .get("vary")
+                .and_then(|v| v.to_str().ok())
+                .unwrap_or("");
+            assert!(
+                vary.to_ascii_lowercase().contains("accept"),
+                "{uri}: missing Vary: Accept (got {vary:?})"
+            );
+        }
+    }
 }

--- a/crates/api-tiles/src/handlers.rs
+++ b/crates/api-tiles/src/handlers.rs
@@ -847,6 +847,17 @@ pub async fn collections(
                     Some("Previous page"),
                 ));
             }
+            // rel="alternate" to the JSON representation, preserving the current
+            // bbox/datetime/q/limit/offset filters (parity with the other HTML
+            // metadata pages).
+            nav.push(LinkView::new(
+                format!(
+                    "{base}/tiles/collections{}",
+                    sp.query_string_with_format(params.limit, params.offset, "json")
+                ),
+                "alternate",
+                Some("This page as JSON"),
+            ));
             Html(ds_core::html::collections_html("Collections", &cards, &nav)).into_response()
         }
     }))

--- a/crates/api-tiles/src/handlers.rs
+++ b/crates/api-tiles/src/handlers.rs
@@ -342,10 +342,17 @@ pub async fn landing_page(
     }))
 }
 
+/// OpenAPI `f` (output-format) query parameter, shared by the content-negotiated
+/// metadata endpoints (landing, conformance, collections, collection detail).
+fn format_parameter() -> serde_json::Value {
+    json!({"name": "f", "in": "query", "required": false, "schema": {"type": "string", "enum": ["json", "html"]},
+           "description": "Output format. 'json' (default) or 'html'; overrides the Accept header."})
+}
+
 /// OpenAPI `parameters` array for the OGC API – Common – Part 4 searchable
-/// `/collections` query parameters.
+/// `/collections` query parameters (plus the shared `f` format selector).
 fn searchable_collections_parameters() -> serde_json::Value {
-    json!([
+    let mut params = json!([
         {"name": "bbox", "in": "query", "required": false, "schema": {"type": "string"},
          "description": "Filter to collections intersecting this CRS84 bbox: 4 (or 6) comma-separated numbers west,south,east,north."},
         {"name": "bbox-crs", "in": "query", "required": false, "schema": {"type": "string"},
@@ -357,10 +364,13 @@ fn searchable_collections_parameters() -> serde_json::Value {
         {"name": "limit", "in": "query", "required": false, "schema": {"type": "integer", "minimum": 1, "maximum": 1000},
          "description": "Maximum number of collections per page (default 1000)."},
         {"name": "offset", "in": "query", "required": false, "schema": {"type": "integer", "minimum": 0},
-         "description": "Number of matching collections to skip (pagination cursor)."},
-        {"name": "f", "in": "query", "required": false, "schema": {"type": "string", "enum": ["json", "html"]},
-         "description": "Output format. 'json' (default) or 'html'; overrides the Accept header."}
-    ])
+         "description": "Number of matching collections to skip (pagination cursor)."}
+    ]);
+    params
+        .as_array_mut()
+        .expect("searchable params is a JSON array")
+        .push(format_parameter());
+    params
 }
 
 /// GET /tiles/api — OpenAPI 3.0.3 definition
@@ -391,6 +401,7 @@ pub async fn api_definition(State(state): State<AppState>) -> impl IntoResponse 
                 "summary": format!("Get {} collection metadata", config.title),
                 "operationId": format!("getCollection_{id}"),
                 "tags": [id],
+                "parameters": [format_parameter()],
                 "responses": {
                     "200": {"description": "Collection metadata"},
                     "404": {"description": "Collection not found"}
@@ -488,6 +499,7 @@ pub async fn api_definition(State(state): State<AppState>) -> impl IntoResponse 
             "get": {
                 "summary": "Landing page",
                 "operationId": "getLandingPage",
+                "parameters": [format_parameter()],
                 "responses": { "200": {"description": "Landing page"} }
             }
         },
@@ -495,6 +507,7 @@ pub async fn api_definition(State(state): State<AppState>) -> impl IntoResponse 
             "get": {
                 "summary": "Conformance classes",
                 "operationId": "getConformance",
+                "parameters": [format_parameter()],
                 "responses": { "200": {"description": "Conformance classes"} }
             }
         },

--- a/crates/api-tiles/src/handlers.rs
+++ b/crates/api-tiles/src/handlers.rs
@@ -109,7 +109,9 @@ fn negotiate(f: Option<&str>, headers: &HeaderMap) -> Result<ds_core::html::Want
 /// Tag a content-negotiated response with `Vary: Accept` so shared caches
 /// don't serve the JSON body to a client that asked for HTML (or vice versa).
 fn with_vary(mut resp: Response) -> Response {
-    resp.headers_mut().insert(
+    // `append` (not `insert`) so a `Vary` set upstream (e.g. compression's
+    // `Vary: Accept-Encoding`) isn't clobbered.
+    resp.headers_mut().append(
         axum::http::header::VARY,
         axum::http::HeaderValue::from_static("accept"),
     );

--- a/crates/api-tiles/src/handlers.rs
+++ b/crates/api-tiles/src/handlers.rs
@@ -106,6 +106,16 @@ fn negotiate(f: Option<&str>, headers: &HeaderMap) -> Result<ds_core::html::Want
     ds_core::html::negotiate(f, accept).map_err(|e| TilesError::BadRequest(e.to_string()))
 }
 
+/// Tag a content-negotiated response with `Vary: Accept` so shared caches
+/// don't serve the JSON body to a client that asked for HTML (or vice versa).
+fn with_vary(mut resp: Response) -> Response {
+    resp.headers_mut().insert(
+        axum::http::header::VARY,
+        axum::http::HeaderValue::from_static("accept"),
+    );
+    resp
+}
+
 fn build_collection_metadata(
     config: &CollectionConfig,
     raster_info: Option<&ds_core::map_engine::RasterInfo>,
@@ -313,7 +323,7 @@ pub async fn landing_page(
             "Tile matrix sets",
         ),
     ];
-    Ok(match wanted {
+    Ok(with_vary(match wanted {
         Wanted::Json => {
             let json_links: Vec<_> = links
                 .iter()
@@ -329,7 +339,7 @@ pub async fn landing_page(
                 .collect();
             Html(ds_core::html::landing_html(title, description, &views)).into_response()
         }
-    })
+    }))
 }
 
 /// OpenAPI `parameters` array for the OGC API – Common – Part 4 searchable
@@ -619,10 +629,10 @@ pub async fn conformance(
         "http://www.opengis.net/spec/ogcapi-tiles-1/1.0/conf/jpeg",
         "http://www.opengis.net/spec/ogcapi-tiles-1/1.0/conf/mvt",
     ];
-    Ok(match wanted {
+    Ok(with_vary(match wanted {
         Wanted::Json => Json(json!({ "conformsTo": classes })).into_response(),
         Wanted::Html => Html(ds_core::html::conformance_html(&classes)).into_response(),
-    })
+    }))
 }
 
 /// GET /tiles/tileMatrixSets — List supported tile matrix sets
@@ -742,7 +752,7 @@ pub async fn collections(
         )
     };
 
-    Ok(match wanted {
+    Ok(with_vary(match wanted {
         Wanted::Json => {
             let colls: Vec<serde_json::Value> =
                 result.page.iter().map(|&i| rows[i].5.clone()).collect();
@@ -804,7 +814,7 @@ pub async fn collections(
             }
             Html(ds_core::html::collections_html("Collections", &cards, &nav)).into_response()
         }
-    })
+    }))
 }
 
 /// GET /tiles/collections/{id} — Collection detail
@@ -833,7 +843,7 @@ pub async fn collection(
         )));
     }
     let base = &state.base_url;
-    Ok(match wanted {
+    Ok(with_vary(match wanted {
         Wanted::Json => {
             let styles = state.styles.get(&id);
             Json(build_collection_metadata(
@@ -866,7 +876,7 @@ pub async fn collection(
             ];
             Html(ds_core::html::collection_html(&card, &links)).into_response()
         }
-    })
+    }))
 }
 
 /// GET /tiles/collections/{id}/tiles — List tilesets for a collection

--- a/crates/api-tiles/src/handlers.rs
+++ b/crates/api-tiles/src/handlers.rs
@@ -4,7 +4,7 @@ use std::sync::{Arc, LazyLock};
 use arc_swap::ArcSwap;
 use axum::extract::{Path, Query, State};
 use axum::http::{header, HeaderMap, StatusCode};
-use axum::response::IntoResponse;
+use axum::response::{Html, IntoResponse, Response};
 use axum::Json;
 use serde_json::json;
 
@@ -96,6 +96,14 @@ fn crs_to_uri(crs: &str) -> &'static str {
         "EPSG:3857" => "http://www.opengis.net/def/crs/EPSG/0/3857",
         _ => "http://www.opengis.net/def/crs/OGC/1.3/CRS84",
     }
+}
+
+/// Resolve the requested representation from `?f=` + the `Accept` header.
+fn negotiate(f: Option<&str>, headers: &HeaderMap) -> Result<ds_core::html::Wanted, TilesError> {
+    let accept = headers
+        .get(axum::http::header::ACCEPT)
+        .and_then(|v| v.to_str().ok());
+    ds_core::html::negotiate(f, accept).map_err(|e| TilesError::BadRequest(e.to_string()))
 }
 
 fn build_collection_metadata(
@@ -255,51 +263,73 @@ fn build_extent(
 // ---------------------------------------------------------------------------
 
 /// GET /tiles/ — Landing page
-pub async fn landing_page(State(state): State<AppState>) -> impl IntoResponse {
+pub async fn landing_page(
+    State(state): State<AppState>,
+    Query(fp): Query<ds_core::html::FormatParams>,
+    headers: HeaderMap,
+) -> Result<Response, TilesError> {
+    use ds_core::html::{LinkView, Wanted};
+    let wanted = negotiate(fp.f.as_deref(), &headers)?;
     let state = state.load_full();
     let base = &state.base_url;
-    Json(json!({
-        "title": "MeteoCore - Tiles",
-        "description": "Metocean Data Server \u{2014} OGC API Tiles",
-        "links": [
-            {
-                "href": format!("{base}/tiles/"),
-                "rel": "self",
-                "type": "application/json",
-                "title": "This document"
-            },
-            {
-                "href": format!("{base}/tiles/api"),
-                "rel": "service-desc",
-                "type": "application/vnd.oai.openapi+json;version=3.0",
-                "title": "API definition"
-            },
-            {
-                "href": format!("{base}/tiles/api/docs"),
-                "rel": "service-doc",
-                "type": "text/html",
-                "title": "API documentation"
-            },
-            {
-                "href": format!("{base}/tiles/conformance"),
-                "rel": "conformance",
-                "type": "application/json",
-                "title": "Conformance classes"
-            },
-            {
-                "href": format!("{base}/tiles/collections"),
-                "rel": "data",
-                "type": "application/json",
-                "title": "Collections"
-            },
-            {
-                "href": format!("{base}/tiles/tileMatrixSets"),
-                "rel": "tiling-schemes",
-                "type": "application/json",
-                "title": "Tile matrix sets"
-            }
-        ]
-    }))
+    let title = "MeteoCore - Tiles";
+    let description = "Metocean Data Server \u{2014} OGC API Tiles";
+    // (href, rel, type, title) — one source for both representations.
+    let links = [
+        (
+            format!("{base}/tiles/"),
+            "self",
+            "application/json",
+            "This document",
+        ),
+        (
+            format!("{base}/tiles/api"),
+            "service-desc",
+            "application/vnd.oai.openapi+json;version=3.0",
+            "API definition",
+        ),
+        (
+            format!("{base}/tiles/api/docs"),
+            "service-doc",
+            "text/html",
+            "API documentation",
+        ),
+        (
+            format!("{base}/tiles/conformance"),
+            "conformance",
+            "application/json",
+            "Conformance classes",
+        ),
+        (
+            format!("{base}/tiles/collections"),
+            "data",
+            "application/json",
+            "Collections",
+        ),
+        (
+            format!("{base}/tiles/tileMatrixSets"),
+            "tiling-schemes",
+            "application/json",
+            "Tile matrix sets",
+        ),
+    ];
+    Ok(match wanted {
+        Wanted::Json => {
+            let json_links: Vec<_> = links
+                .iter()
+                .map(|(h, r, t, ti)| json!({ "href": h, "rel": r, "type": t, "title": ti }))
+                .collect();
+            Json(json!({ "title": title, "description": description, "links": json_links }))
+                .into_response()
+        }
+        Wanted::Html => {
+            let views: Vec<LinkView> = links
+                .iter()
+                .map(|(h, r, _, ti)| LinkView::new(h.clone(), *r, Some(ti)))
+                .collect();
+            Html(ds_core::html::landing_html(title, description, &views)).into_response()
+        }
+    })
 }
 
 /// OpenAPI `parameters` array for the OGC API – Common – Part 4 searchable
@@ -317,7 +347,9 @@ fn searchable_collections_parameters() -> serde_json::Value {
         {"name": "limit", "in": "query", "required": false, "schema": {"type": "integer", "minimum": 1, "maximum": 1000},
          "description": "Maximum number of collections per page (default 1000)."},
         {"name": "offset", "in": "query", "required": false, "schema": {"type": "integer", "minimum": 0},
-         "description": "Number of matching collections to skip (pagination cursor)."}
+         "description": "Number of matching collections to skip (pagination cursor)."},
+        {"name": "f", "in": "query", "required": false, "schema": {"type": "string", "enum": ["json", "html"]},
+         "description": "Output format. 'json' (default) or 'html'; overrides the Accept header."}
     ])
 }
 
@@ -556,32 +588,41 @@ pub async fn api_docs(State(state): State<AppState>) -> impl IntoResponse {
 }
 
 /// GET /tiles/conformance
-pub async fn conformance() -> impl IntoResponse {
-    Json(json!({
-        "conformsTo": [
-            // OGC API - Common - Part 1: Core (landing page, /conformance,
-            // /api) and Part 2: Geospatial Data (/collections + /collections/
-            // {id}, JSON). Both are satisfied structurally; the HTML class
-            // (.../common-2/.../conf/html) is omitted — no HTML /collections.
-            "http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/core",
-            "http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/landing-page",
-            "http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/oas30",
-            "http://www.opengis.net/spec/ogcapi-common-2/1.0/conf/collections",
-            "http://www.opengis.net/spec/ogcapi-common-2/1.0/conf/json",
-            // OGC API - Common - Part 4 (Discovery within many collections,
-            // draft 25-046): /collections supports bbox/bbox-crs/datetime/q/
-            // limit filtering + offset pagination.
-            "http://www.opengis.net/spec/ogcapi-common-4/1.0/conf/searchable-collections",
-            "http://www.opengis.net/spec/ogcapi-tiles-1/1.0/conf/core",
-            "http://www.opengis.net/spec/ogcapi-tiles-1/1.0/conf/tileset",
-            "http://www.opengis.net/spec/ogcapi-tiles-1/1.0/conf/tilesets-list",
-            "http://www.opengis.net/spec/tms/2.0/conf/tilematrixset",
-            "http://www.opengis.net/spec/tms/2.0/conf/json-tilematrixset",
-            "http://www.opengis.net/spec/ogcapi-tiles-1/1.0/conf/png",
-            "http://www.opengis.net/spec/ogcapi-tiles-1/1.0/conf/jpeg",
-            "http://www.opengis.net/spec/ogcapi-tiles-1/1.0/conf/mvt"
-        ]
-    }))
+pub async fn conformance(
+    Query(fp): Query<ds_core::html::FormatParams>,
+    headers: HeaderMap,
+) -> Result<Response, TilesError> {
+    use ds_core::html::Wanted;
+    let wanted = negotiate(fp.f.as_deref(), &headers)?;
+    let classes = [
+        // OGC API - Common - Part 1: Core (landing page, /conformance,
+        // /api) and Part 2: Geospatial Data (/collections + /collections/
+        // {id}, JSON). Both are satisfied structurally; the HTML class
+        // (.../common-2/.../conf/html) is now declared — the HTML
+        // representation is served via `?f=html` / Accept.
+        "http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/core",
+        "http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/landing-page",
+        "http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/oas30",
+        "http://www.opengis.net/spec/ogcapi-common-2/1.0/conf/collections",
+        "http://www.opengis.net/spec/ogcapi-common-2/1.0/conf/json",
+        "http://www.opengis.net/spec/ogcapi-common-2/1.0/conf/html",
+        // OGC API - Common - Part 4 (Discovery within many collections,
+        // draft 25-046): /collections supports bbox/bbox-crs/datetime/q/
+        // limit filtering + offset pagination.
+        "http://www.opengis.net/spec/ogcapi-common-4/1.0/conf/searchable-collections",
+        "http://www.opengis.net/spec/ogcapi-tiles-1/1.0/conf/core",
+        "http://www.opengis.net/spec/ogcapi-tiles-1/1.0/conf/tileset",
+        "http://www.opengis.net/spec/ogcapi-tiles-1/1.0/conf/tilesets-list",
+        "http://www.opengis.net/spec/tms/2.0/conf/tilematrixset",
+        "http://www.opengis.net/spec/tms/2.0/conf/json-tilematrixset",
+        "http://www.opengis.net/spec/ogcapi-tiles-1/1.0/conf/png",
+        "http://www.opengis.net/spec/ogcapi-tiles-1/1.0/conf/jpeg",
+        "http://www.opengis.net/spec/ogcapi-tiles-1/1.0/conf/mvt",
+    ];
+    Ok(match wanted {
+        Wanted::Json => Json(json!({ "conformsTo": classes })).into_response(),
+        Wanted::Html => Html(ds_core::html::conformance_html(&classes)).into_response(),
+    })
 }
 
 /// GET /tiles/tileMatrixSets — List supported tile matrix sets
@@ -632,9 +673,12 @@ pub async fn tile_matrix_set(Path(tms_id): Path<String>) -> Result<impl IntoResp
 pub async fn collections(
     State(state): State<AppState>,
     Query(sp): Query<ds_core::collection_search::SearchQueryParams>,
-) -> Result<Json<serde_json::Value>, TilesError> {
+    headers: HeaderMap,
+) -> Result<Response, TilesError> {
     use ds_core::collection_search::{search, CollectionMatch};
+    use ds_core::html::Wanted;
 
+    let wanted = negotiate(sp.f.as_deref(), &headers)?;
     let params = sp
         .parse()
         .map_err(|e| TilesError::BadRequest(e.to_string()))?;
@@ -691,41 +735,87 @@ pub async fn collections(
         })
         .collect();
     let result = search(&matches, &params);
-    let colls: Vec<serde_json::Value> = result.page.iter().map(|&i| rows[i].5.clone()).collect();
-    let number_returned = colls.len();
-
-    let link = |rel: &str, offset: usize, title: Option<&str>| {
-        let mut o = json!({
-            "href": format!("{base}/tiles/collections{}", sp.query_string(params.limit, offset)),
-            "rel": rel,
-            "type": "application/json"
-        });
-        if let Some(t) = title {
-            o["title"] = json!(t);
-        }
-        o
+    let href = |offset| {
+        format!(
+            "{base}/tiles/collections{}",
+            sp.query_string(params.limit, offset)
+        )
     };
-    let mut links = vec![link("self", params.offset, None)];
-    if result.has_next {
-        links.push(link("next", result.next_offset, Some("Next page")));
-    }
-    if result.has_prev {
-        links.push(link("prev", result.prev_offset, Some("Previous page")));
-    }
 
-    Ok(Json(json!({
-        "collections": colls,
-        "numberMatched": result.number_matched,
-        "numberReturned": number_returned,
-        "links": links
-    })))
+    Ok(match wanted {
+        Wanted::Json => {
+            let colls: Vec<serde_json::Value> =
+                result.page.iter().map(|&i| rows[i].5.clone()).collect();
+            let number_returned = colls.len();
+
+            let link = |rel: &str, offset: usize, title: Option<&str>| {
+                let mut o = json!({ "href": href(offset), "rel": rel, "type": "application/json" });
+                if let Some(t) = title {
+                    o["title"] = json!(t);
+                }
+                o
+            };
+            let mut links = vec![link("self", params.offset, None)];
+            if result.has_next {
+                links.push(link("next", result.next_offset, Some("Next page")));
+            }
+            if result.has_prev {
+                links.push(link("prev", result.prev_offset, Some("Previous page")));
+            }
+
+            Json(json!({
+                "collections": colls,
+                "numberMatched": result.number_matched,
+                "numberReturned": number_returned,
+                "links": links
+            }))
+            .into_response()
+        }
+        Wanted::Html => {
+            use ds_core::html::{CollectionCard, LinkView};
+            let cards: Vec<CollectionCard> = result
+                .page
+                .iter()
+                .map(|&i| CollectionCard {
+                    id: rows[i].0.clone(),
+                    title: rows[i].1.clone(),
+                    description: rows[i].2.clone(),
+                    self_href: format!("{base}/tiles/collections/{}", rows[i].0),
+                })
+                .collect();
+            let mut nav = vec![LinkView::new(
+                href(params.offset),
+                "self",
+                Some("This page"),
+            )];
+            if result.has_next {
+                nav.push(LinkView::new(
+                    href(result.next_offset),
+                    "next",
+                    Some("Next page"),
+                ));
+            }
+            if result.has_prev {
+                nav.push(LinkView::new(
+                    href(result.prev_offset),
+                    "prev",
+                    Some("Previous page"),
+                ));
+            }
+            Html(ds_core::html::collections_html("Collections", &cards, &nav)).into_response()
+        }
+    })
 }
 
 /// GET /tiles/collections/{id} — Collection detail
 pub async fn collection(
     Path(id): Path<String>,
     State(state): State<AppState>,
-) -> Result<impl IntoResponse, TilesError> {
+    Query(fp): Query<ds_core::html::FormatParams>,
+    headers: HeaderMap,
+) -> Result<Response, TilesError> {
+    use ds_core::html::{CollectionCard, LinkView, Wanted};
+    let wanted = negotiate(fp.f.as_deref(), &headers)?;
     let state = state.load_full();
     let raster_info = state.map_engines.get(&id).map(|e| e.raster_info());
     let feature_extent = state
@@ -742,14 +832,41 @@ pub async fn collection(
             "Collection '{id}' has no tile source"
         )));
     }
-    let styles = state.styles.get(&id);
-    Ok(Json(build_collection_metadata(
-        config,
-        raster_info.as_ref(),
-        feature_extent,
-        styles,
-        &state.base_url,
-    )))
+    let base = &state.base_url;
+    Ok(match wanted {
+        Wanted::Json => {
+            let styles = state.styles.get(&id);
+            Json(build_collection_metadata(
+                config,
+                raster_info.as_ref(),
+                feature_extent,
+                styles,
+                base,
+            ))
+            .into_response()
+        }
+        Wanted::Html => {
+            let card = CollectionCard {
+                id: config.id.clone(),
+                title: config.title.clone(),
+                description: config.description.clone(),
+                self_href: format!("{base}/tiles/collections/{}", config.id),
+            };
+            let links = [
+                LinkView::new(
+                    format!("{base}/tiles/collections/{}?f=json", config.id),
+                    "alternate",
+                    Some("JSON"),
+                ),
+                LinkView::new(
+                    format!("{base}/tiles/collections"),
+                    "collection",
+                    Some("All collections"),
+                ),
+            ];
+            Html(ds_core::html::collection_html(&card, &links)).into_response()
+        }
+    })
 }
 
 /// GET /tiles/collections/{id}/tiles — List tilesets for a collection

--- a/crates/api-tiles/src/handlers.rs
+++ b/crates/api-tiles/src/handlers.rs
@@ -335,10 +335,17 @@ pub async fn landing_page(
                 .into_response()
         }
         Wanted::Html => {
-            let views: Vec<LinkView> = links
+            let mut views: Vec<LinkView> = links
                 .iter()
                 .map(|(h, r, _, ti)| LinkView::new(h.clone(), *r, Some(ti)))
                 .collect();
+            // rel="alternate" to the JSON representation (parity with the
+            // collection-detail HTML page).
+            views.push(LinkView::new(
+                format!("{base}/tiles/?f=json"),
+                "alternate",
+                Some("This document as JSON"),
+            ));
             Html(ds_core::html::landing_html(title, description, &views)).into_response()
         }
     }))
@@ -614,11 +621,14 @@ pub async fn api_docs(State(state): State<AppState>) -> impl IntoResponse {
 
 /// GET /tiles/conformance
 pub async fn conformance(
+    State(state): State<AppState>,
     Query(fp): Query<ds_core::html::FormatParams>,
     headers: HeaderMap,
 ) -> Result<Response, TilesError> {
-    use ds_core::html::Wanted;
+    use ds_core::html::{LinkView, Wanted};
     let wanted = negotiate(fp.f.as_deref(), &headers)?;
+    let state = state.load_full();
+    let base = &state.base_url;
     let classes = [
         // OGC API - Common - Part 1: Core (landing page, /conformance,
         // /api) and Part 2: Geospatial Data (/collections + /collections/
@@ -646,7 +656,17 @@ pub async fn conformance(
     ];
     Ok(with_vary(match wanted {
         Wanted::Json => Json(json!({ "conformsTo": classes })).into_response(),
-        Wanted::Html => Html(ds_core::html::conformance_html(&classes)).into_response(),
+        Wanted::Html => {
+            let nav = [
+                LinkView::new(format!("{base}/tiles/"), "up", Some("Landing page")),
+                LinkView::new(
+                    format!("{base}/tiles/conformance?f=json"),
+                    "alternate",
+                    Some("This document as JSON"),
+                ),
+            ];
+            Html(ds_core::html::conformance_html(&classes, &nav)).into_response()
+        }
     }))
 }
 

--- a/crates/api-tiles/tests/integration.rs
+++ b/crates/api-tiles/tests/integration.rs
@@ -1826,4 +1826,39 @@ mod content_negotiation {
         let (status, _, _) = get_raw("/collections?f=xml").await;
         assert_eq!(status, StatusCode::BAD_REQUEST);
     }
+
+    #[tokio::test]
+    async fn accept_header_selects_html() {
+        let app = build_router();
+        let req = Request::builder()
+            .uri("/collections")
+            .header("accept", "text/html")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let ct = resp
+            .headers()
+            .get("content-type")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+        assert!(ct.starts_with("text/html"), "content-type was {ct}");
+    }
+
+    /// Negotiated responses carry `Vary: Accept` so shared caches don't serve
+    /// the wrong representation.
+    #[tokio::test]
+    async fn negotiated_responses_set_vary_accept() {
+        for uri in ["/collections", "/collections?f=html", "/conformance", "/"] {
+            let (_, headers, _) = get_raw(uri).await;
+            let vary = headers
+                .get("vary")
+                .and_then(|v| v.to_str().ok())
+                .unwrap_or("");
+            assert!(
+                vary.to_ascii_lowercase().contains("accept"),
+                "{uri}: missing Vary: Accept (got {vary:?})"
+            );
+        }
+    }
 }

--- a/crates/api-tiles/tests/integration.rs
+++ b/crates/api-tiles/tests/integration.rs
@@ -380,12 +380,12 @@ mod conformance {
     }
 
     #[tokio::test]
-    async fn omits_common_html_class() {
-        // No HTML representation of /collections — declaring the HTML class
-        // would be a false conformance claim (#291).
+    async fn declares_common_html_class() {
+        // HTML representation of the metadata endpoints is now served via
+        // `?f=html` / Accept, so the Common Part 2 HTML class is declared (#296).
         let (_, json) = get("/conformance").await;
         let classes = json["conformsTo"].as_array().unwrap();
-        assert!(!classes
+        assert!(classes
             .iter()
             .any(|c| c.as_str().unwrap().contains("common-2/1.0/conf/html")));
     }
@@ -1790,6 +1790,40 @@ mod part4_searchable {
     #[tokio::test]
     async fn invalid_limit_is_400() {
         let (status, _) = get("/collections?limit=-1").await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Content negotiation — ?f=json|html (OGC API Common Part 2 conf/html, #296)
+// ---------------------------------------------------------------------------
+mod content_negotiation {
+    use super::*;
+
+    #[tokio::test]
+    async fn f_html_serves_html() {
+        let (status, headers, body) = get_raw("/collections?f=html").await;
+        assert_eq!(status, StatusCode::OK);
+        let ct = headers.get("content-type").unwrap().to_str().unwrap();
+        assert!(ct.starts_with("text/html"), "content-type was {ct}");
+        assert!(String::from_utf8_lossy(&body).contains("<!DOCTYPE html>"));
+    }
+
+    #[tokio::test]
+    async fn collection_detail_serves_html() {
+        let (status, headers, _) = get_raw("/collections/radar?f=html").await;
+        assert_eq!(status, StatusCode::OK);
+        assert!(headers
+            .get("content-type")
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .starts_with("text/html"));
+    }
+
+    #[tokio::test]
+    async fn unknown_f_is_400() {
+        let (status, _, _) = get_raw("/collections?f=xml").await;
         assert_eq!(status, StatusCode::BAD_REQUEST);
     }
 }

--- a/crates/api-tiles/tests/integration.rs
+++ b/crates/api-tiles/tests/integration.rs
@@ -1849,7 +1849,13 @@ mod content_negotiation {
     /// the wrong representation.
     #[tokio::test]
     async fn negotiated_responses_set_vary_accept() {
-        for uri in ["/collections", "/collections?f=html", "/conformance", "/"] {
+        for uri in [
+            "/collections",
+            "/collections?f=html",
+            "/collections/radar",
+            "/conformance",
+            "/",
+        ] {
             let (_, headers, _) = get_raw(uri).await;
             let vary = headers
                 .get("vary")

--- a/crates/core/src/collection_search.rs
+++ b/crates/core/src/collection_search.rs
@@ -327,6 +327,10 @@ pub struct SearchQueryParams {
     pub q: Option<String>,
     pub limit: Option<String>,
     pub offset: Option<String>,
+    /// Output-format selector (`json`/`html`) for content negotiation. Not a
+    /// search facet — captured here only so the `/collections` handler can read
+    /// it without a second, conflicting `Query` extractor. See `ds_core::html`.
+    pub f: Option<String>,
 }
 
 impl SearchQueryParams {

--- a/crates/core/src/collection_search.rs
+++ b/crates/core/src/collection_search.rs
@@ -361,6 +361,7 @@ impl SearchQueryParams {
             self.q.as_deref(),
             limit_str.as_deref(),
             offset,
+            self.f.as_deref(),
         )
     }
 }
@@ -376,6 +377,7 @@ pub fn page_query_string(
     q: Option<&str>,
     limit: Option<&str>,
     offset: usize,
+    f: Option<&str>,
 ) -> String {
     let mut parts: Vec<String> = Vec::new();
     let mut push = |key: &str, val: Option<&str>| {
@@ -390,6 +392,13 @@ pub fn page_query_string(
     push("limit", limit);
     if offset > 0 {
         parts.push(format!("offset={offset}"));
+    }
+    // Preserve the requested format across pagination links so an HTML
+    // `/collections` page's next/prev links stay HTML (don't revert to JSON).
+    // Pushed directly (not via the `push` closure) so the closure's mutable
+    // borrow of `parts` ends before the direct `offset` push above.
+    if let Some(v) = f.map(str::trim).filter(|s| !s.is_empty()) {
+        parts.push(format!("f={}", encode_qval(v)));
     }
     if parts.is_empty() {
         String::new()
@@ -663,18 +672,32 @@ mod tests {
             Some("radar"),
             Some("10"),
             10,
+            None,
         );
         assert_eq!(
             qs,
             "?bbox=20,60,30,70&datetime=2026-06-02T00:00:00Z&q=radar&limit=10&offset=10"
         );
         // No params, offset 0 → empty (backward compatible self link).
-        assert_eq!(page_query_string(None, None, None, None, None, 0), "");
+        assert_eq!(page_query_string(None, None, None, None, None, 0, None), "");
         // Spaces get percent-encoded.
         assert_eq!(
-            page_query_string(None, None, None, Some("heavy rain"), None, 0),
+            page_query_string(None, None, None, Some("heavy rain"), None, 0, None),
             "?q=heavy%20rain"
         );
+    }
+
+    #[test]
+    fn query_string_preserves_format_across_pagination() {
+        // An HTML /collections page's next/prev links must keep ?f=html.
+        let sp = SearchQueryParams {
+            f: Some("html".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(sp.query_string(DEFAULT_LIMIT, 20), "?offset=20&f=html");
+        // No format requested → links omit f.
+        let none = SearchQueryParams::default();
+        assert_eq!(none.query_string(DEFAULT_LIMIT, 20), "?offset=20");
     }
 
     #[test]

--- a/crates/core/src/collection_search.rs
+++ b/crates/core/src/collection_search.rs
@@ -364,6 +364,24 @@ impl SearchQueryParams {
             self.f.as_deref(),
         )
     }
+
+    /// Like [`query_string`](Self::query_string) but forces the `f` (format)
+    /// selector instead of echoing the request's own. Used to build a
+    /// `rel="alternate"` link from one representation to the other while
+    /// preserving every search/pagination parameter (bbox, datetime, q,
+    /// limit, offset).
+    pub fn query_string_with_format(&self, limit: usize, offset: usize, f: &str) -> String {
+        let limit_str = self.limit.as_ref().map(|_| limit.to_string());
+        page_query_string(
+            self.bbox.as_deref(),
+            self.bbox_crs.as_deref(),
+            self.datetime.as_deref(),
+            self.q.as_deref(),
+            limit_str.as_deref(),
+            offset,
+            Some(f),
+        )
+    }
 }
 
 /// Reconstruct the `/collections` query string (leading `?`, or empty) for a
@@ -694,6 +712,22 @@ mod tests {
         // No format requested → links omit f.
         let none = SearchQueryParams::default();
         assert_eq!(none.query_string(DEFAULT_LIMIT, 20), "?offset=20");
+    }
+
+    #[test]
+    fn query_string_with_format_overrides_and_preserves_filters() {
+        // The alternate (?f=json) link forces the format but keeps every
+        // search/pagination param — even when the request itself was f=html.
+        let sp = SearchQueryParams {
+            q: Some("radar".to_string()),
+            limit: Some("10".to_string()),
+            f: Some("html".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(
+            sp.query_string_with_format(10, 20, "json"),
+            "?q=radar&limit=10&f=json&offset=20"
+        );
     }
 
     #[test]

--- a/crates/core/src/collection_search.rs
+++ b/crates/core/src/collection_search.rs
@@ -395,8 +395,9 @@ pub fn page_query_string(
     }
     // Preserve the requested format across pagination links so an HTML
     // `/collections` page's next/prev links stay HTML (don't revert to JSON).
-    // Pushed directly (not via the `push` closure) so the closure's mutable
-    // borrow of `parts` ends before the direct `offset` push above.
+    // Pushed directly rather than via the `push` closure: the closure borrows
+    // `parts` mutably, and re-invoking it here (after the direct `offset` push)
+    // would overlap that borrow — so `f` is appended inline instead.
     if let Some(v) = f.map(str::trim).filter(|s| !s.is_empty()) {
         parts.push(format!("f={}", encode_qval(v)));
     }

--- a/crates/core/src/collection_search.rs
+++ b/crates/core/src/collection_search.rs
@@ -390,16 +390,11 @@ pub fn page_query_string(
     push("datetime", datetime);
     push("q", q);
     push("limit", limit);
-    if offset > 0 {
-        parts.push(format!("offset={offset}"));
-    }
     // Preserve the requested format across pagination links so an HTML
     // `/collections` page's next/prev links stay HTML (don't revert to JSON).
-    // Pushed directly rather than via the `push` closure: the closure borrows
-    // `parts` mutably, and re-invoking it here (after the direct `offset` push)
-    // would overlap that borrow — so `f` is appended inline instead.
-    if let Some(v) = f.map(str::trim).filter(|s| !s.is_empty()) {
-        parts.push(format!("f={}", encode_qval(v)));
+    push("f", f);
+    if offset > 0 {
+        parts.push(format!("offset={offset}"));
     }
     if parts.is_empty() {
         String::new()
@@ -695,7 +690,7 @@ mod tests {
             f: Some("html".to_string()),
             ..Default::default()
         };
-        assert_eq!(sp.query_string(DEFAULT_LIMIT, 20), "?offset=20&f=html");
+        assert_eq!(sp.query_string(DEFAULT_LIMIT, 20), "?f=html&offset=20");
         // No format requested → links omit f.
         let none = SearchQueryParams::default();
         assert_eq!(none.query_string(DEFAULT_LIMIT, 20), "?offset=20");

--- a/crates/core/src/html.rs
+++ b/crates/core/src/html.rs
@@ -71,25 +71,35 @@ pub fn negotiate(f: Option<&str>, accept: Option<&str>) -> Result<Wanted, Negoti
     Ok(Wanted::Json)
 }
 
-/// True if the `Accept` header lists a `text/html` (or `text/*`) media range
-/// that isn't disabled with `q=0`. `*/*` does not count — API clients sending
-/// `Accept: */*` stay on the JSON default.
+/// True if the `Accept` header makes `text/html` acceptable. The effective
+/// q-value for `text/html` is taken from the **most specific** matching range —
+/// an exact `text/html` overrides the `text/*` wildcard (RFC 9110 §12.5.1), so
+/// `text/html;q=0, text/*` correctly yields JSON. `*/*` is ignored entirely, so
+/// API clients sending `Accept: */*` (e.g. curl) stay on the JSON default.
 fn accept_allows_html(accept: &str) -> bool {
-    accept.split(',').any(|entry| {
+    let mut exact: Option<f32> = None; // q of an explicit `text/html` range
+    let mut wildcard: Option<f32> = None; // q of a `text/*` range
+    for entry in accept.split(',') {
         let mut parts = entry.split(';').map(str::trim);
-        if !parts.next().is_some_and(|m| {
-            m.eq_ignore_ascii_case("text/html") || m.eq_ignore_ascii_case("text/*")
-        }) {
-            return false;
+        let media = parts.next().unwrap_or("");
+        let is_exact = media.eq_ignore_ascii_case("text/html");
+        let is_wild = media.eq_ignore_ascii_case("text/*");
+        if !is_exact && !is_wild {
+            continue;
         }
-        // Honour an explicit `q=0` (any zero form) as an opt-out.
+        let mut q = 1.0_f32; // absent q defaults to 1.0
         for p in parts {
-            if let Some(q) = p.strip_prefix("q=").or_else(|| p.strip_prefix("Q=")) {
-                return q.trim().parse::<f32>().map(|v| v > 0.0).unwrap_or(true);
+            if let Some(v) = p.strip_prefix("q=").or_else(|| p.strip_prefix("Q=")) {
+                q = v.trim().parse::<f32>().unwrap_or(1.0);
             }
         }
-        true
-    })
+        if is_exact {
+            exact = Some(q);
+        } else {
+            wildcard = Some(q);
+        }
+    }
+    exact.or(wildcard).is_some_and(|q| q > 0.0)
 }
 
 /// A hyperlink rendered in an HTML page (owned so callers build it inline).
@@ -285,6 +295,15 @@ mod tests {
         // `text/*` matches text/html (RFC 9110 §12.5.1); `text/*;q=0` opts out.
         assert_eq!(negotiate(None, Some("text/*")).unwrap(), Wanted::Html);
         assert_eq!(negotiate(None, Some("text/*;q=0")).unwrap(), Wanted::Json);
+        // Most-specific wins: an exact text/html;q=0 overrides the text/* wildcard.
+        assert_eq!(
+            negotiate(None, Some("text/html;q=0, text/*")).unwrap(),
+            Wanted::Json
+        );
+        assert_eq!(
+            negotiate(None, Some("text/html, text/*;q=0")).unwrap(),
+            Wanted::Html
+        );
     }
 
     #[test]

--- a/crates/core/src/html.rs
+++ b/crates/core/src/html.rs
@@ -75,7 +75,10 @@ pub fn negotiate(f: Option<&str>, accept: Option<&str>) -> Result<Wanted, Negoti
 /// q-value for `text/html` is taken from the **most specific** matching range —
 /// an exact `text/html` overrides the `text/*` wildcard (RFC 9110 §12.5.1), so
 /// `text/html;q=0, text/*` correctly yields JSON. `*/*` is ignored entirely, so
-/// API clients sending `Accept: */*` (e.g. curl) stay on the JSON default.
+/// API clients sending `Accept: */*` (e.g. curl) stay on the JSON default. A
+/// malformed q-value (e.g. `q=abc`) is treated as `0` — not acceptable — so a
+/// garbled header falls back to the safe JSON default rather than being read as
+/// maximally preferred.
 fn accept_allows_html(accept: &str) -> bool {
     let mut exact: Option<f32> = None; // q of an explicit `text/html` range
     let mut wildcard: Option<f32> = None; // q of a `text/*` range
@@ -90,7 +93,7 @@ fn accept_allows_html(accept: &str) -> bool {
         let mut q = 1.0_f32; // absent q defaults to 1.0
         for p in parts {
             if let Some(v) = p.strip_prefix("q=").or_else(|| p.strip_prefix("Q=")) {
-                q = v.trim().parse::<f32>().unwrap_or(1.0);
+                q = v.trim().parse::<f32>().unwrap_or(0.0);
             }
         }
         if is_exact {
@@ -153,7 +156,7 @@ fn render_links(links: &[LinkView], class: &str) -> String {
     if links.is_empty() {
         return String::new();
     }
-    let mut s = format!("<ul class=\"{class}\">\n");
+    let mut s = format!("<ul class=\"{}\">\n", escape(class));
     for l in links {
         let label = l
             .title
@@ -303,6 +306,18 @@ mod tests {
         assert_eq!(
             negotiate(None, Some("text/html, text/*;q=0")).unwrap(),
             Wanted::Html
+        );
+        // A malformed q-value must NOT be read as maximally preferred — it falls
+        // back to the safe JSON default (regression: was `unwrap_or(1.0)`).
+        assert_eq!(
+            negotiate(None, Some("text/html;q=abc")).unwrap(),
+            Wanted::Json
+        );
+        // Malformed exact still loses to a healthy wildcard? No — most-specific
+        // wins, so the garbled exact (q=0) overrides text/* and yields JSON.
+        assert_eq!(
+            negotiate(None, Some("text/html;q=nope, text/*")).unwrap(),
+            Wanted::Json
         );
     }
 

--- a/crates/core/src/html.rs
+++ b/crates/core/src/html.rs
@@ -184,9 +184,13 @@ pub fn landing_html(title: &str, description: &str, links: &[LinkView]) -> Strin
     page(title, &body)
 }
 
-/// Conformance declaration (`GET /{api}/conformance`).
-pub fn conformance_html(classes: &[&str]) -> String {
-    let mut body = String::from("<h1>Conformance classes</h1>\n<ul>\n");
+/// Conformance declaration (`GET /{api}/conformance`). `nav` carries links back
+/// to the landing page and a `rel="alternate"` pointer to the JSON
+/// representation, so the HTML page is not a navigation dead-end.
+pub fn conformance_html(classes: &[&str], nav: &[LinkView]) -> String {
+    let mut body = String::from("<h1>Conformance classes</h1>\n");
+    body.push_str(&render_links(nav, "nav"));
+    body.push_str("<ul>\n");
     for c in classes {
         body.push_str(&format!("<li><code>{}</code></li>\n", escape(c)));
     }
@@ -352,7 +356,10 @@ mod tests {
         )];
         let l = landing_html("MeteoCore - EDR", "desc", &links);
         assert!(l.contains("MeteoCore - EDR") && l.contains("/edr/collections"));
-        let c = conformance_html(&["http://example/conf/core"]);
+        let nav = [LinkView::new("/edr/", "up", Some("Landing page"))];
+        let c = conformance_html(&["http://example/conf/core"], &nav);
         assert!(c.contains("http://example/conf/core"));
+        // Not a dead-end: the nav link back to the landing page is rendered.
+        assert!(c.contains("/edr/") && c.contains("Landing page"));
     }
 }

--- a/crates/core/src/html.rs
+++ b/crates/core/src/html.rs
@@ -1,0 +1,269 @@
+//! Minimal HTML representations + content negotiation for the OGC API metadata
+//! endpoints (landing page, `/conformance`, `/collections`, `/collections/{id}`),
+//! satisfying the OGC API – Common – Part 2 `conf/html` class (#296).
+//!
+//! Pure (no framework deps): the API crates pass plain data (titles, links,
+//! collection cards) and `axum::response::Html`-wrap the returned `String`.
+//! ds-core can't consume `serde_json::Value` (it doesn't depend on serde_json),
+//! so HTML is built from primitive inputs the handlers already have, not by
+//! re-parsing the JSON response.
+
+/// Escape the five HTML/XML special characters. All collection-derived text
+/// (titles, descriptions) must pass through this before interpolation.
+pub fn escape(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '"' => out.push_str("&quot;"),
+            '\'' => out.push_str("&#39;"),
+            _ => out.push(c),
+        }
+    }
+    out
+}
+
+/// Which representation a request resolved to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Wanted {
+    Json,
+    Html,
+}
+
+/// An unsupported `?f=` value. The API crates map this to HTTP 400.
+#[derive(Debug, Clone, thiserror::Error)]
+#[error("{0}")]
+pub struct NegotiationError(pub String);
+
+/// Raw `?f=` query parameter, deserialized by handlers that don't already take
+/// a `SearchQueryParams` (landing / conformance / collection-detail).
+#[derive(Debug, Clone, Default, serde::Deserialize)]
+pub struct FormatParams {
+    pub f: Option<String>,
+}
+
+/// Resolve the requested representation. `?f=` wins over the `Accept` header;
+/// `f=json|html` (case-insensitive); an unknown `f` is a 400. With no `f`, an
+/// `Accept` containing `text/html` selects HTML; everything else (including a
+/// missing header, `application/json`, `*/*`) defaults to **JSON** — so the
+/// existing JSON-only behaviour is unchanged unless a client opts in.
+///
+/// `Accept` is matched by simple substring; q-value weighting is not applied
+/// (a deliberate v1 simplification — a client wanting JSON can send `?f=json`).
+pub fn negotiate(f: Option<&str>, accept: Option<&str>) -> Result<Wanted, NegotiationError> {
+    if let Some(f) = f.map(str::trim).filter(|s| !s.is_empty()) {
+        return match f.to_ascii_lowercase().as_str() {
+            "json" => Ok(Wanted::Json),
+            "html" => Ok(Wanted::Html),
+            other => Err(NegotiationError(format!(
+                "unknown format '{other}'; expected 'json' or 'html'"
+            ))),
+        };
+    }
+    if accept.is_some_and(|a| a.contains("text/html")) {
+        return Ok(Wanted::Html);
+    }
+    Ok(Wanted::Json)
+}
+
+/// A hyperlink rendered in an HTML page (owned so callers build it inline).
+#[derive(Debug, Clone)]
+pub struct LinkView {
+    pub href: String,
+    pub rel: String,
+    pub title: Option<String>,
+}
+
+impl LinkView {
+    pub fn new(href: impl Into<String>, rel: impl Into<String>, title: Option<&str>) -> Self {
+        LinkView {
+            href: href.into(),
+            rel: rel.into(),
+            title: title.map(str::to_string),
+        }
+    }
+}
+
+/// One collection in a `/collections` list or a single `/collections/{id}` page.
+#[derive(Debug, Clone)]
+pub struct CollectionCard {
+    pub id: String,
+    pub title: String,
+    pub description: String,
+    /// Link to this collection's own metadata resource.
+    pub self_href: String,
+}
+
+const STYLE: &str = "body{font-family:system-ui,sans-serif;max-width:60rem;margin:2rem auto;\
+padding:0 1rem;line-height:1.5;color:#1a1a1a}h1{font-size:1.5rem}a{color:#0b66c3}\
+code{background:#f2f2f2;padding:.1em .3em;border-radius:3px;font-size:.9em}\
+ul{padding-left:1.1rem}li{margin:.25rem 0}.rel{color:#777;font-size:.85em}\
+.desc{color:#444}.nav{font-size:.9em}";
+
+fn page(title: &str, body: &str) -> String {
+    format!(
+        "<!DOCTYPE html>\n<html lang=\"en\">\n<head>\n<meta charset=\"utf-8\">\n\
+<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">\n\
+<title>{}</title>\n<style>{STYLE}</style>\n</head>\n<body>\n{body}</body>\n</html>\n",
+        escape(title)
+    )
+}
+
+fn render_links(links: &[LinkView], class: &str) -> String {
+    if links.is_empty() {
+        return String::new();
+    }
+    let mut s = format!("<ul class=\"{class}\">\n");
+    for l in links {
+        let label = l
+            .title
+            .as_deref()
+            .filter(|t| !t.is_empty())
+            .unwrap_or(&l.href);
+        s.push_str(&format!(
+            "<li><a href=\"{}\">{}</a> <span class=\"rel\">[{}]</span></li>\n",
+            escape(&l.href),
+            escape(label),
+            escape(&l.rel)
+        ));
+    }
+    s.push_str("</ul>\n");
+    s
+}
+
+/// Landing page (`GET /{api}/`).
+pub fn landing_html(title: &str, description: &str, links: &[LinkView]) -> String {
+    let mut body = format!("<h1>{}</h1>\n", escape(title));
+    if !description.is_empty() {
+        body.push_str(&format!("<p class=\"desc\">{}</p>\n", escape(description)));
+    }
+    body.push_str(&render_links(links, "nav"));
+    page(title, &body)
+}
+
+/// Conformance declaration (`GET /{api}/conformance`).
+pub fn conformance_html(classes: &[&str]) -> String {
+    let mut body = String::from("<h1>Conformance classes</h1>\n<ul>\n");
+    for c in classes {
+        body.push_str(&format!("<li><code>{}</code></li>\n", escape(c)));
+    }
+    body.push_str("</ul>\n");
+    page("Conformance classes", &body)
+}
+
+/// Collections list (`GET /{api}/collections`). `nav` carries self/next/prev.
+pub fn collections_html(title: &str, cards: &[CollectionCard], nav: &[LinkView]) -> String {
+    let mut body = format!("<h1>{}</h1>\n", escape(title));
+    body.push_str(&render_links(nav, "nav"));
+    body.push_str("<ul class=\"collections\">\n");
+    for c in cards {
+        let label = if c.title.is_empty() { &c.id } else { &c.title };
+        body.push_str(&format!(
+            "<li><a href=\"{}\"><strong>{}</strong></a> <code>{}</code>",
+            escape(&c.self_href),
+            escape(label),
+            escape(&c.id)
+        ));
+        if !c.description.is_empty() {
+            body.push_str(&format!(
+                "<div class=\"desc\">{}</div>",
+                escape(&c.description)
+            ));
+        }
+        body.push_str("</li>\n");
+    }
+    body.push_str("</ul>\n");
+    page(title, &body)
+}
+
+/// Single collection (`GET /{api}/collections/{id}`).
+pub fn collection_html(card: &CollectionCard, links: &[LinkView]) -> String {
+    let title = if card.title.is_empty() {
+        &card.id
+    } else {
+        &card.title
+    };
+    let mut body = format!(
+        "<h1>{}</h1>\n<p><code>{}</code></p>\n",
+        escape(title),
+        escape(&card.id)
+    );
+    if !card.description.is_empty() {
+        body.push_str(&format!(
+            "<p class=\"desc\">{}</p>\n",
+            escape(&card.description)
+        ));
+    }
+    body.push_str(&render_links(links, "links"));
+    page(title, &body)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn escape_handles_all_entities() {
+        assert_eq!(escape("a<b>&\"'"), "a&lt;b&gt;&amp;&quot;&#39;");
+    }
+
+    #[test]
+    fn negotiate_f_wins_over_accept() {
+        assert_eq!(
+            negotiate(Some("json"), Some("text/html")).unwrap(),
+            Wanted::Json
+        );
+        assert_eq!(negotiate(Some("HTML"), None).unwrap(), Wanted::Html);
+    }
+
+    #[test]
+    fn negotiate_accept_and_default() {
+        assert_eq!(
+            negotiate(None, Some("text/html,application/json")).unwrap(),
+            Wanted::Html
+        );
+        assert_eq!(
+            negotiate(None, Some("application/json")).unwrap(),
+            Wanted::Json
+        );
+        assert_eq!(negotiate(None, None).unwrap(), Wanted::Json);
+        assert_eq!(negotiate(Some(""), None).unwrap(), Wanted::Json);
+    }
+
+    #[test]
+    fn negotiate_unknown_f_is_error() {
+        assert!(negotiate(Some("xml"), None).is_err());
+    }
+
+    #[test]
+    fn builders_escape_and_render() {
+        let cards = [CollectionCard {
+            id: "radar".into(),
+            title: "A <b>Radar</b>".into(),
+            description: "x & y".into(),
+            self_href: "/maps/collections/radar".into(),
+        }];
+        let html = collections_html("Collections", &cards, &[]);
+        assert!(html.starts_with("<!DOCTYPE html>"));
+        assert!(html.contains("A &lt;b&gt;Radar&lt;/b&gt;"));
+        assert!(html.contains("x &amp; y"));
+        assert!(html.contains("/maps/collections/radar"));
+        // raw unescaped title must not leak
+        assert!(!html.contains("<b>Radar</b>"));
+    }
+
+    #[test]
+    fn landing_and_conformance_render() {
+        let links = [LinkView::new(
+            "/edr/collections",
+            "data",
+            Some("Collections"),
+        )];
+        let l = landing_html("MeteoCore - EDR", "desc", &links);
+        assert!(l.contains("MeteoCore - EDR") && l.contains("/edr/collections"));
+        let c = conformance_html(&["http://example/conf/core"]);
+        assert!(c.contains("http://example/conf/core"));
+    }
+}

--- a/crates/core/src/html.rs
+++ b/crates/core/src/html.rs
@@ -51,10 +51,10 @@ pub struct FormatParams {
 /// `text/html;q=0` opt-out) defaults to **JSON** — so the JSON-only behaviour
 /// is unchanged unless a client explicitly asks for HTML.
 ///
-/// Only an explicit `text/html` range is honoured (not `*/*`), so API clients
-/// that send `Accept: */*` (e.g. curl) keep getting JSON. Full cross-type
-/// q-value preference ordering is not implemented (a client wanting a specific
-/// format can always send `?f=`).
+/// A `text/html` or `text/*` range is honoured (per RFC 9110 §12.5.1), but not
+/// `*/*` — so API clients that send `Accept: */*` (e.g. curl) keep getting JSON.
+/// Full cross-type q-value preference ordering is not implemented (a client
+/// wanting a specific format can always send `?f=`).
 pub fn negotiate(f: Option<&str>, accept: Option<&str>) -> Result<Wanted, NegotiationError> {
     if let Some(f) = f.map(str::trim).filter(|s| !s.is_empty()) {
         return match f.to_ascii_lowercase().as_str() {
@@ -71,16 +71,15 @@ pub fn negotiate(f: Option<&str>, accept: Option<&str>) -> Result<Wanted, Negoti
     Ok(Wanted::Json)
 }
 
-/// True if the `Accept` header lists a `text/html` media range that isn't
-/// disabled with `q=0`. `*/*` does not count — API clients sending `Accept: */*`
-/// stay on the JSON default.
+/// True if the `Accept` header lists a `text/html` (or `text/*`) media range
+/// that isn't disabled with `q=0`. `*/*` does not count — API clients sending
+/// `Accept: */*` stay on the JSON default.
 fn accept_allows_html(accept: &str) -> bool {
     accept.split(',').any(|entry| {
         let mut parts = entry.split(';').map(str::trim);
-        if !parts
-            .next()
-            .is_some_and(|m| m.eq_ignore_ascii_case("text/html"))
-        {
+        if !parts.next().is_some_and(|m| {
+            m.eq_ignore_ascii_case("text/html") || m.eq_ignore_ascii_case("text/*")
+        }) {
             return false;
         }
         // Honour an explicit `q=0` (any zero form) as an opt-out.
@@ -127,6 +126,10 @@ code{background:#f2f2f2;padding:.1em .3em;border-radius:3px;font-size:.9em}\
 ul{padding-left:1.1rem}li{margin:.25rem 0}.rel{color:#777;font-size:.85em}\
 .desc{color:#444}.nav{font-size:.9em}";
 
+/// Wrap `body` in the page skeleton. **`body` must already be HTML-escaped** —
+/// only `title` is escaped here. All builders in this module construct `body`
+/// from `escape()`d pieces; a caller that interpolates raw user-derived text
+/// into `body` would introduce stored XSS.
 fn page(title: &str, body: &str) -> String {
     format!(
         "<!DOCTYPE html>\n<html lang=\"en\">\n<head>\n<meta charset=\"utf-8\">\n\
@@ -279,6 +282,9 @@ mod tests {
         );
         // `*/*` is not an explicit text/html range → JSON (curl-style clients).
         assert_eq!(negotiate(None, Some("*/*")).unwrap(), Wanted::Json);
+        // `text/*` matches text/html (RFC 9110 §12.5.1); `text/*;q=0` opts out.
+        assert_eq!(negotiate(None, Some("text/*")).unwrap(), Wanted::Html);
+        assert_eq!(negotiate(None, Some("text/*;q=0")).unwrap(), Wanted::Json);
     }
 
     #[test]

--- a/crates/core/src/html.rs
+++ b/crates/core/src/html.rs
@@ -45,13 +45,16 @@ pub struct FormatParams {
 }
 
 /// Resolve the requested representation. `?f=` wins over the `Accept` header;
-/// `f=json|html` (case-insensitive); an unknown `f` is a 400. With no `f`, an
-/// `Accept` containing `text/html` selects HTML; everything else (including a
-/// missing header, `application/json`, `*/*`) defaults to **JSON** — so the
-/// existing JSON-only behaviour is unchanged unless a client opts in.
+/// `f=json|html` (case-insensitive); an unknown `f` is a 400. With no `f`, HTML
+/// is served only when `Accept` lists `text/html` with a non-zero q-value;
+/// everything else (missing header, `application/json`, `*/*`, or an explicit
+/// `text/html;q=0` opt-out) defaults to **JSON** — so the JSON-only behaviour
+/// is unchanged unless a client explicitly asks for HTML.
 ///
-/// `Accept` is matched by simple substring; q-value weighting is not applied
-/// (a deliberate v1 simplification — a client wanting JSON can send `?f=json`).
+/// Only an explicit `text/html` range is honoured (not `*/*`), so API clients
+/// that send `Accept: */*` (e.g. curl) keep getting JSON. Full cross-type
+/// q-value preference ordering is not implemented (a client wanting a specific
+/// format can always send `?f=`).
 pub fn negotiate(f: Option<&str>, accept: Option<&str>) -> Result<Wanted, NegotiationError> {
     if let Some(f) = f.map(str::trim).filter(|s| !s.is_empty()) {
         return match f.to_ascii_lowercase().as_str() {
@@ -62,10 +65,32 @@ pub fn negotiate(f: Option<&str>, accept: Option<&str>) -> Result<Wanted, Negoti
             ))),
         };
     }
-    if accept.is_some_and(|a| a.contains("text/html")) {
+    if accept.is_some_and(accept_allows_html) {
         return Ok(Wanted::Html);
     }
     Ok(Wanted::Json)
+}
+
+/// True if the `Accept` header lists a `text/html` media range that isn't
+/// disabled with `q=0`. `*/*` does not count — API clients sending `Accept: */*`
+/// stay on the JSON default.
+fn accept_allows_html(accept: &str) -> bool {
+    accept.split(',').any(|entry| {
+        let mut parts = entry.split(';').map(str::trim);
+        if !parts
+            .next()
+            .is_some_and(|m| m.eq_ignore_ascii_case("text/html"))
+        {
+            return false;
+        }
+        // Honour an explicit `q=0` (any zero form) as an opt-out.
+        for p in parts {
+            if let Some(q) = p.strip_prefix("q=").or_else(|| p.strip_prefix("Q=")) {
+                return q.trim().parse::<f32>().map(|v| v > 0.0).unwrap_or(true);
+            }
+        }
+        true
+    })
 }
 
 /// A hyperlink rendered in an HTML page (owned so callers build it inline).
@@ -230,6 +255,30 @@ mod tests {
         );
         assert_eq!(negotiate(None, None).unwrap(), Wanted::Json);
         assert_eq!(negotiate(Some(""), None).unwrap(), Wanted::Json);
+    }
+
+    #[test]
+    fn negotiate_accept_honours_q_values() {
+        // Explicit opt-out: text/html;q=0 must NOT select HTML.
+        assert_eq!(
+            negotiate(None, Some("text/html;q=0, application/json")).unwrap(),
+            Wanted::Json
+        );
+        assert_eq!(
+            negotiate(None, Some("text/html; q=0.0")).unwrap(),
+            Wanted::Json
+        );
+        // Non-zero q (or no q) selects HTML.
+        assert_eq!(
+            negotiate(None, Some("text/html;q=0.9")).unwrap(),
+            Wanted::Html
+        );
+        assert_eq!(
+            negotiate(None, Some("application/json, text/html;q=0.8")).unwrap(),
+            Wanted::Html
+        );
+        // `*/*` is not an explicit text/html range → JSON (curl-style clients).
+        assert_eq!(negotiate(None, Some("*/*")).unwrap(), Wanted::Json);
     }
 
     #[test]

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -6,6 +6,7 @@ pub mod error;
 pub mod feature;
 pub mod feature_engine;
 pub mod geo;
+pub mod html;
 pub mod map_engine;
 pub mod model;
 pub mod ogc_extent;


### PR DESCRIPTION
Closes the remaining (HTML) part of #296. The structural items (itemType, Tiles `crs`, Features Common declarations) shipped in #298; this adds the HTML representation + content negotiation across **EDR, Maps, Tiles, Features**, and declares `ogcapi-common-2/1.0/conf/html`.

## What

- New **`ds_core::html`** module (pure — chrono/serde/std only, no `serde_json`): `escape`, `Wanted`, `negotiate(f, accept)`, `FormatParams`, `LinkView`/`CollectionCard`, and builders `landing_html` / `conformance_html` / `collections_html` / `collection_html`. Branded, fully-escaped, minimal-CSS pages built from primitives the handlers already have.
- The four metadata endpoints (`/`, `/conformance`, `/collections`, `/collections/{id}`) on each surface now resolve `?f=` + `Accept` and branch JSON vs HTML.
- `/collections` HTML honours the Part 4 filters (`?f=html&q=…&bbox=…`) and renders self/next/prev nav.
- `f` added to the shared `SearchQueryParams` (so `collections()` negotiates without a conflicting second extractor) and documented in each `api_definition()`.

## Negotiation rules

`?f=html` → HTML · `?f=json` → JSON · unknown `?f=` → **400** · no `f` + `Accept: text/html` → HTML · otherwise → **JSON** (default unchanged; q-value weighting is a documented v1 simplification).

## Default behaviour is unchanged

No `?f=` / no `Accept: text/html` ⇒ JSON, byte-for-byte as before. All existing JSON integration tests pass unmodified.

## Tests

- `ds_core::html` unit tests (escape all entities, negotiate precedence/default/400, builder escaping).
- Per-surface `content_negotiation` suites: `f=html` → `text/html` on all four endpoints, `f=json` → `application/json`, `Accept: text/html` → HTML, no header → JSON, unknown `?f=` → 400.
- Flipped the EDR/Maps/Tiles conformance tests that asserted `conf/html` ABSENT → now assert PRESENT; flipped EDR FINDING 6 (no `f` param) → RESOLVED.
- Full workspace (incl. `server`) + `clippy -D warnings` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)