### PR TITLE
build(docker/release): ship icechunk by default (object_store backend, ~+8 MB)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -218,7 +218,12 @@ jobs:
         # producing a release built against a drifted lockfile.
         env:
           TARGET: ${{ matrix.target }}
-        run: cargo build --release --locked --target "${TARGET}" -p server
+        # `--features icechunk`: ship Icechunk Zarr support in release binaries
+        # (object_store S3 backend, ~+8 MB, no AWS SDK — #339). Reuses the
+        # object_store/rustls stack already in the base build, so it adds no new
+        # cross-compilation deps. Remove once the icechunk [patch] forks are
+        # dropped if a leaner default is preferred (#340).
+        run: cargo build --release --locked --target "${TARGET}" -p server --features icechunk
 
       - name: Package tarball
         # All inputs flow through `env:` so the shell never sees an

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,10 @@ RUN cargo install cargo-chef --locked --version 0.1.71
 # stable across source-only changes — the next stage's cache hits.
 FROM chef AS planner
 COPY . .
+# NB: `cargo chef prepare` (0.1.71) takes no `--features` — the recipe captures
+# the full manifest incl. the *optional* `icechunk` dep, so the builder's
+# `cook --features icechunk` pre-warms those crates from it. (Newer cargo-chef
+# adds `prepare --features`; not needed / not supported here.)
 RUN cargo chef prepare --recipe-path recipe.json
 
 # Stage 1c: builder

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,13 +48,22 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # so it stays cache-valid until any Cargo.toml or Cargo.lock changes.
 # Source changes do *not* invalidate it. `type=gha,mode=max` on the
 # workflow's `cache-to` exports this layer.
+#
+# Cargo features compiled into the server. Defaults to `icechunk` (read
+# transactional/versioned Icechunk Zarr repos; ~+8 MB, object_store S3 backend —
+# no AWS SDK, #339). Build a leaner image without it via
+# `--build-arg CARGO_FEATURES=""`, or pass a custom set. Threaded through BOTH
+# `cook` and `build` so the cooked dep cache matches the final build.
+ARG CARGO_FEATURES="icechunk"
 COPY --from=planner /build/recipe.json recipe.json
-RUN cargo chef cook --release --recipe-path recipe.json -p server
+RUN cargo chef cook --release --recipe-path recipe.json -p server \
+        ${CARGO_FEATURES:+--features "$CARGO_FEATURES"}
 
 # Now copy the actual workspace source and build. Only the changed
 # workspace member's crate needs to recompile; deps are already linked.
 COPY . .
-RUN cargo build --release -p server
+RUN cargo build --release -p server \
+        ${CARGO_FEATURES:+--features "$CARGO_FEATURES"}
 
 # Stage 2: Runtime
 FROM debian:bookworm-slim

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,13 +56,16 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # `cook` and `build` so the cooked dep cache matches the final build.
 ARG CARGO_FEATURES="icechunk"
 COPY --from=planner /build/recipe.json recipe.json
-RUN cargo chef cook --release --recipe-path recipe.json -p server \
+# `--locked`: build strictly against the committed Cargo.lock (matches the
+# release build) — important now that the default feature set pulls rev-pinned
+# `[patch.crates-io]` git forks; no silent re-resolution in the shipped image.
+RUN cargo chef cook --release --locked --recipe-path recipe.json -p server \
         ${CARGO_FEATURES:+--features "$CARGO_FEATURES"}
 
 # Now copy the actual workspace source and build. Only the changed
 # workspace member's crate needs to recompile; deps are already linked.
 COPY . .
-RUN cargo build --release -p server \
+RUN cargo build --release --locked -p server \
         ${CARGO_FEATURES:+--features "$CARGO_FEATURES"}
 
 # Stage 2: Runtime


### PR DESCRIPTION
## What

Now that the `icechunk` feature is cheap (#339 — object_store S3 backend, no AWS SDK, +8 MB instead of +28 MB), enable it in the shipped artifacts.

- **Dockerfile:** `ARG CARGO_FEATURES="icechunk"`, threaded through both the cargo-chef `cook` and the final `build` (cargo-chef needs the same features on both so the cooked dep cache matches). **Default-on**; produce a lean image with `--build-arg CARGO_FEATURES=""` (or pass a custom feature set).
- **release.yml:** add `--features icechunk` to the release-binary build. Reuses the `object_store`/rustls stack already in the base build, so it adds **no new cross-compilation deps**.

## Verification

Local `docker build` (default) → 156 MB image. Running it with the committed `testdata/zarr-icechunk-aifs.config.toml` (anonymous AWS S3, from inside the container) loads the repo end-to-end:

```
engine_zarr::catalog: collection 'ecmwf-aifs-single': forecast — latest run 2026-06-07 12:00 UTC (of 3191 runs)...
engine_zarr: [ecmwf-aifs-single] Loaded Zarr store: 1 variable(s) [temperature_2m], 61 time step(s)
server::admin: Collection 'ecmwf-aifs-single': wired to EDR API
```

CI's "Docker Build (PR)" job re-validates the default build.

## Caveat

Until the two icechunk `[patch]` forks land upstream (tracked in #340), the default image/release build pulls them. Drop `--features icechunk` / the ARG default if a fork-free default artifact is required before then.

Relates to #335, #339, #340.

🤖 Generated with [Claude Code](https://claude.com/claude-code)