### PR TITLE
ci(api-edr): drop jsonschema resolve-http (reqwest) from the test build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1740,7 +1740,6 @@ dependencies = [
  "percent-encoding",
  "referencing",
  "regex-syntax",
- "reqwest",
  "serde",
  "serde_json",
  "uuid-simd",
@@ -2735,7 +2734,6 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64",
  "bytes",
- "futures-channel",
  "futures-core",
  "futures-util",
  "h2",

--- a/crates/api-edr/Cargo.toml
+++ b/crates/api-edr/Cargo.toml
@@ -16,7 +16,12 @@ tracing = "0.1"
 tokio = { version = "1", features = ["rt"] }
 
 [dev-dependencies]
-jsonschema = "0.28"
+# default-features = false drops `resolve-http` (and the `reqwest`/hyper-util
+# client stack it pulls in), which the covjson validation tests don't use — they
+# read the schema from disk and it has only internal `#/definitions` $refs. This
+# stops the whole async/HTTP stack (tokio/hyper/axum/tower) from being built a
+# second time with divergent features on a scoped `cargo test -p api-edr`.
+jsonschema = { version = "0.28", default-features = false }
 serde_json = "1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 tower = { version = "0.5", features = ["util"] }


### PR DESCRIPTION
## What

`crates/api-edr/Cargo.toml`: `jsonschema = { version = "0.28", default-features = false }`.

## Why

A scoped `cargo test -p api-edr` compiled the entire async/HTTP stack **twice**. Root cause (via `cargo tree -p api-edr -i tokio -e features`): the `jsonschema` dev-dependency enables `resolve-http` by default → pulls in **`reqwest`** → `hyper-util` "client", which expands `tokio`/`hyper` features beyond api-edr's normal build. Resolver v2 doesn't merge dev-dependency features into the normal build, so `tokio` + `reqwest` + its subtree were built a second time for the test target.

This only bites scoped `-p` builds; `cargo test --workspace` masks it because `server` pulls `tokio = ["full"]`, unifying the feature set.

## Safe because

The CoverageJSON validation tests (`tests/covjson_validation.rs`) read the schema from disk themselves and it contains only internal `#/definitions` `$ref`s — no remote resolution is used. Disabling `resolve-http` changes no behaviour.

## Verified

- `reqwest` dropped from the api-edr dep graph (`cargo tree -p api-edr -i reqwest` → empty).
- `tokio` no longer re-compiled for the test target.
- All 220 api-edr tests pass, including CoverageJSON schema validation.

## Not chased

The residual `axum`/`hyper`/`tower` second build comes from dev-only features (`tower "util"`, `tokio "macros,rt-multi-thread"`, `http-body-util`) that diverge from the normal build. Eliminating it would mean adding test-only features to the library's *normal* deps — not worth it, especially now that compiles are fast after the dev-profile debuginfo trim (#308).

🤖 Generated with [Claude Code](https://claude.com/claude-code)