### PR TITLE
fix(engine-odim): fast PVOL startup — bootstrap scan + concurrent fetch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -796,6 +796,7 @@ dependencies = [
  "ds-core",
  "futures",
  "object_store",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tracing",

--- a/crates/engine-odim/src/volume_engine.rs
+++ b/crates/engine-odim/src/volume_engine.rs
@@ -733,17 +733,17 @@ fn enumerate_local(
     Ok(pending)
 }
 
-/// Extract an acquisition timestamp from an object key by finding the
-/// first run of ≥ 12 consecutive ASCII digits in the basename and
-/// parsing its leading 12 as `%Y%m%d%H%M` (UTC).
+/// Byte range of the acquisition timestamp in `basename`: the first run
+/// of ≥ 12 consecutive ASCII digits, returned as `(start, end)`.
 ///
 /// Handles both source layouts — FMI `202605150000_fivih_PVOL.h5`
 /// (timestamp leads) and DMI `dkste_202512150405.vol.h5` (timestamp
-/// follows the station code). Returns `None` when no such digit run
-/// exists; the caller then keeps the file and relies on the
-/// post-parse `time_window` filter.
-fn parse_key_timestamp(key: &str) -> Option<DateTime<Utc>> {
-    let basename = key.rsplit('/').next().unwrap_or(key);
+/// follows the station code). The single source of truth for "where the
+/// timestamp is," shared by [`parse_key_timestamp`] (which parses it) and
+/// [`stream_key`] (which masks it) so the two can't silently diverge —
+/// the bootstrap newest-per-stream reduction relies on the masked run
+/// being exactly the parsed timestamp.
+fn timestamp_run(basename: &str) -> Option<(usize, usize)> {
     let bytes = basename.as_bytes();
     let mut i = 0;
     while i < bytes.len() {
@@ -753,12 +753,7 @@ fn parse_key_timestamp(key: &str) -> Option<DateTime<Utc>> {
                 i += 1;
             }
             if i - start >= 12 {
-                return chrono::NaiveDateTime::parse_from_str(
-                    &basename[start..start + 12],
-                    "%Y%m%d%H%M",
-                )
-                .ok()
-                .map(|t| t.and_utc());
+                return Some((start, i));
             }
         } else {
             i += 1;
@@ -767,38 +762,38 @@ fn parse_key_timestamp(key: &str) -> Option<DateTime<Utc>> {
     None
 }
 
+/// Extract an acquisition timestamp from an object key by parsing the
+/// leading 12 digits of its [`timestamp_run`] as `%Y%m%d%H%M` (UTC).
+/// Returns `None` when the basename has no such run; the caller then
+/// keeps the file and relies on the post-parse `time_window` filter.
+fn parse_key_timestamp(key: &str) -> Option<DateTime<Utc>> {
+    let basename = key.rsplit('/').next().unwrap_or(key);
+    let (start, _) = timestamp_run(basename)?;
+    chrono::NaiveDateTime::parse_from_str(&basename[start..start + 12], "%Y%m%d%H%M")
+        .ok()
+        .map(|t| t.and_utc())
+}
+
 /// A per-site/per-product grouping key for a remote object: the object's
-/// basename with its acquisition-timestamp digit-run masked to `#`, so
-/// every timestep of the same stream collapses to one key.
+/// basename with its acquisition-timestamp [`timestamp_run`] masked to
+/// `#`, so every timestep of the same stream collapses to one key.
 ///
 /// `202605150000_fivih_PVOL.h5` → `#_fivih_PVOL.h5`,
-/// `dkste_202512150405.vol.h5` → `dkste_#.vol.h5`. Uses the same
-/// first-run-of-≥12-digits rule as [`parse_key_timestamp`], so the masked
-/// run is exactly the timestamp. A basename with no such run is its own
-/// stream (returned unchanged), which keeps it from being dropped during
-/// the bootstrap newest-per-stream reduction.
+/// `dkste_202512150405.vol.h5` → `dkste_#.vol.h5`. A basename with no
+/// timestamp run is its own stream (returned unchanged), which keeps it
+/// from being dropped during the bootstrap newest-per-stream reduction.
 fn stream_key(key: &str) -> String {
     let basename = key.rsplit('/').next().unwrap_or(key);
-    let bytes = basename.as_bytes();
-    let mut i = 0;
-    while i < bytes.len() {
-        if bytes[i].is_ascii_digit() {
-            let start = i;
-            while i < bytes.len() && bytes[i].is_ascii_digit() {
-                i += 1;
-            }
-            if i - start >= 12 {
-                let mut s = String::with_capacity(basename.len() - (i - start) + 1);
-                s.push_str(&basename[..start]);
-                s.push('#');
-                s.push_str(&basename[i..]);
-                return s;
-            }
-        } else {
-            i += 1;
+    match timestamp_run(basename) {
+        Some((start, end)) => {
+            let mut s = String::with_capacity(basename.len() - (end - start) + 1);
+            s.push_str(&basename[..start]);
+            s.push('#');
+            s.push_str(&basename[end..]);
+            s
         }
+        None => basename.to_string(),
     }
-    basename.to_string()
 }
 
 /// Enumerate `.h5` objects under an S3/HTTP store's date-expanded
@@ -997,10 +992,12 @@ fn build_catalog(
     };
 
     // Download the remote misses concurrently, in `FETCH_CONCURRENCY`-sized
-    // chunks so peak memory stays ~one chunk of raw volumes (each chunk's
-    // bytes are parsed into compact `PolarVolume`s and dropped before the
-    // next). This parallelises the dominant scan cost — the per-file S3
-    // download — turning a sequential ~N×RTT stall into ~N/concurrency.
+    // chunks. `get_many` returns a whole chunk's raw bytes together, so
+    // peak memory is ~one chunk of volumes resident at once; those are
+    // parsed into compact `PolarVolume`s and the chunk's bytes freed before
+    // the next chunk is fetched. This parallelises the dominant scan cost —
+    // the per-file S3 download — turning a sequential ~N×RTT stall into
+    // ~N/concurrency.
     for chunk in remote_fetch.chunks(FETCH_CONCURRENCY) {
         let paths: Vec<ObjectPath> = chunk.iter().map(|(_, p)| p.clone()).collect();
         let results = match store.get_many(&paths, FETCH_CONCURRENCY, Some(MAX_REMOTE_FILE_SIZE)) {

--- a/crates/engine-odim/src/volume_engine.rs
+++ b/crates/engine-odim/src/volume_engine.rs
@@ -128,6 +128,37 @@ pub fn pixel_cache_metrics() -> (u64, u64, u64, u64, u64) {
 /// `OdimEngine`'s constant of the same name.
 const DEFAULT_SCAN_DAYS: u32 = 2;
 
+/// How much of a remote source a scan downloads + parses.
+///
+/// PVOL metadata (site, sweep geometry, parameters) lives *inside* each
+/// HDF5 file, so — unlike the COMP engine, which catalogs from filenames
+/// and downloads only a seed — building the catalog means fetching and
+/// parsing every volume. Over a whole-network S3 bucket with a multi-hour
+/// `time_window` that is hundreds of multi-MB files, which made the
+/// startup scan in [`PolarVolumeEngine::new`] take minutes before the HTTP
+/// listener could bind.
+///
+/// [`ScanDepth::Bootstrap`] fixes that: the construction scan fetches only
+/// the **newest volume per site** — enough to discover every active radar
+/// and seed its metadata (which [`derive_site_meta`] derives from the
+/// *latest* volume per site anyway) — and the background [`poll_loop`]
+/// (already non-blocking, on the dedicated poll runtime) fills the full
+/// `time_window` history on its first tick.
+///
+/// "Newest per site" (not "the latest N timestamp slots") is deliberate:
+/// producer uploads are staggered, so the freshest slots are the *least*
+/// complete — sampling them under-discovers radars whose newest upload
+/// lags. Grouping by [`stream_key`] (the filename with its timestamp
+/// masked) and keeping the latest per group fetches one file per radar —
+/// the theoretical minimum — and can't miss an active site.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum ScanDepth {
+    /// Newest volume per site only — fast startup; used by `new`.
+    Bootstrap,
+    /// Every in-window volume — used by the background poll.
+    Full,
+}
+
 /// Mean Earth radius (metres) used by the geodesic helper. A sphere is
 /// the right model here: radar ground range is itself a spherical
 /// approximation, and the per-pixel error of WGS84-vs-sphere at radar
@@ -595,16 +626,39 @@ fn site_coverage_bbox(lon: f64, lat: f64, radius_m: f64) -> [f64; 4] {
     ]
 }
 
-/// One file the scan should ingest: a stable identity plus a thunk
-/// that fetches its raw bytes on a cache miss. Decouples enumeration
-/// (local `read_dir` vs S3 `list`) from the shared parse/cache/group
-/// logic in [`build_catalog`].
-struct PendingFile<'a> {
-    /// Cache-key identity — local path string or S3 object key.
+/// One file the scan should ingest: a stable identity plus where its
+/// bytes live. Decouples enumeration (local `read_dir` vs S3 `list`)
+/// from the shared parse/cache/group logic in [`build_catalog`], and —
+/// unlike an opaque fetch thunk — lets `build_catalog` batch the remote
+/// files into one bounded-concurrent download.
+struct PendingFile {
+    /// Cache-key identity — local path string or S3/HTTP object key.
     id: FileId,
-    /// Fetch the raw HDF5 bytes. Only called on a cache miss.
-    fetch: Box<dyn FnOnce() -> Result<Vec<u8>, String> + 'a>,
+    /// Where to fetch the raw HDF5 bytes on a cache miss.
+    spec: FetchSpec,
 }
+
+/// Where a [`PendingFile`]'s bytes come from.
+enum FetchSpec {
+    /// A local filesystem path, read with `std::fs::read`.
+    Local(PathBuf),
+    /// An object `key` within `store` (S3/HTTP), fetched via the store.
+    /// Carrying the (cheap `Arc`-clone) `store` makes the file
+    /// self-describing so [`build_catalog`] can collect every remote file
+    /// and download them concurrently.
+    Remote {
+        store: ds_storage::DataStore,
+        key: String,
+    },
+}
+
+/// Max concurrent volume downloads in [`build_catalog`]'s remote fetch.
+/// Bounds in-flight S3 requests (and therefore peak memory to
+/// ~`FETCH_CONCURRENCY × volume size`, a few hundred MB) while turning
+/// the previously-sequential per-file download — the dominant cost of a
+/// scan — into a parallel one. Volume fetches are network-bound, not
+/// CPU-bound, so this can exceed the core count.
+const FETCH_CONCURRENCY: usize = 12;
 
 /// Scan `source` for `.h5` polar-volume files and build the catalog,
 /// reusing already-parsed volumes from `cache` (keyed by file identity)
@@ -616,8 +670,13 @@ fn scan_source(
     source: &Source,
     cache: &Mutex<HashMap<FileId, Arc<PolarVolume>>>,
     max_files: Option<usize>,
+    depth: ScanDepth,
 ) -> Result<Catalog, EngineError> {
     match source {
+        // A local directory is small and cheap to enumerate; the
+        // bootstrap bound only matters for remote (S3/HTTP) sources where
+        // each file is a multi-MB network fetch, so local always scans in
+        // full regardless of `depth`.
         Source::Local { data_dir } => {
             let pending = enumerate_local(collection_id, data_dir)?;
             let by_site = build_catalog(collection_id, pending, cache);
@@ -630,7 +689,7 @@ fn scan_source(
             ..
         } => {
             let (pending, time_filter) =
-                enumerate_remote(collection_id, store, prefix_pattern, time_window)?;
+                enumerate_remote(collection_id, store, prefix_pattern, time_window, depth)?;
             let mut by_site = build_catalog(collection_id, pending, cache);
             // A `time_window` also bounds the timestamps kept: the
             // object listing can include volumes just outside the
@@ -646,10 +705,10 @@ fn scan_source(
 }
 
 /// Enumerate `.h5` files directly in a local directory. Non-recursive.
-fn enumerate_local<'a>(
+fn enumerate_local(
     collection_id: &str,
-    data_dir: &'a std::path::Path,
-) -> Result<Vec<PendingFile<'a>>, EngineError> {
+    data_dir: &std::path::Path,
+) -> Result<Vec<PendingFile>, EngineError> {
     let read_dir = std::fs::read_dir(data_dir).map_err(|e| {
         EngineError::Storage(DataServerError::Engine(format!(
             "[{collection_id}] failed to read PVOL directory `{}`: {e}",
@@ -670,7 +729,7 @@ fn enumerate_local<'a>(
         let id = path.display().to_string();
         pending.push(PendingFile {
             id,
-            fetch: Box::new(move || std::fs::read(&path).map_err(|e| format!("read failed: {e}"))),
+            spec: FetchSpec::Local(path),
         });
     }
     Ok(pending)
@@ -710,21 +769,62 @@ fn parse_key_timestamp(key: &str) -> Option<DateTime<Utc>> {
     None
 }
 
+/// A per-site/per-product grouping key for a remote object: the object's
+/// basename with its acquisition-timestamp digit-run masked to `#`, so
+/// every timestep of the same stream collapses to one key.
+///
+/// `202605150000_fivih_PVOL.h5` → `#_fivih_PVOL.h5`,
+/// `dkste_202512150405.vol.h5` → `dkste_#.vol.h5`. Uses the same
+/// first-run-of-≥12-digits rule as [`parse_key_timestamp`], so the masked
+/// run is exactly the timestamp. A basename with no such run is its own
+/// stream (returned unchanged), which keeps it from being dropped during
+/// the bootstrap newest-per-stream reduction.
+fn stream_key(key: &str) -> String {
+    let basename = key.rsplit('/').next().unwrap_or(key);
+    let bytes = basename.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i].is_ascii_digit() {
+            let start = i;
+            while i < bytes.len() && bytes[i].is_ascii_digit() {
+                i += 1;
+            }
+            if i - start >= 12 {
+                let mut s = String::with_capacity(basename.len() - (i - start) + 1);
+                s.push_str(&basename[..start]);
+                s.push('#');
+                s.push_str(&basename[i..]);
+                return s;
+            }
+        } else {
+            i += 1;
+        }
+    }
+    basename.to_string()
+}
+
 /// Enumerate `.h5` objects under an S3/HTTP store's date-expanded
 /// prefixes. Returns the pending-file list plus the optional
 /// `(start, end)` time filter the window implies.
+///
+/// In [`ScanDepth::Bootstrap`] only the newest object per [`stream_key`]
+/// (≈ one volume per radar) is returned, so a construction-time scan
+/// downloads the minimum needed to discover and seed every site instead
+/// of the whole window — the rest is filled by the background poll, which
+/// scans in [`ScanDepth::Full`].
 ///
 /// A prefix that fails to `list` (e.g. a date partition that doesn't
 /// exist yet) is logged and skipped. If *every* prefix fails the call
 /// errors rather than silently returning an empty catalog. Mirrors
 /// `catalog::scan_remote`'s error tolerance.
 #[allow(clippy::type_complexity)]
-fn enumerate_remote<'a>(
+fn enumerate_remote(
     collection_id: &str,
-    store: &'a ds_storage::DataStore,
+    store: &ds_storage::DataStore,
     prefix_pattern: &str,
     time_window: &Option<TimeWindow>,
-) -> Result<(Vec<PendingFile<'a>>, Option<TimeRange>), EngineError> {
+    depth: ScanDepth,
+) -> Result<(Vec<PendingFile>, Option<TimeRange>), EngineError> {
     use ds_storage::object_store::path::Path as ObjectPath;
 
     let now = Utc::now();
@@ -739,7 +839,11 @@ fn enumerate_remote<'a>(
         ),
     };
 
-    let mut pending: Vec<PendingFile<'a>> = Vec::new();
+    // First pass: list each prefix and collect surviving `(key, timestamp)`
+    // candidates. The bootstrap slot filter needs to see every candidate's
+    // timestamp before it can pick the most-recent slots, so building the
+    // fetch closures is deferred to the second pass below.
+    let mut candidates: Vec<(String, Option<DateTime<Utc>>)> = Vec::new();
     let mut errors: Vec<String> = Vec::new();
 
     for prefix in &prefixes {
@@ -755,6 +859,7 @@ fn enumerate_remote<'a>(
             if !key.to_ascii_lowercase().ends_with(".h5") {
                 continue;
             }
+            let ts = parse_key_timestamp(&key);
             // Drop out-of-window objects *before* fetching. A per-day
             // prefix lists a whole day (~288 files at 5-min cadence);
             // without this pre-filter every one would be downloaded and
@@ -762,11 +867,9 @@ fn enumerate_remote<'a>(
             // afterwards — gigabytes of needless transfer. A key whose
             // name carries no parseable timestamp falls through and is
             // caught by the post-parse window filter instead.
-            if let Some((start, end)) = time_filter {
-                if let Some(ts) = parse_key_timestamp(&key) {
-                    if ts < start || ts > end {
-                        continue;
-                    }
+            if let (Some((start, end)), Some(ts)) = (time_filter, ts) {
+                if ts < start || ts > end {
+                    continue;
                 }
             }
             if obj.size as u64 > MAX_REMOTE_FILE_SIZE {
@@ -776,33 +879,49 @@ fn enumerate_remote<'a>(
                 );
                 continue;
             }
-            let store_clone = store.clone();
-            let key_for_fetch = key.clone();
-            pending.push(PendingFile {
-                id: key,
-                fetch: Box::new(move || {
-                    let object = ObjectPath::from(key_for_fetch.as_str());
-                    // Re-check size before `get`: `list` already
-                    // filtered by size; this `head` closes the
-                    // grow-between-list-and-get gap. Mirrors the COMP
-                    // engine's `fetch_bytes` head-before-get.
-                    let meta = store_clone
-                        .head(&object)
-                        .map_err(|e| format!("head failed: {e}"))?;
-                    if meta.size as u64 > MAX_REMOTE_FILE_SIZE {
-                        return Err(format!(
-                            "object is {} bytes — exceeds the {MAX_REMOTE_FILE_SIZE}-byte limit",
-                            meta.size
-                        ));
-                    }
-                    store_clone
-                        .get(&object)
-                        .map(|b| b.to_vec())
-                        .map_err(|e| format!("get failed: {e}"))
-                }),
-            });
+            candidates.push((key, ts));
         }
     }
+
+    // Bootstrap: keep only the newest file per site — grouped by
+    // `stream_key` (the basename with its timestamp masked), keeping the
+    // greatest-timestamp entry in each group. This discovers every active
+    // radar from its latest volume while downloading the theoretical
+    // minimum (one file per site), and — unlike taking the latest N
+    // slots — can't miss a radar whose newest upload lags the freshest
+    // slot. `Option<DateTime>` orders `None < Some`, so a timestamp-less
+    // key only wins its group if no dated key shares the stream.
+    if depth == ScanDepth::Bootstrap {
+        let mut latest: HashMap<String, usize> = HashMap::new();
+        for (i, (key, ts)) in candidates.iter().enumerate() {
+            latest
+                .entry(stream_key(key))
+                .and_modify(|best| {
+                    if *ts > candidates[*best].1 {
+                        *best = i;
+                    }
+                })
+                .or_insert(i);
+        }
+        let mut keep: Vec<usize> = latest.into_values().collect();
+        keep.sort_unstable();
+        candidates = keep.into_iter().map(|i| candidates[i].clone()).collect();
+    }
+
+    // Second pass: turn each retained candidate into a remote fetch spec.
+    // The actual download — with the size re-check that closes the
+    // grow-between-list-and-get gap — happens concurrently in
+    // `build_catalog` via `DataStore::get_many(.., Some(MAX_REMOTE_FILE_SIZE))`.
+    let pending: Vec<PendingFile> = candidates
+        .into_iter()
+        .map(|(key, _)| PendingFile {
+            id: key.clone(),
+            spec: FetchSpec::Remote {
+                store: store.clone(),
+                key,
+            },
+        })
+        .collect();
 
     if pending.is_empty() && !errors.is_empty() {
         return Err(EngineError::Storage(DataServerError::Engine(format!(
@@ -830,77 +949,136 @@ fn enumerate_remote<'a>(
 /// [`derive_catalog`].
 fn build_catalog(
     collection_id: &str,
-    pending: Vec<PendingFile<'_>>,
+    pending: Vec<PendingFile>,
     cache: &Mutex<HashMap<FileId, Arc<PolarVolume>>>,
 ) -> HashMap<String, Vec<VolumeEntry>> {
+    use ds_storage::object_store::path::Path as ObjectPath;
+
     let mut by_site: HashMap<String, Vec<VolumeEntry>> = HashMap::new();
+    // Remote files needing a fetch, gathered for one bounded-concurrent
+    // download pass. Each carries its store (a cheap `Arc` clone; all share
+    // the source's store) so a future mixed-source scan would still work.
+    let mut remote_fetch: Vec<(FileId, ds_storage::DataStore, ObjectPath)> = Vec::new();
 
-    for file in pending {
-        let PendingFile { id, fetch } = file;
-
-        // Cache hit — reuse the parsed volume.
+    for PendingFile { id, spec } in pending {
+        // Cache hit — reuse the parsed volume, no fetch.
         let cached = {
             let guard = cache.lock().unwrap_or_else(|e| e.into_inner());
             guard.get(&id).cloned()
         };
-        let volume = match cached {
-            Some(v) => v,
-            None => {
-                let bytes = match fetch() {
-                    Ok(b) => b,
-                    Err(e) => {
-                        tracing::warn!("[{collection_id}] skipping PVOL file `{id}`: {e}");
-                        continue;
-                    }
-                };
-                match read_polar_volume(&bytes) {
-                    Ok(v) => {
-                        let v = Arc::new(v);
-                        cache
-                            .lock()
-                            .unwrap_or_else(|e| e.into_inner())
-                            .insert(id.clone(), v.clone());
-                        v
-                    }
-                    Err(e) => {
-                        tracing::warn!(
-                            "[{collection_id}] skipping PVOL file `{id}`: parse failed: {e}"
-                        );
-                        continue;
-                    }
-                }
-            }
-        };
-
-        let Some(nod) = volume.site.nod.clone() else {
-            tracing::warn!(
-                "[{collection_id}] skipping PVOL file `{id}`: no NOD identifier in /what/source"
-            );
-            continue;
-        };
-
-        // The NOD becomes part of a URL-routed collection id (`{base}-{nod}`)
-        // and a WMS `LAYERS` token, so reject anything that isn't a clean
-        // path segment. ODIM NODs are spec'd as 5 ASCII-alphanumeric chars
-        // (2-letter country + 3-letter station), so this only fires on a
-        // malformed/adversarial file — a NOD with `/` would make the
-        // collection permanently unreachable (Axum stops `{id}` at the first
-        // `/`), and `?`/`#`/space/non-ASCII would corrupt routing or the IRI.
-        if !is_url_safe_nod(&nod) {
-            tracing::warn!(
-                "[{collection_id}] skipping PVOL file `{id}`: NOD `{nod}` contains \
-                 characters invalid in a URL path segment (expected ASCII alphanumeric)"
-            );
+        if let Some(v) = cached {
+            insert_volume(collection_id, &mut by_site, id, v);
             continue;
         }
+        match spec {
+            // Local reads are cheap; do them inline.
+            FetchSpec::Local(path) => match std::fs::read(&path) {
+                Ok(bytes) => {
+                    if let Some(v) = parse_and_cache(collection_id, &id, &bytes, cache) {
+                        insert_volume(collection_id, &mut by_site, id, v);
+                    }
+                }
+                Err(e) => tracing::warn!("[{collection_id}] skipping PVOL file `{id}`: {e}"),
+            },
+            // Defer remote reads to the concurrent batch below.
+            FetchSpec::Remote { store, key } => {
+                remote_fetch.push((id, store, ObjectPath::from(key.as_str())));
+            }
+        }
+    }
 
-        by_site
-            .entry(nod)
-            .or_default()
-            .push(VolumeEntry { id, volume });
+    // Download the remote misses concurrently, in `FETCH_CONCURRENCY`-sized
+    // chunks so peak memory stays ~one chunk of raw volumes (each chunk's
+    // bytes are parsed into compact `PolarVolume`s and dropped before the
+    // next). This parallelises the dominant scan cost — the per-file S3
+    // download — turning a sequential ~N×RTT stall into ~N/concurrency.
+    for chunk in remote_fetch.chunks(FETCH_CONCURRENCY) {
+        let store = chunk[0].1.clone();
+        let paths: Vec<ObjectPath> = chunk.iter().map(|(_, _, p)| p.clone()).collect();
+        let results = match store.get_many(&paths, FETCH_CONCURRENCY, Some(MAX_REMOTE_FILE_SIZE)) {
+            Ok(r) => r,
+            Err(e) => {
+                tracing::warn!("[{collection_id}] PVOL batch fetch failed: {e}");
+                continue;
+            }
+        };
+        for ((id, _, _), res) in chunk.iter().zip(results) {
+            match res {
+                Ok(bytes) => {
+                    if let Some(v) = parse_and_cache(collection_id, id, &bytes, cache) {
+                        insert_volume(collection_id, &mut by_site, id.clone(), v);
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!("[{collection_id}] skipping PVOL file `{id}`: {e}")
+                }
+            }
+        }
     }
 
     by_site
+}
+
+/// Parse `bytes` into a `PolarVolume`, insert into the shared parse cache
+/// keyed by `id`, and return the shared handle. A parse failure is logged
+/// and yields `None` (the file is skipped, not fatal to the scan).
+fn parse_and_cache(
+    collection_id: &str,
+    id: &str,
+    bytes: &[u8],
+    cache: &Mutex<HashMap<FileId, Arc<PolarVolume>>>,
+) -> Option<Arc<PolarVolume>> {
+    match read_polar_volume(bytes) {
+        Ok(v) => {
+            let v = Arc::new(v);
+            cache
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .insert(id.to_string(), v.clone());
+            Some(v)
+        }
+        Err(e) => {
+            tracing::warn!("[{collection_id}] skipping PVOL file `{id}`: parse failed: {e}");
+            None
+        }
+    }
+}
+
+/// Group one parsed volume under its radar `nod`, applying the
+/// URL-safety guard. A volume with no NOD, or a NOD that isn't a clean
+/// URL path segment, is logged and dropped (never registered).
+fn insert_volume(
+    collection_id: &str,
+    by_site: &mut HashMap<String, Vec<VolumeEntry>>,
+    id: FileId,
+    volume: Arc<PolarVolume>,
+) {
+    let Some(nod) = volume.site.nod.clone() else {
+        tracing::warn!(
+            "[{collection_id}] skipping PVOL file `{id}`: no NOD identifier in /what/source"
+        );
+        return;
+    };
+
+    // The NOD becomes part of a URL-routed collection id (`{base}-{nod}`)
+    // and a WMS `LAYERS` token, so reject anything that isn't a clean
+    // path segment. ODIM NODs are spec'd as 5 ASCII-alphanumeric chars
+    // (2-letter country + 3-letter station), so this only fires on a
+    // malformed/adversarial file — a NOD with `/` would make the
+    // collection permanently unreachable (Axum stops `{id}` at the first
+    // `/`), and `?`/`#`/space/non-ASCII would corrupt routing or the IRI.
+    if !is_url_safe_nod(&nod) {
+        tracing::warn!(
+            "[{collection_id}] skipping PVOL file `{id}`: NOD `{nod}` contains \
+             characters invalid in a URL path segment (expected ASCII alphanumeric)"
+        );
+        return;
+    }
+
+    by_site
+        .entry(nod)
+        .or_default()
+        .push(VolumeEntry { id, volume });
 }
 
 /// Whether `nod` is safe to embed verbatim in a URL-routed collection id
@@ -1123,7 +1301,17 @@ impl PolarVolumeEngine {
         let source = Arc::new(build_source(collection_id, data_path, config)?);
 
         let parse_cache = Arc::new(Mutex::new(HashMap::new()));
-        let catalog = scan_source(collection_id, &source, &parse_cache, config.max_files)?;
+        // Bootstrap scan: parse only the most-recent slots so a whole-network
+        // S3 source doesn't download hundreds of multi-MB volumes before the
+        // server can bind. The background poll fills the full `time_window`
+        // history on its first tick (see `ScanDepth`).
+        let catalog = scan_source(
+            collection_id,
+            &source,
+            &parse_cache,
+            config.max_files,
+            ScanDepth::Bootstrap,
+        )?;
         if catalog.by_site.is_empty() {
             tracing::warn!(
                 "[{collection_id}] no PVOL `.h5` files found at `{}` yet — \
@@ -1132,7 +1320,8 @@ impl PolarVolumeEngine {
             );
         } else {
             tracing::info!(
-                "[{collection_id}] PVOL catalog: {} site(s), {} volume(s)",
+                "[{collection_id}] PVOL bootstrap catalog: {} site(s), {} volume(s) \
+                 (newest volume per site; full history fills on the first poll)",
                 catalog.by_site.len(),
                 catalog.by_site.values().map(|l| l.len()).sum::<usize>(),
             );
@@ -1196,7 +1385,7 @@ impl PolarVolumeEngine {
             time_window: None,
         });
         let parse_cache = Arc::new(Mutex::new(HashMap::new()));
-        let catalog = scan_source(collection_id, &source, &parse_cache, None)?;
+        let catalog = scan_source(collection_id, &source, &parse_cache, None, ScanDepth::Full)?;
         Ok(Self {
             collection_id: collection_id.to_string(),
             source,
@@ -1231,11 +1420,16 @@ impl PolarVolumeEngine {
     /// GeoTIFF / QueryData poll loops, which also call their blocking scan
     /// directly on the poll runtime.
     async fn poll_once(&self) {
+        // Full scan: the poll runs on the background runtime, so downloading
+        // and parsing the whole `time_window` here is off the request path
+        // and off the startup path. This is what backfills the history the
+        // bootstrap scan in `new` deliberately skipped.
         match scan_source(
             &self.collection_id,
             &self.source,
             &self.parse_cache,
             self.max_files,
+            ScanDepth::Full,
         ) {
             Ok(catalog) => {
                 let prev = self.catalog.load();
@@ -3897,6 +4091,49 @@ mod tests {
             build_source("c", Some("/dir"), &bucket_only),
             Err(EngineError::IncompleteS3Config)
         ));
+    }
+
+    /// `ScanDepth::Bootstrap` returns the newest object per site (one
+    /// volume per radar), while `Full` returns every in-window file.
+    /// Drives the real remote enumeration over a `LocalFileSystem`-backed
+    /// `DataStore` (the offline-remote trick); `enumerate_remote` only
+    /// lists keys and parses filename timestamps — it does not open the
+    /// HDF5 — so plain placeholder files exercise the reduction without a
+    /// real fixture, and the test runs in CI.
+    ///
+    /// Crucially, `fikor`'s newest upload (00:05) *lags* `fivih`'s (00:10):
+    /// a "latest N slots" rule would miss `fikor`, but newest-per-site must
+    /// still discover it — the staggered-upload case from the live test.
+    #[test]
+    fn enumerate_remote_bootstrap_keeps_newest_volume_per_site() {
+        let dir = tempfile::tempdir().unwrap();
+        // fivih: 3 slots (newest 00:10). fikor: 2 slots (newest 00:05, lags).
+        for slot in ["202605150000", "202605150005", "202605150010"] {
+            std::fs::write(dir.path().join(format!("{slot}_fivih_PVOL.h5")), b"x").unwrap();
+        }
+        for slot in ["202605150000", "202605150005"] {
+            std::fs::write(dir.path().join(format!("{slot}_fikor_PVOL.h5")), b"x").unwrap();
+        }
+        let (store, _) =
+            ds_storage::build_store(dir.path().canonicalize().unwrap().to_str().unwrap()).unwrap();
+
+        // Full: every file. `time_window: None` so `Utc::now()`-relative
+        // filtering doesn't drop the (necessarily past-dated) fixtures.
+        let (full, _) = enumerate_remote("t", &store, "", &None, ScanDepth::Full).unwrap();
+        assert_eq!(full.len(), 5, "Full scan must enumerate every volume");
+
+        // Bootstrap: exactly one (the newest) per site.
+        let (boot, _) = enumerate_remote("t", &store, "", &None, ScanDepth::Bootstrap).unwrap();
+        let mut ids: Vec<&str> = boot.iter().map(|p| p.id.as_str()).collect();
+        ids.sort_unstable();
+        assert_eq!(
+            ids,
+            vec![
+                "202605150005_fikor_PVOL.h5", // fikor's newest, even though it lags
+                "202605150010_fivih_PVOL.h5", // fivih's newest
+            ],
+            "Bootstrap keeps exactly the newest volume per site"
+        );
     }
 
     /// The pre-fetch window filter hinges on reading a timestamp from

--- a/crates/engine-odim/src/volume_engine.rs
+++ b/crates/engine-odim/src/volume_engine.rs
@@ -642,14 +642,12 @@ struct PendingFile {
 enum FetchSpec {
     /// A local filesystem path, read with `std::fs::read`.
     Local(PathBuf),
-    /// An object `key` within `store` (S3/HTTP), fetched via the store.
-    /// Carrying the (cheap `Arc`-clone) `store` makes the file
-    /// self-describing so [`build_catalog`] can collect every remote file
-    /// and download them concurrently.
-    Remote {
-        store: ds_storage::DataStore,
-        key: String,
-    },
+    /// An object `key` within the scan's single source store (S3/HTTP).
+    /// The store isn't carried per-file: a scan has exactly one
+    /// [`Source`], so [`build_catalog`] receives that one store and uses
+    /// it for every remote key — letting it batch them into one
+    /// bounded-concurrent download.
+    Remote { key: String },
 }
 
 /// Max concurrent volume downloads in [`build_catalog`]'s remote fetch.
@@ -679,7 +677,7 @@ fn scan_source(
         // full regardless of `depth`.
         Source::Local { data_dir } => {
             let pending = enumerate_local(collection_id, data_dir)?;
-            let by_site = build_catalog(collection_id, pending, cache);
+            let by_site = build_catalog(collection_id, pending, None, cache);
             Ok(derive_catalog(by_site, cache, max_files))
         }
         Source::Remote {
@@ -690,7 +688,7 @@ fn scan_source(
         } => {
             let (pending, time_filter) =
                 enumerate_remote(collection_id, store, prefix_pattern, time_window, depth)?;
-            let mut by_site = build_catalog(collection_id, pending, cache);
+            let mut by_site = build_catalog(collection_id, pending, Some(store), cache);
             // A `time_window` also bounds the timestamps kept: the
             // object listing can include volumes just outside the
             // window (the prefix is a whole UTC day).
@@ -916,10 +914,7 @@ fn enumerate_remote(
         .into_iter()
         .map(|(key, _)| PendingFile {
             id: key.clone(),
-            spec: FetchSpec::Remote {
-                store: store.clone(),
-                key,
-            },
+            spec: FetchSpec::Remote { key },
         })
         .collect();
 
@@ -950,15 +945,15 @@ fn enumerate_remote(
 fn build_catalog(
     collection_id: &str,
     pending: Vec<PendingFile>,
+    store: Option<&ds_storage::DataStore>,
     cache: &Mutex<HashMap<FileId, Arc<PolarVolume>>>,
 ) -> HashMap<String, Vec<VolumeEntry>> {
     use ds_storage::object_store::path::Path as ObjectPath;
 
     let mut by_site: HashMap<String, Vec<VolumeEntry>> = HashMap::new();
-    // Remote files needing a fetch, gathered for one bounded-concurrent
-    // download pass. Each carries its store (a cheap `Arc` clone; all share
-    // the source's store) so a future mixed-source scan would still work.
-    let mut remote_fetch: Vec<(FileId, ds_storage::DataStore, ObjectPath)> = Vec::new();
+    // Remote keys needing a fetch, gathered for one bounded-concurrent
+    // download pass against the scan's single source `store`.
+    let mut remote_fetch: Vec<(FileId, ObjectPath)> = Vec::new();
 
     for PendingFile { id, spec } in pending {
         // Cache hit — reuse the parsed volume, no fetch.
@@ -981,11 +976,25 @@ fn build_catalog(
                 Err(e) => tracing::warn!("[{collection_id}] skipping PVOL file `{id}`: {e}"),
             },
             // Defer remote reads to the concurrent batch below.
-            FetchSpec::Remote { store, key } => {
-                remote_fetch.push((id, store, ObjectPath::from(key.as_str())));
+            FetchSpec::Remote { key } => {
+                remote_fetch.push((id, ObjectPath::from(key.as_str())));
             }
         }
     }
+
+    // A `Remote` spec can only come from a `Source::Remote` scan, which
+    // always passes its store — so this is unreachable in practice; guard
+    // rather than `expect` so a future refactor degrades to a warning, not
+    // a panic.
+    let Some(store) = store else {
+        if !remote_fetch.is_empty() {
+            tracing::warn!(
+                "[{collection_id}] {} remote PVOL file(s) enumerated without a store — skipped",
+                remote_fetch.len()
+            );
+        }
+        return by_site;
+    };
 
     // Download the remote misses concurrently, in `FETCH_CONCURRENCY`-sized
     // chunks so peak memory stays ~one chunk of raw volumes (each chunk's
@@ -993,8 +1002,7 @@ fn build_catalog(
     // next). This parallelises the dominant scan cost — the per-file S3
     // download — turning a sequential ~N×RTT stall into ~N/concurrency.
     for chunk in remote_fetch.chunks(FETCH_CONCURRENCY) {
-        let store = chunk[0].1.clone();
-        let paths: Vec<ObjectPath> = chunk.iter().map(|(_, _, p)| p.clone()).collect();
+        let paths: Vec<ObjectPath> = chunk.iter().map(|(_, p)| p.clone()).collect();
         let results = match store.get_many(&paths, FETCH_CONCURRENCY, Some(MAX_REMOTE_FILE_SIZE)) {
             Ok(r) => r,
             Err(e) => {
@@ -1002,7 +1010,7 @@ fn build_catalog(
                 continue;
             }
         };
-        for ((id, _, _), res) in chunk.iter().zip(results) {
+        for ((id, _), res) in chunk.iter().zip(results) {
             match res {
                 Ok(bytes) => {
                     if let Some(v) = parse_and_cache(collection_id, id, &bytes, cache) {

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -13,3 +13,6 @@ futures = "0.3"
 url = "2"
 tracing = "0.1"
 thiserror = "2"
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -128,6 +128,90 @@ impl DataStore {
         self.block_on(async { Ok(self.inner.head(path).await?) })
     }
 
+    /// Fetch many objects concurrently, returning one result per input
+    /// path **in input order**. A per-object failure (missing, oversized,
+    /// network) is carried in that slot's `Err` and does not sink the
+    /// batch; the outer `Err` is reserved for a runtime-bridge failure.
+    ///
+    /// `concurrency` bounds in-flight requests (`buffer_unordered`), which
+    /// also bounds peak memory to ~`concurrency × object size` — so call
+    /// this with a bounded batch (a chunk), not thousands of paths at once.
+    /// When `max_bytes` is set, each object's size is checked with `head`
+    /// before `get`, so an object that grew past the cap isn't pulled into
+    /// memory.
+    ///
+    /// Drives the whole batch on ONE bridge call, so — like every other
+    /// [`DataStore`] method — it is safe at startup and on a multi-thread
+    /// runtime worker (`block_in_place`) but MUST NOT be wrapped in
+    /// `spawn_blocking` or called from a rayon worker.
+    #[allow(clippy::type_complexity)]
+    pub fn get_many(
+        &self,
+        paths: &[ObjectPath],
+        concurrency: usize,
+        max_bytes: Option<u64>,
+    ) -> Result<Vec<Result<Bytes, DataServerError>>, DataServerError> {
+        use futures::StreamExt;
+
+        let conc = concurrency.max(1);
+        let inner = &self.inner;
+        // Drive the batch with NO overall timeout — the 30s budget is
+        // applied PER object below. A whole-batch cap would fail the entire
+        // chunk once the combined transfer exceeds 30s (e.g. a dozen
+        // multi-MB volumes on a constrained link), losing every object
+        // instead of the one that actually stalled.
+        let ordered: Vec<(usize, Result<Bytes, DataServerError>)> =
+            self.block_on_untimed(async {
+                let mut results: Vec<(usize, Result<Bytes, DataServerError>)> =
+                    futures::stream::iter(paths.iter().enumerate().map(|(i, p)| async move {
+                        let fetch = async {
+                            if let Some(cap) = max_bytes {
+                                let meta = inner
+                                    .head(p)
+                                    .await
+                                    .map_err(|e| DataServerError::from(StorageError::from(e)))?;
+                                if meta.size as u64 > cap {
+                                    return Err(DataServerError::Storage(format!(
+                                        "object `{p}` is {} bytes — exceeds the {cap}-byte limit",
+                                        meta.size
+                                    )));
+                                }
+                            }
+                            let res = inner
+                                .get(p)
+                                .await
+                                .map_err(|e| DataServerError::from(StorageError::from(e)))?;
+                            let bytes = res
+                                .bytes()
+                                .await
+                                .map_err(|e| DataServerError::from(StorageError::from(e)))?;
+                            Ok::<Bytes, DataServerError>(bytes)
+                        };
+                        let r = match tokio::time::timeout(Self::REQUEST_TIMEOUT, fetch).await {
+                            Ok(r) => r,
+                            Err(_) => Err(DataServerError::Storage(format!(
+                                "fetch of `{p}` timed out after {}s",
+                                Self::REQUEST_TIMEOUT.as_secs()
+                            ))),
+                        };
+                        (i, r)
+                    }))
+                    .buffer_unordered(conc)
+                    .collect()
+                    .await;
+                results.sort_by_key(|(i, _)| *i);
+                results
+            })?;
+
+        let total: u64 = ordered
+            .iter()
+            .filter_map(|(_, r)| r.as_ref().ok())
+            .map(|b| b.len() as u64)
+            .sum();
+        self.bytes_read.fetch_add(total, Ordering::Relaxed);
+        Ok(ordered.into_iter().map(|(_, r)| r).collect())
+    }
+
     /// Default timeout for individual storage operations (30 seconds).
     const REQUEST_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 
@@ -140,6 +224,29 @@ impl DataStore {
         F: std::future::Future<Output = Result<T, object_store::Error>>,
     {
         self.block_on_with(None, future)
+    }
+
+    /// Drive `future` to completion on the appropriate runtime — like
+    /// [`Self::block_on`] but with **no** overall 30s timeout and an
+    /// unconstrained output type. For batch helpers (e.g. [`Self::get_many`])
+    /// whose total wall-time legitimately exceeds a single request's budget
+    /// and which apply their own per-item timeouts; a batch-wide cap would
+    /// wrongly fail the whole batch. Same thread-context rules as
+    /// [`Self::block_on_with`] with `None`: valid on a runtime worker
+    /// (`block_in_place`) or off-runtime (temporary runtime), never on a
+    /// `spawn_blocking`/rayon thread.
+    fn block_on_untimed<F, T>(&self, future: F) -> Result<T, DataServerError>
+    where
+        F: std::future::Future<Output = T>,
+    {
+        match tokio::runtime::Handle::try_current() {
+            Ok(handle) => Ok(tokio::task::block_in_place(|| handle.block_on(future))),
+            Err(_) => {
+                let rt = tokio::runtime::Runtime::new()
+                    .map_err(|e| DataServerError::Storage(format!("Cannot create runtime: {e}")))?;
+                Ok(rt.block_on(future))
+            }
+        }
     }
 
     /// Core sync→async bridge. With an explicit `handle` (caller is on a
@@ -433,6 +540,45 @@ mod tests {
         // which `strip_scheme` must preserve verbatim.
         assert_eq!(strip_scheme("S3://Bucket/Key", "s3://"), Some("Bucket/Key"));
         assert_eq!(strip_scheme("/local", "s3://"), None);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn get_many_returns_results_in_input_order_and_isolates_failures() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("a.bin"), b"aaa").unwrap();
+        std::fs::write(dir.path().join("c.bin"), b"cccc").unwrap();
+        let (store, _) = build_store(dir.path().to_str().unwrap()).unwrap();
+
+        // Middle key is missing — its slot must be `Err`, the others `Ok`,
+        // and the order must match the input.
+        let paths = [
+            ObjectPath::from("a.bin"),
+            ObjectPath::from("missing.bin"),
+            ObjectPath::from("c.bin"),
+        ];
+        let res = store.get_many(&paths, 8, None).unwrap();
+        assert_eq!(res.len(), 3);
+        assert_eq!(res[0].as_ref().unwrap().as_ref(), b"aaa");
+        assert!(res[1].is_err(), "a missing object yields a per-item Err");
+        assert_eq!(res[2].as_ref().unwrap().as_ref(), b"cccc");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn get_many_max_bytes_rejects_oversized_object() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("big.bin"), vec![0u8; 100]).unwrap();
+        std::fs::write(dir.path().join("ok.bin"), vec![0u8; 8]).unwrap();
+        let (store, _) = build_store(dir.path().to_str().unwrap()).unwrap();
+
+        let res = store
+            .get_many(
+                &[ObjectPath::from("ok.bin"), ObjectPath::from("big.bin")],
+                4,
+                Some(10),
+            )
+            .unwrap();
+        assert!(res[0].is_ok(), "8-byte object is under the 10-byte cap");
+        assert!(res[1].is_err(), "100-byte object exceeds the cap → Err");
     }
 
     #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
## Problem

A whole-network `odim-volume` S3 source — e.g. FMI's `fmi-opendata-radar-volume-hdf5` with `prefix_pattern = "%Y/%m/%d/"`, `time_window = "-PT2H"` — made **server startup take minutes**. `PolarVolumeEngine::new` ran a fully synchronous, **sequential** scan that downloaded + HDF5-parsed *every* in-window volume (~12 radars × ~24 five-minute slots ≈ 240 multi-MB files) before the HTTP listener could bind.

Unlike the COMP engine (which catalogs from filenames and downloads a single seed), PVOL must open each file — the site `nod` and sweep geometry live *inside* the HDF5.

### Range-reading just the header? Investigated, rejected.
`hdf5-reader` supports a custom random-access `Storage` (`from_storage`), so in principle we could range-read only the metadata. But an instrumented `Storage` over a real 22 MB fixture showed a structure parse issues **~78,000 tiny reads (≤384 B) scattered across 100% of the file** — there is no front-loaded header block to fetch cheaply. A single full GET is the efficient per-file transfer; the real problem was fetching *every* file *sequentially* at startup.

## Fix

**1. Bootstrap scan at construction (`ScanDepth::Bootstrap`).** `new` now fetches only the **newest volume per site**: list the window, group keys by `stream_key` (basename with the timestamp digit-run masked, e.g. `#_fivih_PVOL.h5`), keep the latest per group. This discovers every active radar and seeds its metadata — which `derive_site_meta` already derives from the latest volume per site — while downloading the theoretical minimum (one file per radar). The background `poll_loop` (already non-blocking, on the poll runtime) backfills the full `time_window` history in `ScanDepth::Full` on its first tick.

*Why "newest per site" and not "latest N slots":* producer uploads are staggered, so the freshest slots are the **least** complete. A slot-based rule under-discovers radars — observed live (7/12 sites). Newest-per-site can't miss an active radar whose newest upload lags. Site registration in `admin.rs` stays synchronous, so all per-site collections appear at boot with no admin reload.

**2. Concurrent fetch.** New `DataStore::get_many` downloads a bounded batch concurrently (`buffer_unordered`) with a **per-object** 30 s timeout — *not* a batch-wide cap. (A batch-wide cap fails the whole chunk once combined transfer exceeds 30 s on a constrained link, losing every site — caught in live testing.) `build_catalog` collects non-cached remote misses and fetches them in `FETCH_CONCURRENCY`-sized chunks, bounding peak memory to ~one chunk of raw volumes (each chunk is parsed to compact `PolarVolume`s and dropped). Speeds up both the bootstrap and the full background poll.

`PendingFile` now carries a `FetchSpec` (Local path / Remote key+store) instead of an opaque fetch closure, so `build_catalog` can batch remotes.

## Verified live against FMI S3

All **12 sites discovered, 12 volumes** (one per radar), every per-site collection registered at boot, no batch timeout. Startup **~22 s on a ~7 MB/s home link** (download-bandwidth-bound; ~seconds on a datacenter link). Was minutes.

```
PVOL bootstrap catalog: 12 site(s), 12 volume(s) (newest volume per site; full history fills on the first poll)
… wired per-site radar collection 'fi-radar-pvol-fivih' (Vihti)   [×12]
Server ready, accepting requests
```

## Tests

- `DataStore::get_many`: input-order results, per-item error isolation (missing object), `max_bytes` oversize guard.
- PVOL `enumerate_remote` bootstrap reduction: asserts exactly the newest volume per site is kept — including a site whose newest upload *lags* the freshest slot (the staggered-upload case).

`cargo fmt --all --check`, `cargo clippy -p ds-storage -p engine-odim -p server --all-targets`, `cargo test -p ds-storage -p engine-odim` all pass.

## Note / possible follow-up

The first **Full** background poll still downloads every in-window volume (now concurrently). Off the startup path and bounded by `time_window`, but heavy transfer on a slow link. If that ever matters, the lever is reducing `time_window` or making *older-timestep structure* parse lazy — a larger refactor, separate from this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)