### PR TITLE
ci: trim dev/test debuginfo to speed up the build-test loop

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,23 @@ exclude = ["fuzz"]
 # fails the release-PR with `value at path package.version is not tagged`.
 # Until that's fixed upstream, leaving versions inline lets release-please
 # walk the workspace members and bump each one to the same value.
+
+# Dev/test build-speed tuning. The dominant cost of `cargo test` here is not
+# test execution (every binary finishes in <0.5s) but linking — writing and
+# relocating full DWARF debug info across ~440 dependency crates and 17
+# workspace members on every relink. The default dev profile uses `debug = 2`
+# (full debuginfo); a one-line change cost ~14s to rebuild a test binary, of
+# which only ~2.5s was actual compilation.
+#
+# - Workspace crates keep `line-tables-only`: panics/backtraces still resolve to
+#   file:line, but the heavy variable/type DWARF is dropped.
+# - Dependencies get no debuginfo at all (`package."*"`): you never step into
+#   them, and their debug sections are the bulk of the link-time cost.
+#
+# This also speeds up CI (which builds the same dev/test profile). opt-level and
+# codegen-units are left at their fast-compile defaults (0 / 256).
+[profile.dev]
+debug = "line-tables-only"
+
+[profile.dev.package."*"]
+debug = false


### PR DESCRIPTION
## What

Adds `[profile.dev]` tuning to the root `Cargo.toml`:

```toml
[profile.dev]
debug = "line-tables-only"   # workspace crates: keep file:line, drop heavy DWARF

[profile.dev.package."*"]
debug = false                # dependencies: no debuginfo (never stepped into)
```

## Why

The dominant cost of `cargo test` here is **linking**, not test execution — every test binary finishes in <0.5 s. The default dev profile emits full DWARF (`debug = 2`) for ~440 dependency crates + 17 workspace members; writing and relocating that on every relink dominated wall-clock.

`profile.test` inherits these from `profile.dev`, so the test build benefits too. `opt-level` (0) and `codegen-units` (256) are left at their fast-compile defaults.

## Measured (aarch64-apple-darwin)

After also reclaiming a 100 GB stale `target/` via `cargo clean`:

| Step | Before | After |
|---|---|---|
| One-file incremental test rebuild (engine-odim) | 14.4 s | **0.8 s** |
| Warm-deps rebuild of two engine crates | 31.0 s | **0.9 s** |
| `target/` size | 100 GB | 686 MB |

(The big jump is the combination of the debuginfo trim and the one-time target reclaim; the profile change keeps the tree lean going forward. Also speeds up CI, which builds the same profile.)

## Risk

Backtraces in dependency code lose line numbers; workspace code keeps `file:line` via `line-tables-only`. No behavioural change to tests — `ds-core` (156 tests) passes unchanged under the new profile.

## Not in this PR

- **Shared `CARGO_TARGET_DIR`** to stop git worktrees each cold-building all deps — that must be a *global env var* (a committed absolute `target-dir` would break CI and other machines; a relative one isn't shared across worktrees), so it belongs in the developer's shell, not the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)