### PR TITLE
feat(engine-odim): template-based HTTP discovery for non-listable sources (#287)

### DIFF
--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -401,6 +401,19 @@ pub struct OdimConfig {
     /// date expansion and timestamp filtering for S3/HTTP sources. When
     /// unset, the scan falls back to a fixed recent-days window.
     pub time_window: Option<String>,
+    /// Discovery mode for an `http(s)://` `data_path` source (COMP only;
+    /// ignored for local and S3 sources):
+    /// - `"list"` (default) — enumerate the directory with WebDAV
+    ///   `PROPFIND`. Works for listable HTTP stores (#286).
+    /// - `"template"` — don't list; instead build candidate filenames
+    ///   from `filename_template` + `cadence_secs` walking back from now,
+    ///   and probe them with `HEAD`. For non-listable autoindex servers
+    ///   such as DWD opendata (#287). Requires `filename_template`.
+    pub discovery: Option<String>,
+    /// Probe cadence in seconds for `discovery = "template"` — the spacing
+    /// of candidate timestamps (e.g. `300` for a 5-minute radar feed).
+    /// Required in template mode; ignored otherwise.
+    pub cadence_secs: Option<u64>,
 }
 
 fn default_grib_poll_interval() -> u64 {

--- a/crates/engine-odim/Cargo.toml
+++ b/crates/engine-odim/Cargo.toml
@@ -19,3 +19,4 @@ thiserror = "2"
 
 [dev-dependencies]
 tempfile = "3"
+chrono = { version = "0.4", features = ["serde"] }

--- a/crates/engine-odim/src/engine.rs
+++ b/crates/engine-odim/src/engine.rs
@@ -70,7 +70,32 @@ enum Source {
         prefix_pattern: String,
         time_window: Option<TimeWindow>,
     },
+    /// A non-listable HTTP(S) directory discovered by **template probe**
+    /// (#287): instead of `list`, candidate filenames are built from
+    /// `template` (the strftime `filename_template`) for timestamps walked
+    /// back from now over `cadence`, and each is `HEAD`-probed. For
+    /// autoindex servers (DWD opendata) where `list` (WebDAV `PROPFIND`)
+    /// returns nothing. `time_window` bounds how far back to walk;
+    /// `base_url` is diagnostics only.
+    TemplateHttp {
+        store: ds_storage::DataStore,
+        base_url: String,
+        base_prefix: String,
+        template: String,
+        cadence: Duration,
+        time_window: Option<TimeWindow>,
+    },
 }
+
+/// Hard cap on candidate timestamps probed per template scan — a backstop
+/// against an unbounded walk when neither `time_window` nor `max_files`
+/// bounds it. 288 = 24 h at a 5-minute cadence. The probes are concurrent
+/// `HEAD`s (cheap), so this is generous; `time_window`/`max_files` clamp it
+/// far lower in practice (DWD `-PT2H` @ 300 s → 25 probes).
+const HARD_MAX_PROBES: usize = 288;
+
+/// Max concurrent `HEAD` probes in a template scan.
+const PROBE_CONCURRENCY: usize = 16;
 
 /// Diagnostic descriptor for a [`Source::Remote`] store — names the
 /// backend in logs and error messages. The `store` does the real work;
@@ -130,6 +155,119 @@ fn scan_source(
                 max_files,
             )?)
         }
+        Source::TemplateHttp {
+            store,
+            base_prefix,
+            template,
+            cadence,
+            time_window,
+            ..
+        } => Ok(discover_template_at(
+            Utc::now(),
+            store,
+            base_prefix,
+            template,
+            *cadence,
+            time_window.as_ref(),
+            max_files,
+        )?),
+    }
+}
+
+/// Discover ODIM files on a non-listable HTTP source by **probing**
+/// candidate filenames instead of listing the directory.
+///
+/// Builds one candidate per timestamp from `now` walked back by `cadence`
+/// — `N = min(window/cadence, max_files, HARD_MAX_PROBES)` steps — renders
+/// each filename with `time.format(template)` (the strftime inverse of the
+/// catalog matcher), joins it under `base_prefix`, and `HEAD`-probes them
+/// all concurrently. Existing objects become [`CatalogEntry`] values whose
+/// timestamp is the one we generated (no parsing needed); the bytes are
+/// fetched lazily on render via [`fetch_bytes`]. Sorted ascending, deduped
+/// by timestamp.
+///
+/// `now` is a parameter (not `Utc::now()` inside) so the probe is
+/// deterministically testable against a controlled clock.
+fn discover_template_at(
+    now: DateTime<Utc>,
+    store: &ds_storage::DataStore,
+    base_prefix: &str,
+    template: &str,
+    cadence: Duration,
+    time_window: Option<&TimeWindow>,
+    max_files: Option<usize>,
+) -> Result<Vec<CatalogEntry>, EngineError> {
+    use ds_storage::object_store::path::Path as ObjectPath;
+
+    let cadence_secs = (cadence.as_secs().max(1)) as i64;
+
+    // How many timestamp slots back to probe.
+    let window_steps = match time_window {
+        Some(tw) => {
+            let (start, end) = tw.to_range(now);
+            // +1 so the walk includes `now`'s own (aligned) slot.
+            ((end - start).num_seconds().abs() / cadence_secs) as usize + 1
+        }
+        None => HARD_MAX_PROBES,
+    };
+    let bounded = window_steps
+        .min(max_files.unwrap_or(usize::MAX))
+        .min(HARD_MAX_PROBES);
+    let n = bounded.max(1);
+
+    // Align `now` down to the cadence grid (epoch-aligned), then walk back.
+    let now_ts = now.timestamp();
+    let aligned = now_ts - now_ts.rem_euclid(cadence_secs);
+    let stamps: Vec<DateTime<Utc>> = (0..n)
+        .filter_map(|i| DateTime::<Utc>::from_timestamp(aligned - (i as i64) * cadence_secs, 0))
+        .collect();
+
+    // Render candidate filenames via the strftime template, join under the
+    // base prefix, and probe their existence concurrently.
+    let keys: Vec<String> = stamps
+        .iter()
+        .map(|t| join_prefix(base_prefix, &t.format(template).to_string()))
+        .collect();
+    let paths: Vec<ObjectPath> = keys.iter().map(|k| ObjectPath::from(k.as_str())).collect();
+
+    let probed = store.head_many(&paths, PROBE_CONCURRENCY)?;
+
+    let mut entries: Vec<CatalogEntry> = Vec::new();
+    for ((time, key), result) in stamps.iter().zip(keys.iter()).zip(probed.iter()) {
+        match result {
+            Ok(Some(meta)) => {
+                if meta.size as u64 > crate::catalog::MAX_REMOTE_FILE_SIZE {
+                    tracing::warn!(
+                        "[odim-template] skipping oversized object `{key}` ({} bytes)",
+                        meta.size
+                    );
+                    continue;
+                }
+                entries.push(CatalogEntry {
+                    time: *time,
+                    location: Location::Remote {
+                        store: store.clone(),
+                        key: key.clone(),
+                    },
+                });
+            }
+            Ok(None) => {} // absent — expected for most candidate slots
+            Err(e) => tracing::warn!("[odim-template] HEAD `{key}` failed: {e}"),
+        }
+    }
+
+    entries.sort_by_key(|e| e.time);
+    entries.dedup_by(|a, b| a.time == b.time);
+    Ok(entries)
+}
+
+/// Join a base prefix and a filename with exactly one `/` (and none when
+/// the base is empty — an `http(s)://host/` URL pointing at the root).
+fn join_prefix(base_prefix: &str, filename: &str) -> String {
+    if base_prefix.is_empty() {
+        filename.to_string()
+    } else {
+        format!("{}/{}", base_prefix.trim_end_matches('/'), filename)
     }
 }
 
@@ -261,6 +399,25 @@ pub enum EngineError {
          `unit` (only `engine_type = \"odim-volume\"` may omit them)"
     )]
     MissingCompField { field: &'static str },
+    #[error(
+        "ODIM `discovery = \"{value}\"` is not a known mode — use `\"list\"` \
+         (default, WebDAV PROPFIND) or `\"template\"` (HEAD-probe candidate \
+         filenames for non-listable autoindex servers)"
+    )]
+    UnknownDiscovery { value: String },
+    #[error(
+        "ODIM `discovery = \"template\"` requires `filename_template` — the \
+         `filename_pattern` + `timestamp_format` form can't be inverted to a \
+         candidate filename to probe"
+    )]
+    TemplateNeedsFilenameTemplate,
+    #[error(
+        "ODIM `discovery = \"template\"` requires `cadence_secs` > 0 — the \
+         spacing of candidate timestamps to probe (e.g. 300 for a 5-min feed)"
+    )]
+    TemplateNeedsCadence,
+    #[error("ODIM `discovery = \"template\"` only applies to an `http(s)://` `data_path` source")]
+    TemplateNeedsHttp,
 }
 
 impl OdimEngine {
@@ -419,15 +576,51 @@ impl OdimEngine {
         )
     }
 
+    /// Drive the #287 template-discovery probe against a controlled clock —
+    /// the seam the integration suite uses to test the listing-free HTTP
+    /// discovery deterministically (over a `LocalFileSystem`-backed
+    /// `DataStore`, whose `head` returns `NotFound` for absent candidates).
+    /// `time_window` is an ISO 8601 duration string (e.g. `"-PT1H"`).
+    #[doc(hidden)]
+    #[allow(clippy::too_many_arguments)]
+    pub fn discover_template_for_test(
+        now: DateTime<Utc>,
+        store: ds_storage::DataStore,
+        base_prefix: &str,
+        template: &str,
+        cadence_secs: u64,
+        time_window: Option<&str>,
+        max_files: Option<usize>,
+    ) -> Result<Vec<CatalogEntry>, EngineError> {
+        let tw = match time_window {
+            Some(s) => Some(TimeWindow::parse(s)?),
+            None => None,
+        };
+        discover_template_at(
+            now,
+            &store,
+            base_prefix,
+            template,
+            Duration::from_secs(cadence_secs),
+            tw.as_ref(),
+            max_files,
+        )
+    }
+
     /// Run the source poll loop. Exits when [`OdimEngine::shutdown`]
     /// is called. Each tick re-scans the source, atomically swaps the
     /// catalog `ArcSwap` if the file set changed, and logs at INFO
     /// when new files appear so operators can confirm the polling is
     /// alive.
     ///
-    /// The scan runs on `tokio::task::spawn_blocking` so neither a
-    /// slow filesystem (network mount, large directory) nor a slow S3
-    /// `list` stalls a Tokio worker thread for its duration.
+    /// The scan runs **directly on the background poll runtime worker**,
+    /// NOT via `spawn_blocking`: a remote scan reaches `ds-storage`, whose
+    /// `block_in_place` is valid on a multi-thread-runtime worker but
+    /// *panics* on a `spawn_blocking` pool thread. Wrapping it in
+    /// `spawn_blocking` silently fails every remote (S3 / HTTP / template)
+    /// refresh — the `JoinError` is caught, but the catalog never updates.
+    /// Mirrors the GRIB / GeoTIFF / QueryData / PVOL poll loops, which also
+    /// call their blocking scan directly on the poll runtime.
     ///
     /// Errors from the scan (source temporarily unavailable, S3
     /// timeout) are logged at WARN and otherwise ignored — the
@@ -450,7 +643,7 @@ impl OdimEngine {
                     // returning, and we don't want to do extra I/O on
                     // the way out.
                     if !self.shutdown.load(Ordering::Acquire) {
-                        self.poll_once().await;
+                        self.poll_once();
                     }
                 }
                 _ = self.shutdown_notify.notified() => {
@@ -476,27 +669,17 @@ impl OdimEngine {
         }
     }
 
-    async fn poll_once(&self) {
-        let source = self.source.clone();
-        let matcher = self.matcher.clone();
-        let max_files = self.max_files;
-        let scan_result =
-            tokio::task::spawn_blocking(move || scan_source(&source, &matcher, max_files)).await;
-        let scan = match scan_result {
-            Ok(Ok(s)) => s,
-            Ok(Err(e)) => {
+    fn poll_once(&self) {
+        // Direct (not `spawn_blocking`) so a remote scan's `ds-storage`
+        // `block_in_place` runs on the multi-thread poll-runtime worker —
+        // valid there, panics on a `spawn_blocking` thread. See `poll_loop`.
+        let scan = match scan_source(&self.source, &self.matcher, self.max_files) {
+            Ok(s) => s,
+            Err(e) => {
                 tracing::warn!(
                     "[{}] ODIM catalog refresh failed: {}",
                     self.collection_id,
                     e
-                );
-                return;
-            }
-            Err(join_err) => {
-                tracing::error!(
-                    "[{}] ODIM catalog refresh task panicked: {}",
-                    self.collection_id,
-                    join_err
                 );
                 return;
             }
@@ -676,13 +859,21 @@ fn build_matcher(config: &ds_core::config::OdimConfig) -> Result<FilenameMatcher
 ///   with [`ds_storage::build_store`] (the same dispatch the GeoTIFF
 ///   engine uses, so an `amazonaws.com`/`cloudferro.com` URL still
 ///   resolves to S3). The URL path becomes the base prefix; any
-///   `prefix_pattern` is appended under it for date partitioning.
+///   `prefix_pattern` is appended under it. `discovery = "template"`
+///   switches it to the listing-free [`Source::TemplateHttp`] probe
+///   (#287, for non-listable autoindex servers); otherwise it lists.
 /// - a plain `data_path` → a **local** directory.
 fn build_source(
     collection_id: &str,
     data_path: Option<&str>,
     config: &ds_core::config::OdimConfig,
 ) -> Result<Source, EngineError> {
+    // Validate `discovery` up front (catches an unknown value for any
+    // source type); template mode is only valid on HTTP, rejected here for S3.
+    if discovery_mode(config)? == DiscoveryMode::Template && config.endpoint.is_some() {
+        return Err(EngineError::TemplateNeedsHttp);
+    }
+
     match (config.endpoint.as_deref(), config.bucket.as_deref()) {
         (Some(endpoint), Some(bucket)) => {
             // A missing `prefix_pattern` is almost always a config
@@ -714,38 +905,72 @@ fn build_source(
         }
         (None, None) => {
             let data_path = data_path.ok_or(EngineError::NoSource)?;
-            if ds_storage::has_scheme(data_path, "http://")
-                || ds_storage::has_scheme(data_path, "https://")
-            {
-                // HTTP(S) object-store source, mirroring engine-geotiff:
-                // `build_store` dispatches the URL (plain HTTP → WebDAV-
-                // listable `HttpStore`; amazonaws/cloudferro → S3). The
-                // returned base path is the directory the catalog lists;
-                // any `prefix_pattern` is appended for date partitioning.
-                //
-                // NOTE: object_store's `HttpStore` lists via WebDAV
-                // `PROPFIND`, so a plain Apache/nginx autoindex (e.g. DWD
-                // opendata) is *not* discoverable here — that needs the
-                // template-based probe tracked in #287.
+            let is_http = ds_storage::has_scheme(data_path, "http://")
+                || ds_storage::has_scheme(data_path, "https://");
+
+            // `discovery = "template"` only makes sense for an HTTP source —
+            // reject it on a local `data_path` so a misconfig fails loudly.
+            if discovery_mode(config)? == DiscoveryMode::Template && !is_http {
+                return Err(EngineError::TemplateNeedsHttp);
+            }
+
+            if is_http {
+                // `build_store` dispatches the URL (plain HTTP → `HttpStore`;
+                // amazonaws/cloudferro → S3). The returned base path is the
+                // directory; any `prefix_pattern` is appended under it.
                 let (store, base) = ds_storage::build_store(data_path)?;
-                let prefix_pattern =
+                let base_prefix =
                     combine_http_prefix(base.as_ref(), config.prefix_pattern.as_deref());
                 let time_window = match &config.time_window {
                     Some(s) => Some(TimeWindow::parse(s)?),
                     None => None,
                 };
-                tracing::info!(
-                    "[{}] ODIM HTTP source: url={data_path} prefix='{prefix_pattern}'",
-                    collection_id
-                );
-                Ok(Source::Remote {
-                    store,
-                    origin: RemoteOrigin::Http {
-                        base_url: data_path.to_string(),
-                    },
-                    prefix_pattern,
-                    time_window,
-                })
+
+                match discovery_mode(config)? {
+                    // Template probe — for non-listable autoindex servers
+                    // (DWD opendata): no `list`, HEAD candidate filenames
+                    // built from `filename_template` + `cadence_secs`.
+                    DiscoveryMode::Template => {
+                        let template = config
+                            .filename_template
+                            .clone()
+                            .ok_or(EngineError::TemplateNeedsFilenameTemplate)?;
+                        let cadence_secs = config
+                            .cadence_secs
+                            .filter(|c| *c > 0)
+                            .ok_or(EngineError::TemplateNeedsCadence)?;
+                        tracing::info!(
+                            "[{}] ODIM HTTP template source: url={data_path} prefix='{base_prefix}' \
+                             cadence={cadence_secs}s",
+                            collection_id
+                        );
+                        Ok(Source::TemplateHttp {
+                            store,
+                            base_url: data_path.to_string(),
+                            base_prefix,
+                            template,
+                            cadence: Duration::from_secs(cadence_secs),
+                            time_window,
+                        })
+                    }
+                    // List mode (default) — WebDAV `PROPFIND`. NOTE: a plain
+                    // Apache/nginx autoindex is *not* listable; use
+                    // `discovery = "template"` for those.
+                    DiscoveryMode::List => {
+                        tracing::info!(
+                            "[{}] ODIM HTTP source: url={data_path} prefix='{base_prefix}'",
+                            collection_id
+                        );
+                        Ok(Source::Remote {
+                            store,
+                            origin: RemoteOrigin::Http {
+                                base_url: data_path.to_string(),
+                            },
+                            prefix_pattern: base_prefix,
+                            time_window,
+                        })
+                    }
+                }
             } else {
                 Ok(Source::Local {
                     data_dir: PathBuf::from(data_path),
@@ -753,6 +978,25 @@ fn build_source(
             }
         }
         _ => Err(EngineError::IncompleteS3Config),
+    }
+}
+
+/// Parsed `[odim].discovery` mode.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum DiscoveryMode {
+    List,
+    Template,
+}
+
+/// Resolve the discovery mode from config: absent / `"list"` → list,
+/// `"template"` → template, anything else → an explicit error.
+fn discovery_mode(config: &ds_core::config::OdimConfig) -> Result<DiscoveryMode, EngineError> {
+    match config.discovery.as_deref() {
+        None | Some("list") => Ok(DiscoveryMode::List),
+        Some("template") => Ok(DiscoveryMode::Template),
+        Some(other) => Err(EngineError::UnknownDiscovery {
+            value: other.to_string(),
+        }),
     }
 }
 
@@ -798,6 +1042,11 @@ fn source_label(source: &Source) -> String {
                 format!("http {base_url} (prefix '{prefix_pattern}')")
             }
         },
+        Source::TemplateHttp {
+            base_url,
+            base_prefix,
+            ..
+        } => format!("http {base_url} (template-probe, prefix '{base_prefix}')"),
     }
 }
 
@@ -985,6 +1234,8 @@ mod tests {
             bucket: bucket.map(str::to_string),
             prefix_pattern: prefix_pattern.map(str::to_string),
             time_window: time_window.map(str::to_string),
+            discovery: None,
+            cadence_secs: None,
         }
     }
 
@@ -1040,7 +1291,7 @@ mod tests {
                 // The URL path becomes the (flat) list prefix.
                 assert_eq!(prefix_pattern, "weather/radar/composite/hx");
             }
-            Source::Local { .. } => panic!("http data_path must not be a Local source"),
+            _ => panic!("http data_path (list mode) must be a Source::Remote"),
         }
 
         // The label names the HTTP URL, not an S3 bucket.
@@ -1085,8 +1336,100 @@ mod tests {
                     "time_window must apply to an HTTP source"
                 );
             }
-            Source::Local { .. } => panic!("expected a remote HTTP source"),
+            _ => panic!("expected a remote HTTP source"),
         }
+    }
+
+    /// `discovery = "template"` on an `http(s)://` source with a
+    /// `filename_template` + `cadence_secs` builds a `TemplateHttp` source
+    /// (the #287 listing-free probe), carrying the URL path as the base
+    /// prefix and the template + cadence verbatim.
+    #[test]
+    fn build_source_template_mode_builds_template_http() {
+        let mut config = config_with(None, None, None, Some("-PT2H"));
+        config.filename_template = Some("composite_hx_%Y%m%d_%H%M-hd5".into());
+        config.discovery = Some("template".into());
+        config.cadence_secs = Some(300);
+
+        let source = build_source(
+            "dwd",
+            Some("https://opendata.dwd.de/weather/radar/composite/hx/"),
+            &config,
+        )
+        .expect("template-mode http source builds");
+        match &source {
+            Source::TemplateHttp {
+                base_prefix,
+                template,
+                cadence,
+                time_window,
+                ..
+            } => {
+                assert_eq!(base_prefix, "weather/radar/composite/hx");
+                assert_eq!(template, "composite_hx_%Y%m%d_%H%M-hd5");
+                assert_eq!(*cadence, Duration::from_secs(300));
+                assert!(time_window.is_some());
+            }
+            _ => panic!("discovery=template must build a TemplateHttp source"),
+        }
+        // The label flags the listing-free probe mode.
+        assert!(
+            source_label(&source).contains("template-probe"),
+            "source_label should mark template-probe mode, got `{}`",
+            source_label(&source)
+        );
+    }
+
+    /// Template mode requires `cadence_secs` (> 0) and `filename_template`,
+    /// only applies to HTTP, and rejects an unknown `discovery` value.
+    #[test]
+    fn build_source_template_mode_validation() {
+        let http = "https://h.example/radar/";
+
+        // Missing cadence.
+        let mut c = config_with(None, None, None, None);
+        c.filename_template = Some("c_%Y%m%d_%H%M.h5".into());
+        c.discovery = Some("template".into());
+        assert!(matches!(
+            build_source("t", Some(http), &c),
+            Err(EngineError::TemplateNeedsCadence)
+        ));
+        // cadence = 0 is also rejected.
+        c.cadence_secs = Some(0);
+        assert!(matches!(
+            build_source("t", Some(http), &c),
+            Err(EngineError::TemplateNeedsCadence)
+        ));
+
+        // Template form required — the `filename_pattern` form can't be inverted.
+        let mut c = config_with(None, None, None, None);
+        c.filename_template = None;
+        c.filename_pattern = Some(r"^c-(?P<timestamp>\d{12})\.h5$".into());
+        c.timestamp_format = Some("%Y%m%d%H%M".into());
+        c.discovery = Some("template".into());
+        c.cadence_secs = Some(300);
+        assert!(matches!(
+            build_source("t", Some(http), &c),
+            Err(EngineError::TemplateNeedsFilenameTemplate)
+        ));
+
+        // Template mode only applies to HTTP — rejected on a local data_path.
+        let mut c = config_with(None, None, None, None);
+        c.filename_template = Some("c_%Y%m%d_%H%M.h5".into());
+        c.discovery = Some("template".into());
+        c.cadence_secs = Some(300);
+        assert!(matches!(
+            build_source("t", Some("/var/lib/radar"), &c),
+            Err(EngineError::TemplateNeedsHttp)
+        ));
+
+        // Unknown discovery value is an explicit error.
+        let mut c = config_with(None, None, None, None);
+        c.discovery = Some("bogus".into());
+        assert!(matches!(
+            build_source("t", Some(http), &c),
+            Err(EngineError::UnknownDiscovery { value }) if value == "bogus"
+        ));
     }
 
     /// A plain (non-URL) `data_path` is still a local directory source.

--- a/crates/engine-odim/src/volume_engine.rs
+++ b/crates/engine-odim/src/volume_engine.rs
@@ -4019,6 +4019,8 @@ mod tests {
             bucket: None,
             prefix_pattern: None,
             time_window: None,
+            discovery: None,
+            cadence_secs: None,
         }
     }
 

--- a/crates/engine-odim/tests/integration.rs
+++ b/crates/engine-odim/tests/integration.rs
@@ -43,6 +43,8 @@ fn dmi_engine() -> (engine_odim::OdimEngine, tempfile::TempDir) {
         bucket: None,
         prefix_pattern: None,
         time_window: None,
+        discovery: None,
+        cadence_secs: None,
     };
 
     let engine = engine_odim::OdimEngine::new(
@@ -351,6 +353,8 @@ fn edr_query_area_rejects_too_many_timesteps() {
         bucket: None,
         prefix_pattern: None,
         time_window: None,
+        discovery: None,
+        cadence_secs: None,
     };
     let engine = engine_odim::OdimEngine::new(
         "dmi-cap-test",
@@ -449,6 +453,8 @@ fn pvol_engine_renders_fmi_vihti_volume() {
         bucket: None,
         prefix_pattern: None,
         time_window: None,
+        discovery: None,
+        cadence_secs: None,
     };
 
     let engine = engine_odim::PolarVolumeEngine::new("fivih-pvol-test", Some(data_dir), &config)
@@ -644,6 +650,8 @@ fn pvol_bare_render_defaults_to_primary_quantity() {
         bucket: None,
         prefix_pattern: None,
         time_window: None,
+        discovery: None,
+        cadence_secs: None,
     };
     let engine =
         engine_odim::PolarVolumeEngine::new("fivih-pvol-test", Some(data_dir), &config).unwrap();
@@ -694,6 +702,8 @@ fn pvol_fixture_view() -> Option<engine_odim::PolarVolumeSiteView> {
         bucket: None,
         prefix_pattern: None,
         time_window: None,
+        discovery: None,
+        cadence_secs: None,
     };
     let engine = engine_odim::PolarVolumeEngine::new(
         "fivih-edr-test",
@@ -1048,6 +1058,8 @@ fn comp_engine_remote_scan_discovers_and_renders_dmi_fixture() {
         bucket: None,
         prefix_pattern: None,
         time_window: None,
+        discovery: None,
+        cadence_secs: None,
     };
 
     // Empty prefix scans the store root, where the fixtures live.
@@ -1092,4 +1104,74 @@ fn comp_engine_remote_scan_discovers_and_renders_dmi_fixture() {
         )
         .expect("render of the remotely-scanned composite succeeds");
     assert_eq!(tile.values.len(), 64 * 64);
+}
+
+/// #287 — template (listing-free) HTTP discovery.
+///
+/// `object_store`'s `LocalFileSystem` answers `head` per object exactly
+/// like an HTTP `HEAD` (and returns `NotFound` for a missing key), so a
+/// `DataStore` over a tempdir drives the real `head_many` probe path
+/// offline. The probe builds candidate filenames from the strftime
+/// template for timestamps walked back from an **injected** `now`, so the
+/// set of discovered files is deterministic. We lay down files for some
+/// slots and leave a gap, and assert the probe finds exactly the present
+/// ones — never listing the directory.
+#[test]
+fn comp_template_discovery_probes_present_slots_only() {
+    use chrono::{TimeZone, Utc};
+
+    let dir = tempfile::tempdir().expect("create tempdir");
+    let template = "composite_hx_%Y%m%d_%H%M-hd5";
+    // Aligned reference clock; 5-minute cadence.
+    let now = Utc.with_ymd_and_hms(2026, 6, 3, 12, 0, 0).unwrap();
+    let cadence_secs = 300;
+
+    // Present: now, now-5m, now-10m, now-20m. Absent: now-15m (a gap), and
+    // the older slots the -PT30M window still probes (now-25m, now-30m).
+    for back_min in [0i64, 5, 10, 20] {
+        let t = now - chrono::Duration::minutes(back_min);
+        let name = t.format(template).to_string();
+        std::fs::write(dir.path().join(name), b"x").expect("write candidate");
+    }
+    // A decoy with no parseable slot must never be probed/added.
+    std::fs::write(dir.path().join("composite_hx_LATEST-hd5"), b"x").unwrap();
+
+    let (store, _base) = ds_storage::build_store(
+        dir.path()
+            .canonicalize()
+            .expect("tempdir canonicalises")
+            .to_str()
+            .expect("utf8 tempdir path"),
+    )
+    .expect("DataStore over the tempdir");
+
+    // Empty base prefix → probe the store root, where the files live.
+    let catalog = engine_odim::OdimEngine::discover_template_for_test(
+        now,
+        store,
+        "",
+        template,
+        cadence_secs,
+        Some("-PT30M"),
+        None,
+    )
+    .expect("template probe succeeds");
+
+    // Exactly the four present dated slots, ascending; the 11:45 gap and the
+    // empty 11:30/11:35 slots are excluded, and `LATEST` is never probed.
+    let times: Vec<String> = catalog.iter().map(|e| e.time.to_rfc3339()).collect();
+    assert_eq!(
+        times,
+        [
+            "2026-06-03T11:40:00+00:00",
+            "2026-06-03T11:50:00+00:00",
+            "2026-06-03T11:55:00+00:00",
+            "2026-06-03T12:00:00+00:00",
+        ],
+        "probe must discover exactly the present dated slots"
+    );
+    // Keys are the template-rendered names under the (empty) base prefix.
+    assert!(catalog
+        .iter()
+        .all(|e| e.location.id().starts_with("composite_hx_")));
 }

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -212,6 +212,60 @@ impl DataStore {
         Ok(ordered.into_iter().map(|(_, r)| r).collect())
     }
 
+    /// Probe many object keys concurrently with `head`, returning one
+    /// result per input path **in input order**. A **missing** object
+    /// (`NotFound` / HTTP 404) maps to `Ok(None)` — "absent", not an
+    /// error — so a caller probing candidate keys can keep the ones that
+    /// exist; any other failure (timeout, 403, network) is the slot's
+    /// `Err`. The outer `Err` is reserved for a runtime-bridge failure.
+    ///
+    /// This is the listing-free discovery primitive for HTTP stores that
+    /// don't support `list` (a plain Apache/nginx autoindex answers a
+    /// direct `HEAD` but not WebDAV `PROPFIND`). Same concurrency,
+    /// per-object 30s timeout, and thread-context rules as
+    /// [`Self::get_many`].
+    #[allow(clippy::type_complexity)]
+    pub fn head_many(
+        &self,
+        paths: &[ObjectPath],
+        concurrency: usize,
+    ) -> Result<Vec<Result<Option<ObjectMeta>, DataServerError>>, DataServerError> {
+        use futures::StreamExt;
+
+        let conc = concurrency.max(1);
+        let inner = &self.inner;
+        let ordered: Vec<(usize, Result<Option<ObjectMeta>, DataServerError>)> = self
+            .block_on_untimed(async {
+                let mut results: Vec<(usize, Result<Option<ObjectMeta>, DataServerError>)> =
+                    futures::stream::iter(paths.iter().enumerate().map(|(i, p)| async move {
+                        let probe = async {
+                            match inner.head(p).await {
+                                Ok(meta) => Ok(Some(meta)),
+                                // A 404 is the expected answer for a candidate
+                                // key that doesn't exist — not a failure.
+                                Err(object_store::Error::NotFound { .. }) => Ok(None),
+                                Err(e) => Err(DataServerError::from(StorageError::from(e))),
+                            }
+                        };
+                        let r = match tokio::time::timeout(Self::REQUEST_TIMEOUT, probe).await {
+                            Ok(r) => r,
+                            Err(_) => Err(DataServerError::Storage(format!(
+                                "head of `{p}` timed out after {}s",
+                                Self::REQUEST_TIMEOUT.as_secs()
+                            ))),
+                        };
+                        (i, r)
+                    }))
+                    .buffer_unordered(conc)
+                    .collect()
+                    .await;
+                results.sort_by_key(|(i, _)| *i);
+                results
+            })?;
+
+        Ok(ordered.into_iter().map(|(_, r)| r).collect())
+    }
+
     /// Default timeout for individual storage operations (30 seconds).
     const REQUEST_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 
@@ -561,6 +615,30 @@ mod tests {
         assert_eq!(res[0].as_ref().unwrap().as_ref(), b"aaa");
         assert!(res[1].is_err(), "a missing object yields a per-item Err");
         assert_eq!(res[2].as_ref().unwrap().as_ref(), b"cccc");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn head_many_reports_presence_in_input_order() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("a.bin"), b"aaa").unwrap();
+        std::fs::write(dir.path().join("c.bin"), b"cccc").unwrap();
+        let (store, _) = build_store(dir.path().to_str().unwrap()).unwrap();
+
+        // Middle key is absent — a missing object is `Ok(None)`, not an Err.
+        let paths = [
+            ObjectPath::from("a.bin"),
+            ObjectPath::from("missing.bin"),
+            ObjectPath::from("c.bin"),
+        ];
+        let res = store.head_many(&paths, 8).unwrap();
+        assert_eq!(res.len(), 3);
+        assert_eq!(res[0].as_ref().unwrap().as_ref().unwrap().size, 3);
+        assert!(
+            matches!(res[1], Ok(None)),
+            "a missing object is Ok(None), got {:?}",
+            res[1]
+        );
+        assert_eq!(res[2].as_ref().unwrap().as_ref().unwrap().size, 4);
     }
 
     #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
## Summary

Enables ingesting **DWD opendata** radar composites (and any non-listable autoindex server) directly over HTTP. DWD serves `https://opendata.dwd.de/weather/radar/composite/hx/` as a plain Apache autoindex (`composite_hx_YYYYMMDD_HHMM-hd5`, 5-min cadence). object_store's `HttpStore` lists via WebDAV `PROPFIND`, which an autoindex doesn't support — so the #286 list-based scan returns nothing.

This adds a **listing-free discovery mode**: build candidate filenames from the strftime `filename_template` for timestamps walked back from now over the configured cadence, and probe them with concurrent `HEAD`s.

Closes #287. (Builds on #286/#310, merged.)

## Changes

- **`DataStore::head_many`** (ds-storage) — concurrent bounded HEADs, mirroring `get_many` (`block_on_untimed` + `buffer_unordered`, per-object timeout). `NotFound`/404 → `Ok(None)` so a caller keeps the keys that exist. A plain autoindex answers a direct `HEAD` but not `PROPFIND`, so this is the right discovery primitive.
- **`Source::TemplateHttp` + `discover_template_at(now, …)`** (engine-odim) — align `now` to the cadence grid, walk back `min(window/cadence, max_files, HARD_MAX_PROBES=288)` slots, render each candidate via `time.format(template)` (the strftime inverse of the catalog matcher), HEAD-probe concurrently (16-wide), and turn survivors into `CatalogEntry`s (timestamp known from generation; bytes fetched lazily on render). `now` is a parameter for deterministic testing.
- **Config** — `[odim].discovery = "list"` (default) `| "template"` and `cadence_secs`. Template mode requires `filename_template` (the `filename_pattern` form isn't invertible to a filename) + `cadence_secs > 0`, applies to HTTP only, and an unknown `discovery` value is an explicit error. All validated in `build_source`.
- **Fix COMP `poll_once`** — it wrapped `scan_source` in `spawn_blocking`, which makes `ds-storage`'s `block_in_place` *panic* (swallowed as a `JoinError`), so **no remote source ever refreshed via poll** (S3, HTTP-list, or template) — a pre-existing latent bug. Now runs the scan directly on the poll runtime, matching the GRIB/GeoTIFF/QueryData/PVOL pattern. Required for a live DWD feed to actually refresh.

## Scope

**Probe-only.** The optional fixed-`LATEST`-symlink shortcut (`composite_hx_LATEST-hd5`) is deferred to a follow-up — the timestamp probe already reaches `now`, so it covers the always-current case for DWD.

## Validated live against DWD opendata

Ran the server against `https://opendata.dwd.de/weather/radar/composite/hx/`:

```
ODIM HTTP template source: url=…/composite/hx/ prefix='weather/radar/composite/hx' cadence=300s
Server ready, accepting requests
```

`GET /edr/collections/dwd-hx` → temporal extent of **13 discovered slots** (17:05→18:05 over `-PT1H`); `GET …/position?coords=POINT(10 51)` → a valid CoverageJSON Coverage with 13 `reflectivity` time values. The engine discovered the rolling window by `HEAD` probe (no listing), seed-parsed DWD `hx` as ODIM COMP, and served EDR end-to-end.

## Config example

```toml
[[collections]]
id = "dwd-hx"
engine_type = "odim"
apis = ["edr", "wms", "maps", "tiles"]
data_path = "https://opendata.dwd.de/weather/radar/composite/hx/"

[collections.odim]
parameter = "reflectivity"
unit = "dBZ"
filename_template = "composite_hx_%Y%m%d_%H%M-hd5"
discovery = "template"
cadence_secs = 300
time_window = "-PT1H"
poll_interval_secs = 300
```

## Tests

- `head_many`: presence in input order, missing object → `Ok(None)`.
- Template `build_source` validation: cadence + filename_template required, HTTP-only, unknown mode rejected.
- Deterministic offline probe over a `LocalFileSystem` `DataStore` with an **injected clock** — present slots found, a gap and a `LATEST` decoy excluded, never listing.

`cargo fmt --all --check`, `cargo clippy -p ds-core -p ds-storage -p engine-odim -p server --all-targets`, `cargo test -p engine-odim -p ds-storage` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)