### PR TITLE
refactor: case-insensitive URL-scheme detection for data sources

### DIFF
--- a/crates/engine-geotiff/src/lib.rs
+++ b/crates/engine-geotiff/src/lib.rs
@@ -277,9 +277,9 @@ impl GeoTiffEngine {
                 display,
             )
         } else if let Some(data_path) = data_path {
-            let is_remote = data_path.starts_with("s3://")
-                || data_path.starts_with("http://")
-                || data_path.starts_with("https://");
+            let is_remote = ds_storage::has_scheme(data_path, "s3://")
+                || ds_storage::has_scheme(data_path, "http://")
+                || ds_storage::has_scheme(data_path, "https://");
 
             if is_remote {
                 let (store, prefix) = ds_storage::build_store(data_path)?;

--- a/crates/engine-odim/src/engine.rs
+++ b/crates/engine-odim/src/engine.rs
@@ -714,7 +714,9 @@ fn build_source(
         }
         (None, None) => {
             let data_path = data_path.ok_or(EngineError::NoSource)?;
-            if data_path.starts_with("http://") || data_path.starts_with("https://") {
+            if ds_storage::has_scheme(data_path, "http://")
+                || ds_storage::has_scheme(data_path, "https://")
+            {
                 // HTTP(S) object-store source, mirroring engine-geotiff:
                 // `build_store` dispatches the URL (plain HTTP → WebDAV-
                 // listable `HttpStore`; amazonaws/cloudferro → S3). The
@@ -1046,6 +1048,21 @@ mod tests {
         assert!(
             label.starts_with("http https://opendata.example.org/"),
             "source_label should name the HTTP base URL, got `{label}`"
+        );
+    }
+
+    /// URL schemes are case-insensitive (RFC 3986) — an uppercase
+    /// `HTTPS://` `data_path` must still route to a remote source, not
+    /// fall through to a `Source::Local` that errors as a missing
+    /// directory.
+    #[test]
+    fn build_source_http_scheme_is_case_insensitive() {
+        let config = config_with(None, None, None, None);
+        let source = build_source("http-test", Some("HTTPS://host.example/radar/"), &config)
+            .expect("uppercase https data_path builds a remote source");
+        assert!(
+            matches!(source, Source::Remote { .. }),
+            "an HTTPS:// data_path must select a remote source"
         );
     }
 

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -194,20 +194,42 @@ impl std::fmt::Debug for DataStore {
     }
 }
 
+/// Case-insensitively test whether `path` begins with a URL `scheme`
+/// prefix (e.g. `"http://"`, `"s3://"`).
+///
+/// Per RFC 3986 §3.1 URL schemes are case-insensitive (`HTTP://` and
+/// `http://` are the same scheme), but the remainder of a URL is not —
+/// so only the prefix is folded. The comparison is byte-wise so a
+/// non-ASCII `path` can't trip a UTF-8 boundary panic.
+pub fn has_scheme(path: &str, scheme: &str) -> bool {
+    let scheme = scheme.as_bytes();
+    let bytes = path.as_bytes();
+    bytes.len() >= scheme.len() && bytes[..scheme.len()].eq_ignore_ascii_case(scheme)
+}
+
+/// Case-insensitively strip a URL `scheme` prefix, returning the
+/// remainder, or `None` when `path` doesn't start with `scheme`.
+/// `scheme` is ASCII, so the matched prefix length is a valid UTF-8
+/// boundary to slice at.
+fn strip_scheme<'a>(path: &'a str, scheme: &str) -> Option<&'a str> {
+    has_scheme(path, scheme).then(|| &path[scheme.len()..])
+}
+
 /// Build a `DataStore` from a data path string.
 ///
-/// Auto-detects the backend from the path prefix:
+/// Auto-detects the backend from the path prefix (schemes are matched
+/// case-insensitively, per [`has_scheme`]):
 /// - `s3://bucket/prefix/` → Amazon S3 (credentials from AWS standard chain)
 /// - `https://...` or `http://...` → HTTP object store
 /// - Anything else → Local filesystem
 ///
 /// Returns the store and the base path within that store.
 pub fn build_store(data_path: &str) -> Result<(DataStore, ObjectPath), DataServerError> {
-    if data_path.starts_with("s3://") {
+    if has_scheme(data_path, "s3://") {
         build_s3_store(data_path)
     } else if is_s3_http_url(data_path) {
         build_s3_from_http_url(data_path)
-    } else if data_path.starts_with("http://") || data_path.starts_with("https://") {
+    } else if has_scheme(data_path, "http://") || has_scheme(data_path, "https://") {
         build_http_store(data_path)
     } else {
         build_local_store(data_path)
@@ -226,7 +248,7 @@ pub fn build_s3_store_from_parts(
     endpoint: &str,
     bucket: &str,
 ) -> Result<DataStore, DataServerError> {
-    let allow_http = endpoint.starts_with("http://");
+    let allow_http = has_scheme(endpoint, "http://");
 
     let store = object_store::aws::AmazonS3Builder::new()
         .with_bucket_name(bucket)
@@ -264,9 +286,8 @@ fn build_local_store(data_path: &str) -> Result<(DataStore, ObjectPath), DataSer
 }
 
 fn build_s3_store(data_path: &str) -> Result<(DataStore, ObjectPath), DataServerError> {
-    // Parse s3://bucket/prefix/path/
-    let without_scheme = data_path
-        .strip_prefix("s3://")
+    // Parse s3://bucket/prefix/path/ (scheme matched case-insensitively).
+    let without_scheme = strip_scheme(data_path, "s3://")
         .ok_or_else(|| DataServerError::Storage("Expected s3:// prefix".into()))?;
 
     let (bucket, prefix) = match without_scheme.find('/') {
@@ -389,6 +410,30 @@ fn build_http_store(data_path: &str) -> Result<(DataStore, ObjectPath), DataServ
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn has_scheme_is_case_insensitive_on_the_prefix_only() {
+        // Scheme matches regardless of case (RFC 3986 §3.1).
+        for url in [
+            "http://example.com/x",
+            "HTTP://example.com/x",
+            "HtTp://example.com/x",
+        ] {
+            assert!(has_scheme(url, "http://"), "{url} should match http://");
+        }
+        assert!(has_scheme("S3://bucket/key", "s3://"));
+        assert!(has_scheme("HTTPS://h/p", "https://"));
+
+        // Non-matches: different scheme, no scheme, or shorter than the prefix.
+        assert!(!has_scheme("ftp://h/p", "http://"));
+        assert!(!has_scheme("/local/path", "http://"));
+        assert!(!has_scheme("htt", "http://"));
+        assert!(!has_scheme("", "s3://"));
+        // The fold applies to the scheme only — the path keeps its case,
+        // which `strip_scheme` must preserve verbatim.
+        assert_eq!(strip_scheme("S3://Bucket/Key", "s3://"), Some("Bucket/Key"));
+        assert_eq!(strip_scheme("/local", "s3://"), None);
+    }
 
     #[tokio::test(flavor = "multi_thread")]
     async fn local_store_list() {


### PR DESCRIPTION
## Summary

Follow-up to the #310 review nit: URL schemes are case-insensitive (RFC 3986 §3.1), but data-source backends were selected with case-sensitive `starts_with("http://")` / `"s3://"` checks. An `HTTP://…` or `S3://…` `data_path` fell through to the local-filesystem branch and failed with a confusing "not a directory" / canonicalize error instead of routing to the right remote store.

As noted in the review, the fix must touch every scheme-dispatch site **together** — folding only one check would route a URL into a branch where another, still-case-sensitive check then fails (e.g. `build_store` routing `S3://` to `build_s3_store`, whose `strip_prefix("s3://")` would miss).

## Changes

- **New `ds_storage::has_scheme(path, scheme)`** helper — byte-wise, folds only the scheme prefix (so a non-ASCII path can't trip a UTF-8 boundary panic), plus a private `strip_scheme` for the s3 prefix strip.
- Routed through every dispatch site:
  - `ds_storage::build_store` (`s3://` / `http://` / `https://`) + `build_s3_store`'s prefix strip
  - `build_s3_store_from_parts` `allow_http` gating
  - `engine-geotiff` `is_remote` detection
  - `engine-odim` COMP HTTP source arm (added in #310)

## Deliberately left untouched

- `engine-geotiff/src/stac.rs`'s http(s) check is an SSRF **rejection guard**, not dispatch — loosening it is a separate security decision.
- `is_s3_http_url`'s `.amazonaws.com/` host substring match is case-sensitive on the **host**, a different concern (and hosts are conventionally lowercase).

## Tests

- `has_scheme` / `strip_scheme`: lower/upper/mixed case, different scheme, no scheme, too-short input, and that the path remainder keeps its case verbatim.
- `engine-odim`: an `HTTPS://` `data_path` routes to a remote source.

`cargo fmt`, `cargo clippy --all-targets`, and `cargo test -p ds-storage -p engine-odim` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)