### PR TITLE
feat(engine-zarr): S3/HTTP backend + chunk cache — Phase 2 (#125)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,7 +167,7 @@ radar elevation angle. WMS exposes it as the `ELEVATION` dimension; Maps/Tiles a
 | ODIM COMP | `EdrEngine` + `MapEngine` | EDR (position, area), WMS, Maps, Tiles |
 | ODIM PVOL | `EdrEngine` + `MapEngine` (per-site views) + `FeatureEngine` (network engine) | EDR (position, locations, area, trajectory), WMS, Maps, Tiles, Features (site inventory) |
 | QueryData | `EdrEngine` + `MapEngine` | EDR (position only), WMS, Maps, Tiles |
-| Zarr | `EdrEngine` | EDR (position only) — Phase 1 |
+| Zarr | `EdrEngine` | EDR (position only), local + S3/HTTP |
 | PostGIS | `EdrEngine` + `FeatureEngine` | EDR (position, locations, area), Features |
 
 ## ODIM PVOL Engine Notes (per-site collections)
@@ -215,43 +215,57 @@ radar elevation angle. WMS exposes it as the `ELEVATION` dimension; Maps/Tiles a
 ## Zarr Engine Notes
 
 Cloud-native multidimensional arrays (Zarr V2/V3) with CF-conventions metadata,
-tracked in #125. **The crate is phased; Phase 1 is what ships today.**
+tracked in #125. **The crate is phased; Phases 1-2 ship today.**
 
-- **Phase 1 (done):** local store (`data_path`), WGS84/geographic lat-lon grid,
-  multi-variable EDR **position** queries with bilinear interpolation, CF time
-  decoding, CF packing (`scale_factor`/`add_offset`/`_FillValue`/`missing_value`),
-  and a startup WARN for pathological chunk shapes. **Not yet:** S3/HTTP backend
-  (Phase 2), Map/Tiles/WMS rendering (Phase 3), per-item-CRS STAC mode (Phase 4),
-  kerchunk (Phase 5).
-- **The Zarr format + codec pipeline is handled by the `zarrs` crate** (default
-  features: blosc/zstd/gzip/crc32c/sharding/transpose + `filesystem`+`ndarray`).
-  Codecs are transparent to this engine — it only adds CF semantics, the OGC
-  domain mapping, and the poll-and-swap lifecycle. blosc/zstd build from C via
+- **Phases 1-2 (done):** local **and** remote (S3/HTTP) stores, WGS84/geographic
+  lat-lon grid, multi-variable EDR **position** queries with bilinear
+  interpolation, CF time decoding, CF packing
+  (`scale_factor`/`add_offset`/`_FillValue`/`missing_value` + the array's own
+  Zarr fill), byte-range chunk reads with an LRU cache, and a startup WARN for
+  pathological chunk shapes. **Not yet:** Map/Tiles/WMS rendering (Phase 3),
+  per-item-CRS STAC mode (Phase 4), kerchunk (Phase 5).
+- **The Zarr format + codec pipeline is handled by the `zarrs` crate** (features:
+  blosc/zstd/gzip/crc32c/sharding/transpose + `filesystem`+`ndarray`). Codecs are
+  transparent to this engine — it only adds CF semantics, the OGC domain mapping,
+  the storage bridge, and the poll-and-swap lifecycle. blosc/zstd build from C via
   `cmake`+`cc` (same toolchain `libaec-sys` already needs for GRIB).
-- `zarrs` uses **rayon internally for codec decode** (CPU-bound, not I/O) — safe
-  with the Phase-1 `FilesystemStore`. The "no `ds-storage` from a rayon thread"
-  hazard only applies to the Phase-2 adapter; honor it there.
-- **Engine = EDR-only in Phase 1.** The `engine_type → supported_apis` allowlist
-  in `admin.rs` lists `"zarr" => &["edr"]`, so a zarr collection that requests
-  `wms`/`maps`/`tiles` is rejected at load with a clear error (widen the
-  allowlist + implement `MapEngine` in Phase 3).
+- **Storage = `ds-storage` for every backend.** `engine-zarr/src/store.rs`
+  `DsStore` implements zarrs `ReadableStorageTraits` + `ListableStorageTraits`
+  over `ds_storage::DataStore` (local / S3 / HTTP via `build_store` /
+  `build_s3_store_from_parts`), with a `quick_cache` LRU of full chunk-object
+  bytes (byte ranges are served by slicing the cached buffer). Group/child
+  discovery uses one-level delimiter listing (`DataStore::list_dir`), not a
+  recursive chunk-key walk.
+- **`concurrent_target(1)` is load-bearing, not tuning.** `zarrs` parallelises
+  multi-chunk retrieval with **rayon by default**, and would call the storage
+  layer from rayon workers — where `ds-storage`'s `block_in_place` bridge
+  *panics*. `catalog::single_threaded_opts()` pins retrieval to the calling
+  (request/poll) thread via `CodecOptions::with_concurrent_target(1)`, so storage
+  reads never land on rayon. Every `retrieve_*` MUST go through it.
+- **Engine = EDR-only (through Phase 2).** The `engine_type → supported_apis`
+  allowlist in `admin.rs` lists `"zarr" => &["edr"]`, so a zarr collection that
+  requests `wms`/`maps`/`tiles` is rejected at load (widen the allowlist +
+  implement `MapEngine` in Phase 3).
 - **Catalog model:** `catalog::build` opens the root group, lists child arrays,
   treats 1-D arrays named after their dim as CF coordinate variables, classifies
   each dim via `cf::classify_axis` (coord-var `standard_name`/`units` first, name
   heuristic second — projected metre axes resolve to `Other` so they're not
-  mistaken for degrees), and exposes the remaining geographic data variables as
-  parameters. A **time axis is required** in Phase 1 (PointSeries needs a `t`).
-- **Reads:** `retrieve_array_subset::<Vec<T>>` requires the exact dtype, so the
-  read path branches on `data_type()` (`*dt == data_type::float32()`, …) and
-  widens every supported int/float to `f64`. Fill sentinels are compared against
-  the **raw** (pre-scale) value, NaN maps to nodata.
+  mistaken for degrees), validates lat/lon axes are monotonic, and exposes the
+  remaining geographic data variables as parameters. A **time axis is required**
+  (PointSeries needs a `t`). Variables with an unsupported dtype are skipped at
+  build with a WARN.
+- **Reads:** `retrieve_array_subset_opt::<Vec<T>>` (single-threaded) requires the
+  exact dtype, so the read path branches on `data_type()` (`*dt ==
+  data_type::float32()`, …) and widens every supported int/float to `f64`. Fill
+  sentinels are compared against the **raw** (pre-scale) value; NaN/±inf map to
+  nodata.
 - **Bad-chunking WARN (#125):** `time=1, lat=full, lon=full` (each timestep one
   full-domain chunk) is pathological for point/time-series queries; the engine
   logs it at startup but still serves.
-- **Config:** `data_path` (local store dir; mutually exclusive with the Phase-2
-  `endpoint`+`bucket`+`path` S3 source), optional `path` sub-dir, `zarr_version`
-  (2/3, advisory — `zarrs` auto-detects), `parameters` filter, `poll_interval_secs`
-  (default 300), `cache_mb` (default 256, Phase-2 chunk LRU).
+- **Config:** `data_path` (local dir, or an `s3://`/`http(s)://` URL) **or**
+  `endpoint`+`bucket`+`path` (S3) — mutually exclusive; optional `path` sub-path,
+  `zarr_version` (2/3, advisory — `zarrs` auto-detects), `parameters` filter,
+  `poll_interval_secs` (default 300), `cache_mb` (default 256, chunk LRU).
 - **Fixture:** `testdata/zarr-era5-t2m` (committed), regenerated by
   `cargo run -p engine-zarr --example gen_fixture`. Field is linear in lat/lon so
   bilinear is exact and integration assertions are tight.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1063,8 +1063,11 @@ name = "engine-zarr"
 version = "0.1.0"
 dependencies = [
  "arc-swap",
+ "bytes",
  "chrono",
  "ds-core",
+ "ds-storage",
+ "quick_cache",
  "serde",
  "serde_json",
  "tempfile",

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -622,18 +622,19 @@ fn default_zarr_cache_mb() -> u64 {
 /// Configuration for the Zarr engine (`engine_type = "zarr"`).
 ///
 /// Reads cloud-native multidimensional arrays (Zarr V2/V3) with CF-conventions
-/// metadata. Phase 1 supports a **local** store (`data_path`) only; the S3/HTTP
-/// (`endpoint` + `bucket` + `path`) backend is validated here but rejected at
-/// engine construction until Phase 2.
+/// metadata from a **local** store (`data_path`) or a remote **S3/HTTP** store
+/// (`endpoint` + `bucket` + `path`, or an `s3://`/`http(s)://` URL in
+/// `data_path`). The grid must be geographic (WGS84 lat/lon).
 #[derive(Debug, Clone, Deserialize)]
 pub struct ZarrConfig {
-    /// Local path to the Zarr store root directory (the `.zarr` directory).
-    /// Mutually exclusive with the S3 `endpoint`/`bucket` source.
+    /// Local path to the Zarr store root directory (the `.zarr` directory), or
+    /// an `s3://` / `http(s)://` URL. Mutually exclusive with the S3
+    /// `endpoint`/`bucket` source.
     pub data_path: Option<String>,
-    /// S3-compatible endpoint URL, e.g. "https://s3.eu-central-1.amazonaws.com"
-    /// (Phase 2). Required together with `bucket`.
+    /// S3-compatible endpoint URL, e.g. "https://s3.eu-central-1.amazonaws.com".
+    /// Required together with `bucket`.
     pub endpoint: Option<String>,
-    /// S3 bucket name (Phase 2). Required when `endpoint` is set.
+    /// S3 bucket name. Required when `endpoint` is set.
     pub bucket: Option<String>,
     /// Path of the Zarr store within the bucket (S3 source), e.g.
     /// "zarr/2026/01/data/air_temperature_at_2_metres.zarr". Required for the
@@ -650,8 +651,9 @@ pub struct ZarrConfig {
     /// appended time steps surface without a reload. Default: 300 (5 min).
     #[serde(default = "default_zarr_poll_interval")]
     pub poll_interval_secs: u64,
-    /// Chunk LRU cache size in MB (used by the Phase 2 remote byte-range
-    /// reader). Default: 256.
+    /// Chunk LRU cache size in MB. Caches full chunk-object bytes for the
+    /// byte-range reader (most useful for the remote S3/HTTP backends).
+    /// Default: 256.
     #[serde(default = "default_zarr_cache_mb")]
     pub cache_mb: u64,
 }

--- a/crates/engine-zarr/Cargo.toml
+++ b/crates/engine-zarr/Cargo.toml
@@ -5,6 +5,10 @@ edition = "2021"
 
 [dependencies]
 ds-core = { path = "../core" }
+ds-storage = { path = "../storage" }
+# Compressed chunk-bytes LRU cache for the remote byte-range reader.
+quick_cache = "0.6"
+bytes = "1"
 # Zarr V2/V3 format + codec pipeline (blosc/zstd/gzip/crc32c/sharding/transpose).
 # `filesystem` gives the local-directory store used for the Phase-1 backend;
 # `ndarray` is the multi-dimensional element view used to slice chunks.

--- a/crates/engine-zarr/src/catalog.rs
+++ b/crates/engine-zarr/src/catalog.rs
@@ -10,17 +10,25 @@ use std::ops::Range;
 use std::sync::Arc;
 
 use chrono::{DateTime, Utc};
-use zarrs::array::{data_type, Array, ArraySubset};
-use zarrs::filesystem::FilesystemStore;
+use zarrs::array::{data_type, Array, ArraySubset, CodecOptions};
 use zarrs::group::Group;
 
 use ds_core::error::DataServerError;
 
 use crate::cf::{self, AxisRole};
+use crate::store::DsStore;
 
-/// The concrete store type used by the Phase-1 local backend. Phase 2 will
-/// generalise this to a trait object over `ds-storage`.
-type Store = FilesystemStore;
+/// The store type backing every Zarr collection: a `ds-storage` adapter that
+/// serves local, S3, and HTTP backends uniformly (#125 Phase 2).
+type Store = DsStore;
+
+/// Codec options that pin chunk retrieval to the **calling thread** by setting
+/// the concurrency target to 1. This is load-bearing: it stops zarrs from
+/// dispatching storage reads onto `rayon` workers, where ds-storage's
+/// `block_in_place` bridge would panic (see [`crate::store`]).
+fn single_threaded_opts() -> CodecOptions {
+    CodecOptions::default().with_concurrent_target(1)
+}
 
 /// A single exposed data variable (one EDR/Map parameter).
 pub struct Variable {
@@ -640,10 +648,11 @@ fn retrieve_raw_f64(
     subset: &ArraySubset,
 ) -> Result<Vec<f64>, DataServerError> {
     let dt = array.data_type();
+    let opts = single_threaded_opts();
     macro_rules! read_as {
         ($t:ty) => {
             array
-                .retrieve_array_subset::<Vec<$t>>(subset)
+                .retrieve_array_subset_opt::<Vec<$t>>(subset, &opts)
                 .map(|v| v.into_iter().map(|x| x as f64).collect::<Vec<f64>>())
         };
     }

--- a/crates/engine-zarr/src/lib.rs
+++ b/crates/engine-zarr/src/lib.rs
@@ -280,7 +280,10 @@ impl EdrEngine for ZarrEngine {
 ///   optionally suffixed by `path`. `ds_storage::build_store` picks the backend.
 fn build_store(collection_id: &str, config: &ZarrConfig) -> Result<DsStore, DataServerError> {
     if let (Some(endpoint), Some(bucket)) = (config.endpoint.as_deref(), config.bucket.as_deref()) {
-        let path = config.path.as_deref().unwrap_or_default(); // required for remote (config-validated)
+        // `path` is required for a remote source — enforced in
+        // `ServerConfig::validate` ("remote zarr (endpoint+bucket) requires
+        // 'path'"), so by here it is always present.
+        let path = config.path.as_deref().unwrap_or_default();
         let ds = ds_storage::build_s3_store_from_parts(endpoint, bucket).map_err(|e| {
             DataServerError::Config(format!(
                 "Collection '{collection_id}': failed to open S3 Zarr store \

--- a/crates/engine-zarr/src/lib.rs
+++ b/crates/engine-zarr/src/lib.rs
@@ -1,29 +1,31 @@
 //! Zarr engine — reads cloud-native multidimensional arrays (Zarr V2/V3) with
 //! CF-conventions metadata and serves them over the EDR API.
 //!
-//! **Phase 1 scope** (issue #125): a local Zarr store (`data_path`), a
-//! WGS84/geographic lat-lon grid, multi-variable EDR *position* queries with
-//! bilinear interpolation, CF time-axis decoding, CF packing
-//! (`scale_factor`/`add_offset`/`_FillValue`), and a startup warning for
-//! pathological chunk shapes. The S3/HTTP backend (Phase 2) and Map/Tiles/WMS
-//! rendering (Phase 3) are not implemented yet.
+//! **Scope** (issue #125, Phases 1-2): a local **or** remote (S3/HTTP) Zarr
+//! store on a WGS84/geographic lat-lon grid, multi-variable EDR *position*
+//! queries with bilinear interpolation, CF time-axis decoding, CF packing
+//! (`scale_factor`/`add_offset`/`_FillValue`), byte-range chunk reads with an
+//! LRU cache, and a startup warning for pathological chunk shapes. Map/Tiles/WMS
+//! rendering (Phase 3) and projected/per-item-CRS sources (Phase 4) are not
+//! implemented yet.
 //!
 //! The Zarr format and codec pipeline (blosc/zstd/gzip/crc32c/sharding) are
-//! handled by the `zarrs` crate; this engine adds the CF semantics, the OGC
-//! domain mapping, and the poll-and-swap lifecycle shared by the other engines.
+//! handled by the `zarrs` crate; all I/O goes through the shared `ds-storage`
+//! object store via [`store::DsStore`]. This engine adds the CF semantics, the
+//! OGC domain mapping, and the poll-and-swap lifecycle shared by the other
+//! engines.
 
 mod catalog;
 mod cf;
+mod store;
 
 use std::collections::HashMap;
-use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
 use arc_swap::ArcSwap;
 use chrono::{DateTime, Utc};
 use tokio::sync::watch;
-use zarrs::filesystem::FilesystemStore;
 
 use ds_core::config::ZarrConfig;
 use ds_core::edr_engine::EdrEngine;
@@ -33,12 +35,13 @@ use ds_core::model::{
 };
 
 use catalog::Catalog;
+use store::DsStore;
 
 /// Engine for serving Zarr arrays over EDR.
 pub struct ZarrEngine {
     collection_id: String,
-    /// Filesystem store rooted at the Zarr store directory.
-    store: Arc<FilesystemStore>,
+    /// `ds-storage`-backed store (local / S3 / HTTP), shared by query and poll.
+    store: Arc<DsStore>,
     /// Parsed snapshot, swapped atomically by the poll loop.
     catalog: ArcSwap<Catalog>,
     /// Variable filter from config (`None` = expose all).
@@ -48,35 +51,10 @@ pub struct ZarrEngine {
 }
 
 impl ZarrEngine {
-    /// Open a local Zarr store and build the initial catalog.
+    /// Open a Zarr store (local directory or remote S3/HTTP) and build the
+    /// initial catalog.
     pub fn new(collection_id: &str, config: &ZarrConfig) -> Result<Self, DataServerError> {
-        if config.endpoint.is_some() || config.bucket.is_some() {
-            return Err(DataServerError::Config(format!(
-                "Collection '{collection_id}': zarr S3/HTTP backend is not implemented yet \
-                 (Phase 2); use a local 'data_path'"
-            )));
-        }
-        let data_path = config.data_path.as_deref().ok_or_else(|| {
-            DataServerError::Config(format!(
-                "Collection '{collection_id}': zarr engine requires 'data_path'"
-            ))
-        })?;
-        let root: PathBuf = match &config.path {
-            Some(p) => PathBuf::from(data_path).join(p),
-            None => PathBuf::from(data_path),
-        };
-        if !root.exists() {
-            return Err(DataServerError::Config(format!(
-                "Collection '{collection_id}': zarr data_path '{}' does not exist",
-                root.display()
-            )));
-        }
-        let store = Arc::new(FilesystemStore::new(&root).map_err(|e| {
-            DataServerError::Config(format!(
-                "Collection '{collection_id}': failed to open Zarr store '{}': {e}",
-                root.display()
-            ))
-        })?);
+        let store = Arc::new(build_store(collection_id, config)?);
 
         let param_filter = config.parameters.clone();
         let catalog = catalog::build(store.clone(), collection_id, param_filter.as_deref())?;
@@ -292,6 +270,51 @@ impl EdrEngine for ZarrEngine {
             ranges,
         }))
     }
+}
+
+/// Build the `ds-storage`-backed store for a Zarr collection.
+///
+/// - Remote: `endpoint` + `bucket` (+ required `path`) → an S3 store rooted at
+///   `path` within the bucket.
+/// - Local: `data_path` (a directory, or an `s3://` / `http(s)://` URL),
+///   optionally suffixed by `path`. `ds_storage::build_store` picks the backend.
+fn build_store(collection_id: &str, config: &ZarrConfig) -> Result<DsStore, DataServerError> {
+    if let (Some(endpoint), Some(bucket)) = (config.endpoint.as_deref(), config.bucket.as_deref()) {
+        let path = config.path.as_deref().unwrap_or_default(); // required for remote (config-validated)
+        let ds = ds_storage::build_s3_store_from_parts(endpoint, bucket).map_err(|e| {
+            DataServerError::Config(format!(
+                "Collection '{collection_id}': failed to open S3 Zarr store \
+                 (endpoint={endpoint}, bucket={bucket}): {e}"
+            ))
+        })?;
+        return Ok(DsStore::new(ds, path, config.cache_mb));
+    }
+
+    let data_path = config.data_path.as_deref().ok_or_else(|| {
+        DataServerError::Config(format!(
+            "Collection '{collection_id}': zarr engine requires 'data_path' or 'endpoint'+'bucket'"
+        ))
+    })?;
+    // Optional `path` is a relative sub-path under `data_path` (config-validated
+    // to contain no leading slash or `..`).
+    let location = match &config.path {
+        Some(p) => format!(
+            "{}/{}",
+            data_path.trim_end_matches('/'),
+            p.trim_matches('/')
+        ),
+        None => data_path.to_string(),
+    };
+    let (ds, prefix) = ds_storage::build_store(&location).map_err(|e| {
+        DataServerError::Config(format!(
+            "Collection '{collection_id}': failed to open Zarr store '{location}': {e}"
+        ))
+    })?;
+    Ok(DsStore::new(
+        ds,
+        prefix.as_ref().to_string(),
+        config.cache_mb,
+    ))
 }
 
 fn log_loaded(collection_id: &str, cat: &Catalog) {

--- a/crates/engine-zarr/src/store.rs
+++ b/crates/engine-zarr/src/store.rs
@@ -1,0 +1,256 @@
+//! A `zarrs` storage adapter over [`ds_storage::DataStore`].
+//!
+//! Bridges zarrs's synchronous `ReadableStorageTraits` / `ListableStorageTraits`
+//! to the shared `ds-storage` object-store layer (local, S3, HTTP), so the Zarr
+//! engine reaches every backend through the same code path as the other engines
+//! (#125 Phase 2).
+//!
+//! Two invariants make this safe and effective:
+//!
+//! - **Single-threaded retrieval.** The engine drives every read with
+//!   `CodecOptions::with_concurrent_target(1)` (see [`crate::catalog`]), so zarrs
+//!   never dispatches a storage read onto a `rayon` worker. ds-storage's
+//!   `block_in_place` bridge is valid on the calling request/poll thread but
+//!   *panics* on a rayon pool thread — so the single-thread setting is
+//!   load-bearing, not just a tuning knob (CLAUDE.md storage rules).
+//! - **Whole-object reads + LRU cache.** Non-sharded Zarr chunks are read in
+//!   full; the adapter caches the full object bytes (keyed by store key) and
+//!   serves byte-range requests by slicing the cached buffer, so a time-series
+//!   scan over one spatial neighbourhood re-reads each chunk at most once.
+//!   (Sharded objects are read whole — a documented Phase-2 trade-off.)
+
+use std::sync::Arc;
+
+use bytes::Bytes;
+use quick_cache::sync::Cache;
+
+use ds_storage::object_store::path::Path as ObjectPath;
+use ds_storage::DataStore;
+
+use zarrs::storage::byte_range::ByteRangeIterator;
+use zarrs::storage::{
+    ListableStorageTraits, MaybeBytes, MaybeBytesIterator, ReadableStorageTraits, StorageError,
+    StoreKey, StoreKeys, StoreKeysPrefixes, StorePrefix,
+};
+
+/// Weights cache entries by payload size (plus a small per-entry overhead).
+#[derive(Clone)]
+struct BytesWeighter;
+impl quick_cache::Weighter<String, Bytes> for BytesWeighter {
+    fn weight(&self, key: &String, val: &Bytes) -> u64 {
+        val.len() as u64 + key.len() as u64 + 64
+    }
+}
+
+/// A readable + listable zarrs store backed by `ds-storage`.
+pub struct DsStore {
+    store: DataStore,
+    /// Object-path prefix prepended to every zarrs key — the store's location
+    /// within the bucket. Empty for a locally-rooted store. No leading/trailing
+    /// slashes.
+    root: String,
+    cache: Cache<String, Bytes, BytesWeighter>,
+}
+
+impl DsStore {
+    /// Build an adapter over `store`, rooted at `root` (the store location
+    /// within the backend; `""` for a locally-rooted store), with a chunk cache
+    /// of `cache_mb` megabytes.
+    pub fn new(store: DataStore, root: impl Into<String>, cache_mb: u64) -> Self {
+        let max_bytes = cache_mb.saturating_mul(1024 * 1024).max(1024 * 1024);
+        Self {
+            store,
+            root: root.into().trim_matches('/').to_string(),
+            // 1024 is just a sizing hint; eviction is driven by `max_bytes`.
+            cache: Cache::with_weighter(1024, max_bytes, BytesWeighter),
+        }
+    }
+
+    /// Map a zarrs key to a backend object path, applying the root prefix.
+    fn object_path(&self, key: &str) -> ObjectPath {
+        if self.root.is_empty() {
+            ObjectPath::from(key)
+        } else {
+            ObjectPath::from(format!("{}/{}", self.root, key))
+        }
+    }
+
+    /// Strip the root prefix from a backend object path, returning the
+    /// zarrs-relative key, or `None` if the path is outside the root.
+    fn strip_root<'a>(&self, full: &'a str) -> Option<&'a str> {
+        if self.root.is_empty() {
+            return Some(full);
+        }
+        full.strip_prefix(self.root.as_str())
+            .map(|s| s.trim_start_matches('/'))
+    }
+
+    /// Fetch a full object, caching it. `None` when the key is absent.
+    fn get_full(&self, key: &StoreKey) -> Result<Option<Bytes>, StorageError> {
+        let k = key.as_str();
+        if let Some(b) = self.cache.get(k) {
+            return Ok(Some(b));
+        }
+        match self.store.get_opt(&self.object_path(k)).map_err(io_err)? {
+            Some(b) => {
+                self.cache.insert(k.to_string(), b.clone());
+                Ok(Some(b))
+            }
+            None => Ok(None),
+        }
+    }
+}
+
+/// Wrap any ds-storage error as a zarrs `StorageError` (which has no free-text
+/// variant, so we route through an IO error).
+fn io_err(e: ds_core::error::DataServerError) -> StorageError {
+    StorageError::from(Arc::new(std::io::Error::other(e.to_string())))
+}
+
+impl ReadableStorageTraits for DsStore {
+    fn get(&self, key: &StoreKey) -> Result<MaybeBytes, StorageError> {
+        self.get_full(key)
+    }
+
+    fn get_partial_many<'a>(
+        &'a self,
+        key: &StoreKey,
+        byte_ranges: ByteRangeIterator<'a>,
+    ) -> Result<MaybeBytesIterator<'a>, StorageError> {
+        let Some(full) = self.get_full(key)? else {
+            return Ok(None);
+        };
+        let size = full.len() as u64;
+        // Resolve each requested range against the whole object and slice it
+        // (cheap refcounted `Bytes::slice`). Collected eagerly so the returned
+        // iterator borrows nothing from `self`.
+        let slices: Vec<Result<Bytes, StorageError>> = byte_ranges
+            .map(|br| {
+                let start = br.start(size);
+                let end = br.end(size).min(size);
+                if start > end {
+                    Err(io_err(ds_core::error::DataServerError::Storage(format!(
+                        "invalid byte range {start}..{end} for {size}-byte object"
+                    ))))
+                } else {
+                    Ok(full.slice(start as usize..end as usize))
+                }
+            })
+            .collect();
+        Ok(Some(Box::new(slices.into_iter())))
+    }
+
+    fn size_key(&self, key: &StoreKey) -> Result<Option<u64>, StorageError> {
+        // The whole-object read populates the cache, so a following
+        // `get_partial_many`/`get` for the same key is free.
+        Ok(self.get_full(key)?.map(|b| b.len() as u64))
+    }
+
+    fn supports_get_partial(&self) -> bool {
+        // Partials are synthesised by slicing a whole-object read, not by a
+        // server-side range request, so report no efficient partial support.
+        false
+    }
+}
+
+impl ListableStorageTraits for DsStore {
+    fn list(&self) -> Result<StoreKeys, StorageError> {
+        let root = StorePrefix::new(String::new()).map_err(StorageError::from)?;
+        self.list_prefix(&root)
+    }
+
+    fn list_prefix(&self, prefix: &StorePrefix) -> Result<StoreKeys, StorageError> {
+        let metas = self
+            .store
+            .list(&self.object_path(prefix.as_str()))
+            .map_err(io_err)?;
+        let mut keys = Vec::with_capacity(metas.len());
+        for m in metas {
+            if let Some(rel) = self.strip_root(m.location.as_ref()) {
+                if let Ok(k) = StoreKey::new(rel) {
+                    keys.push(k);
+                }
+            }
+        }
+        Ok(keys)
+    }
+
+    fn list_dir(&self, prefix: &StorePrefix) -> Result<StoreKeysPrefixes, StorageError> {
+        let (objects, prefixes) = self
+            .store
+            .list_dir(&self.object_path(prefix.as_str()))
+            .map_err(io_err)?;
+        let mut keys = Vec::with_capacity(objects.len());
+        for m in objects {
+            if let Some(rel) = self.strip_root(m.location.as_ref()) {
+                if let Ok(k) = StoreKey::new(rel) {
+                    keys.push(k);
+                }
+            }
+        }
+        let mut child_prefixes = Vec::with_capacity(prefixes.len());
+        for p in prefixes {
+            if let Some(rel) = self.strip_root(p.as_ref()) {
+                let rel = if rel.ends_with('/') {
+                    rel.to_string()
+                } else {
+                    format!("{rel}/")
+                };
+                if let Ok(sp) = StorePrefix::new(rel) {
+                    child_prefixes.push(sp);
+                }
+            }
+        }
+        Ok(StoreKeysPrefixes::new(keys, child_prefixes))
+    }
+
+    fn size_prefix(&self, prefix: &StorePrefix) -> Result<u64, StorageError> {
+        let metas = self
+            .store
+            .list(&self.object_path(prefix.as_str()))
+            .map_err(io_err)?;
+        Ok(metas.iter().map(|m| m.size as u64).sum())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn store_with_root(root: &str) -> DsStore {
+        let inner = Arc::new(ds_storage::object_store::memory::InMemory::new());
+        DsStore::new(DataStore::new(inner), root, 16)
+    }
+
+    #[test]
+    fn object_path_applies_root_prefix() {
+        let s = store_with_root("zarr/era5.zarr");
+        assert_eq!(
+            s.object_path("t2m/c/0/0/0").as_ref(),
+            "zarr/era5.zarr/t2m/c/0/0/0"
+        );
+        // A leading/trailing slash on the configured root is normalised away.
+        let s2 = store_with_root("/zarr/era5.zarr/");
+        assert_eq!(
+            s2.object_path("lat/zarr.json").as_ref(),
+            "zarr/era5.zarr/lat/zarr.json"
+        );
+    }
+
+    #[test]
+    fn strip_root_inverts_object_path() {
+        let s = store_with_root("zarr/era5.zarr");
+        assert_eq!(
+            s.strip_root("zarr/era5.zarr/t2m/c/0/0/0"),
+            Some("t2m/c/0/0/0")
+        );
+        assert_eq!(s.strip_root("outside/x"), None);
+    }
+
+    #[test]
+    fn empty_root_passes_keys_through() {
+        let s = store_with_root("");
+        assert_eq!(s.object_path("t2m/zarr.json").as_ref(), "t2m/zarr.json");
+        assert_eq!(s.strip_root("t2m/zarr.json"), Some("t2m/zarr.json"));
+    }
+}

--- a/crates/engine-zarr/src/store.rs
+++ b/crates/engine-zarr/src/store.rs
@@ -159,6 +159,11 @@ impl ListableStorageTraits for DsStore {
         self.list_prefix(&root)
     }
 
+    // NOTE: recursive (no delimiter) — its contract is "every key under the
+    // prefix". The engine's child/array discovery goes through `list_dir`
+    // (one-level), so this is not on the open/read hot path; avoid calling it at
+    // the store root of a large remote store, where it would enumerate every
+    // chunk key.
     fn list_prefix(&self, prefix: &StorePrefix) -> Result<StoreKeys, StorageError> {
         let metas = self
             .store

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -128,6 +128,57 @@ impl DataStore {
         self.block_on(async { Ok(self.inner.head(path).await?) })
     }
 
+    /// Like [`Self::get`], but a **missing** object (`NotFound` / HTTP 404)
+    /// maps to `Ok(None)` rather than an error. Zarr stores treat an absent key
+    /// (an unwritten chunk, an optional metadata file) as "use the fill value"
+    /// / "not present", so the engine needs this distinction.
+    pub fn get_opt(&self, path: &ObjectPath) -> Result<Option<Bytes>, DataServerError> {
+        let result = self.block_on(async {
+            match self.inner.get(path).await {
+                Ok(res) => Ok(Some(res.bytes().await?)),
+                Err(object_store::Error::NotFound { .. }) => Ok(None),
+                Err(e) => Err(e),
+            }
+        })?;
+        if let Some(b) = &result {
+            self.bytes_read.fetch_add(b.len() as u64, Ordering::Relaxed);
+        }
+        Ok(result)
+    }
+
+    /// Like [`Self::get_range`], but a missing object maps to `Ok(None)`.
+    pub fn get_range_opt(
+        &self,
+        path: &ObjectPath,
+        range: Range<usize>,
+    ) -> Result<Option<Bytes>, DataServerError> {
+        let result = self.block_on(async {
+            match self.inner.get_range(path, range).await {
+                Ok(b) => Ok(Some(b)),
+                Err(object_store::Error::NotFound { .. }) => Ok(None),
+                Err(e) => Err(e),
+            }
+        })?;
+        if let Some(b) = &result {
+            self.bytes_read.fetch_add(b.len() as u64, Ordering::Relaxed);
+        }
+        Ok(result)
+    }
+
+    /// One-level (delimiter) listing under `prefix`, returning `(objects,
+    /// common_prefixes)` — the immediate child objects and the immediate child
+    /// "directories". Used for Zarr group/child discovery, which only needs the
+    /// next path segment, not a recursive walk of every chunk key.
+    pub fn list_dir(
+        &self,
+        prefix: &ObjectPath,
+    ) -> Result<(Vec<ObjectMeta>, Vec<ObjectPath>), DataServerError> {
+        self.block_on(async {
+            let res = self.inner.list_with_delimiter(Some(prefix)).await?;
+            Ok((res.objects, res.common_prefixes))
+        })
+    }
+
     /// Fetch many objects concurrently, returning one result per input
     /// path **in input order**. A per-object failure (missing, oversized,
     /// network) is carried in that slot's `Err` and does not sink the

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -146,25 +146,6 @@ impl DataStore {
         Ok(result)
     }
 
-    /// Like [`Self::get_range`], but a missing object maps to `Ok(None)`.
-    pub fn get_range_opt(
-        &self,
-        path: &ObjectPath,
-        range: Range<usize>,
-    ) -> Result<Option<Bytes>, DataServerError> {
-        let result = self.block_on(async {
-            match self.inner.get_range(path, range).await {
-                Ok(b) => Ok(Some(b)),
-                Err(object_store::Error::NotFound { .. }) => Ok(None),
-                Err(e) => Err(e),
-            }
-        })?;
-        if let Some(b) = &result {
-            self.bytes_read.fetch_add(b.len() as u64, Ordering::Relaxed);
-        }
-        Ok(result)
-    }
-
     /// One-level (delimiter) listing under `prefix`, returning `(objects,
     /// common_prefixes)` — the immediate child objects and the immediate child
     /// "directories". Used for Zarr group/child discovery, which only needs the

--- a/testdata/zarr-era5-t2m/test-config.toml
+++ b/testdata/zarr-era5-t2m/test-config.toml
@@ -35,16 +35,20 @@ zarr_version = 3
 poll_interval_secs = 300
 
 # ---------------------------------------------------------------------------
-# Real cloud data (NOT runnable on Phase 1 — kept here as a roadmap reference).
-#
-# HRRR-Zarr (s3://hrrrzarr/) needs TWO things this engine doesn't have yet:
-#   1. an S3/HTTP backend  -> Phase 2 (#125)
-#   2. projected-grid (Lambert Conformal) + 2-D lat/lon support -> Phase 4 (#125)
-# so HRRR specifically is not a Phase-2 target. The clean Phase-2 demo target is
-# a geographic (1-D lat/lon) Zarr such as ARCO-ERA5. The eventual shape will be:
+# Remote S3/HTTP backend (Phase 2, #125). A geographic (1-D lat/lon) Zarr on a
+# public bucket is now runnable — give endpoint+bucket+path:
 #
 # [collections.zarr]
-# endpoint = "https://s3.amazonaws.com"
-# bucket = "hrrrzarr"
-# path = "sfc/20210101/20210101_00z_anl.zarr/2m_above_ground/TMP"
+# endpoint = "https://s3.us-west-2.amazonaws.com"
+# bucket = "mur-sst"
+# path = "zarr-v1"
+# parameters = ["analysed_sst"]
+#
+# (MUR-SST also trips the bad-chunking startup WARN by design — time=1,
+# lat=full, lon=full — so a point time-series there decodes a full field per
+# step. It's the issue's negative-test dataset.)
+#
+# HRRR-Zarr (s3://hrrrzarr/) is still NOT supported: it's on a Lambert Conformal
+# projected grid with 2-D lat/lon (no 1-D geographic coordinate variables),
+# which needs the projected/per-item-CRS work in Phase 4.
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

**Phase 2** of #125 — remote **S3/HTTP** support for the Zarr engine, reusing `ds-storage` for every backend, plus a byte-range chunk **LRU cache**. Builds on the merged Phase 1 (#332).

## Design — and the one load-bearing decision

`zarrs` parallelises multi-chunk retrieval with **rayon by default**, and would call the storage layer from rayon workers. `ds-storage`'s `block_in_place` bridge is valid on a request/poll worker but **panics on a rayon thread** (the exact hazard CLAUDE.md warns about). So the engine pins all retrieval to the calling thread with `CodecOptions::with_concurrent_target(1)` — storage reads never land on rayon. This is documented at every relevant site as load-bearing, not tuning.

With that settled, the rest reuses ds-storage cleanly:

- **`ds-storage`** gains `get_opt`/`get_range_opt` (a missing key → `Ok(None)`, since Zarr treats an absent chunk as "use the fill value") and `list_dir` (one-level **delimiter** listing for cheap Zarr group/child discovery — no recursive walk of every chunk key on S3).
- **`engine-zarr/src/store.rs` `DsStore`** implements zarrs `ReadableStorageTraits` + `ListableStorageTraits` over `ds_storage::DataStore`, with a `quick_cache` LRU of full chunk-object bytes (byte-range requests are served by slicing the cached buffer) and a root-prefix mapping for bucket-relative stores.
- **The catalog's store type is now `DsStore` for both local and remote**, so local/S3/HTTP all flow through one ds-storage path (`build_store` / `build_s3_store_from_parts`). Phase 1's `FilesystemStore` special-case is gone.

## Config

```toml
# Local (unchanged) — data_path may also be an s3:// or http(s):// URL
[collections.zarr]
data_path = "testdata/zarr-era5-t2m"

# Remote S3 (new)
[collections.zarr]
endpoint = "https://s3.us-west-2.amazonaws.com"
bucket   = "mur-sst"
path     = "zarr-v1"
parameters = ["analysed_sst"]
```

## Tests

- The **existing integration suite now exercises the entire Phase-2 storage stack** (DsStore adapter, cache, delimiter listing, byte-range slicing, `concurrent_target=1`) **network-free** — the committed fixture flows through `ds-storage`'s local backend now, not zarrs `FilesystemStore`. Verified the running server returns identical EDR values through the adapter.
- Added `DsStore` unit tests for the remote **root-prefix** mapping (`object_path`/`strip_root`), the part the local (`root=""`) path doesn't cover.
- `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` clean.

## Not validated in CI

A **live remote** fetch (network) isn't run in CI. The remote path differs from the (tested) local path only in the object_store backend, which `ds-storage` already provides and the GRIB engine already uses for S3. A manual smoke test against a public geographic Zarr (e.g. MUR-SST) is recommended before relying on it in production. HRRR-Zarr remains out of scope (Lambert projected grid → Phase 4).

## Deferred

Sharded huge objects are read whole (fine for the common non-sharded case; a follow-up could do true server-side range reads). Phase 3 (Map/Tiles/WMS), Phase 4 (per-item-CRS STAC), Phase 5 (kerchunk) remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)