### PR TITLE
build(engine-zarr): drop zarrs_icechunk fork (0.5.1 published); repoint icechunk patch upstream

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -339,16 +339,18 @@ tracked in #125. **The crate is phased; Phases 1-3 ship today.**
   tests; safe because retrieval is `concurrent_target(1)`).
   - **S3 backend = icechunk's `object_store` backend, NOT `aws-sdk-s3`.** The
     deps select `icechunk`/`zarrs_icechunk` with `default-features = false,
-    features = ["object-store-s3", "object-store-fs"]` (via two interim
-    `[patch.crates-io]` git forks; see root `Cargo.toml`), so the build reuses
+    features = ["object-store-s3", "object-store-fs"]`, so the build reuses
     the same `object_store` crate `ds-storage` uses instead of pulling the whole
     `aws-sdk-s3` tree — the icechunk feature's binary cost drops ~28 MB → ~8 MB.
+    `zarrs_icechunk`'s feature-forwarding fix shipped in 0.5.1, so it's a plain
+    crates.io dep now; **`icechunk` still needs one interim `[patch.crates-io]`**
+    (see root `Cargo.toml`) pinned to the upstream merge commit of
+    earth-mover/icechunk#2190 until a release > 2.0.6 carries it (#340).
     `build_storage` uses `new_s3_object_store_storage`; **anonymous access is set
     via `S3Options::with_anonymous(true)`** (the object_store backend keys
     skip-signing off `S3Options.anonymous`, *not* the `S3Credentials` arg —
     without it, it falls through to the AWS credential chain → EC2 IMDS and
-    hangs off-EC2). Public datasets only (#335). Drop the patches + bump versions
-    once zarrs/zarrs_icechunk#13 and earth-mover/icechunk#2190 release.
+    hangs off-EC2). Public datasets only (#335).
   - Icechunk still owns its own object storage, so this path does **not** go
     through `ds-storage`. New snapshots on a branch are picked up on **reload**,
     not poll (v1). Network-free e2e test generates a local repo: `cargo test -p

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1890,7 +1890,7 @@ dependencies = [
 [[package]]
 name = "icechunk"
 version = "2.0.6"
-source = "git+https://github.com/mrauhala/icechunk.git?rev=41f6921e0229928f1a121924d4d5b7c002f6bf7a#41f6921e0229928f1a121924d4d5b7c002f6bf7a"
+source = "git+https://github.com/earth-mover/icechunk.git?rev=5f56b13605745ea06ec6558bcd8ed4a8f5805a3e#5f56b13605745ea06ec6558bcd8ed4a8f5805a3e"
 dependencies = [
  "async-compression",
  "async-recursion",
@@ -1928,7 +1928,7 @@ dependencies = [
 [[package]]
 name = "icechunk-arrow-object-store"
 version = "2.0.6"
-source = "git+https://github.com/mrauhala/icechunk.git?rev=41f6921e0229928f1a121924d4d5b7c002f6bf7a#41f6921e0229928f1a121924d4d5b7c002f6bf7a"
+source = "git+https://github.com/earth-mover/icechunk.git?rev=5f56b13605745ea06ec6558bcd8ed4a8f5805a3e#5f56b13605745ea06ec6558bcd8ed4a8f5805a3e"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1949,7 +1949,7 @@ dependencies = [
 [[package]]
 name = "icechunk-format"
 version = "2.0.6"
-source = "git+https://github.com/mrauhala/icechunk.git?rev=41f6921e0229928f1a121924d4d5b7c002f6bf7a#41f6921e0229928f1a121924d4d5b7c002f6bf7a"
+source = "git+https://github.com/earth-mover/icechunk.git?rev=5f56b13605745ea06ec6558bcd8ed4a8f5805a3e#5f56b13605745ea06ec6558bcd8ed4a8f5805a3e"
 dependencies = [
  "base32",
  "bytes",
@@ -1974,7 +1974,7 @@ dependencies = [
 [[package]]
 name = "icechunk-storage"
 version = "2.0.6"
-source = "git+https://github.com/mrauhala/icechunk.git?rev=41f6921e0229928f1a121924d4d5b7c002f6bf7a#41f6921e0229928f1a121924d4d5b7c002f6bf7a"
+source = "git+https://github.com/earth-mover/icechunk.git?rev=5f56b13605745ea06ec6558bcd8ed4a8f5805a3e#5f56b13605745ea06ec6558bcd8ed4a8f5805a3e"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1994,7 +1994,7 @@ dependencies = [
 [[package]]
 name = "icechunk-types"
 version = "2.0.6"
-source = "git+https://github.com/mrauhala/icechunk.git?rev=41f6921e0229928f1a121924d4d5b7c002f6bf7a#41f6921e0229928f1a121924d4d5b7c002f6bf7a"
+source = "git+https://github.com/earth-mover/icechunk.git?rev=5f56b13605745ea06ec6558bcd8ed4a8f5805a3e#5f56b13605745ea06ec6558bcd8ed4a8f5805a3e"
 dependencies = [
  "serde",
  "serde_with",
@@ -3228,7 +3228,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -3268,9 +3268,9 @@ dependencies = [
 
 [[package]]
 name = "quick_cache"
-version = "0.6.21"
+version = "0.6.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a70b1b8b47e31d0498ecbc3c5470bb931399a8bfed1fd79d1717a61ce7f96e3"
+checksum = "3a3db184a8b66cfe87f0263a1de147a6b554c864d1767c6f7fa4eb0e5497b565"
 dependencies = [
  "ahash",
  "equivalent",
@@ -3870,9 +3870,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "indexmap 2.13.0",
  "itoa",
@@ -5598,8 +5598,9 @@ dependencies = [
 
 [[package]]
 name = "zarrs_icechunk"
-version = "0.5.0"
-source = "git+https://github.com/mrauhala/zarrs_icechunk.git?rev=4ff7690420900a5f9b576eb492452ca9da77540b#4ff7690420900a5f9b576eb492452ca9da77540b"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2737168a21a5d7afa973a92e6d3308da85dee10961fdcf936852e4ac347df4df"
 dependencies = [
  "async-trait",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,18 +51,18 @@ debug = "line-tables-only"
 [profile.dev.package."*"]
 debug = false
 
-# Interim patches (icechunk feature only) — both submitted upstream; drop each
-# once a release including it lands on crates.io, then bump the version.
-# Tracked for removal in #340.
+# Interim patch (icechunk feature only). Tracked for removal in #340.
+#
+# `zarrs_icechunk`'s feature-forwarding fix (zarrs/zarrs_icechunk#13) shipped in
+# 0.5.1 (2026-06-08), so that patch is gone — engine-zarr now depends on the
+# published crate directly.
+#
+# `icechunk`'s one-line build fix (earth-mover/icechunk#2190: a bare `?` on a
+# FromUtf8Error only convertible under the `s3`/aws-sdk feature, in
+# virtual_chunks.rs) is merged upstream but NOT yet in a crates.io release (latest
+# is 2.0.6, cut before the merge). Until icechunk releases > 2.0.6 with the fix,
+# patch to the upstream merge commit so the `object-store-s3`-without-`s3` build
+# compiles. Pinned to an immutable `rev` (not the branch) so a future
+# `cargo update` can't silently follow a moved branch tip.
 [patch.crates-io]
-# Forward icechunk's backend features so `engine-zarr` can select the lighter
-# `object_store` S3 backend and drop the `aws-sdk-s3` tree (~28 MB / ~300 crates)
-# the published crate pulls via icechunk's default features. Non-breaking
-# (default still enables every backend). Upstream: zarrs/zarrs_icechunk#13.
-# Pinned to an immutable `rev` (not the branch) so a future `cargo update` can't
-# silently follow a moved branch tip.
-zarrs_icechunk = { git = "https://github.com/mrauhala/zarrs_icechunk.git", rev = "4ff7690420900a5f9b576eb492452ca9da77540b" }
-# One-line fix so icechunk's `object-store-s3` backend compiles without the `s3`
-# (aws-sdk) feature (a bare `?` on a FromUtf8Error only convertible under `s3`;
-# virtual_chunks.rs). Upstream: earth-mover/icechunk#2190.
-icechunk = { git = "https://github.com/mrauhala/icechunk.git", rev = "41f6921e0229928f1a121924d4d5b7c002f6bf7a" }
+icechunk = { git = "https://github.com/earth-mover/icechunk.git", rev = "5f56b13605745ea06ec6558bcd8ed4a8f5805a3e" }

--- a/crates/engine-zarr/Cargo.toml
+++ b/crates/engine-zarr/Cargo.toml
@@ -34,13 +34,15 @@ thiserror = "2"
 # `zarrs/async` is required for the async Icechunk store + the async→sync adapter.
 # Select only the `object_store`-based S3 backend (+ local filesystem), NOT
 # icechunk's default `s3` backend which pulls the full `aws-sdk-s3` tree — we
-# reuse the same `object_store` crate `ds-storage` already links. Requires the
-# `zarrs_icechunk` `[patch]` in the workspace root (it forwards these features).
+# reuse the same `object_store` crate `ds-storage` already links. The
+# backend-forwarding features were published in zarrs_icechunk 0.5.1; `icechunk`
+# still needs the workspace-root `[patch]` until a release > 2.0.6 carries the
+# `object-store-s3`-without-`s3` build fix (earth-mover/icechunk#2190).
 icechunk = { version = "2", optional = true, default-features = false, features = [
     "object-store-s3",
     "object-store-fs",
 ] }
-zarrs_icechunk = { version = "0.5", optional = true, default-features = false, features = [
+zarrs_icechunk = { version = "0.5.1", optional = true, default-features = false, features = [
     "object-store-s3",
     "object-store-fs",
 ] }


### PR DESCRIPTION
## What

The interim `[patch.crates-io]` git **forks** for the icechunk feature (#340) are now half-removable:

- **`zarrs_icechunk`** — the backend feature-forwarding fix (zarrs/zarrs_icechunk#13, merged 2026-06-07) shipped in **0.5.1** (2026-06-08). The personal-fork `[patch]` is **dropped**; `engine-zarr` depends on the published crate directly (`version = "0.5.1"`).
- **`icechunk`** — the one-line build fix that lets `object-store-s3` compile **without** the `s3`/aws-sdk feature (earth-mover/icechunk#2190, merged 2026-06-07) is **not yet in a crates.io release** (latest is `2.0.6`, cut before the merge). So the `[patch]` stays, but is **repointed from the personal fork to the upstream `earth-mover/icechunk` merge commit** (pinned to an immutable `rev`). Once icechunk releases `> 2.0.6` with the fix, this last patch can go too.

Net effect: **both personal forks are gone** — only one patch remains, and it points at canonical upstream.

## Lock bumps

The new upstream icechunk rev raised its own floors, so `Cargo.lock` bumps `quick_cache 0.6.21 → 0.6.23` (`>=0.6.22` required) and `serde_json 1.0.149 → 1.0.150` (`>=1.0.150` required). These are **forced** by the rev, not opportunistic — pinning them back fails to resolve.

## Verification

- `cargo test -p engine-zarr --features icechunk` — **pass** (incl. the network-free `reads_local_icechunk_repo` e2e + all 16 integration tests)
- `cargo check --workspace` — **pass** (default features, confirms the lock bumps don't break other crates)

CLAUDE.md updated to reflect "one patch, not two".

🤖 Generated with [Claude Code](https://claude.com/claude-code)