### PR TITLE
feat(edr): model-run support — EDR instances + shared run machinery (#337)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,6 +156,43 @@ radar elevation angle. WMS exposes it as the `ELEVATION` dimension; Maps/Tiles a
 `elevation` query parameter; EDR as the `z` query parameter. The API layer rejects a
 `z`/`elevation` against a collection with no vertical extent (HTTP 400).
 
+### Model runs / forecast reference time (EDR instances) — #337
+
+Forecast datasets have **two** time axes: the **model run** (forecast *reference
+time* / init / analysis time) and the **valid time** (run + lead). The shared
+machinery lives in **`ds_core::instances`** so every forecast engine selects runs,
+builds instance lists, and encodes instance ids **identically** (no per-engine
+duplication):
+
+- `RunInfo { reference_time, valid_times }` — one model run; `instance_id()` =
+  canonical compact stamp `%Y%m%dT%H%MZ`.
+- `format_instance_id` / `parse_instance_id` — the URL ↔ reference-time codec
+  (parse also accepts RFC 3339); the **API layer** owns the string form, engines
+  only see `Option<DateTime<Utc>>`.
+- `select_run(&BTreeMap<DateTime<Utc>, T>, Option<DateTime<Utc>>)` — `None` ⇒
+  latest, `Some(rt)` ⇒ that exact run (absent ⇒ `None` → 404). The one selection
+  rule everywhere.
+- `build_instances(&runs, |rt, run| valid_times)` — `Vec<RunInfo>` from a
+  reference-time-keyed run map.
+
+**Engine contract:** store runs in a `BTreeMap<DateTime<Utc>, _>` keyed by
+reference time; implement `EdrEngine::get_instances() -> Vec<RunInfo>` (default
+empty = non-forecast); honour the trailing `reference_time: Option<DateTime<Utc>>`
+on the query methods and `MapEngine::get_raster_tile` (`None` ⇒ latest); populate
+`RasterInfo.reference_times`. **GRIB** (catalog `runs` map) and **QueryData**
+(`max_runs` recent `.sqd` files, keyed by origin time) implement it; other engines
+accept-and-ignore. Zarr's forecast-reference/lead detection → instances is a
+follow-up (it currently pins the latest run internally; see [[project_zarr_engine]]).
+
+**API surface:** EDR exposes `GET /collections/{id}/instances`,
+`/instances/{instanceId}` (per-run metadata), and `/instances/{instanceId}/{position,area}`
+(query a specific run); the no-instance routes default to the latest run
+(unchanged). Collection metadata gains an `instances` data_query and the OpenAPI
+spec advertises the instance paths — both gated on `get_instances()` being
+non-empty. **WMS `reference_time` dimension + Maps/Tiles `reference_time` query
+parameter are a follow-up** (the engines already honour the selector in
+`get_raster_tile`; the API layer currently passes `None`).
+
 ## Engine Capabilities
 
 | Engine | Traits | APIs |
@@ -206,11 +243,17 @@ radar elevation angle. WMS exposes it as the `ELEVATION` dimension; Maps/Tiles a
 
 - FMI QueryData (.sqd) binary format. Memory-mapped file access via `memmap2`.
 - Multi-parameter: exposes all parameters from the file. `wms_parameter` config selects which to render.
-- Polls directory for latest `.sqd` file, atomically swaps via `ArcSwap`.
+- **Model runs (#337):** polls the directory and retains the most recent `max_runs`
+  `.sqd` files as model runs, keyed by each file's **origin (analysis) time**
+  (`RunSet: BTreeMap<DateTime<Utc>, _>`), atomically swapped via `ArcSwap`.
+  Already-loaded files are reused on poll (not re-parsed). Each run is an EDR
+  instance / `RasterInfo.reference_times` entry; the latest run is the default for
+  un-pinned queries. See the "Model runs" section above and [[project_querydata_engine_plan]].
 - Supports WGS84, Stereographic, and Rotated Lat-Lon grids.
 - EDR position queries use bilinear interpolation. Map rendering uses nearest-neighbor.
 - Missing value sentinel: 32700.0.
-- Config: `wms_parameter` (name/short name/ID), `poll_interval_secs` (default 30).
+- Config: `wms_parameter` (name/short name/ID), `poll_interval_secs` (default 30),
+  `max_runs` (default 4; recent runs retained — set 1 for latest-only/no history).
 
 ## Zarr Engine Notes
 

--- a/crates/api-edr/src/handlers.rs
+++ b/crates/api-edr/src/handlers.rs
@@ -980,10 +980,12 @@ pub async fn instances(
     let (engine, config) = lookup_collection(&state, &id)?;
     let base = &state.base_url;
     let runs = engine.get_instances();
-    let collections: Vec<serde_json::Value> = runs
+    let instances: Vec<serde_json::Value> = runs
         .iter()
         .map(|run| build_collection_metadata(engine.as_ref(), config, base, Some(run)))
         .collect();
+    // OGC API - EDR 1.1 §8.2.3 `instancesJSON`: the array field is `instances`
+    // (each item a collection-shaped instance), not `collections`.
     Ok(Json(json!({
         "links": [{
             "href": format!("{base}/edr/collections/{}/instances", config.id),
@@ -991,7 +993,7 @@ pub async fn instances(
             "type": "application/json",
             "title": format!("{} — instances", config.title)
         }],
-        "collections": collections,
+        "instances": instances,
     })))
 }
 

--- a/crates/api-edr/src/handlers.rs
+++ b/crates/api-edr/src/handlers.rs
@@ -131,6 +131,11 @@ fn lookup_collection<'a>(
 /// and confirm the engine exposes that run (`get_instances`): an unparseable id
 /// is 400, an unknown run is 404. The validated reference time is then passed to
 /// the engine query methods.
+///
+/// The existence check is **best-effort**: it reads a catalog snapshot, and a
+/// background poll could evict that run before the subsequent query reads its
+/// own snapshot. In that rare race the query just fails (the engine has no such
+/// run) — a benign 400 instead of 404 for a run that no longer exists.
 fn resolve_instance(
     engine: &Arc<dyn EdrEngine>,
     instance_id: Option<&str>,

--- a/crates/api-edr/src/handlers.rs
+++ b/crates/api-edr/src/handlers.rs
@@ -1014,24 +1014,22 @@ pub async fn instance(
             })),
         )
     })?;
-    let runs = engine.get_instances();
-    let run = runs
-        .iter()
-        .find(|r| r.reference_time == rt)
-        .ok_or_else(|| {
-            (
-                StatusCode::NOT_FOUND,
-                Json(json!({
-                    "code": "NotFound",
-                    "description": format!("Instance '{instance_id}' not found")
-                })),
-            )
-        })?;
+    // O(1) single-run lookup — avoids cloning every run's valid times just to
+    // find one (the engine builds only the requested run's RunInfo).
+    let run = engine.find_instance(rt).ok_or_else(|| {
+        (
+            StatusCode::NOT_FOUND,
+            Json(json!({
+                "code": "NotFound",
+                "description": format!("Instance '{instance_id}' not found")
+            })),
+        )
+    })?;
     Ok(Json(build_collection_metadata(
         engine.as_ref(),
         config,
         base,
-        Some(run),
+        Some(&run),
     )))
 }
 

--- a/crates/api-edr/src/handlers.rs
+++ b/crates/api-edr/src/handlers.rs
@@ -124,6 +124,45 @@ fn lookup_collection<'a>(
     Ok((engine, config))
 }
 
+/// Resolve an optional `{instanceId}` path segment to a forecast model run.
+///
+/// `None` (the no-instance routes) ⇒ `Ok(None)` (the engine serves its latest
+/// run). `Some(id)` ⇒ parse the id to a reference time ([`instances::parse_instance_id`])
+/// and confirm the engine exposes that run (`get_instances`): an unparseable id
+/// is 400, an unknown run is 404. The validated reference time is then passed to
+/// the engine query methods.
+fn resolve_instance(
+    engine: &Arc<dyn EdrEngine>,
+    instance_id: Option<&str>,
+) -> Result<Option<chrono::DateTime<chrono::Utc>>, (StatusCode, Json<serde_json::Value>)> {
+    let Some(iid) = instance_id else {
+        return Ok(None);
+    };
+    let rt = ds_core::instances::parse_instance_id(iid).ok_or_else(|| {
+        (
+            StatusCode::BAD_REQUEST,
+            Json(json!({
+                "code": "BadRequest",
+                "description": format!("Invalid instance id '{iid}' (expected a reference time like 20260607T0600Z)")
+            })),
+        )
+    })?;
+    if !engine
+        .get_instances()
+        .iter()
+        .any(|r| r.reference_time == rt)
+    {
+        return Err((
+            StatusCode::NOT_FOUND,
+            Json(json!({
+                "code": "NotFound",
+                "description": format!("Instance '{iid}' not found")
+            })),
+        ));
+    }
+    Ok(Some(rt))
+}
+
 /// Parse and resolve the request `z` parameter into the concrete level
 /// list an engine samples.
 ///
@@ -471,6 +510,117 @@ pub async fn api_definition(State(state): State<AppState>) -> impl IntoResponse 
                 }
             });
         }
+
+        // Instances (forecast model runs; #337). Only advertised for engines
+        // that expose runs, so the OpenAPI spec matches the `instances`
+        // data_query in the collection metadata.
+        let has_instances = state
+            .engines
+            .get(id)
+            .map(|e| !e.get_instances().is_empty())
+            .unwrap_or(false);
+        if has_instances {
+            let instance_id_param = json!({
+                "name": "instanceId",
+                "in": "path",
+                "required": true,
+                "description": "Forecast model run (reference time), e.g. 20260607T0600Z.",
+                "schema": {"type": "string"}
+            });
+            let instances_path = format!("/edr/collections/{id}/instances");
+            collection_paths[&instances_path] = json!({
+                "get": {
+                    "summary": format!("List model runs (instances) for {}", config.title),
+                    "operationId": format!("getInstances_{id}"),
+                    "tags": [id],
+                    "responses": {
+                        "200": {"description": "Available instances (model runs)"},
+                        "404": {"description": "Collection not found"}
+                    }
+                }
+            });
+            let instance_path = format!("/edr/collections/{id}/instances/{{instanceId}}");
+            collection_paths[&instance_path] = json!({
+                "get": {
+                    "summary": format!("Get one model run's metadata for {}", config.title),
+                    "operationId": format!("getInstance_{id}"),
+                    "tags": [id],
+                    "parameters": [instance_id_param.clone()],
+                    "responses": {
+                        "200": {"description": "Instance (model run) metadata"},
+                        "400": {"description": "Bad request"},
+                        "404": {"description": "Instance not found"}
+                    }
+                }
+            });
+            if supported.contains("position") {
+                let p = format!("/edr/collections/{id}/instances/{{instanceId}}/position");
+                collection_paths[&p] = json!({
+                    "get": {
+                        "summary": format!("Position query against a model run for {}", config.title),
+                        "operationId": format!("getInstancePosition_{id}"),
+                        "tags": [id],
+                        "parameters": [
+                            instance_id_param.clone(),
+                            {"$ref": "#/components/parameters/coords-point"},
+                            {"$ref": "#/components/parameters/datetime"},
+                            {"$ref": "#/components/parameters/parameter-name"},
+                            {"$ref": "#/components/parameters/z"},
+                            {
+                                "name": "f",
+                                "in": "query",
+                                "required": false,
+                                "schema": {"type": "string", "enum": ["CoverageJSON", "PNG"]}
+                            }
+                        ],
+                        "responses": {
+                            "200": {
+                                "description": "Coverage data",
+                                "content": {
+                                    "application/prs.coverage+json": {
+                                        "schema": {"$ref": "#/components/schemas/coverageJSON"}
+                                    },
+                                    "image/png": {"schema": {"type": "string", "format": "binary"}}
+                                }
+                            },
+                            "400": {"description": "Bad request"},
+                            "404": {"description": "Not found"},
+                            "500": {"description": "Server error"}
+                        }
+                    }
+                });
+            }
+            if supported.contains("area") {
+                let p = format!("/edr/collections/{id}/instances/{{instanceId}}/area");
+                collection_paths[&p] = json!({
+                    "get": {
+                        "summary": format!("Area query against a model run for {}", config.title),
+                        "operationId": format!("getInstanceArea_{id}"),
+                        "tags": [id],
+                        "parameters": [
+                            instance_id_param.clone(),
+                            {"$ref": "#/components/parameters/coords-polygon"},
+                            {"$ref": "#/components/parameters/datetime"},
+                            {"$ref": "#/components/parameters/parameter-name"},
+                            {"$ref": "#/components/parameters/z"}
+                        ],
+                        "responses": {
+                            "200": {
+                                "description": "Coverage data",
+                                "content": {
+                                    "application/prs.coverage+json": {
+                                        "schema": {"$ref": "#/components/schemas/coverageJSON"}
+                                    }
+                                }
+                            },
+                            "400": {"description": "Bad request"},
+                            "404": {"description": "Not found"},
+                            "500": {"description": "Server error"}
+                        }
+                    }
+                });
+            }
+        }
     }
 
     let mut paths = json!({
@@ -676,7 +826,7 @@ pub async fn collections(
                 );
                 return None;
             };
-            let value = build_collection_metadata(engine.as_ref(), config, base);
+            let value = build_collection_metadata(engine.as_ref(), config, base, None);
             Some((
                 config.id.clone(),
                 config.title.clone(),
@@ -797,9 +947,13 @@ pub async fn collection(
     let (engine, config) = lookup_collection(&state, &id)?;
     let base = &state.base_url;
     Ok(with_vary(match wanted {
-        Wanted::Json => {
-            Json(build_collection_metadata(engine.as_ref(), config, base)).into_response()
-        }
+        Wanted::Json => Json(build_collection_metadata(
+            engine.as_ref(),
+            config,
+            base,
+            None,
+        ))
+        .into_response(),
         Wanted::Html => {
             let card = CollectionCard {
                 id: config.id.clone(),
@@ -824,6 +978,69 @@ pub async fn collection(
             Html(ds_core::html::collection_html(&card, &links)).into_response()
         }
     }))
+}
+
+/// `GET /collections/{id}/instances` — list the collection's forecast model runs
+/// as OGC API - EDR instances. Empty `collections` for non-forecast engines.
+pub async fn instances(
+    Path(id): Path<String>,
+    State(state): State<AppState>,
+) -> Result<impl IntoResponse, (StatusCode, Json<serde_json::Value>)> {
+    let state = state.load_full();
+    let (engine, config) = lookup_collection(&state, &id)?;
+    let base = &state.base_url;
+    let runs = engine.get_instances();
+    let collections: Vec<serde_json::Value> = runs
+        .iter()
+        .map(|run| build_collection_metadata(engine.as_ref(), config, base, Some(run)))
+        .collect();
+    Ok(Json(json!({
+        "links": [{
+            "href": format!("{base}/edr/collections/{}/instances", config.id),
+            "rel": "self",
+            "type": "application/json",
+            "title": format!("{} — instances", config.title)
+        }],
+        "collections": collections,
+    })))
+}
+
+/// `GET /collections/{id}/instances/{instanceId}` — one model run's metadata.
+pub async fn instance(
+    Path((id, instance_id)): Path<(String, String)>,
+    State(state): State<AppState>,
+) -> Result<impl IntoResponse, (StatusCode, Json<serde_json::Value>)> {
+    let state = state.load_full();
+    let (engine, config) = lookup_collection(&state, &id)?;
+    let base = &state.base_url;
+    let rt = ds_core::instances::parse_instance_id(&instance_id).ok_or_else(|| {
+        (
+            StatusCode::BAD_REQUEST,
+            Json(json!({
+                "code": "BadRequest",
+                "description": format!("Invalid instance id '{instance_id}' (expected a reference time like 20260607T0600Z)")
+            })),
+        )
+    })?;
+    let runs = engine.get_instances();
+    let run = runs
+        .iter()
+        .find(|r| r.reference_time == rt)
+        .ok_or_else(|| {
+            (
+                StatusCode::NOT_FOUND,
+                Json(json!({
+                    "code": "NotFound",
+                    "description": format!("Instance '{instance_id}' not found")
+                })),
+            )
+        })?;
+    Ok(Json(build_collection_metadata(
+        engine.as_ref(),
+        config,
+        base,
+        Some(run),
+    )))
 }
 
 pub async fn locations(
@@ -881,7 +1098,13 @@ pub async fn location_query(
     let z = resolve_request_z(engine, params.z.as_deref())?;
 
     let result = engine
-        .query_location(&loc_id, datetime, param_names.as_deref(), z.as_deref())
+        .query_location(
+            &loc_id,
+            datetime,
+            param_names.as_deref(),
+            z.as_deref(),
+            None,
+        )
         .map_err(|e| match &e {
             ds_core::error::DataServerError::LocationNotFound(_) => (
                 StatusCode::NOT_FOUND,
@@ -909,8 +1132,28 @@ pub async fn position_query(
     Query(params): Query<PositionQueryParams>,
     State(state): State<AppState>,
 ) -> Result<impl IntoResponse, (StatusCode, Json<serde_json::Value>)> {
+    run_position_query(id, None, params, state).await
+}
+
+/// `GET /collections/{id}/instances/{instanceId}/position` — position query
+/// against a specific forecast model run.
+pub async fn instance_position_query(
+    Path((id, instance_id)): Path<(String, String)>,
+    Query(params): Query<PositionQueryParams>,
+    State(state): State<AppState>,
+) -> Result<impl IntoResponse, (StatusCode, Json<serde_json::Value>)> {
+    run_position_query(id, Some(instance_id), params, state).await
+}
+
+async fn run_position_query(
+    id: String,
+    instance_id: Option<String>,
+    params: PositionQueryParams,
+    state: AppState,
+) -> Result<impl IntoResponse, (StatusCode, Json<serde_json::Value>)> {
     let state = state.load_full();
     let (engine, _config) = lookup_collection(&state, &id)?;
+    let reference_time = resolve_instance(engine, instance_id.as_deref())?;
 
     let datetime = params
         .datetime
@@ -967,7 +1210,13 @@ pub async fn position_query(
 
     if points.len() == 1 {
         let result = engine
-            .query_position(&points[0], datetime, param_names.as_deref(), z.as_deref())
+            .query_position(
+                &points[0],
+                datetime,
+                param_names.as_deref(),
+                z.as_deref(),
+                reference_time,
+            )
             .map_err(|e| map_engine_error(&e))?;
         return render_coverage_response(result, format, params.width, params.height);
     }
@@ -977,7 +1226,13 @@ pub async fn position_query(
     let mut coverages = Vec::with_capacity(points.len());
     for point in &points {
         let qr = engine
-            .query_position(point, datetime, param_names.as_deref(), z.as_deref())
+            .query_position(
+                point,
+                datetime,
+                param_names.as_deref(),
+                z.as_deref(),
+                reference_time,
+            )
             .map_err(|e| map_engine_error(&e))?;
         match qr {
             CoverageResponse::Single(q) => coverages.push(q),
@@ -998,8 +1253,28 @@ pub async fn area_query(
     Query(params): Query<AreaQueryParams>,
     State(state): State<AppState>,
 ) -> Result<impl IntoResponse, (StatusCode, Json<serde_json::Value>)> {
+    run_area_query(id, None, params, state).await
+}
+
+/// `GET /collections/{id}/instances/{instanceId}/area` — area query against a
+/// specific forecast model run.
+pub async fn instance_area_query(
+    Path((id, instance_id)): Path<(String, String)>,
+    Query(params): Query<AreaQueryParams>,
+    State(state): State<AppState>,
+) -> Result<impl IntoResponse, (StatusCode, Json<serde_json::Value>)> {
+    run_area_query(id, Some(instance_id), params, state).await
+}
+
+async fn run_area_query(
+    id: String,
+    instance_id: Option<String>,
+    params: AreaQueryParams,
+    state: AppState,
+) -> Result<impl IntoResponse, (StatusCode, Json<serde_json::Value>)> {
     let state = state.load_full();
     let (engine, _config) = lookup_collection(&state, &id)?;
+    let reference_time = resolve_instance(engine, instance_id.as_deref())?;
 
     // An area result is gridded / multi-coverage, not a single line plot.
     if parse_edr_format(params.f.as_deref()).map_err(|e| bad_request(&e))? == EdrFormat::Png {
@@ -1033,6 +1308,7 @@ pub async fn area_query(
             datetime,
             param_names.as_deref(),
             z.as_deref(),
+            reference_time,
         )
         .map_err(|e| match &e {
             ds_core::error::DataServerError::InvalidParameter(_)
@@ -1133,7 +1409,13 @@ pub async fn trajectory_query(
     let engine = engine.clone();
     let coords = params.coords.clone();
     let result = tokio::task::spawn_blocking(move || {
-        engine.query_trajectory(&coords, datetime, param_names.as_deref(), z.as_deref())
+        engine.query_trajectory(
+            &coords,
+            datetime,
+            param_names.as_deref(),
+            z.as_deref(),
+            None,
+        )
     })
     .await
     .map_err(|e| {
@@ -1196,14 +1478,44 @@ pub async fn trajectory_query(
     }
 }
 
+/// Build a collection (or instance) metadata document.
+///
+/// `instance = None` ⇒ the collection itself (un-pinned; latest run for forecast
+/// engines). `instance = Some(run)` ⇒ that forecast model run as an OGC EDR
+/// *instance*: `id`, temporal extent and data-query hrefs are scoped to the run
+/// (`/collections/{id}/instances/{instanceId}/…`). See [`ds_core::instances`].
 fn build_collection_metadata(
     engine: &dyn EdrEngine,
     config: &CollectionConfig,
     base_url: &str,
+    instance: Option<&ds_core::instances::RunInfo>,
 ) -> serde_json::Value {
     let param_descs = engine.get_parameter_descriptions();
-    let temporal = engine.get_temporal_extent();
     let spatial = engine.get_spatial_extent();
+
+    let coll_id = &config.id;
+    // The self id and the base path every data-query href hangs off — scoped to
+    // the instance when one is given.
+    let (self_id, query_base) = match instance {
+        Some(run) => (
+            run.instance_id(),
+            format!(
+                "{base_url}/edr/collections/{coll_id}/instances/{}",
+                run.instance_id()
+            ),
+        ),
+        None => (
+            coll_id.clone(),
+            format!("{base_url}/edr/collections/{coll_id}"),
+        ),
+    };
+
+    // Temporal extent + advertised timesteps: the run's for an instance, the
+    // engine's (latest run) for the collection.
+    let temporal = match instance {
+        Some(run) => run.temporal_extent(),
+        None => engine.get_temporal_extent(),
+    };
 
     let mut extent = serde_json::Map::new();
     if let Some(bbox) = spatial {
@@ -1223,8 +1535,13 @@ fn build_collection_metadata(
             json!("http://www.opengis.net/def/uom/ISO-8601/0/Gregorian"),
         );
 
-        // Include individual timesteps if the engine provides them
-        if let Some(times) = engine.get_available_times() {
+        // Include individual timesteps if available (the run's valid times for
+        // an instance, the engine's for the collection).
+        let times = match instance {
+            Some(run) => (!run.valid_times.is_empty()).then(|| run.valid_times.clone()),
+            None => engine.get_available_times(),
+        };
+        if let Some(times) = times {
             let values: Vec<String> = times.iter().map(|t| t.to_rfc3339()).collect();
             temporal_obj.insert("values".to_string(), json!(values));
         }
@@ -1278,24 +1595,31 @@ fn build_collection_metadata(
         })
         .collect();
 
-    let query_types = engine.supported_query_types();
+    // Data queries hang off `query_base` (instance-scoped when applicable).
+    // Under an instance only the run-queryable types (position/area) get routes.
+    let query_types: Vec<String> = if instance.is_some() {
+        engine
+            .supported_query_types()
+            .into_iter()
+            .filter(|qt| qt == "position" || qt == "area")
+            .collect()
+    } else {
+        engine.supported_query_types()
+    };
     let mut data_queries = serde_json::Map::new();
     for qt in &query_types {
         let (endpoint, output_formats) = match qt.as_str() {
             "locations" => (
-                format!("{base_url}/edr/collections/{}/locations", config.id),
+                format!("{query_base}/locations"),
                 json!(["CoverageJSON", "PNG"]),
             ),
             "position" => (
-                format!("{base_url}/edr/collections/{}/position", config.id),
+                format!("{query_base}/position"),
                 json!(["CoverageJSON", "PNG"]),
             ),
-            "area" => (
-                format!("{base_url}/edr/collections/{}/area", config.id),
-                json!(["CoverageJSON"]),
-            ),
+            "area" => (format!("{query_base}/area"), json!(["CoverageJSON"])),
             "trajectory" => (
-                format!("{base_url}/edr/collections/{}/trajectory", config.id),
+                format!("{query_base}/trajectory"),
                 json!(["CoverageJSON", "PNG"]),
             ),
             _ => continue,
@@ -1315,13 +1639,40 @@ fn build_collection_metadata(
             }),
         );
     }
+    // Advertise the model runs (forecast reference times) as EDR instances on
+    // the collection itself (not on an instance document).
+    if instance.is_none() && !engine.get_instances().is_empty() {
+        data_queries.insert(
+            "instances".to_string(),
+            json!({
+                "link": {
+                    "href": format!("{base_url}/edr/collections/{coll_id}/instances"),
+                    "rel": "data",
+                    "variables": { "query_type": "instances" }
+                }
+            }),
+        );
+    }
 
+    let self_title = match instance {
+        Some(run) => format!("{} — run {}", config.title, run.reference_time.to_rfc3339()),
+        None => config.title.clone(),
+    };
     let mut links = vec![json!({
-        "href": format!("{base_url}/edr/collections/{}", config.id),
+        "href": query_base,
         "rel": "self",
         "type": "application/json",
-        "title": config.title
+        "title": self_title.clone()
     })];
+    if instance.is_some() {
+        // Link an instance document back to its parent collection.
+        links.push(json!({
+            "href": format!("{base_url}/edr/collections/{coll_id}"),
+            "rel": "collection",
+            "type": "application/json",
+            "title": config.title
+        }));
+    }
     if let Some((title, url)) = config.license.as_ref().and_then(|l| l.card_link()) {
         // No `type`: an operator-supplied license URL may not be HTML, and OGC
         // API Common §6.5.2 wants the link's real media type — omitting is valid.
@@ -1329,8 +1680,8 @@ fn build_collection_metadata(
     }
 
     let mut metadata = json!({
-        "id": config.id,
-        "title": config.title,
+        "id": self_id,
+        "title": self_title,
         "description": config.description,
         // No `itemType`: OGC API – Common – Part 2 registers only "feature"
         // and "record", and the field describes a /collections/{id}/items

--- a/crates/api-edr/src/handlers.rs
+++ b/crates/api-edr/src/handlers.rs
@@ -127,17 +127,15 @@ fn lookup_collection<'a>(
 /// Resolve an optional `{instanceId}` path segment to a forecast model run.
 ///
 /// `None` (the no-instance routes) ⇒ `Ok(None)` (the engine serves its latest
-/// run). `Some(id)` ⇒ parse the id to a reference time ([`instances::parse_instance_id`])
-/// and confirm the engine exposes that run (`get_instances`): an unparseable id
-/// is 400, an unknown run is 404. The validated reference time is then passed to
-/// the engine query methods.
+/// run). `Some(id)` ⇒ parse the id to a reference time
+/// ([`instances::parse_instance_id`]); an unparseable id is 400.
 ///
-/// The existence check is **best-effort**: it reads a catalog snapshot, and a
-/// background poll could evict that run before the subsequent query reads its
-/// own snapshot. In that rare race the query just fails (the engine has no such
-/// run) — a benign 400 instead of 404 for a run that no longer exists.
+/// Existence is **not** checked here. The engine query returns
+/// [`DataServerError::ReferenceTimeNotFound`] (→ 404) for an absent run, so the
+/// status is correct without a validate-then-query race *and* without cloning
+/// the engine's `get_instances()` `Vec` (with every run's valid times) on the
+/// hot query path (CLAUDE.md #211).
 fn resolve_instance(
-    engine: &Arc<dyn EdrEngine>,
     instance_id: Option<&str>,
 ) -> Result<Option<chrono::DateTime<chrono::Utc>>, (StatusCode, Json<serde_json::Value>)> {
     let Some(iid) = instance_id else {
@@ -152,19 +150,6 @@ fn resolve_instance(
             })),
         )
     })?;
-    if !engine
-        .get_instances()
-        .iter()
-        .any(|r| r.reference_time == rt)
-    {
-        return Err((
-            StatusCode::NOT_FOUND,
-            Json(json!({
-                "code": "NotFound",
-                "description": format!("Instance '{iid}' not found")
-            })),
-        ));
-    }
     Ok(Some(rt))
 }
 
@@ -522,7 +507,7 @@ pub async fn api_definition(State(state): State<AppState>) -> impl IntoResponse 
         let has_instances = state
             .engines
             .get(id)
-            .map(|e| !e.get_instances().is_empty())
+            .map(|e| e.has_instances())
             .unwrap_or(false);
         if has_instances {
             let instance_id_param = json!({
@@ -1158,7 +1143,7 @@ async fn run_position_query(
 ) -> Result<impl IntoResponse, (StatusCode, Json<serde_json::Value>)> {
     let state = state.load_full();
     let (engine, _config) = lookup_collection(&state, &id)?;
-    let reference_time = resolve_instance(engine, instance_id.as_deref())?;
+    let reference_time = resolve_instance(instance_id.as_deref())?;
 
     let datetime = params
         .datetime
@@ -1198,7 +1183,8 @@ async fn run_position_query(
         ),
         ds_core::error::DataServerError::LocationNotFound(_)
         | ds_core::error::DataServerError::CollectionNotFound(_)
-        | ds_core::error::DataServerError::FeatureNotFound(_) => (
+        | ds_core::error::DataServerError::FeatureNotFound(_)
+        | ds_core::error::DataServerError::ReferenceTimeNotFound(_) => (
             StatusCode::NOT_FOUND,
             Json(json!({ "code": "NotFound", "description": e.to_string() })),
         ),
@@ -1279,7 +1265,7 @@ async fn run_area_query(
 ) -> Result<impl IntoResponse, (StatusCode, Json<serde_json::Value>)> {
     let state = state.load_full();
     let (engine, _config) = lookup_collection(&state, &id)?;
-    let reference_time = resolve_instance(engine, instance_id.as_deref())?;
+    let reference_time = resolve_instance(instance_id.as_deref())?;
 
     // An area result is gridded / multi-coverage, not a single line plot.
     if parse_edr_format(params.f.as_deref()).map_err(|e| bad_request(&e))? == EdrFormat::Png {
@@ -1323,7 +1309,8 @@ async fn run_area_query(
                 Json(json!({ "code": "BadRequest", "description": e.to_string() })),
             ),
             ds_core::error::DataServerError::LocationNotFound(_)
-            | ds_core::error::DataServerError::CollectionNotFound(_) => (
+            | ds_core::error::DataServerError::CollectionNotFound(_)
+            | ds_core::error::DataServerError::ReferenceTimeNotFound(_) => (
                 StatusCode::NOT_FOUND,
                 Json(json!({ "code": "NotFound", "description": e.to_string() })),
             ),
@@ -1646,7 +1633,7 @@ fn build_collection_metadata(
     }
     // Advertise the model runs (forecast reference times) as EDR instances on
     // the collection itself (not on an instance document).
-    if instance.is_none() && !engine.get_instances().is_empty() {
+    if instance.is_none() && engine.has_instances() {
         data_queries.insert(
             "instances".to_string(),
             json!({

--- a/crates/api-edr/src/handlers.rs
+++ b/crates/api-edr/src/handlers.rs
@@ -993,6 +993,14 @@ pub async fn instances(
     let state = state.load_full();
     let (engine, config) = lookup_collection(&state, &id)?;
     let base = &state.base_url;
+    // A non-forecast collection (no instances) returns 200 with an empty
+    // `instances` list rather than 404. This is the standard REST list
+    // convention and matches `/collections` (empty ⇒ 200 `{"collections":[]}`),
+    // while the *item* paths `/instances/{id}[/…]` 404 for such collections.
+    // OGC EDR 1.1 §8.2.3 ("only applies to resources that have temporal
+    // instances") permits a stricter 404 here; the lenient 200-empty is the
+    // deliberate, self-consistent choice (the resource is never advertised for
+    // non-forecast collections, so conformant clients don't reach it).
     let runs = engine.get_instances();
     // Each instance doc rebuilds the run-invariant bits (parameters, spatial
     // extent) via build_collection_metadata. That's a handful of redundant

--- a/crates/api-edr/src/handlers.rs
+++ b/crates/api-edr/src/handlers.rs
@@ -1304,14 +1304,18 @@ async fn run_area_query(
 ) -> Result<impl IntoResponse, (StatusCode, Json<serde_json::Value>)> {
     let state = state.load_full();
     let (engine, _config) = lookup_collection(&state, &id)?;
-    let reference_time = resolve_instance(engine, instance_id.as_deref())?;
 
-    // An area result is gridded / multi-coverage, not a single line plot.
+    // Static request-level checks before engine/instance resolution, so the
+    // instance variant rejects the same way as the non-instance `area_query`
+    // (e.g. `…/instances/x/area?f=png` → 400 "PNG not available", not a 404 on
+    // the instance). An area result is gridded / multi-coverage, not a plot.
     if parse_edr_format(params.f.as_deref()).map_err(|e| bad_request(&e))? == EdrFormat::Png {
         return Err(bad_request(&DataServerError::InvalidParameter(
             "PNG output is not available for area queries".into(),
         )));
     }
+
+    let reference_time = resolve_instance(engine, instance_id.as_deref())?;
 
     let datetime = params
         .datetime

--- a/crates/api-edr/src/handlers.rs
+++ b/crates/api-edr/src/handlers.rs
@@ -127,20 +127,34 @@ fn lookup_collection<'a>(
 /// Resolve an optional `{instanceId}` path segment to a forecast model run.
 ///
 /// `None` (the no-instance routes) ⇒ `Ok(None)` (the engine serves its latest
-/// run). `Some(id)` ⇒ parse the id to a reference time
-/// ([`instances::parse_instance_id`]); an unparseable id is 400.
+/// run). `Some(id)` ⇒ a run query, which requires the collection to actually
+/// expose model runs: a collection whose engine has no instances returns **404**
+/// (otherwise a non-forecast engine — which ignores `reference_time` — would
+/// wrongly answer 200 with its latest data for any instance path). The id is
+/// then parsed to a reference time ([`instances::parse_instance_id`]); an
+/// unparseable id is 400.
 ///
-/// Existence is **not** checked here. The engine query returns
-/// [`DataServerError::ReferenceTimeNotFound`] (→ 404) for an absent run, so the
-/// status is correct without a validate-then-query race *and* without cloning
-/// the engine's `get_instances()` `Vec` (with every run's valid times) on the
-/// hot query path (CLAUDE.md #211).
+/// The collection-level check is the **O(1)** [`EdrEngine::has_instances`], not
+/// a `get_instances()` clone (CLAUDE.md #211). The *specific*-run existence is
+/// left to the engine query, which returns
+/// [`DataServerError::ReferenceTimeNotFound`] (→ 404) for an absent run — no
+/// validate-then-query race.
 fn resolve_instance(
+    engine: &Arc<dyn EdrEngine>,
     instance_id: Option<&str>,
 ) -> Result<Option<chrono::DateTime<chrono::Utc>>, (StatusCode, Json<serde_json::Value>)> {
     let Some(iid) = instance_id else {
         return Ok(None);
     };
+    if !engine.has_instances() {
+        return Err((
+            StatusCode::NOT_FOUND,
+            Json(json!({
+                "code": "NotFound",
+                "description": "This collection has no model-run instances"
+            })),
+        ));
+    }
     let rt = ds_core::instances::parse_instance_id(iid).ok_or_else(|| {
         (
             StatusCode::BAD_REQUEST,
@@ -1143,7 +1157,7 @@ async fn run_position_query(
 ) -> Result<impl IntoResponse, (StatusCode, Json<serde_json::Value>)> {
     let state = state.load_full();
     let (engine, _config) = lookup_collection(&state, &id)?;
-    let reference_time = resolve_instance(instance_id.as_deref())?;
+    let reference_time = resolve_instance(engine, instance_id.as_deref())?;
 
     let datetime = params
         .datetime
@@ -1265,7 +1279,7 @@ async fn run_area_query(
 ) -> Result<impl IntoResponse, (StatusCode, Json<serde_json::Value>)> {
     let state = state.load_full();
     let (engine, _config) = lookup_collection(&state, &id)?;
-    let reference_time = resolve_instance(instance_id.as_deref())?;
+    let reference_time = resolve_instance(engine, instance_id.as_deref())?;
 
     // An area result is gridded / multi-coverage, not a single line plot.
     if parse_edr_format(params.f.as_deref()).map_err(|e| bad_request(&e))? == EdrFormat::Png {

--- a/crates/api-edr/src/handlers.rs
+++ b/crates/api-edr/src/handlers.rs
@@ -1520,13 +1520,11 @@ fn build_collection_metadata(
     // The self id and the base path every data-query href hangs off — scoped to
     // the instance when one is given.
     let (self_id, query_base) = match instance {
-        Some(run) => (
-            run.instance_id(),
-            format!(
-                "{base_url}/edr/collections/{coll_id}/instances/{}",
-                run.instance_id()
-            ),
-        ),
+        Some(run) => {
+            let iid = run.instance_id();
+            let base = format!("{base_url}/edr/collections/{coll_id}/instances/{iid}");
+            (iid, base)
+        }
         None => (
             coll_id.clone(),
             format!("{base_url}/edr/collections/{coll_id}"),

--- a/crates/api-edr/src/handlers.rs
+++ b/crates/api-edr/src/handlers.rs
@@ -994,6 +994,11 @@ pub async fn instances(
     let (engine, config) = lookup_collection(&state, &id)?;
     let base = &state.base_url;
     let runs = engine.get_instances();
+    // Each instance doc rebuilds the run-invariant bits (parameters, spatial
+    // extent) via build_collection_metadata. That's a handful of redundant
+    // clones (run count is bounded — a few to a few dozen) on a low-QPS
+    // discovery endpoint, not the `/collections`/`/api` hot paths #211 guards —
+    // kept simple over threading a precomputed-metadata variant through.
     let instances: Vec<serde_json::Value> = runs
         .iter()
         .map(|run| build_collection_metadata(engine.as_ref(), config, base, Some(run)))
@@ -1019,6 +1024,18 @@ pub async fn instance(
     let state = state.load_full();
     let (engine, config) = lookup_collection(&state, &id)?;
     let base = &state.base_url;
+    // A collection with no instances has no instance sub-resources at all, so
+    // any id (parseable or not) is 404 — consistent with the query path's
+    // `resolve_instance` guard, rather than 400 on an unparseable id.
+    if !engine.has_instances() {
+        return Err((
+            StatusCode::NOT_FOUND,
+            Json(json!({
+                "code": "NotFound",
+                "description": "This collection has no model-run instances"
+            })),
+        ));
+    }
     let rt = ds_core::instances::parse_instance_id(&instance_id).ok_or_else(|| {
         (
             StatusCode::BAD_REQUEST,

--- a/crates/api-edr/src/lib.rs
+++ b/crates/api-edr/src/lib.rs
@@ -27,5 +27,19 @@ pub fn router(state: AppState) -> Router {
             "/collections/{id}/trajectory",
             get(handlers::trajectory_query),
         )
+        // OGC API - EDR instances (forecast model runs; #337).
+        .route("/collections/{id}/instances", get(handlers::instances))
+        .route(
+            "/collections/{id}/instances/{instance_id}",
+            get(handlers::instance),
+        )
+        .route(
+            "/collections/{id}/instances/{instance_id}/position",
+            get(handlers::instance_position_query),
+        )
+        .route(
+            "/collections/{id}/instances/{instance_id}/area",
+            get(handlers::instance_area_query),
+        )
         .with_state(state)
 }

--- a/crates/api-edr/src/lib.rs
+++ b/crates/api-edr/src/lib.rs
@@ -27,18 +27,19 @@ pub fn router(state: AppState) -> Router {
             "/collections/{id}/trajectory",
             get(handlers::trajectory_query),
         )
-        // OGC API - EDR instances (forecast model runs; #337).
+        // OGC API - EDR instances (forecast model runs; #337). The `{instanceId}`
+        // segment name matches the OpenAPI `api_definition()` path parameter.
         .route("/collections/{id}/instances", get(handlers::instances))
         .route(
-            "/collections/{id}/instances/{instance_id}",
+            "/collections/{id}/instances/{instanceId}",
             get(handlers::instance),
         )
         .route(
-            "/collections/{id}/instances/{instance_id}/position",
+            "/collections/{id}/instances/{instanceId}/position",
             get(handlers::instance_position_query),
         )
         .route(
-            "/collections/{id}/instances/{instance_id}/area",
+            "/collections/{id}/instances/{instanceId}/area",
             get(handlers::instance_area_query),
         )
         .with_state(state)

--- a/crates/api-edr/tests/instances_tests.rs
+++ b/crates/api-edr/tests/instances_tests.rs
@@ -90,8 +90,12 @@ impl EdrEngine for ForecastMock {
         _z: Option<&[f64]>,
         reference_time: Option<DateTime<Utc>>,
     ) -> Result<CoverageResponse, DataServerError> {
-        // None ⇒ latest run; encode the selected run's hour into every value.
+        // None ⇒ latest run; a pinned run that doesn't exist → 404 (mirrors the
+        // real engines, which return ReferenceTimeNotFound).
         let rt = reference_time.unwrap_or_else(|| dt(LATEST_RUN_HOUR));
+        if !Self::run_times().contains(&rt) {
+            return Err(DataServerError::ReferenceTimeNotFound(rt.to_rfc3339()));
+        }
         let marker = rt.hour() as f64;
         let times: Vec<DateTime<Utc>> = (0..3).map(|h| rt + chrono::Duration::hours(h)).collect();
         let mut parameters = HashMap::new();

--- a/crates/api-edr/tests/instances_tests.rs
+++ b/crates/api-edr/tests/instances_tests.rs
@@ -261,8 +261,8 @@ async fn instances_list_has_both_runs() {
         .iter()
         .map(|c| c["id"].as_str().unwrap())
         .collect();
-    assert!(ids.contains(&"20260607T0000Z"), "ids: {ids:?}");
-    assert!(ids.contains(&"20260607T1200Z"), "ids: {ids:?}");
+    // Ascending by reference time, latest last (the build_instances contract).
+    assert_eq!(ids, ["20260607T0000Z", "20260607T1200Z"], "order: {ids:?}");
 }
 
 #[tokio::test]

--- a/crates/api-edr/tests/instances_tests.rs
+++ b/crates/api-edr/tests/instances_tests.rs
@@ -1,0 +1,252 @@
+//! OGC API - EDR instances (forecast model runs; #337).
+//!
+//! Exercises the instances endpoints against a mock forecast engine exposing two
+//! runs (00Z, 12Z). The mock encodes the selected run's hour into every value so
+//! a query can prove which run it hit (None ⇒ latest run = 12Z).
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use arc_swap::ArcSwap;
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use chrono::{DateTime, TimeZone, Timelike, Utc};
+use http_body_util::BodyExt;
+use serde_json::Value;
+use tower::util::ServiceExt;
+
+use api_edr::handlers::EdrState;
+use ds_core::config::CollectionConfig;
+use ds_core::edr_engine::EdrEngine;
+use ds_core::error::DataServerError;
+use ds_core::instances::RunInfo;
+use ds_core::model::*;
+
+fn dt(h: u32) -> DateTime<Utc> {
+    Utc.with_ymd_and_hms(2026, 6, 7, h, 0, 0).unwrap()
+}
+
+const LATEST_RUN_HOUR: u32 = 12;
+
+struct ForecastMock;
+
+impl ForecastMock {
+    fn run_times() -> Vec<DateTime<Utc>> {
+        vec![dt(0), dt(LATEST_RUN_HOUR)] // 00Z, 12Z (latest)
+    }
+}
+
+impl EdrEngine for ForecastMock {
+    fn get_locations(&self) -> Result<Vec<Location>, DataServerError> {
+        Ok(vec![])
+    }
+
+    fn get_instances(&self) -> Vec<RunInfo> {
+        Self::run_times()
+            .into_iter()
+            .map(|rt| RunInfo {
+                reference_time: rt,
+                valid_times: (0..3).map(|h| rt + chrono::Duration::hours(h)).collect(),
+            })
+            .collect()
+    }
+
+    fn query_location(
+        &self,
+        _location_id: &str,
+        _datetime: Option<(DateTime<Utc>, DateTime<Utc>)>,
+        _parameters: Option<&[String]>,
+        _z: Option<&[f64]>,
+        _reference_time: Option<DateTime<Utc>>,
+    ) -> Result<CoverageResponse, DataServerError> {
+        Err(DataServerError::InvalidParameter("no locations".into()))
+    }
+
+    fn get_parameters(&self) -> Vec<String> {
+        vec!["temperature".to_string()]
+    }
+
+    fn get_temporal_extent(&self) -> Option<(DateTime<Utc>, DateTime<Utc>)> {
+        // Latest run's valid-time span.
+        Some((
+            dt(LATEST_RUN_HOUR),
+            dt(LATEST_RUN_HOUR) + chrono::Duration::hours(2),
+        ))
+    }
+
+    fn get_spatial_extent(&self) -> Option<[f64; 4]> {
+        Some([-180.0, -90.0, 180.0, 90.0])
+    }
+
+    fn supported_query_types(&self) -> Vec<String> {
+        vec!["position".to_string()]
+    }
+
+    fn query_position(
+        &self,
+        _coords: &str,
+        _datetime: Option<(DateTime<Utc>, DateTime<Utc>)>,
+        _parameters: Option<&[String]>,
+        _z: Option<&[f64]>,
+        reference_time: Option<DateTime<Utc>>,
+    ) -> Result<CoverageResponse, DataServerError> {
+        // None ⇒ latest run; encode the selected run's hour into every value.
+        let rt = reference_time.unwrap_or_else(|| dt(LATEST_RUN_HOUR));
+        let marker = rt.hour() as f64;
+        let times: Vec<DateTime<Utc>> = (0..3).map(|h| rt + chrono::Duration::hours(h)).collect();
+        let mut parameters = HashMap::new();
+        parameters.insert(
+            "temperature".to_string(),
+            ParameterDescription {
+                label: "temperature".to_string(),
+                unit: "degC".to_string(),
+                observed_property: "temperature".to_string(),
+            },
+        );
+        let mut ranges = HashMap::new();
+        ranges.insert(
+            "temperature".to_string(),
+            NdArray {
+                shape: vec![3],
+                axis_names: vec!["t".to_string()],
+                values: vec![Some(marker); 3],
+            },
+        );
+        Ok(CoverageResponse::Single(QueryResult {
+            domain: DomainDescription::PointSeries {
+                x: 25.0,
+                y: 60.0,
+                t: times,
+                z: None,
+            },
+            parameters,
+            ranges,
+        }))
+    }
+}
+
+fn state() -> api_edr::handlers::AppState {
+    let mut engines: HashMap<String, Arc<dyn EdrEngine>> = HashMap::new();
+    let mut collections = HashMap::new();
+    engines.insert("fc".to_string(), Arc::new(ForecastMock));
+    collections.insert(
+        "fc".to_string(),
+        CollectionConfig {
+            id: "fc".to_string(),
+            title: "Forecast".to_string(),
+            description: "Mock forecast".to_string(),
+            data_path: None,
+            apis: vec!["edr".to_string()],
+            engine_type: "grib".to_string(),
+            keywords: Vec::new(),
+            license: None,
+            geotiff: None,
+            querydata: None,
+            wms: None,
+            grib: None,
+            zarr: None,
+            odim: None,
+            postgis: None,
+            preview: None,
+        },
+    );
+    Arc::new(ArcSwap::from_pointee(EdrState {
+        engines,
+        collections,
+        base_url: String::new(),
+    }))
+}
+
+async fn get(uri: &str) -> (StatusCode, Value) {
+    let app = api_edr::router(state());
+    let resp = app
+        .oneshot(Request::builder().uri(uri).body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    let status = resp.status();
+    let body = resp.into_body().collect().await.unwrap().to_bytes();
+    let json = if body.is_empty() {
+        Value::Null
+    } else {
+        serde_json::from_slice(&body).unwrap()
+    };
+    (status, json)
+}
+
+#[tokio::test]
+async fn instances_list_has_both_runs() {
+    let (status, body) = get("/collections/fc/instances").await;
+    assert_eq!(status, StatusCode::OK);
+    let collections = body["collections"].as_array().unwrap();
+    assert_eq!(collections.len(), 2);
+    let ids: Vec<&str> = collections
+        .iter()
+        .map(|c| c["id"].as_str().unwrap())
+        .collect();
+    assert!(ids.contains(&"20260607T0000Z"), "ids: {ids:?}");
+    assert!(ids.contains(&"20260607T1200Z"), "ids: {ids:?}");
+}
+
+#[tokio::test]
+async fn instance_metadata_scopes_extent_and_links() {
+    let (status, body) = get("/collections/fc/instances/20260607T0000Z").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["id"], "20260607T0000Z");
+    // Temporal extent is the 00Z run's valid times (00:00..02:00), NOT the
+    // collection's latest-run (12Z) extent.
+    let interval = &body["extent"]["temporal"]["interval"][0];
+    assert_eq!(interval[0], "2026-06-07T00:00:00+00:00");
+    assert_eq!(interval[1], "2026-06-07T02:00:00+00:00");
+    // Data-query hrefs are instance-scoped.
+    let pos = body["data_queries"]["position"]["link"]["href"]
+        .as_str()
+        .unwrap();
+    assert!(
+        pos.ends_with("/collections/fc/instances/20260607T0000Z/position"),
+        "{pos}"
+    );
+}
+
+#[tokio::test]
+async fn instance_position_query_hits_the_pinned_run() {
+    // Pinned 00Z run → marker 0.
+    let (status, body) =
+        get("/collections/fc/instances/20260607T0000Z/position?coords=POINT(25%2060)").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["ranges"]["temperature"]["values"][0], 0.0);
+
+    // No instance → latest run (12Z) → marker 12.
+    let (status, body) = get("/collections/fc/position?coords=POINT(25%2060)").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["ranges"]["temperature"]["values"][0], 12.0);
+}
+
+#[tokio::test]
+async fn unknown_instance_is_404_bad_id_is_400() {
+    // A well-formed but absent run → 404 (both metadata and query).
+    assert_eq!(
+        get("/collections/fc/instances/20260607T0600Z").await.0,
+        StatusCode::NOT_FOUND
+    );
+    assert_eq!(
+        get("/collections/fc/instances/20260607T0600Z/position?coords=POINT(25%2060)")
+            .await
+            .0,
+        StatusCode::NOT_FOUND
+    );
+    // An unparseable instance id → 400.
+    assert_eq!(
+        get("/collections/fc/instances/not-a-time").await.0,
+        StatusCode::BAD_REQUEST
+    );
+}
+
+#[tokio::test]
+async fn collection_advertises_instances_data_query() {
+    let (status, body) = get("/collections/fc").await;
+    assert_eq!(status, StatusCode::OK);
+    let href = body["data_queries"]["instances"]["link"]["href"]
+        .as_str()
+        .expect("instances data_query present");
+    assert!(href.ends_with("/collections/fc/instances"), "{href}");
+}

--- a/crates/api-edr/tests/instances_tests.rs
+++ b/crates/api-edr/tests/instances_tests.rs
@@ -129,31 +129,104 @@ impl EdrEngine for ForecastMock {
     }
 }
 
+/// A non-forecast engine: no instances, and `query_position` IGNORES
+/// `reference_time` (returns latest data). Proves the API rejects instance
+/// queries on such a collection rather than silently serving 200.
+struct NonForecastMock;
+
+impl EdrEngine for NonForecastMock {
+    fn get_locations(&self) -> Result<Vec<Location>, DataServerError> {
+        Ok(vec![])
+    }
+    fn query_location(
+        &self,
+        _: &str,
+        _: Option<(DateTime<Utc>, DateTime<Utc>)>,
+        _: Option<&[String]>,
+        _: Option<&[f64]>,
+        _: Option<DateTime<Utc>>,
+    ) -> Result<CoverageResponse, DataServerError> {
+        Err(DataServerError::InvalidParameter("no locations".into()))
+    }
+    fn get_parameters(&self) -> Vec<String> {
+        vec!["temperature".to_string()]
+    }
+    fn get_temporal_extent(&self) -> Option<(DateTime<Utc>, DateTime<Utc>)> {
+        Some((dt(0), dt(2)))
+    }
+    fn get_spatial_extent(&self) -> Option<[f64; 4]> {
+        Some([-180.0, -90.0, 180.0, 90.0])
+    }
+    fn supported_query_types(&self) -> Vec<String> {
+        vec!["position".to_string()]
+    }
+    fn query_position(
+        &self,
+        _coords: &str,
+        _datetime: Option<(DateTime<Utc>, DateTime<Utc>)>,
+        _parameters: Option<&[String]>,
+        _z: Option<&[f64]>,
+        _reference_time: Option<DateTime<Utc>>, // ignored — the engine has no runs
+    ) -> Result<CoverageResponse, DataServerError> {
+        let mut parameters = HashMap::new();
+        parameters.insert(
+            "temperature".to_string(),
+            ParameterDescription {
+                label: "temperature".to_string(),
+                unit: "degC".to_string(),
+                observed_property: "temperature".to_string(),
+            },
+        );
+        let mut ranges = HashMap::new();
+        ranges.insert(
+            "temperature".to_string(),
+            NdArray {
+                shape: vec![1],
+                axis_names: vec!["t".to_string()],
+                values: vec![Some(1.0)],
+            },
+        );
+        Ok(CoverageResponse::Single(QueryResult {
+            domain: DomainDescription::PointSeries {
+                x: 25.0,
+                y: 60.0,
+                t: vec![dt(0)],
+                z: None,
+            },
+            parameters,
+            ranges,
+        }))
+    }
+}
+
+fn config(id: &str, engine_type: &str) -> CollectionConfig {
+    CollectionConfig {
+        id: id.to_string(),
+        title: id.to_string(),
+        description: String::new(),
+        data_path: None,
+        apis: vec!["edr".to_string()],
+        engine_type: engine_type.to_string(),
+        keywords: Vec::new(),
+        license: None,
+        geotiff: None,
+        querydata: None,
+        wms: None,
+        grib: None,
+        zarr: None,
+        odim: None,
+        postgis: None,
+        preview: None,
+    }
+}
+
 fn state() -> api_edr::handlers::AppState {
     let mut engines: HashMap<String, Arc<dyn EdrEngine>> = HashMap::new();
     let mut collections = HashMap::new();
     engines.insert("fc".to_string(), Arc::new(ForecastMock));
-    collections.insert(
-        "fc".to_string(),
-        CollectionConfig {
-            id: "fc".to_string(),
-            title: "Forecast".to_string(),
-            description: "Mock forecast".to_string(),
-            data_path: None,
-            apis: vec!["edr".to_string()],
-            engine_type: "grib".to_string(),
-            keywords: Vec::new(),
-            license: None,
-            geotiff: None,
-            querydata: None,
-            wms: None,
-            grib: None,
-            zarr: None,
-            odim: None,
-            postgis: None,
-            preview: None,
-        },
-    );
+    collections.insert("fc".to_string(), config("fc", "grib"));
+    engines.insert("obs".to_string(), Arc::new(NonForecastMock));
+    collections.insert("obs".to_string(), config("obs", "geotiff"));
     Arc::new(ArcSwap::from_pointee(EdrState {
         engines,
         collections,
@@ -243,6 +316,36 @@ async fn unknown_instance_is_404_bad_id_is_400() {
     assert_eq!(
         get("/collections/fc/instances/not-a-time").await.0,
         StatusCode::BAD_REQUEST
+    );
+}
+
+#[tokio::test]
+async fn instance_query_on_non_forecast_collection_is_404() {
+    // The `obs` collection has no instances; its engine ignores reference_time.
+    // An instance path must 404, not silently serve 200 with latest data.
+    assert_eq!(
+        get("/collections/obs/instances").await.1["instances"]
+            .as_array()
+            .map(|a| a.len()),
+        Some(0)
+    );
+    assert_eq!(
+        get("/collections/obs/instances/20260607T0000Z").await.0,
+        StatusCode::NOT_FOUND
+    );
+    assert_eq!(
+        get("/collections/obs/instances/20260607T0000Z/position?coords=POINT(25%2060)")
+            .await
+            .0,
+        StatusCode::NOT_FOUND,
+        "instance query on a non-forecast collection must be 404, not 200"
+    );
+    // The plain (no-instance) position query still works.
+    assert_eq!(
+        get("/collections/obs/position?coords=POINT(25%2060)")
+            .await
+            .0,
+        StatusCode::OK
     );
 }
 

--- a/crates/api-edr/tests/instances_tests.rs
+++ b/crates/api-edr/tests/instances_tests.rs
@@ -340,6 +340,12 @@ async fn instance_query_on_non_forecast_collection_is_404() {
         StatusCode::NOT_FOUND,
         "instance query on a non-forecast collection must be 404, not 200"
     );
+    // Even an unparseable id is 404 here (no instance sub-resources at all) —
+    // consistent between the metadata and query paths.
+    assert_eq!(
+        get("/collections/obs/instances/not-a-time").await.0,
+        StatusCode::NOT_FOUND
+    );
     // The plain (no-instance) position query still works.
     assert_eq!(
         get("/collections/obs/position?coords=POINT(25%2060)")

--- a/crates/api-edr/tests/instances_tests.rs
+++ b/crates/api-edr/tests/instances_tests.rs
@@ -181,9 +181,10 @@ async fn get(uri: &str) -> (StatusCode, Value) {
 async fn instances_list_has_both_runs() {
     let (status, body) = get("/collections/fc/instances").await;
     assert_eq!(status, StatusCode::OK);
-    let collections = body["collections"].as_array().unwrap();
-    assert_eq!(collections.len(), 2);
-    let ids: Vec<&str> = collections
+    // OGC EDR `instancesJSON` array field is `instances`, not `collections`.
+    let instances = body["instances"].as_array().unwrap();
+    assert_eq!(instances.len(), 2);
+    let ids: Vec<&str> = instances
         .iter()
         .map(|c| c["id"].as_str().unwrap())
         .collect();

--- a/crates/api-edr/tests/ogc_edr_api_tests.rs
+++ b/crates/api-edr/tests/ogc_edr_api_tests.rs
@@ -92,6 +92,7 @@ impl EdrEngine for MockEngine {
         _datetime: Option<(DateTime<Utc>, DateTime<Utc>)>,
         _parameters: Option<&[String]>,
         _z: Option<&[f64]>,
+        _reference_time: Option<DateTime<Utc>>,
     ) -> Result<CoverageResponse, DataServerError> {
         if location_id == "helsinki" || location_id == "tampere" {
             Ok(CoverageResponse::Single(Self::sample_query_result()))
@@ -125,6 +126,7 @@ impl EdrEngine for MockEngine {
         _datetime: Option<(DateTime<Utc>, DateTime<Utc>)>,
         _parameters: Option<&[String]>,
         _z: Option<&[f64]>,
+        _reference_time: Option<DateTime<Utc>>,
     ) -> Result<CoverageResponse, DataServerError> {
         let polygon = ds_core::feature::parse_area_coords(coords)?;
         let mut coverages = Vec::new();
@@ -147,6 +149,7 @@ impl EdrEngine for MockEngine {
         _datetime: Option<(DateTime<Utc>, DateTime<Utc>)>,
         _parameters: Option<&[String]>,
         _z: Option<&[f64]>,
+        _reference_time: Option<DateTime<Utc>>,
     ) -> Result<CoverageResponse, DataServerError> {
         // Accept any well-formed POINT(lon lat). Parsing is handled here to
         // exercise the handler's MULTIPOINT fan-out (which normalizes each
@@ -438,8 +441,9 @@ mod collections {
                 dt: Option<(DateTime<Utc>, DateTime<Utc>)>,
                 params: Option<&[String]>,
                 z: Option<&[f64]>,
+                rt: Option<DateTime<Utc>>,
             ) -> Result<CoverageResponse, DataServerError> {
-                self.0.query_location(location_id, dt, params, z)
+                self.0.query_location(location_id, dt, params, z, rt)
             }
             fn get_parameters(&self) -> Vec<String> {
                 self.0.get_parameters()
@@ -1207,6 +1211,7 @@ mod unimplemented_queries {
                 _dt: Option<(DateTime<Utc>, DateTime<Utc>)>,
                 _p: Option<&[String]>,
                 _z: Option<&[f64]>,
+                _rt: Option<DateTime<Utc>>,
             ) -> Result<CoverageResponse, DataServerError> {
                 Err(DataServerError::LocationNotFound("n/a".into()))
             }
@@ -1228,6 +1233,7 @@ mod unimplemented_queries {
                 _dt: Option<(DateTime<Utc>, DateTime<Utc>)>,
                 _p: Option<&[String]>,
                 _z: Option<&[f64]>,
+                _rt: Option<DateTime<Utc>>,
             ) -> Result<CoverageResponse, DataServerError> {
                 let t = "2024-01-01T00:00:00Z".parse::<DateTime<Utc>>().unwrap();
                 let nodes = vec![(t, 24.0, 60.0), (t, 24.5, 60.5), (t, 25.0, 61.0)];

--- a/crates/api-edr/tests/performance_tests.rs
+++ b/crates/api-edr/tests/performance_tests.rs
@@ -82,6 +82,7 @@ impl EdrEngine for ScalableEngine {
         _datetime: Option<(DateTime<Utc>, DateTime<Utc>)>,
         _parameters: Option<&[String]>,
         _z: Option<&[f64]>,
+        _reference_time: Option<DateTime<Utc>>,
     ) -> Result<CoverageResponse, DataServerError> {
         let idx: usize = location_id
             .strip_prefix("loc_")

--- a/crates/api-edr/tests/png_plot_tests.rs
+++ b/crates/api-edr/tests/png_plot_tests.rs
@@ -104,6 +104,7 @@ macro_rules! impl_common {
                 _dt: Option<(DateTime<Utc>, DateTime<Utc>)>,
                 _p: Option<&[String]>,
                 _z: Option<&[f64]>,
+                _rt: Option<DateTime<Utc>>,
             ) -> Result<CoverageResponse, DataServerError> {
                 Ok(CoverageResponse::Single($result))
             }
@@ -125,6 +126,7 @@ macro_rules! impl_common {
                 _dt: Option<(DateTime<Utc>, DateTime<Utc>)>,
                 _p: Option<&[String]>,
                 _z: Option<&[f64]>,
+                _rt: Option<DateTime<Utc>>,
             ) -> Result<CoverageResponse, DataServerError> {
                 Ok(CoverageResponse::Single($result))
             }
@@ -134,6 +136,7 @@ macro_rules! impl_common {
                 _dt: Option<(DateTime<Utc>, DateTime<Utc>)>,
                 _p: Option<&[String]>,
                 _z: Option<&[f64]>,
+                _rt: Option<DateTime<Utc>>,
             ) -> Result<CoverageResponse, DataServerError> {
                 Ok(CoverageResponse::Single($result))
             }

--- a/crates/api-edr/tests/security_tests.rs
+++ b/crates/api-edr/tests/security_tests.rs
@@ -36,6 +36,7 @@ impl EdrEngine for MockEngine {
         _datetime: Option<(DateTime<Utc>, DateTime<Utc>)>,
         _parameters: Option<&[String]>,
         _z: Option<&[f64]>,
+        _reference_time: Option<DateTime<Utc>>,
     ) -> Result<CoverageResponse, DataServerError> {
         if location_id != "helsinki" {
             return Err(DataServerError::LocationNotFound(location_id.to_string()));

--- a/crates/api-edr/tests/spec_compliance_tests.rs
+++ b/crates/api-edr/tests/spec_compliance_tests.rs
@@ -755,14 +755,15 @@ async fn declares_ogcapi_common_part2_classes() {
 // EDR 1.1 /collections/{id}/instances exposes forecast model runs as instances.
 // Implemented for forecast engines (GRIB/QueryData) via EdrEngine::get_instances;
 // non-forecast engines (this MockEngine) report no runs, so the endpoint returns
-// 200 with an empty `collections` list rather than 404.
+// 200 with an empty `instances` list rather than 404.
 
 #[tokio::test]
 async fn finding_20_instances_endpoint_present() {
     let (status, body) = get_json("/collections/weather/instances").await;
     assert_eq!(status, StatusCode::OK, "instances endpoint must exist");
+    // OGC EDR `instancesJSON` array field is `instances`.
     assert_eq!(
-        body["collections"].as_array().map(|a| a.len()),
+        body["instances"].as_array().map(|a| a.len()),
         Some(0),
         "a non-forecast collection has no model-run instances"
     );

--- a/crates/api-edr/tests/spec_compliance_tests.rs
+++ b/crates/api-edr/tests/spec_compliance_tests.rs
@@ -54,6 +54,7 @@ impl EdrEngine for MockEngine {
         _datetime: Option<(DateTime<Utc>, DateTime<Utc>)>,
         _parameters: Option<&[String]>,
         _z: Option<&[f64]>,
+        _reference_time: Option<DateTime<Utc>>,
     ) -> Result<CoverageResponse, DataServerError> {
         if location_id != "station1" && location_id != "station2" {
             return Err(DataServerError::LocationNotFound(location_id.to_string()));
@@ -629,6 +630,7 @@ async fn data_queries_default_output_format_set_for_all_query_types() {
             _: Option<(DateTime<Utc>, DateTime<Utc>)>,
             _: Option<&[String]>,
             _: Option<&[f64]>,
+            _: Option<DateTime<Utc>>,
         ) -> Result<ds_core::model::CoverageResponse, DataServerError> {
             Err(DataServerError::LocationNotFound(location_id.into()))
         }
@@ -748,20 +750,21 @@ async fn declares_ogcapi_common_part2_classes() {
 // Impact: Minor - only needed for URL canonicalization.
 
 // ===========================================================================
-// FINDING 20: No "instances" endpoint
+// FINDING 20 (RESOLVED, #337): "instances" endpoint implemented
 // ===========================================================================
-// Spec: EDR 1.1 supports /collections/{id}/instances for temporal instances
-//   (e.g., different forecast runs).
-// Implementation: No instances endpoint exists.
-// Fix: If applicable, add /collections/{id}/instances endpoint.
+// EDR 1.1 /collections/{id}/instances exposes forecast model runs as instances.
+// Implemented for forecast engines (GRIB/QueryData) via EdrEngine::get_instances;
+// non-forecast engines (this MockEngine) report no runs, so the endpoint returns
+// 200 with an empty `collections` list rather than 404.
 
 #[tokio::test]
-async fn finding_20_instances_not_implemented() {
-    let (status, _) = get_json("/collections/weather/instances").await;
+async fn finding_20_instances_endpoint_present() {
+    let (status, body) = get_json("/collections/weather/instances").await;
+    assert_eq!(status, StatusCode::OK, "instances endpoint must exist");
     assert_eq!(
-        status,
-        StatusCode::NOT_FOUND,
-        "Instances endpoint is not implemented"
+        body["collections"].as_array().map(|a| a.len()),
+        Some(0),
+        "a non-forecast collection has no model-run instances"
     );
 }
 

--- a/crates/api-maps/src/handlers.rs
+++ b/crates/api-maps/src/handlers.rs
@@ -1139,6 +1139,7 @@ async fn render_map(
             &output_crs,
             render_parameter.as_deref(),
             render_z,
+            None,
         )?;
         // If every pixel is nodata, skip colorization + encoding entirely.
         if tile.is_empty() {

--- a/crates/api-maps/tests/integration.rs
+++ b/crates/api-maps/tests/integration.rs
@@ -45,6 +45,7 @@ impl MockMapEngine {
             // bbox [10,55,30,70] over 2000x1500 cells => 0.01° per cell.
             grid_size: Some([2000, 1500]),
             layer_subtitle: None,
+            reference_times: Vec::new(),
         }
     }
 }
@@ -59,6 +60,7 @@ impl MapEngine for MockMapEngine {
         _output_crs: &OutputCrs,
         _parameter: Option<&str>,
         _z: Option<f64>,
+        _reference_time: Option<chrono::DateTime<chrono::Utc>>,
     ) -> Result<RasterTile, DataServerError> {
         let pixel_count = (width * height) as usize;
         let values: Vec<Option<f64>> = (0..pixel_count)
@@ -92,6 +94,7 @@ impl MapEngine for InvalidParamEngine {
         _output_crs: &OutputCrs,
         _parameter: Option<&str>,
         _z: Option<f64>,
+        _reference_time: Option<chrono::DateTime<chrono::Utc>>,
     ) -> Result<RasterTile, DataServerError> {
         Err(DataServerError::InvalidParameter(
             "collection requires a `<site>:<quantity>` parameter (e.g. `fivih:DBZH`)".into(),
@@ -1217,6 +1220,7 @@ impl MapEngine for EmptyMockMapEngine {
         _output_crs: &OutputCrs,
         _parameter: Option<&str>,
         _z: Option<f64>,
+        _reference_time: Option<chrono::DateTime<chrono::Utc>>,
     ) -> Result<RasterTile, DataServerError> {
         let pixel_count = (width * height) as usize;
         Ok(RasterTile {
@@ -1302,6 +1306,7 @@ impl MapEngine for MultiParamMockEngine {
         _output_crs: &ds_core::map_engine::OutputCrs,
         parameter: Option<&str>,
         _z: Option<f64>,
+        _reference_time: Option<chrono::DateTime<chrono::Utc>>,
     ) -> Result<ds_core::map_engine::RasterTile, ds_core::error::DataServerError> {
         // Vary the pixel values by parameter so the `parameter` field on the
         // cache key actually changes the rendered bytes — the cross-parameter
@@ -1341,6 +1346,7 @@ impl MapEngine for MultiParamMockEngine {
             vertical: None,
             grid_size: None,
             layer_subtitle: None,
+            reference_times: Vec::new(),
         }
     }
 }
@@ -1486,6 +1492,7 @@ mod vertical_extent {
             _output_crs: &OutputCrs,
             _parameter: Option<&str>,
             _z: Option<f64>,
+            _reference_time: Option<chrono::DateTime<chrono::Utc>>,
         ) -> Result<RasterTile, DataServerError> {
             Ok(RasterTile {
                 width,
@@ -1508,6 +1515,7 @@ mod vertical_extent {
                 )),
                 grid_size: None,
                 layer_subtitle: None,
+                reference_times: Vec::new(),
             }
         }
     }
@@ -1550,6 +1558,7 @@ mod vertical_extent {
             _output_crs: &OutputCrs,
             _parameter: Option<&str>,
             _z: Option<f64>,
+            _reference_time: Option<chrono::DateTime<chrono::Utc>>,
         ) -> Result<RasterTile, DataServerError> {
             Ok(RasterTile {
                 width,
@@ -1569,6 +1578,7 @@ mod vertical_extent {
                 vertical: Some(VerticalDimension::new(VerticalKind::ElevationAngle, vec![])),
                 grid_size: None,
                 layer_subtitle: None,
+                reference_times: Vec::new(),
             }
         }
     }
@@ -1610,6 +1620,7 @@ mod extent_edge_cases {
             _output_crs: &OutputCrs,
             _parameter: Option<&str>,
             _z: Option<f64>,
+            _reference_time: Option<chrono::DateTime<chrono::Utc>>,
         ) -> Result<RasterTile, DataServerError> {
             Ok(RasterTile {
                 width,
@@ -1629,6 +1640,7 @@ mod extent_edge_cases {
                 vertical: None,
                 grid_size: Some([2000, 1500]),
                 layer_subtitle: None,
+                reference_times: Vec::new(),
             }
         }
     }
@@ -1647,6 +1659,7 @@ mod extent_edge_cases {
             _output_crs: &OutputCrs,
             _parameter: Option<&str>,
             _z: Option<f64>,
+            _reference_time: Option<chrono::DateTime<chrono::Utc>>,
         ) -> Result<RasterTile, DataServerError> {
             Ok(RasterTile {
                 width,
@@ -1677,6 +1690,7 @@ mod extent_edge_cases {
                 vertical: None,
                 grid_size: None,
                 layer_subtitle: None,
+                reference_times: Vec::new(),
             }
         }
     }
@@ -1731,6 +1745,7 @@ mod extent_edge_cases {
             _output_crs: &OutputCrs,
             _parameter: Option<&str>,
             _z: Option<f64>,
+            _reference_time: Option<chrono::DateTime<chrono::Utc>>,
         ) -> Result<RasterTile, DataServerError> {
             Ok(RasterTile {
                 width,
@@ -1751,6 +1766,7 @@ mod extent_edge_cases {
                 vertical: None,
                 grid_size: Some([2000, 1000]),
                 layer_subtitle: None,
+                reference_times: Vec::new(),
             }
         }
     }

--- a/crates/api-tiles/src/handlers.rs
+++ b/crates/api-tiles/src/handlers.rs
@@ -1501,6 +1501,7 @@ async fn render_tile(
             &output_crs,
             render_parameter.as_deref(),
             render_z,
+            None,
         )?;
 
         // If every pixel is nodata, skip colorization + encoding entirely.

--- a/crates/api-tiles/tests/integration.rs
+++ b/crates/api-tiles/tests/integration.rs
@@ -46,6 +46,7 @@ impl MockMapEngine {
             // bbox [10,55,30,70] over 2000x1500 cells => 0.01° per cell.
             grid_size: Some([2000, 1500]),
             layer_subtitle: None,
+            reference_times: Vec::new(),
         }
     }
 }
@@ -60,6 +61,7 @@ impl MapEngine for MockMapEngine {
         _output_crs: &OutputCrs,
         _parameter: Option<&str>,
         _z: Option<f64>,
+        _reference_time: Option<chrono::DateTime<chrono::Utc>>,
     ) -> Result<RasterTile, DataServerError> {
         let pixel_count = (width * height) as usize;
         let values: Vec<Option<f64>> = (0..pixel_count)
@@ -93,6 +95,7 @@ impl MapEngine for InvalidParamEngine {
         _output_crs: &OutputCrs,
         _parameter: Option<&str>,
         _z: Option<f64>,
+        _reference_time: Option<chrono::DateTime<chrono::Utc>>,
     ) -> Result<RasterTile, DataServerError> {
         Err(DataServerError::InvalidParameter(
             "collection requires a `<site>:<quantity>` parameter (e.g. `fivih:DBZH`)".into(),
@@ -988,6 +991,7 @@ impl MapEngine for EmptyMockMapEngine {
         _output_crs: &OutputCrs,
         _parameter: Option<&str>,
         _z: Option<f64>,
+        _reference_time: Option<chrono::DateTime<chrono::Utc>>,
     ) -> Result<RasterTile, DataServerError> {
         let pixel_count = (width * height) as usize;
         Ok(RasterTile {
@@ -1076,6 +1080,7 @@ impl MapEngine for MultiParamMockEngine {
         _output_crs: &OutputCrs,
         parameter: Option<&str>,
         _z: Option<f64>,
+        _reference_time: Option<chrono::DateTime<chrono::Utc>>,
     ) -> Result<RasterTile, DataServerError> {
         // Vary the pixel values by parameter so the `parameter` field on
         // the cache key actually changes the rendered bytes — the
@@ -1115,6 +1120,7 @@ impl MapEngine for MultiParamMockEngine {
             vertical: None,
             grid_size: None,
             layer_subtitle: None,
+            reference_times: Vec::new(),
         }
     }
 }
@@ -1699,6 +1705,7 @@ mod temporal_grid_jitter {
             _output_crs: &OutputCrs,
             _parameter: Option<&str>,
             _z: Option<f64>,
+            _reference_time: Option<chrono::DateTime<chrono::Utc>>,
         ) -> Result<RasterTile, DataServerError> {
             Ok(RasterTile {
                 width,
@@ -1729,6 +1736,7 @@ mod temporal_grid_jitter {
                 vertical: None,
                 grid_size: None,
                 layer_subtitle: None,
+                reference_times: Vec::new(),
             }
         }
     }

--- a/crates/api-wms/src/handlers.rs
+++ b/crates/api-wms/src/handlers.rs
@@ -294,6 +294,7 @@ pub async fn wms_handler(
                             &output_crs,
                             style_parameter.as_deref(),
                             elevation,
+                            None,
                         )?;
                         // If every pixel is nodata, skip colorization + encoding entirely.
                         if tile.is_empty() {
@@ -337,6 +338,7 @@ pub async fn wms_handler(
                                     &OutputCrs::WebMercator,
                                     style_parameter.as_deref(),
                                     elevation,
+                                    None,
                                 )
                             },
                         )?;

--- a/crates/api-wms/tests/integration.rs
+++ b/crates/api-wms/tests/integration.rs
@@ -37,6 +37,7 @@ impl MapEngine for EmptyMockMapEngine {
         _output_crs: &OutputCrs,
         _parameter: Option<&str>,
         _z: Option<f64>,
+        _reference_time: Option<chrono::DateTime<chrono::Utc>>,
     ) -> Result<RasterTile, DataServerError> {
         let pixel_count = (width * height) as usize;
         Ok(RasterTile {
@@ -59,6 +60,7 @@ impl MapEngine for EmptyMockMapEngine {
             vertical: None,
             grid_size: None,
             layer_subtitle: None,
+            reference_times: Vec::new(),
         }
     }
 }
@@ -196,6 +198,7 @@ impl MapEngine for FailingMockMapEngine {
         _output_crs: &OutputCrs,
         _parameter: Option<&str>,
         _z: Option<f64>,
+        _reference_time: Option<chrono::DateTime<chrono::Utc>>,
     ) -> Result<RasterTile, DataServerError> {
         Err(DataServerError::Engine("intentional render failure".into()))
     }
@@ -213,6 +216,7 @@ impl MapEngine for FailingMockMapEngine {
             vertical: None,
             grid_size: None,
             layer_subtitle: None,
+            reference_times: Vec::new(),
         }
     }
 }
@@ -331,6 +335,7 @@ impl MapEngine for PopulatedMockMapEngine {
         _output_crs: &OutputCrs,
         _parameter: Option<&str>,
         _z: Option<f64>,
+        _reference_time: Option<chrono::DateTime<chrono::Utc>>,
     ) -> Result<RasterTile, DataServerError> {
         let pixel_count = (width * height) as usize;
         // Linear gradient — yields a non-uniform PNG so the test isn't
@@ -358,6 +363,7 @@ impl MapEngine for PopulatedMockMapEngine {
             vertical: None,
             grid_size: None,
             layer_subtitle: None,
+            reference_times: Vec::new(),
         }
     }
 }
@@ -681,6 +687,7 @@ impl MapEngine for CountingMockMapEngine {
         _output_crs: &OutputCrs,
         _parameter: Option<&str>,
         _z: Option<f64>,
+        _reference_time: Option<chrono::DateTime<chrono::Utc>>,
     ) -> Result<RasterTile, DataServerError> {
         self.calls
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
@@ -706,6 +713,7 @@ impl MapEngine for CountingMockMapEngine {
             vertical: None,
             grid_size: None,
             layer_subtitle: None,
+            reference_times: Vec::new(),
         }
     }
 }
@@ -901,6 +909,7 @@ impl MapEngine for SiteMockMapEngine {
         _output_crs: &OutputCrs,
         _parameter: Option<&str>,
         _z: Option<f64>,
+        _reference_time: Option<chrono::DateTime<chrono::Utc>>,
     ) -> Result<RasterTile, DataServerError> {
         let pixel_count = (width * height) as usize;
         Ok(RasterTile {
@@ -929,6 +938,7 @@ impl MapEngine for SiteMockMapEngine {
             vertical: None,
             grid_size: None,
             layer_subtitle: Some("Vihti".into()),
+            reference_times: Vec::new(),
         }
     }
 }

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -439,6 +439,10 @@ fn default_poll_interval() -> u64 {
     30
 }
 
+fn default_querydata_max_runs() -> usize {
+    4
+}
+
 fn default_exclude_patterns() -> Vec<String> {
     vec!["*.tmp".to_string(), "*.part".to_string()]
 }
@@ -459,6 +463,12 @@ pub struct QueryDataConfig {
     /// Directory poll interval in seconds. Default: 30.
     #[serde(default = "default_poll_interval")]
     pub poll_interval_secs: u64,
+    /// How many recent model runs (`.sqd` files, keyed by origin/analysis time)
+    /// to retain and expose as OGC EDR instances / a WMS `reference_time`
+    /// dimension. The newest run is always the default for un-pinned queries.
+    /// Default: 4. Set to 1 to keep only the latest run (no model-run history).
+    #[serde(default = "default_querydata_max_runs")]
+    pub max_runs: usize,
 }
 
 /// Configuration for the ODIM_H5 weather-radar engine

--- a/crates/core/src/edr_engine.rs
+++ b/crates/core/src/edr_engine.rs
@@ -36,6 +36,10 @@ pub trait EdrEngine: Send + Sync {
     /// times cloned). Any engine whose `get_instances` is non-trivial MUST
     /// override this.
     fn has_instances(&self) -> bool {
+        // NOTE: forecast engines MUST override this — the default clones
+        // `Vec<RunInfo>` (with every run's valid times), acceptable only for the
+        // non-forecast engines that take it (where `get_instances` is `Vec::new()`).
+        // Not enforceable at compile time; see the doc above.
         !self.get_instances().is_empty()
     }
 

--- a/crates/core/src/edr_engine.rs
+++ b/crates/core/src/edr_engine.rs
@@ -22,6 +22,17 @@ pub trait EdrEngine: Send + Sync {
         Vec::new()
     }
 
+    /// Whether this engine exposes any model runs, **O(1)** from a snapshot.
+    ///
+    /// Hot metadata paths (`/api`, `/collections/{id}`) only need to know
+    /// *whether* a collection has instances to gate the instances links — they
+    /// must not clone the whole [`Self::get_instances`] `Vec` (with every run's
+    /// valid times) per request. Forecast engines override this with a cheap
+    /// "is the run map non-empty" check. Default mirrors `get_instances`.
+    fn has_instances(&self) -> bool {
+        !self.get_instances().is_empty()
+    }
+
     /// Execute a query for a named location.
     ///
     /// `z` selects vertical levels: `None` returns every level (a profile),

--- a/crates/core/src/edr_engine.rs
+++ b/crates/core/src/edr_engine.rs
@@ -3,11 +3,24 @@ use std::collections::HashMap;
 use chrono::{DateTime, Utc};
 
 use crate::error::DataServerError;
+use crate::instances::RunInfo;
 use crate::model::{CoverageResponse, Location, ParameterDescription};
 use crate::vertical::VerticalDimension;
 
 pub trait EdrEngine: Send + Sync {
     fn get_locations(&self) -> Result<Vec<Location>, DataServerError>;
+
+    /// The forecast model runs this engine exposes as OGC API - EDR
+    /// *instances*, ascending by reference time (latest last).
+    ///
+    /// Default: empty — the engine has no model-run concept and exposes only a
+    /// single time axis (observations, analyses, a single forecast). Forecast
+    /// engines (GRIB, QueryData, …) override this, building the list with
+    /// [`crate::instances::build_instances`]. When non-empty, the `reference_time`
+    /// argument on the query methods selects a run (`None` ⇒ the latest).
+    fn get_instances(&self) -> Vec<RunInfo> {
+        Vec::new()
+    }
 
     /// Execute a query for a named location.
     ///
@@ -15,12 +28,17 @@ pub trait EdrEngine: Send + Sync {
     /// `Some([v])` pins one level, `Some([v1, v2, …])` selects several.
     /// Engines with no vertical dimension ignore it (the API layer rejects
     /// a `z` against a collection that has no vertical extent).
+    ///
+    /// `reference_time` selects a forecast model run (see [`Self::get_instances`]):
+    /// `None` ⇒ the latest run (the default and only behaviour for non-forecast
+    /// engines, which ignore it).
     fn query_location(
         &self,
         location_id: &str,
         datetime: Option<(DateTime<Utc>, DateTime<Utc>)>,
         parameters: Option<&[String]>,
         z: Option<&[f64]>,
+        reference_time: Option<DateTime<Utc>>,
     ) -> Result<CoverageResponse, DataServerError>;
 
     fn get_parameters(&self) -> Vec<String>;
@@ -73,8 +91,9 @@ pub trait EdrEngine: Send + Sync {
         datetime: Option<(DateTime<Utc>, DateTime<Utc>)>,
         parameters: Option<&[String]>,
         z: Option<&[f64]>,
+        reference_time: Option<DateTime<Utc>>,
     ) -> Result<CoverageResponse, DataServerError> {
-        let _ = (coords, datetime, parameters, z);
+        let _ = (coords, datetime, parameters, z, reference_time);
         Err(DataServerError::InvalidParameter(
             "Area query not supported by this engine".into(),
         ))
@@ -88,8 +107,9 @@ pub trait EdrEngine: Send + Sync {
         datetime: Option<(DateTime<Utc>, DateTime<Utc>)>,
         parameters: Option<&[String]>,
         z: Option<&[f64]>,
+        reference_time: Option<DateTime<Utc>>,
     ) -> Result<CoverageResponse, DataServerError> {
-        let _ = (coords, datetime, parameters, z);
+        let _ = (coords, datetime, parameters, z, reference_time);
         Err(DataServerError::InvalidParameter(
             "Position query not supported by this engine".into(),
         ))
@@ -108,8 +128,9 @@ pub trait EdrEngine: Send + Sync {
         datetime: Option<(DateTime<Utc>, DateTime<Utc>)>,
         parameters: Option<&[String]>,
         z: Option<&[f64]>,
+        reference_time: Option<DateTime<Utc>>,
     ) -> Result<CoverageResponse, DataServerError> {
-        let _ = (coords, datetime, parameters, z);
+        let _ = (coords, datetime, parameters, z, reference_time);
         Err(DataServerError::InvalidParameter(
             "Trajectory query not supported by this engine".into(),
         ))

--- a/crates/core/src/edr_engine.rs
+++ b/crates/core/src/edr_engine.rs
@@ -28,7 +28,13 @@ pub trait EdrEngine: Send + Sync {
     /// *whether* a collection has instances to gate the instances links — they
     /// must not clone the whole [`Self::get_instances`] `Vec` (with every run's
     /// valid times) per request. Forecast engines override this with a cheap
-    /// "is the run map non-empty" check. Default mirrors `get_instances`.
+    /// "is the run map non-empty" check.
+    ///
+    /// The default delegates to `get_instances`, which is acceptable precisely
+    /// because the engines that take the default are the **non-forecast** ones —
+    /// their `get_instances` returns an empty `Vec` (a no-op allocation, no valid
+    /// times cloned). Any engine whose `get_instances` is non-trivial MUST
+    /// override this.
     fn has_instances(&self) -> bool {
         !self.get_instances().is_empty()
     }

--- a/crates/core/src/edr_engine.rs
+++ b/crates/core/src/edr_engine.rs
@@ -39,6 +39,18 @@ pub trait EdrEngine: Send + Sync {
         !self.get_instances().is_empty()
     }
 
+    /// Look up a single model run by reference time, or `None` if absent.
+    ///
+    /// The instance-metadata endpoint needs exactly one run; the default
+    /// builds the full list and filters, but forecast engines override this to
+    /// build only the requested run's [`RunInfo`] (a direct catalog lookup),
+    /// avoiding the clone of every other run's valid times.
+    fn find_instance(&self, reference_time: DateTime<Utc>) -> Option<RunInfo> {
+        self.get_instances()
+            .into_iter()
+            .find(|r| r.reference_time == reference_time)
+    }
+
     /// Execute a query for a named location.
     ///
     /// `z` selects vertical levels: `None` returns every level (a profile),

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -20,6 +20,12 @@ pub enum DataServerError {
     #[error("Feature not found: {0}")]
     FeatureNotFound(String),
 
+    /// A syntactically valid forecast model run (reference time / EDR instance)
+    /// that the engine does not have. Maps to HTTP 404 (the resource is absent),
+    /// not 400 (the request is well-formed). See `ds_core::instances`.
+    #[error("Reference time not found: {0}")]
+    ReferenceTimeNotFound(String),
+
     #[error("Invalid bbox: {0}")]
     InvalidBbox(String),
 

--- a/crates/core/src/instances.rs
+++ b/crates/core/src/instances.rs
@@ -1,0 +1,194 @@
+//! Model-run / forecast-reference-time support shared across engines (issue
+//! #337).
+//!
+//! Forecast datasets have **two** time axes: the **model run** (a.k.a. forecast
+//! *reference time* / init time / analysis time) and the **valid time** (run +
+//! lead). OGC API - EDR exposes each run as an **instance**; OGC WMS exposes the
+//! run as a custom `reference_time` dimension. This module is the single home
+//! for the pieces every forecast engine needs, so GRIB, QueryData (and later
+//! Zarr) select runs, build instance lists, and encode/decode instance ids
+//! **identically** — no per-engine duplication.
+//!
+//! The contract for a forecast engine:
+//! - store runs in a `BTreeMap<DateTime<Utc>, _>` keyed by reference time
+//!   (ascending — so `iter().next_back()` is the latest run),
+//! - resolve an incoming `reference_time: Option<DateTime<Utc>>` with
+//!   [`select_run`] (`None` ⇒ latest),
+//! - build [`EdrEngine::get_instances`](crate::edr_engine::EdrEngine::get_instances)
+//!   with [`build_instances`].
+//!
+//! The API layer (`api-edr`) parses the `{instanceId}` path segment to a
+//! reference time with [`parse_instance_id`] and formats instance ids with
+//! [`format_instance_id`]; engines never touch the string form.
+
+use std::collections::BTreeMap;
+
+use chrono::{DateTime, NaiveDateTime, Utc};
+
+/// One forecast model run, surfaced as an OGC API - EDR *instance*.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RunInfo {
+    /// The model run / forecast reference time (init / analysis time, UTC).
+    pub reference_time: DateTime<Utc>,
+    /// The valid times produced by this run (`reference_time + lead`), ascending.
+    pub valid_times: Vec<DateTime<Utc>>,
+}
+
+impl RunInfo {
+    /// The instance id used in EDR URLs (the canonical compact UTC stamp, e.g.
+    /// `20260607T0600Z`). Round-trips through [`parse_instance_id`].
+    pub fn instance_id(&self) -> String {
+        format_instance_id(self.reference_time)
+    }
+
+    /// This run's valid-time extent `(first, last)`, or `None` when the run has
+    /// no valid times.
+    pub fn temporal_extent(&self) -> Option<(DateTime<Utc>, DateTime<Utc>)> {
+        match (self.valid_times.first(), self.valid_times.last()) {
+            (Some(&a), Some(&b)) => Some((a, b)),
+            _ => None,
+        }
+    }
+}
+
+/// The canonical EDR instance id for a model run: a compact UTC stamp
+/// `%Y%m%dT%H%MZ` (e.g. `20260607T0600Z`). URL- and filesystem-safe (no
+/// colons), and stable across engines.
+pub fn format_instance_id(reference_time: DateTime<Utc>) -> String {
+    reference_time.format("%Y%m%dT%H%MZ").to_string()
+}
+
+/// Parse an EDR instance id back to a run reference time.
+///
+/// Accepts the canonical compact form emitted by [`format_instance_id`]
+/// (`20260607T0600Z`, and the seconds variant `20260607T060000Z`) as well as
+/// full RFC 3339 (`2026-06-07T06:00:00Z`), so clients that echo a run's
+/// reference time verbatim still resolve. Returns `None` for anything else.
+pub fn parse_instance_id(s: &str) -> Option<DateTime<Utc>> {
+    if let Ok(dt) = NaiveDateTime::parse_from_str(s, "%Y%m%dT%H%MZ") {
+        return Some(dt.and_utc());
+    }
+    if let Ok(dt) = NaiveDateTime::parse_from_str(s, "%Y%m%dT%H%M%SZ") {
+        return Some(dt.and_utc());
+    }
+    DateTime::parse_from_rfc3339(s)
+        .ok()
+        .map(|d| d.with_timezone(&Utc))
+}
+
+/// Select the run to serve from a reference-time-keyed map.
+///
+/// `None` ⇒ the latest run (largest key). `Some(rt)` ⇒ the run with exactly
+/// that reference time, or `None` if absent (the API layer maps that to a 404).
+/// This is the one selection rule every forecast engine uses, so "default to
+/// latest" and "pick an instance" behave the same everywhere.
+pub fn select_run<T>(
+    runs: &BTreeMap<DateTime<Utc>, T>,
+    reference_time: Option<DateTime<Utc>>,
+) -> Option<(&DateTime<Utc>, &T)> {
+    match reference_time {
+        Some(rt) => runs.get_key_value(&rt),
+        None => runs.iter().next_back(),
+    }
+}
+
+/// Build the [`RunInfo`] list (ascending by reference time, latest last) from a
+/// reference-time-keyed run map, deriving each run's valid times via `valid_times`.
+///
+/// Engines differ only in how they enumerate a run's valid times (GRIB:
+/// `reference_time + step`; QueryData: the file's time axis), so they pass that
+/// as a closure and share everything else.
+pub fn build_instances<T>(
+    runs: &BTreeMap<DateTime<Utc>, T>,
+    valid_times: impl Fn(&DateTime<Utc>, &T) -> Vec<DateTime<Utc>>,
+) -> Vec<RunInfo> {
+    runs.iter()
+        .map(|(rt, run)| RunInfo {
+            reference_time: *rt,
+            valid_times: valid_times(rt, run),
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    fn dt(y: i32, mo: u32, d: u32, h: u32) -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(y, mo, d, h, 0, 0).unwrap()
+    }
+
+    #[test]
+    fn instance_id_round_trips_compact() {
+        let rt = dt(2026, 6, 7, 6);
+        let id = format_instance_id(rt);
+        assert_eq!(id, "20260607T0600Z");
+        assert_eq!(parse_instance_id(&id), Some(rt));
+    }
+
+    #[test]
+    fn parse_accepts_rfc3339_and_seconds_variant() {
+        let rt = dt(2026, 6, 7, 6);
+        assert_eq!(parse_instance_id("2026-06-07T06:00:00Z"), Some(rt));
+        assert_eq!(parse_instance_id("20260607T060000Z"), Some(rt));
+    }
+
+    #[test]
+    fn parse_rejects_garbage() {
+        assert_eq!(parse_instance_id("latest"), None);
+        assert_eq!(parse_instance_id(""), None);
+        assert_eq!(parse_instance_id("2026-06-07"), None);
+    }
+
+    #[test]
+    fn select_run_none_is_latest() {
+        let mut runs = BTreeMap::new();
+        runs.insert(dt(2026, 6, 7, 0), "00Z");
+        runs.insert(dt(2026, 6, 7, 12), "12Z");
+        runs.insert(dt(2026, 6, 7, 6), "06Z");
+        assert_eq!(select_run(&runs, None), Some((&dt(2026, 6, 7, 12), &"12Z")));
+    }
+
+    #[test]
+    fn select_run_some_picks_exact_run() {
+        let mut runs = BTreeMap::new();
+        runs.insert(dt(2026, 6, 7, 0), "00Z");
+        runs.insert(dt(2026, 6, 7, 12), "12Z");
+        assert_eq!(
+            select_run(&runs, Some(dt(2026, 6, 7, 0))),
+            Some((&dt(2026, 6, 7, 0), &"00Z"))
+        );
+        // A run that isn't present resolves to None (→ 404 at the API layer).
+        assert_eq!(select_run(&runs, Some(dt(2026, 6, 7, 6))), None);
+    }
+
+    #[test]
+    fn select_run_empty_is_none() {
+        let runs: BTreeMap<DateTime<Utc>, &str> = BTreeMap::new();
+        assert_eq!(select_run(&runs, None), None);
+        assert_eq!(select_run(&runs, Some(dt(2026, 6, 7, 0))), None);
+    }
+
+    #[test]
+    fn build_instances_orders_and_derives_valid_times() {
+        let mut runs = BTreeMap::new();
+        runs.insert(dt(2026, 6, 7, 12), 2u32); // 2 leads
+        runs.insert(dt(2026, 6, 7, 0), 3u32); // 3 leads
+        let instances = build_instances(&runs, |rt, &n| {
+            (0..n as i64)
+                .map(|i| *rt + chrono::Duration::hours(i))
+                .collect()
+        });
+        assert_eq!(instances.len(), 2);
+        // Ascending by reference time, latest last.
+        assert_eq!(instances[0].reference_time, dt(2026, 6, 7, 0));
+        assert_eq!(instances[1].reference_time, dt(2026, 6, 7, 12));
+        assert_eq!(instances[0].valid_times.len(), 3);
+        assert_eq!(
+            instances[1].temporal_extent(),
+            Some((dt(2026, 6, 7, 12), dt(2026, 6, 7, 13)))
+        );
+        assert_eq!(instances[1].instance_id(), "20260607T1200Z");
+    }
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -7,6 +7,7 @@ pub mod feature;
 pub mod feature_engine;
 pub mod geo;
 pub mod html;
+pub mod instances;
 pub mod map_engine;
 pub mod model;
 pub mod ogc_extent;

--- a/crates/core/src/map_engine.rs
+++ b/crates/core/src/map_engine.rs
@@ -140,6 +140,11 @@ pub struct RasterInfo {
     /// parent-layer tree can still tell siblings apart. `None` for standalone
     /// collections.
     pub layer_subtitle: Option<String>,
+    /// Available forecast model runs (reference times), ascending. Empty for
+    /// non-forecast collections. WMS surfaces these as a custom `reference_time`
+    /// dimension and `get_raster_tile`'s `reference_time` argument selects one
+    /// (`None` ⇒ latest); see [`crate::instances`].
+    pub reference_times: Vec<DateTime<Utc>>,
 }
 
 /// Trait for serving raster data as map images.
@@ -164,8 +169,13 @@ pub trait MapEngine: Send + Sync {
     /// pressure level). Engines with no vertical dimension ignore it; engines
     /// that have one resolve it against `raster_info().vertical`.
     ///
+    /// The optional `reference_time` selects a forecast model run against
+    /// `raster_info().reference_times` (`None` ⇒ the latest run, the default and
+    /// only behaviour for non-forecast engines, which ignore it). See
+    /// [`crate::instances`].
+    ///
     /// The engine handles CRS reprojection to source data internally.
-    #[allow(clippy::too_many_arguments)] // bbox/size/time/crs/parameter/z are all genuine selectors
+    #[allow(clippy::too_many_arguments)] // bbox/size/time/crs/parameter/z/reference_time are all genuine selectors
     fn get_raster_tile(
         &self,
         bbox: [f64; 4],
@@ -175,6 +185,7 @@ pub trait MapEngine: Send + Sync {
         output_crs: &OutputCrs,
         parameter: Option<&str>,
         z: Option<f64>,
+        reference_time: Option<DateTime<Utc>>,
     ) -> Result<RasterTile, DataServerError>;
 
     /// Return metadata for capabilities documents.

--- a/crates/engine-csv/benches/csv_engine.rs
+++ b/crates/engine-csv/benches/csv_engine.rs
@@ -26,7 +26,7 @@ fn bench_query_location(c: &mut Criterion) {
         b.iter(|| {
             black_box(
                 engine
-                    .query_location(black_box(loc_id), None, None, None)
+                    .query_location(black_box(loc_id), None, None, None, None)
                     .unwrap(),
             )
         })
@@ -37,7 +37,7 @@ fn bench_query_location(c: &mut Criterion) {
         b.iter(|| {
             black_box(
                 engine
-                    .query_location(black_box(loc_id), None, Some(&params), None)
+                    .query_location(black_box(loc_id), None, Some(&params), None, None)
                     .unwrap(),
             )
         })
@@ -69,7 +69,7 @@ fn bench_query_area(c: &mut Criterion) {
         b.iter(|| {
             black_box(
                 engine
-                    .query_area(black_box(coords), None, None, None)
+                    .query_area(black_box(coords), None, None, None, None)
                     .unwrap(),
             )
         })

--- a/crates/engine-csv/src/engine.rs
+++ b/crates/engine-csv/src/engine.rs
@@ -164,6 +164,7 @@ impl EdrEngine for CsvEngine {
         datetime: Option<(DateTime<Utc>, DateTime<Utc>)>,
         parameters: Option<&[String]>,
         _z: Option<&[f64]>,
+        _reference_time: Option<DateTime<Utc>>,
     ) -> Result<CoverageResponse, DataServerError> {
         Ok(CoverageResponse::Single(self.location_series(
             location_id,
@@ -229,6 +230,7 @@ impl EdrEngine for CsvEngine {
         datetime: Option<(DateTime<Utc>, DateTime<Utc>)>,
         parameters: Option<&[String]>,
         _z: Option<&[f64]>,
+        _reference_time: Option<DateTime<Utc>>,
     ) -> Result<CoverageResponse, DataServerError> {
         const MAX_LOCATIONS: usize = 500;
 

--- a/crates/engine-geotiff/benches/geotiff_engine.rs
+++ b/crates/engine-geotiff/benches/geotiff_engine.rs
@@ -51,7 +51,7 @@ fn bench_query_position(c: &mut Criterion) {
         b.iter(|| {
             black_box(
                 engine
-                    .query_position(black_box(coords), None, None, None)
+                    .query_position(black_box(coords), None, None, None, None)
                     .unwrap(),
             )
         })
@@ -63,13 +63,13 @@ fn bench_query_position_cached(c: &mut Criterion) {
     let coords = "POINT(25.0 60.5)";
 
     // Warm the cache
-    let _ = engine.query_position(coords, None, None, None);
+    let _ = engine.query_position(coords, None, None, None, None);
 
     c.bench_function("geotiff_query_position_cached", |b| {
         b.iter(|| {
             black_box(
                 engine
-                    .query_position(black_box(coords), None, None, None)
+                    .query_position(black_box(coords), None, None, None, None)
                     .unwrap(),
             )
         })
@@ -82,13 +82,13 @@ fn bench_query_area_small(c: &mut Criterion) {
     let coords = "POLYGON((24.5 60.0, 25.0 60.0, 25.0 60.5, 24.5 60.5, 24.5 60.0))";
 
     // Warm cache
-    let _ = engine.query_area(coords, None, None, None);
+    let _ = engine.query_area(coords, None, None, None, None);
 
     c.bench_function("geotiff_query_area_small", |b| {
         b.iter(|| {
             black_box(
                 engine
-                    .query_area(black_box(coords), None, None, None)
+                    .query_area(black_box(coords), None, None, None, None)
                     .unwrap(),
             )
         })
@@ -101,13 +101,13 @@ fn bench_query_area_large(c: &mut Criterion) {
     let coords = "POLYGON((22.0 59.0, 26.0 59.0, 26.0 62.0, 22.0 62.0, 22.0 59.0))";
 
     // Warm cache
-    let _ = engine.query_area(coords, None, None, None);
+    let _ = engine.query_area(coords, None, None, None, None);
 
     c.bench_function("geotiff_query_area_large", |b| {
         b.iter(|| {
             black_box(
                 engine
-                    .query_area(black_box(coords), None, None, None)
+                    .query_area(black_box(coords), None, None, None, None)
                     .unwrap(),
             )
         })
@@ -141,6 +141,7 @@ fn bench_get_raster_tile_projected(c: &mut Criterion) {
                         1024,
                         None,
                         &OutputCrs::WebMercator,
+                        None,
                         None,
                         None,
                     )
@@ -192,6 +193,7 @@ fn bench_get_raster_tile_fmi_metatile(c: &mut Criterion) {
                         &OutputCrs::WebMercator,
                         None,
                         None,
+                        None,
                     )
                     .unwrap(),
             )
@@ -217,6 +219,7 @@ fn bench_get_raster_tile_fmi_fullscreen(c: &mut Criterion) {
                         1024,
                         None,
                         &OutputCrs::WebMercator,
+                        None,
                         None,
                         None,
                     )

--- a/crates/engine-geotiff/benches/geotiff_remote.rs
+++ b/crates/engine-geotiff/benches/geotiff_remote.rs
@@ -73,7 +73,7 @@ fn bench_position_cache_comparison(c: &mut Criterion) {
         b.iter(|| {
             black_box(
                 engine_nocache
-                    .query_position(black_box(coords), None, None, None)
+                    .query_position(black_box(coords), None, None, None, None)
                     .unwrap(),
             )
         })
@@ -87,19 +87,19 @@ fn bench_position_cache_comparison(c: &mut Criterion) {
             let engine = load_engine(64);
             black_box(
                 engine
-                    .query_position(black_box(coords), None, None, None)
+                    .query_position(black_box(coords), None, None, None, None)
                     .unwrap(),
             )
         })
     });
 
     // With cache, warm
-    let _ = engine_cached.query_position(coords, None, None, None);
+    let _ = engine_cached.query_position(coords, None, None, None, None);
     group.bench_function("cache_warm", |b| {
         b.iter(|| {
             black_box(
                 engine_cached
-                    .query_position(black_box(coords), None, None, None)
+                    .query_position(black_box(coords), None, None, None, None)
                     .unwrap(),
             )
         })
@@ -143,7 +143,7 @@ fn bench_area_scaling(c: &mut Criterion) {
             b.iter(|| {
                 black_box(
                     engine
-                        .query_area(black_box(coords), None, None, None)
+                        .query_area(black_box(coords), None, None, None, None)
                         .unwrap(),
                 )
             })
@@ -165,7 +165,7 @@ fn bench_concurrent_position(c: &mut Criterion) {
     let coords = "POINT(25.0 60.5)";
 
     // Warm cache
-    let _ = engine.query_position(coords, None, None, None);
+    let _ = engine.query_position(coords, None, None, None, None);
 
     for concurrency in [1, 2, 4, 8, 16] {
         group.bench_with_input(
@@ -180,6 +180,7 @@ fn bench_concurrent_position(c: &mut Criterion) {
                                 black_box(
                                     eng.query_position(
                                         black_box("POINT(25.0 60.5)"),
+                                        None,
                                         None,
                                         None,
                                         None,

--- a/crates/engine-geotiff/src/lib.rs
+++ b/crates/engine-geotiff/src/lib.rs
@@ -230,6 +230,7 @@ impl GeoTiffEngine {
             native_crs: crs_name,
             spatial_extent: catalog.spatial_extent,
             times,
+            reference_times: Vec::new(),
             parameter: self.parameter.clone(),
             unit: self.unit.clone(),
             parameters: vec![], // single-parameter engine
@@ -396,6 +397,7 @@ impl GeoTiffEngine {
                 native_crs: "CRS:84".to_string(),
                 spatial_extent: None,
                 times: vec![],
+                reference_times: Vec::new(),
                 parameter: config.parameter.clone(),
                 unit: config.unit.clone(),
                 parameters: vec![],
@@ -1340,6 +1342,7 @@ fn crs_label(crs: &ds_core::geo::Crs) -> String {
 }
 
 impl ds_core::map_engine::MapEngine for GeoTiffEngine {
+    #[allow(clippy::too_many_arguments)]
     fn get_raster_tile(
         &self,
         bbox: [f64; 4],
@@ -1349,6 +1352,7 @@ impl ds_core::map_engine::MapEngine for GeoTiffEngine {
         output_crs: &ds_core::map_engine::OutputCrs,
         parameter: Option<&str>,
         z: Option<f64>,
+        _reference_time: Option<DateTime<Utc>>,
     ) -> Result<ds_core::map_engine::RasterTile, DataServerError> {
         let _ = (parameter, z); // GeoTIFF engine serves a single 2-D band per collection
                                 // For STAC: ensure we have items around the requested time
@@ -1598,6 +1602,7 @@ impl EdrEngine for GeoTiffEngine {
         _datetime: Option<(DateTime<Utc>, DateTime<Utc>)>,
         _parameters: Option<&[String]>,
         _z: Option<&[f64]>,
+        _reference_time: Option<DateTime<Utc>>,
     ) -> Result<CoverageResponse, DataServerError> {
         Err(DataServerError::InvalidParameter(
             "GeoTIFF engine does not support named location queries. \
@@ -1612,6 +1617,7 @@ impl EdrEngine for GeoTiffEngine {
         datetime: Option<(DateTime<Utc>, DateTime<Utc>)>,
         parameters: Option<&[String]>,
         _z: Option<&[f64]>,
+        _reference_time: Option<DateTime<Utc>>,
     ) -> Result<CoverageResponse, DataServerError> {
         let (lat, lon) = parse_coords(coords)?;
         Ok(CoverageResponse::Single(
@@ -1625,6 +1631,7 @@ impl EdrEngine for GeoTiffEngine {
         datetime: Option<(DateTime<Utc>, DateTime<Utc>)>,
         parameters: Option<&[String]>,
         _z: Option<&[f64]>,
+        _reference_time: Option<DateTime<Utc>>,
     ) -> Result<CoverageResponse, DataServerError> {
         let polygon = ds_core::feature::parse_area_coords(coords)?;
 

--- a/crates/engine-geotiff/tests/render_projection.rs
+++ b/crates/engine-geotiff/tests/render_projection.rs
@@ -66,7 +66,16 @@ fn renders_projected_geotiff_to_wgs84() {
     let engine = tm35fin_engine();
     let (w, h) = (256, 256);
     let tile = engine
-        .get_raster_tile(COVERED_BBOX, w, h, None, &OutputCrs::Wgs84, None, None)
+        .get_raster_tile(
+            COVERED_BBOX,
+            w,
+            h,
+            None,
+            &OutputCrs::Wgs84,
+            None,
+            None,
+            None,
+        )
         .expect("render should succeed");
 
     assert_eq!(tile.width, w);
@@ -98,10 +107,20 @@ fn web_mercator_and_wgs84_render_consistently() {
             &OutputCrs::WebMercator,
             None,
             None,
+            None,
         )
         .expect("render should succeed");
     let wgs = engine
-        .get_raster_tile(COVERED_BBOX, w, h, None, &OutputCrs::Wgs84, None, None)
+        .get_raster_tile(
+            COVERED_BBOX,
+            w,
+            h,
+            None,
+            &OutputCrs::Wgs84,
+            None,
+            None,
+            None,
+        )
         .expect("render should succeed");
 
     let (dm, dw) = (count_data(&merc) as f64, count_data(&wgs) as f64);
@@ -131,7 +150,7 @@ fn renders_projected_geotiff_to_epsg3067() {
     };
     let (w, h) = (256, 256);
     let tile = engine
-        .get_raster_tile(wgs84, w, h, None, &output_crs, None, None)
+        .get_raster_tile(wgs84, w, h, None, &output_crs, None, None, None)
         .expect("projected render should succeed");
 
     assert_eq!(tile.values.len() as u32, w * h);
@@ -146,7 +165,16 @@ fn renders_projected_geotiff_to_epsg3067() {
     // Sanity: the projected render covers a comparable amount of data to the
     // WGS84 render over the same geographic region.
     let wgs = engine
-        .get_raster_tile(COVERED_BBOX, w, h, None, &OutputCrs::Wgs84, None, None)
+        .get_raster_tile(
+            COVERED_BBOX,
+            w,
+            h,
+            None,
+            &OutputCrs::Wgs84,
+            None,
+            None,
+            None,
+        )
         .expect("wgs84 render should succeed");
     let (dp, dw) = (data as f64, count_data(&wgs) as f64);
     assert!(
@@ -161,7 +189,7 @@ fn bbox_outside_coverage_is_empty() {
     // Mid-Atlantic — nowhere near the TM35FIN raster.
     let bbox = [-50.0, 10.0, -40.0, 20.0];
     let tile = engine
-        .get_raster_tile(bbox, 64, 64, None, &OutputCrs::Wgs84, None, None)
+        .get_raster_tile(bbox, 64, 64, None, &OutputCrs::Wgs84, None, None, None)
         .expect("render should succeed even with no overlap");
     assert!(
         tile.is_empty(),
@@ -180,7 +208,7 @@ fn renders_via_overview_for_small_output() {
     let bbox = [8.0, 57.0, 42.0, 71.0];
     let (w, h) = (96, 96);
     let tile = engine
-        .get_raster_tile(bbox, w, h, None, &OutputCrs::Wgs84, None, None)
+        .get_raster_tile(bbox, w, h, None, &OutputCrs::Wgs84, None, None, None)
         .expect("overview render should succeed");
     assert_eq!(tile.values.len() as u32, w * h);
     // The whole-extent render of this echo-dense fixture always has data;
@@ -203,7 +231,7 @@ fn partially_overlapping_bbox_is_partially_filled() {
     let bbox = [20.0, 50.0, 32.0, 62.0];
     let (w, h) = (128, 128);
     let tile = engine
-        .get_raster_tile(bbox, w, h, None, &OutputCrs::Wgs84, None, None)
+        .get_raster_tile(bbox, w, h, None, &OutputCrs::Wgs84, None, None, None)
         .expect("render should succeed");
     let data = count_data(&tile);
     assert!(data > 0, "the on-raster side should have data");

--- a/crates/engine-grib/src/lib.rs
+++ b/crates/engine-grib/src/lib.rs
@@ -17,6 +17,7 @@ use tokio::sync::watch;
 use ds_core::config::GribConfig;
 use ds_core::edr_engine::EdrEngine;
 use ds_core::error::DataServerError;
+use ds_core::instances::{self, RunInfo};
 use ds_core::map_engine::{MapEngine, OutputCrs, RasterInfo, RasterTile};
 use ds_core::model::*;
 
@@ -813,9 +814,16 @@ impl GribEngine {
             .unwrap_or_else(|| ParamMetadata::placeholder(short_name))
     }
 
-    /// Find the best step file for a datetime query.
+    /// Find the best step file for a datetime query, optionally pinned to a
+    /// specific model run.
+    ///
+    /// `reference_time = Some(rt)` restricts the search to exactly that run
+    /// (an unknown run is an error → 404 at the API layer); `None` keeps the
+    /// existing "latest run, or the most recent run covering `datetime`"
+    /// behaviour. See [`instances::select_run`].
     fn resolve_time(
         &self,
+        reference_time: Option<DateTime<Utc>>,
         datetime: Option<(DateTime<Utc>, DateTime<Utc>)>,
     ) -> Result<(u32, StepFile), DataServerError> {
         let catalog = self.catalog.load();
@@ -824,6 +832,31 @@ impl GribEngine {
             return Err(DataServerError::Engine(
                 "No forecast data available".to_string(),
             ));
+        }
+
+        // A pinned run constrains the step search to that single run.
+        if let Some(rt) = reference_time {
+            let (_, run) = instances::select_run(&catalog.runs, Some(rt)).ok_or_else(|| {
+                DataServerError::InvalidParameter(format!(
+                    "No forecast run for reference time {rt}"
+                ))
+            })?;
+            return match datetime {
+                Some((start, _end)) => run
+                    .find_step_for_time(start)
+                    .map(|(step, sf)| (step, sf.clone()))
+                    .ok_or_else(|| {
+                        DataServerError::InvalidParameter(format!(
+                            "Run {rt} has no forecast step for time {start}"
+                        ))
+                    }),
+                None => {
+                    let (&step, sf) = run.steps.iter().next_back().ok_or_else(|| {
+                        DataServerError::Engine(format!("Run {rt} has no forecast steps"))
+                    })?;
+                    Ok((step, sf.clone()))
+                }
+            };
         }
 
         let target = match datetime {
@@ -857,12 +890,20 @@ impl EdrEngine for GribEngine {
         Ok(Vec::new())
     }
 
+    /// Each forecast run is an EDR instance (latest last). Valid times are
+    /// `reference_time + step` for every step retained in that run.
+    fn get_instances(&self) -> Vec<RunInfo> {
+        let catalog = self.catalog.load();
+        instances::build_instances(&catalog.runs, |_, run| run.valid_times())
+    }
+
     fn query_location(
         &self,
         _location_id: &str,
         _datetime: Option<(DateTime<Utc>, DateTime<Utc>)>,
         _parameters: Option<&[String]>,
         _z: Option<&[f64]>,
+        _reference_time: Option<DateTime<Utc>>,
     ) -> Result<CoverageResponse, DataServerError> {
         Err(DataServerError::InvalidParameter(
             "GRIB engine does not support location queries; use position or area instead"
@@ -924,6 +965,7 @@ impl EdrEngine for GribEngine {
         datetime: Option<(DateTime<Utc>, DateTime<Utc>)>,
         parameters: Option<&[String]>,
         _z: Option<&[f64]>,
+        reference_time: Option<DateTime<Utc>>,
     ) -> Result<CoverageResponse, DataServerError> {
         let (lon, lat) = parse_coords(coords)?;
         let catalog = self.catalog.load();
@@ -934,22 +976,33 @@ impl EdrEngine for GribEngine {
             ));
         }
 
-        // Find the best forecast run
-        let run = match datetime {
-            Some((start, _)) => {
-                // Find the run whose valid times include the requested time
-                catalog
-                    .runs
-                    .values()
-                    .rev()
-                    .find(|r| r.find_step_for_time(start).is_some())
-                    .ok_or_else(|| {
-                        DataServerError::InvalidParameter(format!(
-                            "No forecast run covers time {start}"
-                        ))
-                    })?
-            }
-            None => catalog.latest_run().unwrap(),
+        // Find the forecast run to serve. A pinned `reference_time` selects that
+        // exact run (the EDR instance); otherwise fall back to the most recent
+        // run covering `datetime`, or the latest run.
+        let run = match reference_time {
+            Some(rt) => instances::select_run(&catalog.runs, Some(rt))
+                .map(|(_, r)| r)
+                .ok_or_else(|| {
+                    DataServerError::InvalidParameter(format!(
+                        "No forecast run for reference time {rt}"
+                    ))
+                })?,
+            None => match datetime {
+                Some((start, _)) => {
+                    // Find the run whose valid times include the requested time
+                    catalog
+                        .runs
+                        .values()
+                        .rev()
+                        .find(|r| r.find_step_for_time(start).is_some())
+                        .ok_or_else(|| {
+                            DataServerError::InvalidParameter(format!(
+                                "No forecast run covers time {start}"
+                            ))
+                        })?
+                }
+                None => catalog.latest_run().unwrap(),
+            },
         };
 
         // Determine which forecast steps to include
@@ -1067,9 +1120,10 @@ impl EdrEngine for GribEngine {
         datetime: Option<(DateTime<Utc>, DateTime<Utc>)>,
         parameters: Option<&[String]>,
         _z: Option<&[f64]>,
+        reference_time: Option<DateTime<Utc>>,
     ) -> Result<CoverageResponse, DataServerError> {
         let bbox = parse_bbox_from_wkt(coords)?;
-        let (_step, step_file) = self.resolve_time(datetime)?;
+        let (_step, step_file) = self.resolve_time(reference_time, datetime)?;
 
         // Default to first near-surface parameter
         let query_params: Vec<&str> = match parameters {
@@ -1181,6 +1235,7 @@ impl EdrEngine for GribEngine {
 // ---------------------------------------------------------------------------
 
 impl MapEngine for GribEngine {
+    #[allow(clippy::too_many_arguments)] // bbox/size/time/crs/parameter/z/reference_time are all genuine selectors
     fn get_raster_tile(
         &self,
         bbox: [f64; 4],
@@ -1190,10 +1245,11 @@ impl MapEngine for GribEngine {
         output_crs: &OutputCrs,
         parameter: Option<&str>,
         z: Option<f64>,
+        reference_time: Option<DateTime<Utc>>,
     ) -> Result<RasterTile, DataServerError> {
         let _ = z; // GRIB collections expose no vertical dimension yet (#185)
         let datetime = time.map(|t| (t, t));
-        let (_step, step_file) = self.resolve_time(datetime)?;
+        let (_step, step_file) = self.resolve_time(reference_time, datetime)?;
 
         // Determine parameter to render
         let param_name = parameter.unwrap_or_else(|| {
@@ -1279,6 +1335,9 @@ impl MapEngine for GribEngine {
             // unadvertised for now (tracked as a follow-up).
             grid_size: None,
             layer_subtitle: None,
+            // Each retained forecast run is a selectable reference time (WMS
+            // `reference_time` dimension); ascending, latest last.
+            reference_times: catalog.runs.keys().copied().collect(),
         }
     }
 }

--- a/crates/engine-grib/src/lib.rs
+++ b/crates/engine-grib/src/lib.rs
@@ -827,56 +827,65 @@ impl GribEngine {
         datetime: Option<(DateTime<Utc>, DateTime<Utc>)>,
     ) -> Result<(u32, StepFile), DataServerError> {
         let catalog = self.catalog.load();
-
-        if catalog.runs.is_empty() {
-            return Err(DataServerError::Engine(
-                "No forecast data available".to_string(),
-            ));
+        // Run selection is shared with `query_position` (see `resolve_run`); this
+        // path additionally narrows to a single step.
+        let run = resolve_run(&catalog, reference_time, datetime)?;
+        match datetime {
+            Some((start, _end)) => run
+                .find_step_for_time(start)
+                .map(|(step, sf)| (step, sf.clone()))
+                .ok_or_else(|| {
+                    DataServerError::InvalidParameter(format!("No forecast step for time {start}"))
+                }),
+            None => {
+                let (&step, sf) = run.steps.iter().next_back().ok_or_else(|| {
+                    DataServerError::Engine("forecast run has no steps".to_string())
+                })?;
+                Ok((step, sf.clone()))
+            }
         }
+    }
+}
 
-        // A pinned run constrains the step search to that single run.
-        if let Some(rt) = reference_time {
-            let (_, run) = instances::select_run(&catalog.runs, Some(rt)).ok_or_else(|| {
+/// Select the forecast run to serve, shared by `query_position` and
+/// `resolve_time` (the EDR and Maps paths) so run selection — and its
+/// error mapping — is identical everywhere.
+///
+/// `reference_time = Some(rt)` pins exactly that run (absent ⇒
+/// [`DataServerError::ReferenceTimeNotFound`] → 404); `None` falls back to the
+/// most recent run whose steps cover `datetime`, or the latest run. See
+/// [`instances::select_run`].
+fn resolve_run(
+    catalog: &Catalog,
+    reference_time: Option<DateTime<Utc>>,
+    datetime: Option<(DateTime<Utc>, DateTime<Utc>)>,
+) -> Result<&ForecastRun, DataServerError> {
+    if catalog.runs.is_empty() {
+        return Err(DataServerError::Engine(
+            "No forecast data available".to_string(),
+        ));
+    }
+    match reference_time {
+        Some(rt) => instances::select_run(&catalog.runs, Some(rt))
+            .map(|(_, r)| r)
+            .ok_or_else(|| {
                 DataServerError::ReferenceTimeNotFound(format!(
                     "no forecast run for reference time {rt}"
                 ))
-            })?;
-            return match datetime {
-                Some((start, _end)) => run
-                    .find_step_for_time(start)
-                    .map(|(step, sf)| (step, sf.clone()))
-                    .ok_or_else(|| {
-                        DataServerError::InvalidParameter(format!(
-                            "Run {rt} has no forecast step for time {start}"
-                        ))
-                    }),
-                None => {
-                    let (&step, sf) = run.steps.iter().next_back().ok_or_else(|| {
-                        DataServerError::Engine(format!("Run {rt} has no forecast steps"))
-                    })?;
-                    Ok((step, sf.clone()))
-                }
-            };
-        }
-
-        let target = match datetime {
-            Some((start, _end)) => start,
-            None => {
-                // Default to latest available time
-                let run = catalog.latest_run().unwrap();
-                let (&step, sf) = run.steps.iter().next_back().unwrap();
-                return Ok((step, sf.clone()));
-            }
-        };
-
-        catalog
-            .find_for_time(target)
-            .map(|(step, sf)| (step, sf.clone()))
-            .ok_or_else(|| {
-                DataServerError::InvalidParameter(format!(
-                    "No forecast data available for time {target}"
-                ))
-            })
+            }),
+        None => match datetime {
+            Some((start, _)) => catalog
+                .runs
+                .values()
+                .rev()
+                .find(|r| r.find_step_for_time(start).is_some())
+                .ok_or_else(|| {
+                    DataServerError::InvalidParameter(format!(
+                        "No forecast run covers time {start}"
+                    ))
+                }),
+            None => Ok(catalog.latest_run().expect("runs is non-empty")),
+        },
     }
 }
 
@@ -899,6 +908,14 @@ impl EdrEngine for GribEngine {
 
     fn has_instances(&self) -> bool {
         !self.catalog.load().runs.is_empty()
+    }
+
+    fn find_instance(&self, reference_time: DateTime<Utc>) -> Option<RunInfo> {
+        let catalog = self.catalog.load();
+        catalog.runs.get(&reference_time).map(|run| RunInfo {
+            reference_time,
+            valid_times: run.valid_times(),
+        })
     }
 
     fn query_location(
@@ -974,40 +991,10 @@ impl EdrEngine for GribEngine {
         let (lon, lat) = parse_coords(coords)?;
         let catalog = self.catalog.load();
 
-        if catalog.runs.is_empty() {
-            return Err(DataServerError::Engine(
-                "No forecast data available".to_string(),
-            ));
-        }
-
-        // Find the forecast run to serve. A pinned `reference_time` selects that
-        // exact run (the EDR instance); otherwise fall back to the most recent
-        // run covering `datetime`, or the latest run.
-        let run = match reference_time {
-            Some(rt) => instances::select_run(&catalog.runs, Some(rt))
-                .map(|(_, r)| r)
-                .ok_or_else(|| {
-                    DataServerError::ReferenceTimeNotFound(format!(
-                        "no forecast run for reference time {rt}"
-                    ))
-                })?,
-            None => match datetime {
-                Some((start, _)) => {
-                    // Find the run whose valid times include the requested time
-                    catalog
-                        .runs
-                        .values()
-                        .rev()
-                        .find(|r| r.find_step_for_time(start).is_some())
-                        .ok_or_else(|| {
-                            DataServerError::InvalidParameter(format!(
-                                "No forecast run covers time {start}"
-                            ))
-                        })?
-                }
-                None => catalog.latest_run().unwrap(),
-            },
-        };
+        // Run selection (pinned instance, datetime-covering, or latest) is shared
+        // with `resolve_time` via `resolve_run`; this path then enumerates the
+        // run's steps into a time series.
+        let run = resolve_run(&catalog, reference_time, datetime)?;
 
         // Determine which forecast steps to include
         let steps_to_query: Vec<(u32, &StepFile)> = match datetime {

--- a/crates/engine-grib/src/lib.rs
+++ b/crates/engine-grib/src/lib.rs
@@ -837,8 +837,8 @@ impl GribEngine {
         // A pinned run constrains the step search to that single run.
         if let Some(rt) = reference_time {
             let (_, run) = instances::select_run(&catalog.runs, Some(rt)).ok_or_else(|| {
-                DataServerError::InvalidParameter(format!(
-                    "No forecast run for reference time {rt}"
+                DataServerError::ReferenceTimeNotFound(format!(
+                    "no forecast run for reference time {rt}"
                 ))
             })?;
             return match datetime {
@@ -895,6 +895,10 @@ impl EdrEngine for GribEngine {
     fn get_instances(&self) -> Vec<RunInfo> {
         let catalog = self.catalog.load();
         instances::build_instances(&catalog.runs, |_, run| run.valid_times())
+    }
+
+    fn has_instances(&self) -> bool {
+        !self.catalog.load().runs.is_empty()
     }
 
     fn query_location(
@@ -983,8 +987,8 @@ impl EdrEngine for GribEngine {
             Some(rt) => instances::select_run(&catalog.runs, Some(rt))
                 .map(|(_, r)| r)
                 .ok_or_else(|| {
-                    DataServerError::InvalidParameter(format!(
-                        "No forecast run for reference time {rt}"
+                    DataServerError::ReferenceTimeNotFound(format!(
+                        "no forecast run for reference time {rt}"
                     ))
                 })?,
             None => match datetime {

--- a/crates/engine-grib/tests/local_source.rs
+++ b/crates/engine-grib/tests/local_source.rs
@@ -68,6 +68,7 @@ fn grib_engine_serves_local_directory() {
             &OutputCrs::Wgs84,
             Some(&param),
             None,
+            None,
         )
         .expect("render a tile from the local grib");
     assert_eq!(tile.values.len(), 32 * 16);

--- a/crates/engine-odim/src/edr.rs
+++ b/crates/engine-odim/src/edr.rs
@@ -451,6 +451,7 @@ impl EdrEngine for OdimEngine {
         _datetime: Option<(DateTime<Utc>, DateTime<Utc>)>,
         _parameters: Option<&[String]>,
         _z: Option<&[f64]>,
+        _reference_time: Option<DateTime<Utc>>,
     ) -> Result<CoverageResponse, DataServerError> {
         // An ODIM composite is a gridded field with no named
         // locations, so any location id is genuinely "not found" →
@@ -509,6 +510,7 @@ impl EdrEngine for OdimEngine {
         datetime: Option<(DateTime<Utc>, DateTime<Utc>)>,
         parameters: Option<&[String]>,
         _z: Option<&[f64]>,
+        _reference_time: Option<DateTime<Utc>>,
     ) -> Result<CoverageResponse, DataServerError> {
         let (lat, lon) = parse_point_coords(coords)?;
         Ok(CoverageResponse::Single(
@@ -522,6 +524,7 @@ impl EdrEngine for OdimEngine {
         datetime: Option<(DateTime<Utc>, DateTime<Utc>)>,
         parameters: Option<&[String]>,
         _z: Option<&[f64]>,
+        _reference_time: Option<DateTime<Utc>>,
     ) -> Result<CoverageResponse, DataServerError> {
         let polygon = parse_area_coords(coords)?;
         let result = self.query_polygon(&polygon, datetime, parameters)?;

--- a/crates/engine-odim/src/engine.rs
+++ b/crates/engine-odim/src/engine.rs
@@ -1093,6 +1093,7 @@ fn source_label(source: &Source) -> String {
 }
 
 impl MapEngine for OdimEngine {
+    #[allow(clippy::too_many_arguments)]
     fn get_raster_tile(
         &self,
         bbox: [f64; 4],
@@ -1102,6 +1103,7 @@ impl MapEngine for OdimEngine {
         output_crs: &OutputCrs,
         _parameter: Option<&str>,
         _z: Option<f64>,
+        _reference_time: Option<DateTime<Utc>>,
     ) -> Result<RasterTile, DataServerError> {
         let entry = self.select_entry(time).ok_or_else(|| {
             DataServerError::Engine(format!(
@@ -1199,6 +1201,7 @@ impl MapEngine for OdimEngine {
             vertical: None, // 2-D composite, no vertical dimension
             grid_size: Some([self.seed_xsize, self.seed_ysize]),
             layer_subtitle: None,
+            reference_times: Vec::new(),
         }
     }
 }

--- a/crates/engine-odim/src/volume_engine.rs
+++ b/crates/engine-odim/src/volume_engine.rs
@@ -2922,6 +2922,7 @@ pub struct PolarVolumeSiteView {
 }
 
 impl MapEngine for PolarVolumeSiteView {
+    #[allow(clippy::too_many_arguments)]
     fn get_raster_tile(
         &self,
         bbox: [f64; 4],
@@ -2931,6 +2932,7 @@ impl MapEngine for PolarVolumeSiteView {
         output_crs: &OutputCrs,
         parameter: Option<&str>,
         z: Option<f64>,
+        _reference_time: Option<DateTime<Utc>>,
     ) -> Result<RasterTile, DataServerError> {
         let catalog = self.catalog.load();
         // A per-site PVOL collection is still multi-parameter — one layer per
@@ -3024,6 +3026,7 @@ impl MapEngine for PolarVolumeSiteView {
             // value `get_locations` uses — so WMS can prefix each child
             // layer's title and flat clients can tell the sites apart.
             layer_subtitle: meta.map(|m| m.plc.clone().unwrap_or_else(|| self.nod.clone())),
+            reference_times: Vec::new(),
         }
     }
 }
@@ -3055,6 +3058,7 @@ impl EdrEngine for PolarVolumeSiteView {
         datetime: Option<(DateTime<Utc>, DateTime<Utc>)>,
         parameters: Option<&[String]>,
         z: Option<&[f64]>,
+        _reference_time: Option<DateTime<Utc>>,
     ) -> Result<CoverageResponse, DataServerError> {
         if location_id != self.nod {
             return Err(DataServerError::LocationNotFound(location_id.to_string()));
@@ -3153,6 +3157,7 @@ impl EdrEngine for PolarVolumeSiteView {
         datetime: Option<(DateTime<Utc>, DateTime<Utc>)>,
         parameters: Option<&[String]>,
         z: Option<&[f64]>,
+        _reference_time: Option<DateTime<Utc>>,
     ) -> Result<CoverageResponse, DataServerError> {
         let (lat, lon) = parse_point_coords(coords)?;
         let catalog = self.catalog.load();
@@ -3207,6 +3212,7 @@ impl EdrEngine for PolarVolumeSiteView {
         datetime: Option<(DateTime<Utc>, DateTime<Utc>)>,
         parameters: Option<&[String]>,
         z: Option<&[f64]>,
+        _reference_time: Option<DateTime<Utc>>,
     ) -> Result<CoverageResponse, DataServerError> {
         let polygon = parse_area_coords(coords)?;
         let catalog = self.catalog.load();
@@ -3265,6 +3271,7 @@ impl EdrEngine for PolarVolumeSiteView {
         datetime: Option<(DateTime<Utc>, DateTime<Utc>)>,
         parameters: Option<&[String]>,
         z: Option<&[f64]>,
+        _reference_time: Option<DateTime<Utc>>,
     ) -> Result<CoverageResponse, DataServerError> {
         let path = resample_section_path(coords)?;
         let catalog = self.catalog.load();
@@ -4792,6 +4799,7 @@ mod tests {
             &OutputCrs::Wgs84,
             Some("DBZH"),
             None,
+            None,
         )
         .expect("render with a bare quantity");
         assert_eq!(tile.values.len(), 32 * 4);
@@ -4803,8 +4811,18 @@ mod tests {
         // No parameter named → render the site's primary (first) quantity,
         // not a 400, so a bare `LAYERS={site}` WMS / Maps request works.
         assert!(
-            MapEngine::get_raster_tile(&view, bbox, 32, 4, None, &OutputCrs::Wgs84, None, None)
-                .is_ok(),
+            MapEngine::get_raster_tile(
+                &view,
+                bbox,
+                32,
+                4,
+                None,
+                &OutputCrs::Wgs84,
+                None,
+                None,
+                None
+            )
+            .is_ok(),
             "a bare (no-parameter) render must default to the primary quantity"
         );
 
@@ -4820,6 +4838,7 @@ mod tests {
                 None,
                 &OutputCrs::Wgs84,
                 Some("DBZH"),
+                None,
                 None,
             ),
             Err(DataServerError::LocationNotFound(_))
@@ -4920,7 +4939,7 @@ mod tests {
         // (`CoverageResponse` is not `Debug`, so assert on the variant.)
         assert!(
             matches!(
-                EdrEngine::query_position(&view, "POINT(25.0 60.0)", None, None, None),
+                EdrEngine::query_position(&view, "POINT(25.0 60.0)", None, None, None, None),
                 Err(DataServerError::LocationNotFound(_))
             ),
             "an all-empty point coverage must be LocationNotFound, not HTTP 200"
@@ -4929,7 +4948,7 @@ mod tests {
         // Same for an area query whose polygon contains the antenna.
         assert!(
             matches!(
-                EdrEngine::query_area(&view, "24.0,59.0,26.0,61.0", None, None, None),
+                EdrEngine::query_area(&view, "24.0,59.0,26.0,61.0", None, None, None, None),
                 Err(DataServerError::LocationNotFound(_))
             ),
             "an all-empty area coverage must be LocationNotFound"
@@ -4951,14 +4970,14 @@ mod tests {
         // Single elevation angle → still a CoverageCollection.
         assert!(
             matches!(
-                EdrEngine::query_area(&view, "24.0,59.0,26.0,61.0", None, None, Some(&[0.5])),
+                EdrEngine::query_area(&view, "24.0,59.0,26.0,61.0", None, None, Some(&[0.5]), None),
                 Ok(CoverageResponse::Collection(_))
             ),
             "a single-z area query must stay a CoverageCollection"
         );
         // No z → also a Collection (one VerticalProfile per timestep).
         assert!(matches!(
-            EdrEngine::query_area(&view, "24.0,59.0,26.0,61.0", None, None, None),
+            EdrEngine::query_area(&view, "24.0,59.0,26.0,61.0", None, None, None, None),
             Ok(CoverageResponse::Collection(_))
         ));
     }
@@ -5007,6 +5026,7 @@ mod tests {
             &OutputCrs::Wgs84,
             Some("VRADH"),
             None,
+            None,
         )
         .expect("a higher-sweep-only quantity must render, not 400");
         assert_eq!(tile.values.len(), 16 * 4);
@@ -5048,14 +5068,14 @@ mod tests {
         // ~5° east at 60°N ≈ 280 km — well beyond the 100 km radius.
         assert!(
             matches!(
-                EdrEngine::query_position(&view, "POINT(30.0 60.0)", None, None, None),
+                EdrEngine::query_position(&view, "POINT(30.0 60.0)", None, None, None, None),
                 Err(DataServerError::LocationNotFound(_))
             ),
             "a point outside the coverage radius must be 404"
         );
         // ~11 km north — inside coverage, resolves to a coverage.
         assert!(
-            EdrEngine::query_position(&view, "POINT(25.0 60.1)", None, None, None).is_ok(),
+            EdrEngine::query_position(&view, "POINT(25.0 60.1)", None, None, None, None).is_ok(),
             "a point within coverage must succeed"
         );
     }
@@ -5078,7 +5098,7 @@ mod tests {
         ));
         // ...and a direct query_location returns 404, not InvalidParameter.
         assert!(matches!(
-            EdrEngine::query_location(&view, "fivih", None, None, None),
+            EdrEngine::query_location(&view, "fivih", None, None, None, None),
             Err(DataServerError::LocationNotFound(_))
         ));
         // ...and so does query_trajectory (same by_site_meta gate).
@@ -5086,6 +5106,7 @@ mod tests {
             EdrEngine::query_trajectory(
                 &view,
                 "LINESTRING(24.5 60.3, 24.5 60.9)",
+                None,
                 None,
                 None,
                 None
@@ -5118,6 +5139,7 @@ mod tests {
                 None,
                 Some(&["DBZH".to_string()]),
                 Some(&[15.0]),
+                None,
             ),
             Err(DataServerError::LocationNotFound(_))
         ));
@@ -5142,14 +5164,14 @@ mod tests {
         let dlat_70 = 70_000.0 / EARTH_RADIUS_M * 180.0 / std::f64::consts::PI;
         let near = format!("POINT(25.0 {})", 60.0 + dlat_70);
         assert!(
-            EdrEngine::query_position(&view, &near, None, None, None).is_ok(),
+            EdrEngine::query_position(&view, &near, None, None, None, None).is_ok(),
             "a point within the longest sweep's range must not be rejected"
         );
         // ~200 km: beyond every sweep → 404.
         let dlat_200 = 200_000.0 / EARTH_RADIUS_M * 180.0 / std::f64::consts::PI;
         let far = format!("POINT(25.0 {})", 60.0 + dlat_200);
         assert!(matches!(
-            EdrEngine::query_position(&view, &far, None, None, None),
+            EdrEngine::query_position(&view, &far, None, None, None, None),
             Err(DataServerError::LocationNotFound(_))
         ));
     }
@@ -5167,7 +5189,7 @@ mod tests {
 
         // Even at the antenna itself — no usable geometry → fail closed.
         assert!(matches!(
-            EdrEngine::query_position(&view, "POINT(25.0 60.0)", None, None, None),
+            EdrEngine::query_position(&view, "POINT(25.0 60.0)", None, None, None, None),
             Err(DataServerError::LocationNotFound(_))
         ));
     }

--- a/crates/engine-odim/tests/integration.rs
+++ b/crates/engine-odim/tests/integration.rs
@@ -124,6 +124,7 @@ fn get_raster_tile_over_denmark_renders() {
             &OutputCrs::Wgs84,
             None,
             None,
+            None,
         )
         .expect("render succeeds");
 
@@ -149,6 +150,7 @@ fn get_raster_tile_in_web_mercator_renders() {
             &OutputCrs::WebMercator,
             None,
             None,
+            None,
         )
         .expect("Mercator render succeeds");
 
@@ -172,7 +174,7 @@ fn get_raster_tile_full_extent_does_not_panic() {
     let bbox = info.spatial_extent.expect("fixture has spatial extent");
 
     let tile = engine
-        .get_raster_tile(bbox, 32, 32, None, &OutputCrs::Wgs84, None, None)
+        .get_raster_tile(bbox, 32, 32, None, &OutputCrs::Wgs84, None, None, None)
         .expect("full-extent render succeeds");
 
     assert_eq!(tile.values.len(), 32 * 32);
@@ -213,7 +215,9 @@ fn edr_metadata_is_consistent() {
     // ODIM has no station list — locations is empty, query_location
     // is unsupported.
     assert!(engine.get_locations().unwrap().is_empty());
-    assert!(engine.query_location("anything", None, None, None).is_err());
+    assert!(engine
+        .query_location("anything", None, None, None, None)
+        .is_err());
 }
 
 /// `query_position` over central Denmark returns a `PointSeries`
@@ -224,7 +228,7 @@ fn edr_metadata_is_consistent() {
 fn edr_query_position_returns_point_series() {
     let (engine, _guard) = dmi_engine();
     let response = engine
-        .query_position("POINT(10.5 56.0)", None, None, None)
+        .query_position("POINT(10.5 56.0)", None, None, None, None)
         .expect("position query succeeds");
     let result = match response {
         CoverageResponse::Single(qr) => qr,
@@ -254,7 +258,7 @@ fn edr_query_position_returns_point_series() {
 fn edr_query_position_off_grid_is_none() {
     let (engine, _guard) = dmi_engine();
     let response = engine
-        .query_position("POINT(-140.0 12.0)", None, None, None)
+        .query_position("POINT(-140.0 12.0)", None, None, None, None)
         .expect("off-grid position query still succeeds");
     let result = match response {
         CoverageResponse::Single(qr) => qr,
@@ -274,6 +278,7 @@ fn edr_query_position_rejects_unknown_parameter() {
             None,
             Some(&["temperature".to_string()]),
             None,
+            None,
         )
         .unwrap_err();
     assert!(format!("{err}").contains("Unknown parameter"));
@@ -286,7 +291,7 @@ fn edr_query_position_rejects_unknown_parameter() {
 fn edr_query_area_returns_grid() {
     let (engine, _guard) = dmi_engine();
     let result = engine
-        .query_area("9.0,55.0,12.0,57.5", None, None, None)
+        .query_area("9.0,55.0,12.0,57.5", None, None, None, None)
         .expect("area query succeeds");
 
     let coverage = match result {
@@ -367,7 +372,7 @@ fn edr_query_area_rejects_too_many_timesteps() {
 
     // No datetime filter → all 65 entries → over the cap → error.
     let err = engine
-        .query_area("9.0,55.0,12.0,57.5", None, None, None)
+        .query_area("9.0,55.0,12.0,57.5", None, None, None, None)
         .unwrap_err();
     assert!(
         format!("{err}").contains("maximum is 64"),
@@ -380,7 +385,7 @@ fn edr_query_area_rejects_too_many_timesteps() {
     let end = Utc.with_ymd_and_hms(2026, 5, 14, 0, 30, 0).unwrap();
     assert!(
         engine
-            .query_area("9.0,55.0,12.0,57.5", Some((start, end)), None, None)
+            .query_area("9.0,55.0,12.0,57.5", Some((start, end)), None, None, None)
             .is_ok(),
         "a 7-timestep window must stay under the cap"
     );
@@ -395,6 +400,7 @@ fn edr_query_area_masks_outside_polygon() {
     let result = engine
         .query_area(
             "POLYGON((9.0 55.0, 12.0 55.0, 9.0 57.0, 9.0 55.0))",
+            None,
             None,
             None,
             None,
@@ -508,6 +514,7 @@ fn pvol_engine_renders_fmi_vihti_volume() {
             None,
             &OutputCrs::Wgs84,
             Some(&render_param),
+            None,
             None,
         )
         .expect("PVOL site get_raster_tile over the coverage bbox");
@@ -724,6 +731,7 @@ fn pvol_engine_remote_scan_discovers_fmi_volume() {
             &OutputCrs::Wgs84,
             Some(&render_param),
             None,
+            None,
         )
         .expect("render of the remotely-scanned volume succeeds");
     assert_eq!(tile.values.len(), 64 * 64);
@@ -775,6 +783,7 @@ fn pvol_bare_render_defaults_to_primary_quantity() {
             8,
             None,
             &OutputCrs::Wgs84,
+            None,
             None,
             None,
         )
@@ -863,7 +872,7 @@ fn pvol_edr_position_outside_coverage_is_404() {
     };
     assert!(
         matches!(
-            EdrEngine::query_position(&view, "POINT(-100 40)", None, None, None),
+            EdrEngine::query_position(&view, "POINT(-100 40)", None, None, None, None),
             Err(ds_core::error::DataServerError::LocationNotFound(_))
         ),
         "a point ~7000 km from the radar must be outside coverage (404)"
@@ -878,7 +887,7 @@ fn pvol_edr_query_position_returns_vertical_profiles() {
         return;
     };
     // ~30 km north of Vihti — inside the lowest sweep.
-    let response = EdrEngine::query_position(&view, "POINT(24.5 60.85)", None, None, None)
+    let response = EdrEngine::query_position(&view, "POINT(24.5 60.85)", None, None, None, None)
         .expect("position query inside radar coverage");
     let coverages = match response {
         CoverageResponse::Collection(c) => c,
@@ -915,7 +924,7 @@ fn pvol_edr_query_position_with_z_returns_point_series() {
     let vertical = EdrEngine::get_vertical_extent(&view).expect("PVOL has a vertical extent");
     let level = vertical.levels[0];
     let response =
-        EdrEngine::query_position(&view, "POINT(24.5 60.85)", None, None, Some(&[level]))
+        EdrEngine::query_position(&view, "POINT(24.5 60.85)", None, None, Some(&[level]), None)
             .expect("z-pinned position query");
     let result = match response {
         CoverageResponse::Single(qr) => qr,
@@ -937,7 +946,7 @@ fn pvol_edr_query_location_by_nod() {
         eprintln!("skipping pvol_edr_query_location_by_nod: fixture absent");
         return;
     };
-    let response = EdrEngine::query_location(&view, "fivih", None, None, None)
+    let response = EdrEngine::query_location(&view, "fivih", None, None, None, None)
         .expect("query_location for the fivih site");
     let coverages = match response {
         CoverageResponse::Collection(c) => c,
@@ -951,7 +960,7 @@ fn pvol_edr_query_location_by_nod() {
         ));
     }
 
-    match EdrEngine::query_location(&view, "nosuchsite", None, None, None) {
+    match EdrEngine::query_location(&view, "nosuchsite", None, None, None, None) {
         Err(ds_core::error::DataServerError::LocationNotFound(_)) => {}
         other => panic!("unknown location id must be LocationNotFound, got {other:?}"),
     }
@@ -966,7 +975,7 @@ fn pvol_edr_query_area_collects_sites() {
         return;
     };
     // A bbox enclosing Vihti (24.50E, 60.56N).
-    let result = EdrEngine::query_area(&view, "23.0,59.0,26.0,62.0", None, None, None)
+    let result = EdrEngine::query_area(&view, "23.0,59.0,26.0,62.0", None, None, None, None)
         .expect("area query enclosing the fivih site");
     match result {
         CoverageResponse::Collection(coverages) => {
@@ -987,7 +996,7 @@ fn pvol_edr_query_area_collects_sites() {
     }
 
     // A polygon far from any FMI radar matches nothing.
-    match EdrEngine::query_area(&view, "0.0,0.0,1.0,1.0", None, None, None) {
+    match EdrEngine::query_area(&view, "0.0,0.0,1.0,1.0", None, None, None, None) {
         Err(ds_core::error::DataServerError::LocationNotFound(_)) => {}
         other => panic!("an empty area must be LocationNotFound, got {other:?}"),
     }
@@ -1019,6 +1028,7 @@ fn pvol_edr_query_trajectory_returns_section() {
         None,
         Some(&["DBZH".to_string()]),
         Some(&[0.5, 5.0]),
+        None,
     )
     .expect("trajectory query inside radar coverage");
     let qr = match &response {
@@ -1074,6 +1084,7 @@ fn pvol_edr_query_trajectory_out_of_coverage_yields_empty_cells() {
         None,
         Some(&["DBZH".to_string()]),
         Some(&[0.5, 3.0]),
+        None,
     ) {
         Ok(response) => {
             let qr = match response {
@@ -1110,7 +1121,7 @@ fn pvol_edr_query_trajectory_rejects_malformed_linestring() {
         "LINESTRINGZ(27.1 60.9 0, 27.1 61.1 100)",
         "LINESTRING(NaN 60.9, 27.1 61.1)",
     ] {
-        match EdrEngine::query_trajectory(&view, bad, None, None, None) {
+        match EdrEngine::query_trajectory(&view, bad, None, None, None, None) {
             Err(ds_core::error::DataServerError::InvalidParameter(_)) => {}
             other => panic!("expected InvalidParameter for `{bad}`, got {other:?}"),
         }
@@ -1209,6 +1220,7 @@ fn comp_engine_remote_scan_discovers_and_renders_dmi_fixture() {
             64,
             None,
             &OutputCrs::Wgs84,
+            None,
             None,
             None,
         )

--- a/crates/engine-postgis/src/engine.rs
+++ b/crates/engine-postgis/src/engine.rs
@@ -148,6 +148,7 @@ impl EdrEngine for PostgisEngine {
         datetime: Option<(DateTime<Utc>, DateTime<Utc>)>,
         parameters: Option<&[String]>,
         _z: Option<&[f64]>,
+        _reference_time: Option<DateTime<Utc>>,
     ) -> Result<CoverageResponse, DataServerError> {
         let source_keys = resolve_source_keys(&self.config, parameters)?;
         let key_refs: Vec<&str> = source_keys.iter().map(String::as_str).collect();
@@ -173,10 +174,11 @@ impl EdrEngine for PostgisEngine {
         datetime: Option<(DateTime<Utc>, DateTime<Utc>)>,
         parameters: Option<&[String]>,
         z: Option<&[f64]>,
+        reference_time: Option<DateTime<Utc>>,
     ) -> Result<CoverageResponse, DataServerError> {
         let (lon, lat) = parse_coords(coords)?;
         let station_id = resolve_nearest_station(&self.pool, &self.config, lon, lat)?;
-        self.query_location(&station_id, datetime, parameters, z)
+        self.query_location(&station_id, datetime, parameters, z, reference_time)
     }
 
     fn query_area(
@@ -185,6 +187,7 @@ impl EdrEngine for PostgisEngine {
         datetime: Option<(DateTime<Utc>, DateTime<Utc>)>,
         parameters: Option<&[String]>,
         _z: Option<&[f64]>,
+        _reference_time: Option<DateTime<Utc>>,
     ) -> Result<CoverageResponse, DataServerError> {
         let polygon_wkt = normalize_area_wkt(coords)?;
         let source_keys = resolve_source_keys(&self.config, parameters)?;

--- a/crates/engine-querydata/src/engine.rs
+++ b/crates/engine-querydata/src/engine.rs
@@ -219,6 +219,14 @@ impl EdrEngine for QueryDataEngine {
         !self.runs.load().runs.is_empty()
     }
 
+    fn find_instance(&self, reference_time: DateTime<Utc>) -> Option<RunInfo> {
+        let set = self.runs.load();
+        set.runs.get(&reference_time).map(|e| RunInfo {
+            reference_time,
+            valid_times: e.data.times.clone(),
+        })
+    }
+
     fn query_location(
         &self,
         _location_id: &str,
@@ -531,6 +539,10 @@ impl MapEngine for QueryDataEngine {
 /// the latest run). Returns empty on a directory read error.
 fn list_sqd_files(dir: &Path) -> Vec<PathBuf> {
     let Ok(rd) = std::fs::read_dir(dir) else {
+        // A read failure (e.g. a permissions regression) is indistinguishable
+        // from "empty" to callers — log it so a silent stale-data situation has
+        // a breadcrumb. Poll then keeps the current data.
+        tracing::warn!(dir = %dir.display(), "cannot read .sqd directory; keeping current data");
         return Vec::new();
     };
     let mut entries: Vec<PathBuf> = rd

--- a/crates/engine-querydata/src/engine.rs
+++ b/crates/engine-querydata/src/engine.rs
@@ -566,6 +566,15 @@ fn list_sqd_files(dir: &Path) -> Vec<PathBuf> {
 ///
 /// `files` is the directory listing (ascending; see [`list_sqd_files`]) — the
 /// caller lists once and passes it in so poll never reads the directory twice.
+///
+/// The "most recent" window is taken by **filename sort**, which assumes the
+/// standard `…YYYYMMDDHHMM.sqd` naming where lexical order matches origin-time
+/// order. This keeps poll cheap — only the window's files are parsed (others are
+/// reused from `prev` by path) rather than parsing every file in the directory
+/// to read its origin time. A reissued run whose filename sorts out of origin
+/// order could thus be windowed wrong; that's an accepted limitation of the
+/// naming-convention assumption (the BTreeMap still keys by origin time, and a
+/// same-origin collision is logged below).
 fn build_runset(files: &[PathBuf], max_runs: usize, prev: &RunSet, collection_id: &str) -> RunSet {
     // Keep only the most recent `max_runs` files (the listing is ascending).
     let window = &files[files.len().saturating_sub(max_runs)..];

--- a/crates/engine-querydata/src/engine.rs
+++ b/crates/engine-querydata/src/engine.rs
@@ -161,8 +161,8 @@ impl QueryDataEngine {
         instances::select_run(&set.runs, reference_time)
             .map(|(_, e)| e.data.clone())
             .ok_or_else(|| match reference_time {
-                Some(rt) => DataServerError::InvalidParameter(format!(
-                    "No model run for reference time {rt}"
+                Some(rt) => DataServerError::ReferenceTimeNotFound(format!(
+                    "no model run for reference time {rt}"
                 )),
                 None => DataServerError::Engine("No data available".into()),
             })
@@ -213,6 +213,10 @@ impl EdrEngine for QueryDataEngine {
     fn get_instances(&self) -> Vec<RunInfo> {
         let set = self.runs.load();
         instances::build_instances(&set.runs, |_, e| e.data.times.clone())
+    }
+
+    fn has_instances(&self) -> bool {
+        !self.runs.load().runs.is_empty()
     }
 
     fn query_location(

--- a/crates/engine-querydata/src/engine.rs
+++ b/crates/engine-querydata/src/engine.rs
@@ -130,17 +130,19 @@ impl QueryDataEngine {
             return; // no files (or unreadable dir) — keep current data
         }
 
-        // Successful directory read — update staleness tracker
+        let prev = self.runs.load();
+        let new_set = build_runset(&files, self.max_runs, &prev, &self.collection_id);
+        if new_set.runs.is_empty() {
+            return; // nothing loadable (e.g. all files corrupt) — keep old data
+                    // and do NOT stamp freshness; data_age keeps growing.
+        }
+
+        // We have a usable run set — stamp freshness (reflects loadable data, not
+        // merely a readable directory).
         *self
             .data_updated_at
             .lock()
             .unwrap_or_else(|e| e.into_inner()) = Some(Utc::now());
-
-        let prev = self.runs.load();
-        let new_set = build_runset(&files, self.max_runs, &prev, &self.collection_id);
-        if new_set.runs.is_empty() {
-            return; // nothing loadable — keep old data
-        }
 
         // Swap only when the retained file set actually changed (add/remove).
         let prev_paths: BTreeSet<&Path> = prev.runs.values().map(|e| e.path.as_path()).collect();

--- a/crates/engine-querydata/src/engine.rs
+++ b/crates/engine-querydata/src/engine.rs
@@ -78,7 +78,8 @@ impl QueryDataEngine {
         max_runs: usize,
     ) -> Result<Self, DataServerError> {
         let max_runs = max_runs.max(1);
-        let runset = load_runset(data_dir, max_runs, &RunSet::default(), collection_id);
+        let files = list_sqd_files(data_dir);
+        let runset = build_runset(&files, max_runs, &RunSet::default(), collection_id);
         if runset.runs.is_empty() {
             return Err(DataServerError::Engine(format!(
                 "[{collection_id}] No loadable .sqd files found in {}",
@@ -123,9 +124,10 @@ impl QueryDataEngine {
     }
 
     fn poll_once(&self) {
-        // No directory read at all → keep current data (don't touch staleness).
-        if list_sqd_files(&self.data_dir).is_empty() {
-            return;
+        // List the directory once; reuse for the staleness guard and the rebuild.
+        let files = list_sqd_files(&self.data_dir);
+        if files.is_empty() {
+            return; // no files (or unreadable dir) — keep current data
         }
 
         // Successful directory read — update staleness tracker
@@ -135,7 +137,7 @@ impl QueryDataEngine {
             .unwrap_or_else(|e| e.into_inner()) = Some(Utc::now());
 
         let prev = self.runs.load();
-        let new_set = load_runset(&self.data_dir, self.max_runs, &prev, &self.collection_id);
+        let new_set = build_runset(&files, self.max_runs, &prev, &self.collection_id);
         if new_set.runs.is_empty() {
             return; // nothing loadable — keep old data
         }
@@ -543,29 +545,32 @@ fn list_sqd_files(dir: &Path) -> Vec<PathBuf> {
 /// as model runs (keyed by origin time), reusing already-parsed entries from
 /// `prev` whose path is unchanged (so poll never re-parses a stable run).
 /// Unloadable files are logged and skipped.
-fn load_runset(dir: &Path, max_runs: usize, prev: &RunSet, collection_id: &str) -> RunSet {
-    let mut files = list_sqd_files(dir);
-    // Keep only the most recent `max_runs` files.
-    if files.len() > max_runs {
-        files.drain(0..files.len() - max_runs);
-    }
+///
+/// `files` is the directory listing (ascending; see [`list_sqd_files`]) — the
+/// caller lists once and passes it in so poll never reads the directory twice.
+fn build_runset(files: &[PathBuf], max_runs: usize, prev: &RunSet, collection_id: &str) -> RunSet {
+    // Keep only the most recent `max_runs` files (the listing is ascending).
+    let window = &files[files.len().saturating_sub(max_runs)..];
 
     let by_path: HashMap<&Path, &RunEntry> =
         prev.runs.values().map(|e| (e.path.as_path(), e)).collect();
 
     let mut runs: BTreeMap<DateTime<Utc>, RunEntry> = BTreeMap::new();
-    for path in files {
+    for path in window {
         let entry = if let Some(existing) = by_path.get(path.as_path()) {
             RunEntry {
                 data: existing.data.clone(),
-                path,
+                path: path.clone(),
             }
         } else {
-            match load_file(&path, collection_id) {
+            match load_file(path, collection_id) {
                 Ok(data) => {
                     let data = Arc::new(data);
-                    log_loaded(collection_id, &path, &data);
-                    RunEntry { data, path }
+                    log_loaded(collection_id, path, &data);
+                    RunEntry {
+                        data,
+                        path: path.clone(),
+                    }
                 }
                 Err(e) => {
                     // `e` already carries the `[collection_id]` prefix.
@@ -574,7 +579,16 @@ fn load_runset(dir: &Path, max_runs: usize, prev: &RunSet, collection_id: &str) 
                 }
             }
         };
-        runs.insert(entry.data.origin_time, entry);
+        // Two files decoding to the same origin time (e.g. a reissued run) would
+        // collide on the key; the later-sorted file wins. Surface the drop so it
+        // isn't silent.
+        if let Some(prev) = runs.insert(entry.data.origin_time, entry) {
+            tracing::warn!(
+                "[{collection_id}] two .sqd files share origin time {}; keeping the later one, dropping {}",
+                prev.data.origin_time,
+                prev.path.display()
+            );
+        }
     }
     RunSet { runs }
 }

--- a/crates/engine-querydata/src/engine.rs
+++ b/crates/engine-querydata/src/engine.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -9,6 +9,7 @@ use tokio::sync::watch;
 
 use ds_core::edr_engine::EdrEngine;
 use ds_core::error::DataServerError;
+use ds_core::instances::{self, RunInfo};
 use ds_core::map_engine::{MapEngine, OutputCrs, RasterInfo, RasterTile};
 use ds_core::model::{
     CoverageResponse, DomainDescription, Location, NdArray, ParameterDescription, QueryResult,
@@ -16,24 +17,48 @@ use ds_core::model::{
 
 use crate::parse::QueryData;
 
+/// One retained model run: a parsed `.sqd` file plus its source path (for
+/// change detection on poll). Keyed in [`RunSet`] by the file's origin time.
+struct RunEntry {
+    data: Arc<QueryData>,
+    path: PathBuf,
+}
+
+/// The retained model runs, keyed by origin (analysis / forecast reference)
+/// time, ascending — so `values().next_back()` is the latest run. Swapped
+/// atomically on poll. See [`ds_core::instances`].
+#[derive(Default)]
+struct RunSet {
+    runs: BTreeMap<DateTime<Utc>, RunEntry>,
+}
+
+impl RunSet {
+    /// The latest (most recent reference time) run, if any.
+    fn latest(&self) -> Option<&RunEntry> {
+        self.runs.values().next_back()
+    }
+}
+
 /// QueryData engine serving multi-parameter NWP/observation gridded data.
 ///
-/// Polls a directory for `.sqd` files. The latest file (by filename sort)
-/// is loaded and served. When a new file appears, it is atomically swapped
-/// in via `ArcSwap`.
+/// Polls a directory for `.sqd` files and retains the most recent `max_runs`
+/// as model runs (keyed by origin time), exposing each as an OGC EDR instance /
+/// WMS `reference_time` (#337). The newest run is the default for un-pinned
+/// queries. New/removed files are picked up on poll and the run set is swapped
+/// atomically via `ArcSwap`; already-loaded files are reused (not re-parsed).
 pub struct QueryDataEngine {
-    /// Current loaded data. Swapped atomically on poll.
-    data: ArcSwap<QueryData>,
+    /// Retained model runs. Swapped atomically on poll.
+    runs: ArcSwap<RunSet>,
     /// Directory to poll for .sqd files.
     data_dir: PathBuf,
-    /// Currently loaded filename (for change detection).
-    current_file: ArcSwap<Option<PathBuf>>,
     /// Parameter name to render for MapEngine (matched by name on each load).
     wms_parameter: Option<String>,
     /// Collection ID for logging.
     collection_id: String,
     /// Poll interval.
     poll_interval: Duration,
+    /// How many recent runs to retain (>= 1).
+    max_runs: usize,
     /// Shutdown signal.
     shutdown_tx: watch::Sender<()>,
     /// Tracks when data was last successfully loaded/updated.
@@ -50,27 +75,26 @@ impl QueryDataEngine {
         collection_id: &str,
         wms_parameter: Option<&str>,
         poll_interval_secs: u64,
+        max_runs: usize,
     ) -> Result<Self, DataServerError> {
-        let latest = find_latest_sqd(data_dir).ok_or_else(|| {
-            DataServerError::Engine(format!(
-                "[{collection_id}] No .sqd files found in {}",
+        let max_runs = max_runs.max(1);
+        let runset = load_runset(data_dir, max_runs, &RunSet::default(), collection_id);
+        if runset.runs.is_empty() {
+            return Err(DataServerError::Engine(format!(
+                "[{collection_id}] No loadable .sqd files found in {}",
                 data_dir.display()
-            ))
-        })?;
-
-        let data = load_file(&latest, collection_id)?;
-
-        log_loaded(collection_id, &latest, &data);
+            )));
+        }
 
         let (shutdown_tx, _) = watch::channel(());
 
         Ok(Self {
-            data: ArcSwap::from_pointee(data),
+            runs: ArcSwap::from_pointee(runset),
             data_dir: data_dir.to_path_buf(),
-            current_file: ArcSwap::from_pointee(Some(latest)),
             wms_parameter: wms_parameter.map(String::from),
             collection_id: collection_id.to_string(),
             poll_interval: Duration::from_secs(poll_interval_secs.max(1)),
+            max_runs,
             shutdown_tx,
             data_updated_at: Mutex::new(Some(Utc::now())),
         })
@@ -99,10 +123,10 @@ impl QueryDataEngine {
     }
 
     fn poll_once(&self) {
-        let latest = match find_latest_sqd(&self.data_dir) {
-            Some(p) => p,
-            None => return, // no files — keep current data
-        };
+        // No directory read at all → keep current data (don't touch staleness).
+        if list_sqd_files(&self.data_dir).is_empty() {
+            return;
+        }
 
         // Successful directory read — update staleness tracker
         *self
@@ -110,32 +134,42 @@ impl QueryDataEngine {
             .lock()
             .unwrap_or_else(|e| e.into_inner()) = Some(Utc::now());
 
-        // Check if file changed
-        let current = self.current_file.load();
-        if current.as_deref() == Some(&latest) {
-            return;
+        let prev = self.runs.load();
+        let new_set = load_runset(&self.data_dir, self.max_runs, &prev, &self.collection_id);
+        if new_set.runs.is_empty() {
+            return; // nothing loadable — keep old data
         }
 
-        match load_file(&latest, &self.collection_id) {
-            Ok(new_data) => {
-                log_loaded(&self.collection_id, &latest, &new_data);
-                self.data.store(Arc::new(new_data));
-                self.current_file.store(Arc::new(Some(latest)));
-            }
-            Err(e) => {
-                tracing::error!(
-                    "[{}] Failed to load {}: {e}",
-                    self.collection_id,
-                    latest.display()
-                );
-                // Keep old data on failure
-            }
+        // Swap only when the retained file set actually changed (add/remove).
+        let prev_paths: BTreeSet<&Path> = prev.runs.values().map(|e| e.path.as_path()).collect();
+        let new_paths: BTreeSet<&Path> = new_set.runs.values().map(|e| e.path.as_path()).collect();
+        if prev_paths != new_paths {
+            self.runs.store(Arc::new(new_set));
         }
     }
 
-    /// Get a snapshot of the current data.
-    fn load_data(&self) -> arc_swap::Guard<Arc<QueryData>> {
-        self.data.load()
+    /// The data for a requested model run: `None` ⇒ the latest run; `Some(rt)` ⇒
+    /// the run with exactly that reference time (absent ⇒ error → 404). Shares
+    /// the selection rule with every forecast engine via [`instances::select_run`].
+    fn select_data(
+        &self,
+        reference_time: Option<DateTime<Utc>>,
+    ) -> Result<Arc<QueryData>, DataServerError> {
+        let set = self.runs.load();
+        instances::select_run(&set.runs, reference_time)
+            .map(|(_, e)| e.data.clone())
+            .ok_or_else(|| match reference_time {
+                Some(rt) => DataServerError::InvalidParameter(format!(
+                    "No model run for reference time {rt}"
+                )),
+                None => DataServerError::Engine("No data available".into()),
+            })
+    }
+
+    /// A snapshot of the latest run's data (for run-agnostic metadata). The
+    /// engine always retains at least one run after construction.
+    fn latest_data(&self) -> Option<Arc<QueryData>> {
+        self.runs.load().latest().map(|e| e.data.clone())
     }
 
     /// Resolve the map parameter index for the current data snapshot.
@@ -149,7 +183,7 @@ impl QueryDataEngine {
 
     /// Check if this engine has data loaded.
     pub fn has_data(&self) -> bool {
-        !self.data.load().times.is_empty()
+        self.latest_data().is_some_and(|d| !d.times.is_empty())
     }
 
     /// The collection ID this engine serves.
@@ -172,12 +206,20 @@ impl EdrEngine for QueryDataEngine {
         Ok(vec![])
     }
 
+    /// Each retained `.sqd` file is a model run / EDR instance (latest last),
+    /// with its own valid times.
+    fn get_instances(&self) -> Vec<RunInfo> {
+        let set = self.runs.load();
+        instances::build_instances(&set.runs, |_, e| e.data.times.clone())
+    }
+
     fn query_location(
         &self,
         _location_id: &str,
         _datetime: Option<(DateTime<Utc>, DateTime<Utc>)>,
         _parameters: Option<&[String]>,
         _z: Option<&[f64]>,
+        _reference_time: Option<DateTime<Utc>>,
     ) -> Result<CoverageResponse, DataServerError> {
         Err(DataServerError::InvalidParameter(
             "QueryData engine does not support location queries (use position query)".into(),
@@ -185,12 +227,16 @@ impl EdrEngine for QueryDataEngine {
     }
 
     fn get_parameters(&self) -> Vec<String> {
-        let data = self.load_data();
+        let Some(data) = self.latest_data() else {
+            return Vec::new();
+        };
         data.params.iter().map(|p| p.name.clone()).collect()
     }
 
     fn get_parameter_descriptions(&self) -> HashMap<String, ParameterDescription> {
-        let data = self.load_data();
+        let Some(data) = self.latest_data() else {
+            return HashMap::new();
+        };
         data.params
             .iter()
             .map(|p| {
@@ -207,14 +253,14 @@ impl EdrEngine for QueryDataEngine {
     }
 
     fn get_temporal_extent(&self) -> Option<(DateTime<Utc>, DateTime<Utc>)> {
-        let data = self.load_data();
+        let data = self.latest_data()?;
         let first = data.times.first()?;
         let last = data.times.last()?;
         Some((*first, *last))
     }
 
     fn get_spatial_extent(&self) -> Option<[f64; 4]> {
-        let data = self.load_data();
+        let data = self.latest_data()?;
         let bl = data.grid.area.bottom_left;
         let tr = data.grid.area.top_right;
         // Normalize to [west, south, east, north]. `bottom_left`/`top_right` are
@@ -240,9 +286,10 @@ impl EdrEngine for QueryDataEngine {
         datetime: Option<(DateTime<Utc>, DateTime<Utc>)>,
         parameters: Option<&[String]>,
         _z: Option<&[f64]>,
+        reference_time: Option<DateTime<Utc>>,
     ) -> Result<CoverageResponse, DataServerError> {
         let (lat, lon) = parse_coords(coords)?;
-        let data = self.load_data();
+        let data = self.select_data(reference_time)?;
 
         let time_indices = find_time_range(&data, datetime);
         if time_indices.is_empty() {
@@ -313,6 +360,7 @@ impl EdrEngine for QueryDataEngine {
 }
 
 impl MapEngine for QueryDataEngine {
+    #[allow(clippy::too_many_arguments)] // bbox/size/time/crs/parameter/z/reference_time are all genuine selectors
     fn get_raster_tile(
         &self,
         bbox: [f64; 4],
@@ -322,9 +370,10 @@ impl MapEngine for QueryDataEngine {
         output_crs: &OutputCrs,
         parameter: Option<&str>,
         z: Option<f64>,
+        reference_time: Option<DateTime<Utc>>,
     ) -> Result<RasterTile, DataServerError> {
         let _ = z; // QueryData collections expose no vertical dimension yet (#185)
-        let data = self.load_data();
+        let data = self.select_data(reference_time)?;
         let param_idx = if let Some(param_name) = parameter {
             data.param_index_by_name(param_name)
                 .unwrap_or_else(|| self.resolve_map_param_idx(&data))
@@ -391,7 +440,29 @@ impl MapEngine for QueryDataEngine {
     }
 
     fn raster_info(&self) -> RasterInfo {
-        let data = self.load_data();
+        let set = self.runs.load();
+        // Every retained run is a selectable reference time (WMS dimension /
+        // EDR instance); ascending, latest last.
+        let reference_times: Vec<DateTime<Utc>> = set.runs.keys().copied().collect();
+        let data = match set.latest() {
+            Some(e) => e.data.clone(),
+            None => {
+                // No runs retained (shouldn't happen post-construction).
+                return RasterInfo {
+                    native_crs: "CRS:84".to_string(),
+                    spatial_extent: None,
+                    times: Vec::new(),
+                    parameter: String::new(),
+                    unit: String::new(),
+                    parameters: Vec::new(),
+                    vertical: None,
+                    grid_size: None,
+                    layer_subtitle: None,
+                    reference_times,
+                };
+            }
+        };
+        drop(set);
         let param_idx = self.resolve_map_param_idx(&data);
 
         let param_name = data
@@ -440,6 +511,7 @@ impl MapEngine for QueryDataEngine {
             vertical: None,
             grid_size: Some([gt.width, gt.height]),
             layer_subtitle: None,
+            reference_times,
         }
     }
 }
@@ -448,10 +520,14 @@ impl MapEngine for QueryDataEngine {
 // Free functions (operate on QueryData snapshots, not &self)
 // ============================================================================
 
-/// Find the latest .sqd file in a directory (by filename, lexicographic sort).
-fn find_latest_sqd(dir: &Path) -> Option<PathBuf> {
-    let mut entries: Vec<PathBuf> = std::fs::read_dir(dir)
-        .ok()?
+/// List `.sqd` files in a directory, sorted ascending by filename (lexicographic
+/// ≈ chronological for the usual `…YYYYMMDDHHMM.sqd` naming, so the last entry is
+/// the latest run). Returns empty on a directory read error.
+fn list_sqd_files(dir: &Path) -> Vec<PathBuf> {
+    let Ok(rd) = std::fs::read_dir(dir) else {
+        return Vec::new();
+    };
+    let mut entries: Vec<PathBuf> = rd
         .filter_map(|e| e.ok())
         .map(|e| e.path())
         .filter(|p| {
@@ -459,9 +535,48 @@ fn find_latest_sqd(dir: &Path) -> Option<PathBuf> {
                 .is_some_and(|ext| ext.eq_ignore_ascii_case("sqd"))
         })
         .collect();
-
     entries.sort();
-    entries.pop() // last = lexicographically latest
+    entries
+}
+
+/// Build a [`RunSet`] from the directory: load the most recent `max_runs` files
+/// as model runs (keyed by origin time), reusing already-parsed entries from
+/// `prev` whose path is unchanged (so poll never re-parses a stable run).
+/// Unloadable files are logged and skipped.
+fn load_runset(dir: &Path, max_runs: usize, prev: &RunSet, collection_id: &str) -> RunSet {
+    let mut files = list_sqd_files(dir);
+    // Keep only the most recent `max_runs` files.
+    if files.len() > max_runs {
+        files.drain(0..files.len() - max_runs);
+    }
+
+    let by_path: HashMap<&Path, &RunEntry> =
+        prev.runs.values().map(|e| (e.path.as_path(), e)).collect();
+
+    let mut runs: BTreeMap<DateTime<Utc>, RunEntry> = BTreeMap::new();
+    for path in files {
+        let entry = if let Some(existing) = by_path.get(path.as_path()) {
+            RunEntry {
+                data: existing.data.clone(),
+                path,
+            }
+        } else {
+            match load_file(&path, collection_id) {
+                Ok(data) => {
+                    let data = Arc::new(data);
+                    log_loaded(collection_id, &path, &data);
+                    RunEntry { data, path }
+                }
+                Err(e) => {
+                    // `e` already carries the `[collection_id]` prefix.
+                    tracing::error!("{e}");
+                    continue;
+                }
+            }
+        };
+        runs.insert(entry.data.origin_time, entry);
+    }
+    RunSet { runs }
 }
 
 fn load_file(path: &Path, collection_id: &str) -> Result<QueryData, DataServerError> {
@@ -675,13 +790,13 @@ mod tests {
     }
 
     fn test_file_exists() -> bool {
-        test_dir().exists() && find_latest_sqd(&test_dir()).is_some()
+        test_dir().exists() && !list_sqd_files(&test_dir()).is_empty()
     }
 
     #[test]
     fn engine_from_directory() {
         assert!(test_file_exists(), "ecmwf-kenya fixture missing");
-        let engine = QueryDataEngine::new(&test_dir(), "test", None, 30).unwrap();
+        let engine = QueryDataEngine::new(&test_dir(), "test", None, 30, 4).unwrap();
         assert!(engine.has_data());
         let params = engine.get_parameters();
         assert_eq!(params.len(), 3);
@@ -690,7 +805,7 @@ mod tests {
     #[test]
     fn engine_spatial_extent() {
         assert!(test_file_exists(), "ecmwf-kenya fixture missing");
-        let engine = QueryDataEngine::new(&test_dir(), "test", None, 30).unwrap();
+        let engine = QueryDataEngine::new(&test_dir(), "test", None, 30, 4).unwrap();
         // [west, south, east, north] — normalized, so south < north even though
         // this fixture's stored bottom_left lat (4.75) is north of top_right
         // (-5.25). Guards the get_spatial_extent min/max normalization.
@@ -709,10 +824,10 @@ mod tests {
         // the result must still be a valid [west, south, east, north].
         let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../testdata/meps");
         assert!(
-            dir.exists() && find_latest_sqd(&dir).is_some(),
+            dir.exists() && !list_sqd_files(&dir).is_empty(),
             "meps fixture missing"
         );
-        let engine = QueryDataEngine::new(&dir, "test", None, 30).unwrap();
+        let engine = QueryDataEngine::new(&dir, "test", None, 30, 4).unwrap();
         let bbox = engine.get_spatial_extent().unwrap();
         assert!(bbox[0] < bbox[2], "west {} < east {}", bbox[0], bbox[2]);
         assert!(bbox[1] < bbox[3], "south {} < north {}", bbox[1], bbox[3]);
@@ -727,7 +842,7 @@ mod tests {
     #[test]
     fn engine_temporal_extent() {
         assert!(test_file_exists(), "ecmwf-kenya fixture missing");
-        let engine = QueryDataEngine::new(&test_dir(), "test", None, 30).unwrap();
+        let engine = QueryDataEngine::new(&test_dir(), "test", None, 30, 4).unwrap();
         let (first, last) = engine.get_temporal_extent().unwrap();
         assert_eq!(
             first.format("%Y-%m-%dT%H:%M").to_string(),
@@ -739,10 +854,10 @@ mod tests {
     #[test]
     fn engine_position_query() {
         assert!(test_file_exists(), "ecmwf-kenya fixture missing");
-        let engine = QueryDataEngine::new(&test_dir(), "test", None, 30).unwrap();
+        let engine = QueryDataEngine::new(&test_dir(), "test", None, 30, 4).unwrap();
 
         let response = engine
-            .query_position("POINT(36.8 -1.3)", None, None, None)
+            .query_position("POINT(36.8 -1.3)", None, None, None, None)
             .unwrap();
         let result = match response {
             CoverageResponse::Single(qr) => qr,
@@ -760,11 +875,11 @@ mod tests {
     #[test]
     fn engine_position_query_filtered_params() {
         assert!(test_file_exists(), "ecmwf-kenya fixture missing");
-        let engine = QueryDataEngine::new(&test_dir(), "test", None, 30).unwrap();
+        let engine = QueryDataEngine::new(&test_dir(), "test", None, 30, 4).unwrap();
 
         let params = vec!["2 Metre Temperature (2t)".to_string()];
         let response = engine
-            .query_position("POINT(36.8 -1.3)", None, Some(&params), None)
+            .query_position("POINT(36.8 -1.3)", None, Some(&params), None, None)
             .unwrap();
         let result = match response {
             CoverageResponse::Single(qr) => qr,
@@ -779,7 +894,7 @@ mod tests {
     fn map_engine_raster_tile() {
         assert!(test_file_exists(), "ecmwf-kenya fixture missing");
         let engine =
-            QueryDataEngine::new(&test_dir(), "test", Some("2 Metre Temperature (2t)"), 30)
+            QueryDataEngine::new(&test_dir(), "test", Some("2 Metre Temperature (2t)"), 30, 4)
                 .unwrap();
 
         let tile = engine
@@ -789,6 +904,7 @@ mod tests {
                 16,
                 None,
                 &OutputCrs::Wgs84,
+                None,
                 None,
                 None,
             )
@@ -809,7 +925,7 @@ mod tests {
         // the fixture is nowhere near the TM35FIN zone.
         assert!(test_file_exists(), "ecmwf-kenya fixture missing");
         let engine =
-            QueryDataEngine::new(&test_dir(), "test", Some("2 Metre Temperature (2t)"), 30)
+            QueryDataEngine::new(&test_dir(), "test", Some("2 Metre Temperature (2t)"), 30, 4)
                 .unwrap();
         let crs = ds_core::geo::projected_output_crs("EPSG:3067").unwrap();
         let proj = ds_core::geo::projected_envelope(&crs, [33.0, -5.0, 42.0, 5.0]);
@@ -821,6 +937,7 @@ mod tests {
                 16,
                 None,
                 &OutputCrs::Projected { crs, bbox: proj },
+                None,
                 None,
                 None,
             )
@@ -841,7 +958,7 @@ mod tests {
     fn map_engine_raster_info() {
         assert!(test_file_exists(), "ecmwf-kenya fixture missing");
         let engine =
-            QueryDataEngine::new(&test_dir(), "test", Some("2 Metre Temperature (2t)"), 30)
+            QueryDataEngine::new(&test_dir(), "test", Some("2 Metre Temperature (2t)"), 30, 4)
                 .unwrap();
         let info = engine.raster_info();
 
@@ -853,11 +970,43 @@ mod tests {
     }
 
     #[test]
-    fn find_latest_sqd_in_dir() {
+    fn list_sqd_files_in_dir() {
         assert!(test_file_exists(), "ecmwf-kenya fixture missing");
-        let latest = find_latest_sqd(&test_dir());
-        assert!(latest.is_some());
-        let name = latest.unwrap();
-        assert!(name.to_string_lossy().ends_with(".sqd"));
+        let files = list_sqd_files(&test_dir());
+        assert!(!files.is_empty());
+        let latest = files.last().unwrap();
+        assert!(latest.to_string_lossy().ends_with(".sqd"));
+    }
+
+    #[test]
+    fn instances_expose_runs_latest_default() {
+        assert!(test_file_exists(), "ecmwf-kenya fixture missing");
+        let engine = QueryDataEngine::new(&test_dir(), "test", None, 30, 4).unwrap();
+        let instances = engine.get_instances();
+        // The fixture dir has at least one .sqd → at least one run/instance.
+        assert!(!instances.is_empty());
+        // raster_info advertises the same runs as reference times.
+        assert_eq!(engine.raster_info().reference_times.len(), instances.len());
+        // An un-pinned position query (reference_time = None) serves the latest
+        // run; pinning the latest run's reference time returns the same series.
+        let latest_rt = instances.last().unwrap().reference_time;
+        let default = engine
+            .query_position("POINT(36.8 -1.3)", None, None, None, None)
+            .unwrap();
+        let pinned = engine
+            .query_position("POINT(36.8 -1.3)", None, None, None, Some(latest_rt))
+            .unwrap();
+        let (a, b) = match (default, pinned) {
+            (CoverageResponse::Single(a), CoverageResponse::Single(b)) => (a, b),
+            _ => panic!("expected Single coverages"),
+        };
+        assert_eq!(a.ranges.len(), b.ranges.len());
+        // A bogus reference time is rejected (→ 404 at the API layer).
+        let bogus = chrono::DateTime::parse_from_rfc3339("1990-01-01T00:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        assert!(engine
+            .query_position("POINT(36.8 -1.3)", None, None, None, Some(bogus))
+            .is_err());
     }
 }

--- a/crates/engine-zarr/src/catalog.rs
+++ b/crates/engine-zarr/src/catalog.rs
@@ -758,6 +758,7 @@ fn build_raster_info(
         native_crs: "CRS:84".to_string(),
         spatial_extent: Some(extent),
         times: times.to_vec(),
+        reference_times: Vec::new(),
         parameter,
         unit,
         parameters,

--- a/crates/engine-zarr/src/lib.rs
+++ b/crates/engine-zarr/src/lib.rs
@@ -148,6 +148,7 @@ impl EdrEngine for ZarrEngine {
         _datetime: Option<(DateTime<Utc>, DateTime<Utc>)>,
         _parameters: Option<&[String]>,
         _z: Option<&[f64]>,
+        _reference_time: Option<DateTime<Utc>>,
     ) -> Result<CoverageResponse, DataServerError> {
         Err(DataServerError::InvalidParameter(
             "Zarr engine does not support location queries (use a position query)".into(),
@@ -209,6 +210,7 @@ impl EdrEngine for ZarrEngine {
         datetime: Option<(DateTime<Utc>, DateTime<Utc>)>,
         parameters: Option<&[String]>,
         _z: Option<&[f64]>,
+        _reference_time: Option<DateTime<Utc>>,
     ) -> Result<CoverageResponse, DataServerError> {
         let (lon, lat) = parse_coords(coords)?;
         let cat = self.catalog.load();
@@ -346,6 +348,7 @@ fn build_store(collection_id: &str, config: &ZarrConfig) -> Result<EngineStore, 
 }
 
 impl MapEngine for ZarrEngine {
+    #[allow(clippy::too_many_arguments)]
     fn get_raster_tile(
         &self,
         bbox: [f64; 4],
@@ -355,6 +358,7 @@ impl MapEngine for ZarrEngine {
         output_crs: &OutputCrs,
         parameter: Option<&str>,
         _z: Option<f64>, // Zarr collections expose no vertical dimension yet
+        _reference_time: Option<DateTime<Utc>>,
     ) -> Result<RasterTile, DataServerError> {
         let cat = self.catalog.load();
         let var = match parameter {

--- a/crates/engine-zarr/tests/icechunk.rs
+++ b/crates/engine-zarr/tests/icechunk.rs
@@ -280,6 +280,7 @@ async fn probe_models() {
                     None,
                     Some(&["temperature_2m".to_string()]),
                     None,
+                    None,
                 ) {
                     Ok(CoverageResponse::Single(qr)) => qr
                         .ranges
@@ -337,7 +338,7 @@ async fn reads_local_icechunk_repo() {
     // 278.97 at t=0, +0.5/step.
     let t0 = Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 0).unwrap();
     let resp = engine
-        .query_position("POINT(2 58)", Some((t0, t0)), None, None)
+        .query_position("POINT(2 58)", Some((t0, t0)), None, None, None)
         .expect("position query");
     let qr = match resp {
         CoverageResponse::Single(qr) => qr,

--- a/crates/engine-zarr/tests/integration.rs
+++ b/crates/engine-zarr/tests/integration.rs
@@ -156,7 +156,10 @@ fn forecast_uses_latest_run_with_lead_as_time() {
 
     // A position query at (lon=10, lat=60) must read the LATEST run (init=1):
     // value = 1*1000 + lead_idx + 0.1*60 + 0.01*10 = 1006.1, 1007.1, 1008.1.
-    let qr = single(e.query_position("POINT(10 60)", None, None, None).unwrap());
+    let qr = single(
+        e.query_position("POINT(10 60)", None, None, None, None)
+            .unwrap(),
+    );
     let vals = &qr.ranges.get("temp").unwrap().values;
     assert_eq!(vals.len(), 3);
     assert!(
@@ -182,6 +185,7 @@ fn forecast_uses_latest_run_with_lead_as_time() {
             Some(first),
             &OutputCrs::Wgs84,
             Some("temp"),
+            None,
             None,
         )
         .unwrap();
@@ -263,7 +267,7 @@ fn supported_query_types_is_position() {
 fn position_query_bilinear_matches_linear_field() {
     let e = engine();
     let qr = single(
-        e.query_position("POINT(5.5 54.5)", None, None, None)
+        e.query_position("POINT(5.5 54.5)", None, None, None, None)
             .unwrap(),
     );
     assert_eq!(qr.parameters.len(), 2);
@@ -294,6 +298,7 @@ fn fill_value_maps_to_nodata() {
             None,
             Some(&["t2m_packed".to_string()]),
             None,
+            None,
         )
         .unwrap(),
     );
@@ -308,7 +313,7 @@ fn parameter_filter_restricts_variables() {
     let e = ZarrEngine::new("zarr-test", &config(Some(vec!["t2m".to_string()]))).unwrap();
     assert_eq!(e.get_parameters(), vec!["t2m".to_string()]);
     let qr = single(
-        e.query_position("POINT(5.5 54.5)", None, None, None)
+        e.query_position("POINT(5.5 54.5)", None, None, None, None)
             .unwrap(),
     );
     assert_eq!(qr.parameters.len(), 1);
@@ -324,6 +329,7 @@ fn datetime_filter_selects_single_step() {
             "POINT(5.5 54.5)",
             Some((t, t)),
             Some(&["t2m".to_string()]),
+            None,
             None,
         )
         .unwrap(),
@@ -359,6 +365,7 @@ fn raster_tile_wgs84_matches_linear_field() {
             &OutputCrs::Wgs84,
             Some("t2m"),
             None,
+            None,
         )
         .unwrap();
     assert_eq!(tile.values.len(), 16 * 12);
@@ -386,6 +393,7 @@ fn raster_tile_projected_via_build_2d_no_nan_leak() {
             &OutputCrs::Projected { crs, bbox: proj },
             Some("t2m"),
             None,
+            None,
         )
         .unwrap();
     assert_eq!(tile.values.len(), 16 * 16);
@@ -410,6 +418,7 @@ fn raster_tile_off_grid_is_transparent() {
             &OutputCrs::Wgs84,
             Some("t2m"),
             None,
+            None,
         )
         .unwrap();
     assert_eq!(tile.values.len(), 64);
@@ -433,6 +442,7 @@ fn raster_tile_between_cell_centres_still_renders() {
             &OutputCrs::Wgs84,
             Some("t2m"),
             None,
+            None,
         )
         .unwrap();
     assert!(
@@ -450,7 +460,7 @@ fn off_grid_position_is_nodata() {
     // axes to locate).
     for coords in ["POINT(100.0 0.0)", "POINT(100.0 54.5)", "POINT(5.5 0.0)"] {
         let qr = single(
-            e.query_position(coords, None, Some(&only_t2m), None)
+            e.query_position(coords, None, Some(&only_t2m), None, None)
                 .unwrap(),
         );
         let nd = qr.ranges.get("t2m").unwrap();

--- a/crates/server/src/admin.rs
+++ b/crates/server/src/admin.rs
@@ -837,12 +837,14 @@ pub fn load_collections(
                 let qd_config = collection.querydata.as_ref();
                 let wms_param = qd_config.and_then(|c| c.wms_parameter.as_deref());
                 let poll_secs = qd_config.map_or(30, |c| c.poll_interval_secs);
+                let max_runs = qd_config.map_or(4, |c| c.max_runs);
 
                 let engine = match engine_querydata::QueryDataEngine::new(
                     std::path::Path::new(data_path),
                     &collection.id,
                     wms_param,
                     poll_secs,
+                    max_runs,
                 ) {
                     Ok(e) => Arc::new(e),
                     Err(e) => {

--- a/crates/server/src/preview.rs
+++ b/crates/server/src/preview.rs
@@ -789,6 +789,7 @@ mod tests {
             _datetime: Option<(DateTime<Utc>, DateTime<Utc>)>,
             _parameters: Option<&[String]>,
             _z: Option<&[f64]>,
+            _reference_time: Option<DateTime<Utc>>,
         ) -> Result<CoverageResponse, DataServerError> {
             unimplemented!()
         }
@@ -831,6 +832,7 @@ mod tests {
     }
 
     impl MapEngine for RasterMock {
+        #[allow(clippy::too_many_arguments)]
         fn get_raster_tile(
             &self,
             _bbox: [f64; 4],
@@ -840,6 +842,7 @@ mod tests {
             _crs: &OutputCrs,
             _param: Option<&str>,
             _z: Option<f64>,
+            _reference_time: Option<DateTime<Utc>>,
         ) -> Result<RasterTile, DataServerError> {
             unimplemented!()
         }
@@ -854,6 +857,7 @@ mod tests {
                 vertical: None,
                 grid_size: None,
                 layer_subtitle: None,
+                reference_times: Vec::new(),
             }
         }
     }
@@ -1246,6 +1250,7 @@ mod tests {
                 _: Option<(DateTime<Utc>, DateTime<Utc>)>,
                 _: Option<&[String]>,
                 _: Option<&[f64]>,
+                _: Option<DateTime<Utc>>,
             ) -> Result<CoverageResponse, DataServerError> {
                 unimplemented!()
             }
@@ -1319,6 +1324,7 @@ mod tests {
                 _: Option<(DateTime<Utc>, DateTime<Utc>)>,
                 _: Option<&[String]>,
                 _: Option<&[f64]>,
+                _: Option<DateTime<Utc>>,
             ) -> Result<CoverageResponse, DataServerError> {
                 unimplemented!()
             }
@@ -1612,6 +1618,7 @@ mod tests {
                 _: Option<(DateTime<Utc>, DateTime<Utc>)>,
                 _: Option<&[String]>,
                 _: Option<&[f64]>,
+                _: Option<DateTime<Utc>>,
             ) -> Result<CoverageResponse, DataServerError> {
                 unimplemented!()
             }
@@ -1713,6 +1720,7 @@ mod tests {
                 _: Option<(DateTime<Utc>, DateTime<Utc>)>,
                 _: Option<&[String]>,
                 _: Option<&[f64]>,
+                _: Option<DateTime<Utc>>,
             ) -> Result<CoverageResponse, DataServerError> {
                 unimplemented!()
             }
@@ -1810,6 +1818,7 @@ mod tests {
                 _: Option<(DateTime<Utc>, DateTime<Utc>)>,
                 _: Option<&[String]>,
                 _: Option<&[f64]>,
+                _: Option<DateTime<Utc>>,
             ) -> Result<CoverageResponse, DataServerError> {
                 unimplemented!()
             }
@@ -1855,6 +1864,7 @@ mod tests {
         /// MapEngine that only exposes 2 of the EDR's 3 parameters.
         struct PartialRaster;
         impl MapEngine for PartialRaster {
+            #[allow(clippy::too_many_arguments)]
             fn get_raster_tile(
                 &self,
                 _: [f64; 4],
@@ -1864,6 +1874,7 @@ mod tests {
                 _: &OutputCrs,
                 _: Option<&str>,
                 _: Option<f64>,
+                _: Option<DateTime<Utc>>,
             ) -> Result<RasterTile, DataServerError> {
                 unimplemented!()
             }
@@ -1882,6 +1893,7 @@ mod tests {
                     vertical: None,
                     grid_size: None,
                     layer_subtitle: None,
+                    reference_times: Vec::new(),
                 }
             }
         }

--- a/crates/server/tests/middleware.rs
+++ b/crates/server/tests/middleware.rs
@@ -26,6 +26,7 @@ use ds_render::{BuiltinColormap, LutColorMap, RenderedCache, StyleInfo};
 struct MockMapEngine;
 
 impl MapEngine for MockMapEngine {
+    #[allow(clippy::too_many_arguments)]
     fn get_raster_tile(
         &self,
         _bbox: [f64; 4],
@@ -35,6 +36,7 @@ impl MapEngine for MockMapEngine {
         _output_crs: &OutputCrs,
         _parameter: Option<&str>,
         _z: Option<f64>,
+        _reference_time: Option<chrono::DateTime<chrono::Utc>>,
     ) -> Result<RasterTile, DataServerError> {
         let n = (width * height) as usize;
         Ok(RasterTile {
@@ -57,6 +59,7 @@ impl MapEngine for MockMapEngine {
             vertical: None,
             grid_size: None,
             layer_subtitle: None,
+            reference_times: Vec::new(),
         }
     }
 }


### PR DESCRIPTION
Implements **Phase 1** of #337: first-class forecast **model-run** selection, defaulting to the latest run, with the shared machinery in **ds-core** so GRIB and QueryData (and later Zarr) never duplicate it (per the explicit no-duplication ask).

## The shared core — `ds_core::instances`
- `RunInfo { reference_time, valid_times }` + instance-id codec (`format_instance_id`/`parse_instance_id`, canonical compact `%Y%m%dT%H%MZ`, parse also accepts RFC 3339). The **API layer** owns the string form; engines only ever see `Option<DateTime<Utc>>`.
- `select_run(&BTreeMap<DateTime<Utc>, _>, Option<DateTime<Utc>>)` — `None` ⇒ latest, `Some(rt)` ⇒ that exact run (absent ⇒ `None` → 404). One selection rule everywhere.
- `build_instances(&runs, |rt, run| valid_times)` — `Vec<RunInfo>` from a reference-time-keyed map.

## Trait shape (Option 1, as agreed)
- `EdrEngine::get_instances() -> Vec<RunInfo>` (default empty = non-forecast).
- A trailing `reference_time: Option<DateTime<Utc>>` on `query_location/area/position/trajectory` and on `MapEngine::get_raster_tile` (`None` ⇒ latest — the unchanged default; non-forecast engines ignore it).
- `RasterInfo.reference_times: Vec<DateTime<Utc>>`.

Doing the wide signature change **once** keeps the follow-up phases purely additive (no further churn). Every non-forecast engine + the WMS/Maps/Tiles call sites accept-and-ignore (`None`).

## Engines
- **GRIB** (reference impl): exposes its catalog `runs` as instances; `resolve_time`/`query_position` honour `reference_time` (pin a run, else latest/covering-datetime); `raster_info.reference_times` carries the run list.
- **QueryData**: now retains the most recent **`max_runs`** `.sqd` files as runs keyed by **origin time** (`RunSet: BTreeMap<DateTime<Utc>, _>`), reusing already-parsed files on poll; instances + selection reuse the ds-core helpers. New `max_runs` config (default 4; `1` = latest-only). No behaviour change for the un-pinned/default path.

## api-edr
- `GET /collections/{id}/instances`, `/instances/{instanceId}` (per-run metadata: extent + data-query hrefs scoped to the run), and `/instances/{instanceId}/{position,area}` (query a specific run).
- No-instance routes default to the latest run (**unchanged**). Unknown run → **404**, unparseable id → **400**.
- Collection metadata gains an `instances` data_query and the OpenAPI spec advertises the instance paths — both gated on `get_instances()` being non-empty.

## Tests
- `ds-core` instances unit tests (codec round-trip, select/latest, build_instances).
- QueryData multi-run/instances unit test (latest default, run-pinning equivalence, bogus-run error) against the real `.sqd` fixture.
- **api-edr instances integration test** with a 2-run mock: list, per-run metadata extent, run-pinned query proves which run it hit, 404/400 cases, `instances` data_query.
- Inverted the previously-documented "instances not implemented" spec-gap test.
- **Live server smoke test** (QueryData fixture): `/instances` lists the run by origin time, `/instances/{id}/position` returns a Coverage, bogus run → 404.

All **1443** workspace tests pass; `cargo fmt` + `cargo clippy --workspace --all-targets` clean.

## Deferred (follow-ups, this PR is the foundation)
- **WMS `reference_time` dimension** + **Maps/Tiles `reference_time` query param** — the engines already honour the selector in `get_raster_tile`; the map APIs currently pass `None`.
- **Zarr** forecast-reference/lead → instances (it currently pins the latest run internally).

Part of #337 (Phase 1). #337 stays open for the WMS `reference_time` dimension, Maps/Tiles param, and Zarr instances phases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
