### PR TITLE
feat(engine-odim): DWD COMP collection config + incremental template probe

### DIFF
--- a/collections.d/radar-de-composite-dbzh-http-h5.toml
+++ b/collections.d/radar-de-composite-dbzh-http-h5.toml
@@ -1,0 +1,48 @@
+# DWD Germany radar composite HX (ODIM_H5 v2.3) — HTTP source, template discovery.
+#
+# Streams `composite_hx_YYYYMMDD_HHMM-hd5` composites directly from DWD open
+# data over plain HTTP — no local mirror, no S3. DWD serves the directory as
+# an Apache autoindex (HTML), which `object_store`'s HttpStore can't list (it
+# lists via WebDAV PROPFIND, which autoindex doesn't support). So this uses
+# `discovery = "template"` (#287): candidate filenames are built from
+# `filename_template` + `cadence_secs` walked back from now over `time_window`
+# and probed directly with HEAD — no listing required.
+#
+#   https://opendata.dwd.de/weather/radar/composite/hx/
+#
+# 4400×4800 grid at 250m/px over Germany + neighbours, polar stereographic
+# (lat_0=90, lat_ts=60, lon_0=10 — same family as FMI/OPERA composites). DBZH
+# quantity, u16 pixels (gain=0.00293, offset=-64 → -64..+128 dBZ; nodata=65535,
+# undetect=0). A new composite lands every 5 minutes; DWD keeps a rolling ~48h
+# archive.
+#
+# The first scan probes the whole `time_window` (~25 HEADs for -PT2H); the
+# probe is incremental, so each poll thereafter only HEADs the new slot(s)
+# — already-known slots are carried forward, not re-probed. So a wider
+# `time_window` (up to 24h = the 288-candidate cap) costs more only at boot.
+#
+# NOTE: DWD's URLs carry no file extension, so the template ends in `-hd5` —
+# unlike the local twin `radar-de-composite-dbzh-local-h5`, which appends `.h5`
+# to the saved sample files.
+
+id = "radar-de-composite-dbzh-http-h5"
+title = "DWD — radar reflectivity composite (HTTP, ODIM_H5)"
+description = "German radar reflectivity (DBZH) composite (HX product) from DWD open data, streamed over HTTP via listing-free template discovery. Polar stereographic projection."
+engine_type = "odim"
+apis = ["edr", "wms", "maps", "tiles"]
+data_path = "https://opendata.dwd.de/weather/radar/composite/hx/"
+
+[odim]
+filename_template = "composite_hx_%Y%m%d_%H%M-hd5"
+parameter = "reflectivity"
+unit = "dBZ"
+# Listing-free discovery for DWD's non-listable autoindex (#287).
+discovery = "template"
+# 5-minute composite cadence — the spacing of probed candidate timestamps.
+cadence_secs = 300
+# Keep the last 2h in the catalog (25 HEAD probes/poll); DWD retains ~48h.
+time_window = "-PT2H"
+poll_interval_secs = 300
+
+[wms]
+colormap = "radar_dbz"

--- a/crates/engine-odim/src/engine.rs
+++ b/crates/engine-odim/src/engine.rs
@@ -127,6 +127,11 @@ fn scan_source(
     source: &Source,
     matcher: &FilenameMatcher,
     max_files: Option<usize>,
+    // The current catalog, used only by the template-probe source to skip
+    // re-probing already-known slots. Empty at construction; the poll
+    // passes the live catalog. List-based sources ignore it (one `list`
+    // call already returns the whole set cheaply).
+    known: &[CatalogEntry],
 ) -> Result<Vec<CatalogEntry>, EngineError> {
     match source {
         Source::Local { data_dir } => Ok(scan_local_directory(data_dir, matcher, max_files)?),
@@ -170,6 +175,7 @@ fn scan_source(
             *cadence,
             time_window.as_ref(),
             max_files,
+            known,
         )?),
     }
 }
@@ -178,16 +184,25 @@ fn scan_source(
 /// candidate filenames instead of listing the directory.
 ///
 /// Builds one candidate per timestamp from `now` walked back by `cadence`
-/// — `N = min(window/cadence, max_files, HARD_MAX_PROBES)` steps — renders
-/// each filename with `time.format(template)` (the strftime inverse of the
-/// catalog matcher), joins it under `base_prefix`, and `HEAD`-probes them
-/// all concurrently. Existing objects become [`CatalogEntry`] values whose
-/// timestamp is the one we generated (no parsing needed); the bytes are
-/// fetched lazily on render via [`fetch_bytes`]. Sorted ascending, deduped
-/// by timestamp.
+/// — `N = min(window/cadence, max_files, HARD_MAX_PROBES)` steps — and
+/// renders each filename with `time.format(template)` (the strftime
+/// inverse of the catalog matcher) joined under `base_prefix`.
+///
+/// **Incremental.** A candidate already present in `known` (the current
+/// catalog) is carried forward unchanged — radar files are immutable once
+/// published, so re-`HEAD`-ing them is pure overhead. Only the candidates
+/// *not* in `known` are `HEAD`-probed (concurrently): the freshly-arrived
+/// newest slot, plus any still-missing slots (a gap or a late upload),
+/// which keep being retried until they arrive or age out of the window.
+/// So the first scan probes the whole window, but each subsequent poll
+/// probes only ~one slot. Survivors (carried + newly-found) become
+/// [`CatalogEntry`] values whose timestamp is the one we generated (no
+/// parsing); bytes are fetched lazily on render via [`fetch_bytes`].
+/// Sorted ascending, deduped by timestamp.
 ///
 /// `now` is a parameter (not `Utc::now()` inside) so the probe is
 /// deterministically testable against a controlled clock.
+#[allow(clippy::too_many_arguments)]
 fn discover_template_at(
     now: DateTime<Utc>,
     store: &ds_storage::DataStore,
@@ -196,8 +211,10 @@ fn discover_template_at(
     cadence: Duration,
     time_window: Option<&TimeWindow>,
     max_files: Option<usize>,
+    known: &[CatalogEntry],
 ) -> Result<Vec<CatalogEntry>, EngineError> {
     use ds_storage::object_store::path::Path as ObjectPath;
+    use std::collections::HashMap;
 
     let cadence_secs = (cadence.as_secs().max(1)) as i64;
 
@@ -222,18 +239,35 @@ fn discover_template_at(
         .filter_map(|i| DateTime::<Utc>::from_timestamp(aligned - (i as i64) * cadence_secs, 0))
         .collect();
 
-    // Render candidate filenames via the strftime template, join under the
-    // base prefix, and probe their existence concurrently.
-    let keys: Vec<String> = stamps
+    // Carry forward already-known in-window entries (no re-probe); collect
+    // the rest as the slots to actually HEAD.
+    let known_by_time: HashMap<DateTime<Utc>, &CatalogEntry> =
+        known.iter().map(|e| (e.time, e)).collect();
+    let mut entries: Vec<CatalogEntry> = Vec::new();
+    let mut probe_stamps: Vec<DateTime<Utc>> = Vec::new();
+    for stamp in &stamps {
+        match known_by_time.get(stamp) {
+            Some(entry) => entries.push((*entry).clone()),
+            None => probe_stamps.push(*stamp),
+        }
+    }
+
+    // Render + probe only the unknown candidates' filenames concurrently.
+    let probe_keys: Vec<String> = probe_stamps
         .iter()
         .map(|t| join_prefix(base_prefix, &t.format(template).to_string()))
         .collect();
-    let paths: Vec<ObjectPath> = keys.iter().map(|k| ObjectPath::from(k.as_str())).collect();
-
+    let paths: Vec<ObjectPath> = probe_keys
+        .iter()
+        .map(|k| ObjectPath::from(k.as_str()))
+        .collect();
     let probed = store.head_many(&paths, PROBE_CONCURRENCY)?;
 
-    let mut entries: Vec<CatalogEntry> = Vec::new();
-    for ((time, key), result) in stamps.iter().zip(keys.iter()).zip(probed.iter()) {
+    for ((time, key), result) in probe_stamps
+        .iter()
+        .zip(probe_keys.iter())
+        .zip(probed.iter())
+    {
         match result {
             Ok(Some(meta)) => {
                 if meta.size as u64 > crate::catalog::MAX_REMOTE_FILE_SIZE {
@@ -490,7 +524,9 @@ impl OdimEngine {
         max_files: Option<usize>,
         poll_interval_secs: u64,
     ) -> Result<Self, EngineError> {
-        let catalog = scan_source(&source, &matcher, max_files)?;
+        // Construction: no prior catalog, so the template probe scans the
+        // whole window (`known` is empty).
+        let catalog = scan_source(&source, &matcher, max_files, &[])?;
         if catalog.is_empty() {
             return Err(EngineError::NoFiles {
                 location: source_label(&source),
@@ -591,6 +627,7 @@ impl OdimEngine {
         cadence_secs: u64,
         time_window: Option<&str>,
         max_files: Option<usize>,
+        known: &[CatalogEntry],
     ) -> Result<Vec<CatalogEntry>, EngineError> {
         let tw = match time_window {
             Some(s) => Some(TimeWindow::parse(s)?),
@@ -604,6 +641,7 @@ impl OdimEngine {
             Duration::from_secs(cadence_secs),
             tw.as_ref(),
             max_files,
+            known,
         )
     }
 
@@ -670,10 +708,15 @@ impl OdimEngine {
     }
 
     fn poll_once(&self) {
+        // Snapshot the current catalog *before* scanning so the template
+        // probe can carry forward already-known slots and HEAD only the new
+        // ones (list-based sources ignore it). Held across the scan — a
+        // cheap `ArcSwap` guard on the background poll path.
+        let prev = self.catalog.load_full();
         // Direct (not `spawn_blocking`) so a remote scan's `ds-storage`
         // `block_in_place` runs on the multi-thread poll-runtime worker —
         // valid there, panics on a `spawn_blocking` thread. See `poll_loop`.
-        let scan = match scan_source(&self.source, &self.matcher, self.max_files) {
+        let scan = match scan_source(&self.source, &self.matcher, self.max_files, &prev) {
             Ok(s) => s,
             Err(e) => {
                 tracing::warn!(
@@ -688,7 +731,6 @@ impl OdimEngine {
         // timestamp. Producing-side renames are rare; this is cheap
         // and accurate for the append-only / rolling-window case ODIM
         // producers actually use.
-        let prev = self.catalog.load();
         let prev_count = prev.len();
         let prev_latest = prev.last().map(|e| e.time);
         let new_latest = scan.last().map(|e| e.time);

--- a/crates/engine-odim/tests/integration.rs
+++ b/crates/engine-odim/tests/integration.rs
@@ -1154,6 +1154,7 @@ fn comp_template_discovery_probes_present_slots_only() {
         cadence_secs,
         Some("-PT30M"),
         None,
+        &[], // cold scan — no prior catalog
     )
     .expect("template probe succeeds");
 
@@ -1174,4 +1175,76 @@ fn comp_template_discovery_probes_present_slots_only() {
     assert!(catalog
         .iter()
         .all(|e| e.location.id().starts_with("composite_hx_")));
+}
+
+/// #287 — incremental polling: a slot already in `known` is carried
+/// forward WITHOUT being re-probed (radar files are immutable), so only
+/// genuinely-new slots cost a `HEAD`.
+///
+/// Proven by making the known slots' files **absent from disk**: if the
+/// probe re-`HEAD`-ed them they'd 404 and drop out; their survival proves
+/// they were carried forward, not re-probed. Meanwhile a new slot that
+/// *does* exist on disk is discovered.
+#[test]
+fn comp_template_discovery_carries_forward_known_without_reprobe() {
+    use chrono::{TimeZone, Utc};
+    use engine_odim::catalog::{CatalogEntry, Location};
+
+    let dir = tempfile::tempdir().expect("create tempdir");
+    let template = "composite_hx_%Y%m%d_%H%M-hd5";
+    let now = Utc.with_ymd_and_hms(2026, 6, 3, 12, 0, 0).unwrap();
+
+    // On disk: ONLY the freshest slot (now). The two older slots are NOT
+    // written — they exist only in `known`.
+    let now_name = now.format(template).to_string();
+    std::fs::write(dir.path().join(&now_name), b"x").unwrap();
+
+    let (store, _base) = ds_storage::build_store(
+        dir.path()
+            .canonicalize()
+            .unwrap()
+            .to_str()
+            .expect("utf8 path"),
+    )
+    .unwrap();
+
+    // `known` carries the two older slots (11:55, 11:50) whose files are absent.
+    let known: Vec<CatalogEntry> = [5i64, 10]
+        .iter()
+        .map(|&back| {
+            let t = now - chrono::Duration::minutes(back);
+            CatalogEntry {
+                time: t,
+                location: Location::Remote {
+                    store: store.clone(),
+                    key: t.format(template).to_string(),
+                },
+            }
+        })
+        .collect();
+
+    let catalog = engine_odim::OdimEngine::discover_template_for_test(
+        now,
+        store,
+        "",
+        template,
+        300,
+        Some("-PT30M"),
+        None,
+        &known,
+    )
+    .expect("incremental probe succeeds");
+
+    // All three present: the two carried-forward (file-less) known slots and
+    // the one freshly-probed slot — proving known slots were NOT re-HEADed.
+    let times: Vec<String> = catalog.iter().map(|e| e.time.to_rfc3339()).collect();
+    assert_eq!(
+        times,
+        [
+            "2026-06-03T11:50:00+00:00", // carried forward (no file on disk)
+            "2026-06-03T11:55:00+00:00", // carried forward (no file on disk)
+            "2026-06-03T12:00:00+00:00", // freshly discovered by HEAD
+        ],
+        "known slots must be carried forward without re-probing"
+    );
 }


### PR DESCRIPTION
## Summary

Two related changes:

1. **New collection config** `collections.d/radar-de-composite-dbzh-http-h5.toml` — the DWD Germany HX radar composite streamed directly from DWD opendata over HTTP via #287 template discovery. It's the HTTP twin of the existing local-fixture `radar-de-composite-dbzh-local-h5`.
2. **Incremental template probe** — answering "why re-probe slots we already have?": the probe now carries forward already-known slots and HEADs only new ones.

## Incremental probe

`discover_template_at` previously re-`HEAD`-ed **every** candidate slot in the `time_window` on every poll — ~25 for `-PT2H`, up to 288 for a 24h window. That's redundant: radar composites are immutable once published, so re-probing a slot already in the catalog is pure overhead.

Now it takes the current catalog (`known`), carries forward already-known in-window slots untouched, and `HEAD`-probes only the rest:
- The freshly-arrived newest slot.
- Any still-missing slot (a gap or late upload), which keeps being retried until it arrives or ages out of the window.

So the **first scan probes the whole window**, but each subsequent poll probes **~one slot**. A wider `time_window` now costs more only at boot, not every poll.

Plumbing: `scan_source` gains `known: &[CatalogEntry]` (list-based S3/HTTP sources ignore it — one `list` already returns the whole set); `assemble` passes `&[]` (cold start), `poll_once` snapshots the catalog before scanning and passes it.

## Config

```toml
id = "radar-de-composite-dbzh-http-h5"
engine_type = "odim"
apis = ["edr", "wms", "maps", "tiles"]
data_path = "https://opendata.dwd.de/weather/radar/composite/hx/"

[odim]
filename_template = "composite_hx_%Y%m%d_%H%M-hd5"
parameter = "reflectivity"
unit = "dBZ"
discovery = "template"
cadence_secs = 300
time_window = "-PT2H"
poll_interval_secs = 300

[wms]
colormap = "radar_dbz"
```

(DWD's URLs carry no extension, so the template ends in `-hd5` — unlike the local twin which appends `.h5`.)

## Validation

- The collection loads against **live DWD**; `GET /edr/collections/radar-de-composite-dbzh-http-h5` reports the 25 discovered slots (`-PT2H` window).
- **Test**: a known slot whose file is *absent from disk* still appears in the probe result — proving it was carried forward, not re-probed (a re-probe would 404 and drop it). Plus the existing cold-probe test (present slots found, gap + `LATEST` decoy excluded).

`cargo fmt`, `cargo clippy -p engine-odim --all-targets`, `cargo test -p engine-odim`, and `cargo build -p server` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)