### PR TITLE
feat(wms): reference_time dimension for forecast model runs (#337)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,9 +189,19 @@ follow-up (it currently pins the latest run internally; see [[project_zarr_engin
 (query a specific run); the no-instance routes default to the latest run
 (unchanged). Collection metadata gains an `instances` data_query and the OpenAPI
 spec advertises the instance paths — both gated on `get_instances()` being
-non-empty. **WMS `reference_time` dimension + Maps/Tiles `reference_time` query
-parameter are a follow-up** (the engines already honour the selector in
-`get_raster_tile`; the API layer currently passes `None`).
+non-empty.
+
+**WMS `reference_time` dimension (done).** Forecast layers (non-empty
+`RasterInfo.reference_times`) advertise a custom `<Dimension name="reference_time">`
+in `GetCapabilities` alongside the standard `time` dimension (the valid-time axis),
+defaulting to the latest run. `GetMap` accepts `DIM_REFERENCE_TIME=<run>`
+(RFC 3339, or the compact instance-id stamp); the handler validates it against the
+advertised runs and returns `InvalidDimensionValue` (HTTP 400) for an unknown run
+or a non-forecast layer (no `nearestValue` — the engine requires an exact match).
+The run flows through `get_raster_tile` and into the rendered + meta-tile cache
+keys (`CacheKey.reference_time`, `TileKeyPrefix.reference_time`) so distinct runs
+don't collide. **Maps/Tiles `reference_time` query parameter is still a follow-up**
+(api-maps/api-tiles pass `reference_time: None` today).
 
 ## Engine Capabilities
 

--- a/crates/api-maps/src/handlers.rs
+++ b/crates/api-maps/src/handlers.rs
@@ -1066,6 +1066,9 @@ async fn render_map(
         time,
         parameter: effective_parameter.clone(),
         z: validated.z.map(ds_render::quantize_z),
+        // Maps `reference_time` query parameter is a follow-up (#337 Phase 4);
+        // the handler always queries the engine's latest run for now.
+        reference_time: None,
     };
 
     let cache_control = cache_control_value(has_explicit_time);

--- a/crates/api-tiles/src/handlers.rs
+++ b/crates/api-tiles/src/handlers.rs
@@ -1430,6 +1430,9 @@ async fn render_tile(
         time,
         parameter: effective_parameter.clone(),
         z: validated.z.map(ds_render::quantize_z),
+        // Tiles `reference_time` query parameter is a follow-up (#337 Phase 4);
+        // the handler always queries the engine's latest run for now.
+        reference_time: None,
     };
 
     let cache_control = cache_control_value(has_explicit_time);

--- a/crates/api-wms/src/capabilities.rs
+++ b/crates/api-wms/src/capabilities.rs
@@ -273,6 +273,32 @@ fn write_layer_metadata(writer: &mut Writer<Vec<u8>>, info: &RasterInfo) {
             let _ = writer.write_event(Event::End(BytesEnd::new("Dimension")));
         }
     }
+
+    // Forecast reference-time (model run) dimension — advertised only for
+    // forecast collections that retain multiple runs. The standard `time`
+    // dimension stays the *valid* time axis; this custom `reference_time`
+    // dimension selects the run (the de-facto ncWMS/THREDDS convention,
+    // requested as `DIM_REFERENCE_TIME`). Default = latest run. No
+    // `nearestValue` — the run must match an advertised value exactly (the
+    // handler validates membership and the engine requires an exact match).
+    if !info.reference_times.is_empty() {
+        let mut dim = BytesStart::new("Dimension");
+        dim.push_attribute(("name", "reference_time"));
+        dim.push_attribute(("units", "ISO8601"));
+        if let Some(latest) = info.reference_times.last() {
+            dim.push_attribute(("default", latest.to_rfc3339().as_str()));
+        }
+        let _ = writer.write_event(Event::Start(dim));
+
+        let run_values: Vec<String> = info
+            .reference_times
+            .iter()
+            .map(|t| t.to_rfc3339())
+            .collect();
+        let _ = writer.write_event(Event::Text(BytesText::new(&run_values.join(","))));
+
+        let _ = writer.write_event(Event::End(BytesEnd::new("Dimension")));
+    }
 }
 
 /// Write style elements for a layer.

--- a/crates/api-wms/src/handlers.rs
+++ b/crates/api-wms/src/handlers.rs
@@ -163,6 +163,27 @@ pub async fn wms_handler(
                 )));
             }
 
+            // Validate `DIM_REFERENCE_TIME` against the layer's advertised model
+            // runs. The engine requires an exact run match (`select_run` →
+            // `ReferenceTimeNotFound`, which the GetMap render path would turn
+            // into a red 200 tile); surfacing `InvalidDimensionValue` here is the
+            // correct WMS response — mirroring the parameter/ELEVATION checks.
+            if let Some(rt) = params.reference_time {
+                let reference_times = engine.raster_info().reference_times;
+                if reference_times.is_empty() {
+                    return Err(WmsError::InvalidDimensionValue(format!(
+                        "Layer '{collection_id}' has no reference_time dimension"
+                    )));
+                }
+                if !reference_times.contains(&rt) {
+                    return Err(WmsError::InvalidDimensionValue(format!(
+                        "reference_time '{}' is not an available model run for layer \
+                         '{collection_id}'",
+                        rt.to_rfc3339()
+                    )));
+                }
+            }
+
             let colormap = style_info.colormap.clone();
             let content_type = params.format.content_type();
             let has_explicit_time = params.time.is_some();
@@ -197,6 +218,9 @@ pub async fn wms_handler(
                     .clone()
                     .or_else(|| style_info.parameter.clone()),
                 z: params.elevation.map(ds_render::quantize_z),
+                // The forecast run pinned via the `reference_time` dimension
+                // (None ⇒ latest), so runs don't collide in the rendered cache.
+                reference_time: params.reference_time,
             };
 
             let cache_control = cache_control_value(has_explicit_time);
@@ -264,6 +288,7 @@ pub async fn wms_handler(
             let output_crs = params.output_crs.clone();
             let format = params.format;
             let elevation = params.elevation;
+            let reference_time = params.reference_time;
             let z_q = elevation.map(ds_render::quantize_z);
             let layer = params.layer.clone();
             // Key meta-tiles on the *resolved* style name, not the raw STYLES
@@ -294,7 +319,7 @@ pub async fn wms_handler(
                             &output_crs,
                             style_parameter.as_deref(),
                             elevation,
-                            None,
+                            reference_time,
                         )?;
                         // If every pixel is nodata, skip colorization + encoding entirely.
                         if tile.is_empty() {
@@ -317,6 +342,7 @@ pub async fn wms_handler(
                             style,
                             time,
                             z: z_q,
+                            reference_time,
                         };
                         // `bbox` is in WGS84 degrees here — the params layer
                         // converts EPSG:3857 metres to degrees before this point;
@@ -338,7 +364,7 @@ pub async fn wms_handler(
                                     &OutputCrs::WebMercator,
                                     style_parameter.as_deref(),
                                     elevation,
-                                    None,
+                                    reference_time,
                                 )
                             },
                         )?;

--- a/crates/api-wms/src/handlers.rs
+++ b/crates/api-wms/src/handlers.rs
@@ -191,6 +191,17 @@ pub async fn wms_handler(
             let content_type = params.format.content_type();
             let has_explicit_time = params.time.is_some();
 
+            // Normalise an explicit pin of the *current* latest run to `None`, so
+            // it shares cache entries (and the engine's latest-run path) with
+            // requests that omit the dimension — they render identical pixels.
+            // The common client flow is echoing the GetCapabilities `default=`
+            // (= the latest run), so without this those requests fragment the
+            // cache from the no-dimension ones. A pin of an *older* run stays
+            // explicit. (`info.reference_times` is ascending; latest is `.last()`.)
+            let reference_time = params
+                .reference_time
+                .filter(|&rt| info.reference_times.last().copied() != Some(rt));
+
             // Build cache key
             let cache_key = CacheKey {
                 layer: params.layer.clone(),
@@ -223,7 +234,7 @@ pub async fn wms_handler(
                 z: params.elevation.map(ds_render::quantize_z),
                 // The forecast run pinned via the `reference_time` dimension
                 // (None ⇒ latest), so runs don't collide in the rendered cache.
-                reference_time: params.reference_time,
+                reference_time,
             };
 
             let cache_control = cache_control_value(has_explicit_time);
@@ -291,7 +302,8 @@ pub async fn wms_handler(
             let output_crs = params.output_crs.clone();
             let format = params.format;
             let elevation = params.elevation;
-            let reference_time = params.reference_time;
+            // `reference_time` (normalised above) is `Copy`; it flows into both
+            // the direct and meta-tile render closures below.
             let z_q = elevation.map(ds_render::quantize_z);
             let layer = params.layer.clone();
             // Key meta-tiles on the *resolved* style name, not the raw STYLES

--- a/crates/api-wms/src/handlers.rs
+++ b/crates/api-wms/src/handlers.rs
@@ -135,13 +135,17 @@ pub async fn wms_handler(
                 ))
             })?;
 
+            // One metadata snapshot for all parameter/dimension validation
+            // below. `raster_info()` clones its vecs, so take it once rather
+            // than once per check (parameter, ELEVATION, reference_time).
+            let info = engine.raster_info();
+
             // Validate `LAYERS=collection/parameter` against the engine's
             // advertised list (mirroring Maps + Tiles). Without this, an
             // unknown parameter would silently render whatever the engine
             // defaults to and cache that result under the invalid name —
             // ServiceException is the correct OGC response here.
             if let Some(pname) = layer_parameter.as_deref() {
-                let info = engine.raster_info();
                 if !info.parameters.is_empty()
                     && !info.parameters.iter().any(|(name, _)| name == pname)
                 {
@@ -157,7 +161,7 @@ pub async fn wms_handler(
             }
 
             // Reject an `ELEVATION` against a layer with no vertical axis.
-            if params.elevation.is_some() && engine.raster_info().vertical.is_none() {
+            if params.elevation.is_some() && info.vertical.is_none() {
                 return Err(WmsError::invalid_parameter(&format!(
                     "Layer '{collection_id}' has no ELEVATION dimension"
                 )));
@@ -169,13 +173,12 @@ pub async fn wms_handler(
             // into a red 200 tile); surfacing `InvalidDimensionValue` here is the
             // correct WMS response — mirroring the parameter/ELEVATION checks.
             if let Some(rt) = params.reference_time {
-                let reference_times = engine.raster_info().reference_times;
-                if reference_times.is_empty() {
+                if info.reference_times.is_empty() {
                     return Err(WmsError::InvalidDimensionValue(format!(
                         "Layer '{collection_id}' has no reference_time dimension"
                     )));
                 }
-                if !reference_times.contains(&rt) {
+                if !info.reference_times.contains(&rt) {
                     return Err(WmsError::InvalidDimensionValue(format!(
                         "reference_time '{}' is not an available model run for layer \
                          '{collection_id}'",

--- a/crates/api-wms/src/params.rs
+++ b/crates/api-wms/src/params.rs
@@ -81,12 +81,9 @@ pub struct WmsQuery {
     pub elevation: Option<String>,
     /// Forecast model run selector — the custom `reference_time` dimension
     /// (de-facto ncWMS/THREDDS convention). Per WMS, a dimension `foo` is
-    /// requested via `DIM_FOO`; we accept the common case variants.
-    #[serde(
-        alias = "DIM_REFERENCE_TIME",
-        alias = "Dim_Reference_Time",
-        alias = "dim_reference_time"
-    )]
+    /// requested via `DIM_FOO`; serde matches the lowercase field name itself,
+    /// these aliases add the upper/title-case variants real clients send.
+    #[serde(alias = "DIM_REFERENCE_TIME", alias = "Dim_Reference_Time")]
     pub dim_reference_time: Option<String>,
 }
 

--- a/crates/api-wms/src/params.rs
+++ b/crates/api-wms/src/params.rs
@@ -79,6 +79,15 @@ pub struct WmsQuery {
     pub time: Option<String>,
     #[serde(alias = "ELEVATION", alias = "Elevation")]
     pub elevation: Option<String>,
+    /// Forecast model run selector — the custom `reference_time` dimension
+    /// (de-facto ncWMS/THREDDS convention). Per WMS, a dimension `foo` is
+    /// requested via `DIM_FOO`; we accept the common case variants.
+    #[serde(
+        alias = "DIM_REFERENCE_TIME",
+        alias = "Dim_Reference_Time",
+        alias = "dim_reference_time"
+    )]
+    pub dim_reference_time: Option<String>,
 }
 
 /// Validated GetMap parameters.
@@ -98,6 +107,9 @@ pub struct GetMapParams {
     pub format: ds_render::ImageFormat,
     /// Vertical level from the WMS `ELEVATION` dimension, when supplied.
     pub elevation: Option<f64>,
+    /// Forecast model run from the custom `reference_time` dimension
+    /// (`DIM_REFERENCE_TIME`), when supplied. `None` ⇒ the engine's latest run.
+    pub reference_time: Option<DateTime<Utc>>,
 }
 
 impl WmsQuery {
@@ -231,6 +243,17 @@ impl WmsQuery {
             None => None,
         };
 
+        // DIM_REFERENCE_TIME — the forecast model run. A single value; the
+        // handler validates it against the layer's advertised runs (and rejects
+        // it for a non-forecast layer). Empty/whitespace ⇒ latest run (None).
+        let reference_time = self
+            .dim_reference_time
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(parse_reference_time)
+            .transpose()?;
+
         // STYLES — empty string or missing = "default"
         let style = self
             .styles
@@ -255,6 +278,7 @@ impl WmsQuery {
             output_crs,
             format: image_format,
             elevation,
+            reference_time,
         })
     }
 }
@@ -389,6 +413,23 @@ fn parse_time(s: &str) -> Result<DateTime<Utc>, WmsError> {
     Err(WmsError::InvalidDimensionValue(format!(
         "Cannot parse TIME '{s}' as ISO 8601"
     )))
+}
+
+/// Parse a `DIM_REFERENCE_TIME` value (the forecast model run / reference time).
+///
+/// Accepts the same ISO 8601 forms as `TIME` (the values GetCapabilities
+/// advertises for the `reference_time` dimension are RFC 3339) and, as a
+/// convenience, the compact EDR instance-id stamp (`20260607T0600Z`) so a
+/// client can echo either the WMS dimension value or an EDR instance id.
+fn parse_reference_time(s: &str) -> Result<DateTime<Utc>, WmsError> {
+    if let Ok(dt) = parse_time(s) {
+        return Ok(dt);
+    }
+    ds_core::instances::parse_instance_id(s).ok_or_else(|| {
+        WmsError::InvalidDimensionValue(format!(
+            "Cannot parse DIM_REFERENCE_TIME '{s}' as ISO 8601 or a run id"
+        ))
+    })
 }
 
 /// Supported CRS list for GetCapabilities.

--- a/crates/api-wms/tests/integration.rs
+++ b/crates/api-wms/tests/integration.rs
@@ -1123,3 +1123,389 @@ fn capabilities_single_param_layer_emits_keywords_and_attribution() {
         "Attribution must follow the Dimension elements; got:\n{xml}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Forecast `reference_time` dimension (#337 Phase 2)
+// ---------------------------------------------------------------------------
+
+/// Records the `reference_time` argument of each `get_raster_tile` call, so a
+/// test can assert which model run the WMS handler asked the engine to render.
+type RunRecorder = Arc<std::sync::Mutex<Vec<Option<chrono::DateTime<chrono::Utc>>>>>;
+
+/// Two forecast model runs, ascending (latest last). Matches the canonical
+/// EDR/GRIB convention.
+fn forecast_runs() -> [chrono::DateTime<chrono::Utc>; 2] {
+    [
+        chrono::DateTime::parse_from_rfc3339("2026-06-07T00:00:00Z")
+            .unwrap()
+            .with_timezone(&chrono::Utc),
+        chrono::DateTime::parse_from_rfc3339("2026-06-07T12:00:00Z")
+            .unwrap()
+            .with_timezone(&chrono::Utc),
+    ]
+}
+
+/// Mock forecast engine that retains two model runs and records the
+/// `reference_time` it was asked to render, so tests can assert that the WMS
+/// `DIM_REFERENCE_TIME` selector reaches the engine (and that omitting it
+/// defaults to `None` ⇒ latest run).
+struct ForecastMockMapEngine {
+    calls: RunRecorder,
+}
+
+impl MapEngine for ForecastMockMapEngine {
+    fn get_raster_tile(
+        &self,
+        _bbox: [f64; 4],
+        width: u32,
+        height: u32,
+        _time: Option<chrono::DateTime<chrono::Utc>>,
+        _output_crs: &OutputCrs,
+        _parameter: Option<&str>,
+        _z: Option<f64>,
+        reference_time: Option<chrono::DateTime<chrono::Utc>>,
+    ) -> Result<RasterTile, DataServerError> {
+        self.calls.lock().unwrap().push(reference_time);
+        let pixel_count = (width * height) as usize;
+        // Non-uniform so the response avoids the all-nodata fast path.
+        let values: Vec<Option<f64>> = (0..pixel_count)
+            .map(|i| Some(i as f64 / pixel_count as f64))
+            .collect();
+        Ok(RasterTile {
+            width,
+            height,
+            values,
+        })
+    }
+
+    fn raster_info(&self) -> RasterInfo {
+        RasterInfo {
+            native_crs: "EPSG:4326".into(),
+            spatial_extent: Some([10.0, 55.0, 30.0, 70.0]),
+            times: vec![chrono::DateTime::parse_from_rfc3339("2026-06-07T00:00:00Z")
+                .unwrap()
+                .with_timezone(&chrono::Utc)],
+            parameter: "2t".into(),
+            unit: "K".into(),
+            parameters: vec![],
+            vertical: None,
+            grid_size: None,
+            layer_subtitle: None,
+            reference_times: forecast_runs().to_vec(),
+        }
+    }
+}
+
+/// Build a WMS router whose `ecmwf-fc` collection is a forecast engine with two
+/// runs. Returns the router and the call-recorder so tests can assert which run
+/// the engine was asked to render.
+fn build_forecast_router() -> (axum::Router, RunRecorder) {
+    let calls = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let engine: Arc<dyn MapEngine> = Arc::new(ForecastMockMapEngine {
+        calls: calls.clone(),
+    });
+    let mut engines = HashMap::new();
+    let mut collections = HashMap::new();
+    let mut styles_map = HashMap::new();
+
+    engines.insert("ecmwf-fc".to_string(), engine);
+    collections.insert(
+        "ecmwf-fc".to_string(),
+        CollectionConfig {
+            id: "ecmwf-fc".to_string(),
+            title: "ECMWF Forecast".to_string(),
+            description: "Forecast fixture for #337 reference_time".into(),
+            data_path: None,
+            apis: vec!["wms".to_string()],
+            engine_type: "grib".to_string(),
+            keywords: Vec::new(),
+            license: None,
+            geotiff: None,
+            querydata: None,
+            wms: None,
+            grib: None,
+            zarr: None,
+            odim: None,
+            postgis: None,
+            preview: None,
+        },
+    );
+
+    let cmap = Arc::new(LutColorMap::from_builtin(
+        BuiltinColormap::Viridis,
+        0.0,
+        1.0,
+    ));
+    let mut layer_styles = HashMap::new();
+    layer_styles.insert(
+        "default".to_string(),
+        StyleInfo {
+            name: "default".to_string(),
+            title: "Default".to_string(),
+            colormap: cmap,
+            min: 0.0,
+            max: 1.0,
+            parameter: None,
+        },
+    );
+    styles_map.insert("ecmwf-fc".to_string(), layer_styles);
+
+    let state = Arc::new(ArcSwap::from_pointee(WmsState {
+        engines,
+        collections,
+        styles: styles_map,
+        render_semaphore: Arc::new(tokio::sync::Semaphore::new(4)),
+        rendered_cache: Arc::new(RenderedCache::new(16)),
+        tile_cache: Arc::new(ds_render::TilePixelCache::new(16)),
+        base_url: String::new(),
+    }));
+    (api_wms::router(state), calls)
+}
+
+const FC_GETMAP_URI: &str = "/?SERVICE=WMS&REQUEST=GetMap&VERSION=1.3.0&LAYERS=ecmwf-fc\
+                             &CRS=CRS:84&BBOX=10,55,30,70&WIDTH=64&HEIGHT=64\
+                             &FORMAT=image/png";
+
+/// A forecast collection advertises a custom `reference_time` dimension (the
+/// model run) alongside the standard `time` dimension, defaulting to the latest
+/// run, with both runs in the value list — and it sits among the `<Dimension>`s
+/// (before any `<Attribution>`/`<Style>`).
+#[test]
+fn capabilities_emit_reference_time_dimension_for_forecast() {
+    let mut engines: HashMap<String, Arc<dyn MapEngine>> = HashMap::new();
+    let mut collections = HashMap::new();
+    engines.insert(
+        "ecmwf-fc".to_string(),
+        Arc::new(ForecastMockMapEngine {
+            calls: Arc::new(std::sync::Mutex::new(Vec::new())),
+        }),
+    );
+    collections.insert(
+        "ecmwf-fc".to_string(),
+        CollectionConfig {
+            id: "ecmwf-fc".to_string(),
+            title: "ECMWF Forecast".to_string(),
+            description: "Forecast fixture".into(),
+            data_path: None,
+            apis: vec!["wms".to_string()],
+            engine_type: "grib".to_string(),
+            keywords: Vec::new(),
+            license: None,
+            geotiff: None,
+            querydata: None,
+            wms: None,
+            grib: None,
+            zarr: None,
+            odim: None,
+            postgis: None,
+            preview: None,
+        },
+    );
+
+    let styles: HashMap<String, HashMap<String, StyleInfo>> = HashMap::new();
+    let xml = api_wms::capabilities::get_capabilities_xml(&engines, &collections, &styles, "");
+    let xml = String::from_utf8(xml).expect("capabilities XML is UTF-8");
+
+    // Both dimensions present: the valid-time axis and the run axis.
+    assert!(
+        xml.contains("<Dimension name=\"time\""),
+        "forecast layer must keep the standard time dimension; got:\n{xml}"
+    );
+    assert!(
+        xml.contains("<Dimension name=\"reference_time\" units=\"ISO8601\""),
+        "forecast layer must advertise a reference_time dimension; got:\n{xml}"
+    );
+    // Default is the latest run.
+    assert!(
+        xml.contains("default=\"2026-06-07T12:00:00+00:00\""),
+        "reference_time default must be the latest run; got:\n{xml}"
+    );
+    // Both runs listed as values.
+    assert!(
+        xml.contains("2026-06-07T00:00:00+00:00,2026-06-07T12:00:00+00:00</Dimension>"),
+        "reference_time must list both runs ascending; got:\n{xml}"
+    );
+    // No nearestValue on the run dimension (exact match required).
+    let rt_idx = xml.find("name=\"reference_time\"").unwrap();
+    let rt_end = rt_idx + xml[rt_idx..].find('>').unwrap();
+    assert!(
+        !xml[rt_idx..rt_end].contains("nearestValue"),
+        "reference_time dimension must not advertise nearestValue; got:\n{xml}"
+    );
+}
+
+/// A non-forecast layer (no `reference_times`) emits no `reference_time`
+/// dimension — the standard `time` dimension is the only one.
+#[test]
+fn capabilities_omit_reference_time_dimension_for_non_forecast() {
+    let mut engines: HashMap<String, Arc<dyn MapEngine>> = HashMap::new();
+    let mut collections = HashMap::new();
+    engines.insert("empty".to_string(), Arc::new(EmptyMockMapEngine));
+    collections.insert(
+        "empty".to_string(),
+        CollectionConfig {
+            id: "empty".to_string(),
+            title: "Empty".to_string(),
+            description: "Non-forecast".to_string(),
+            data_path: None,
+            apis: vec!["wms".to_string()],
+            engine_type: "geotiff".to_string(),
+            keywords: Vec::new(),
+            license: None,
+            geotiff: None,
+            querydata: None,
+            wms: None,
+            grib: None,
+            zarr: None,
+            odim: None,
+            postgis: None,
+            preview: None,
+        },
+    );
+
+    let styles: HashMap<String, HashMap<String, StyleInfo>> = HashMap::new();
+    let xml = api_wms::capabilities::get_capabilities_xml(&engines, &collections, &styles, "");
+    let xml = String::from_utf8(xml).expect("capabilities XML is UTF-8");
+    assert!(
+        !xml.contains("reference_time"),
+        "non-forecast layer must not advertise a reference_time dimension; got:\n{xml}"
+    );
+}
+
+/// `GetMap` with no `DIM_REFERENCE_TIME` defaults to the latest run — the
+/// engine is called with `reference_time = None`.
+#[tokio::test]
+async fn getmap_default_reference_time_is_none() {
+    let (app, calls) = build_forecast_router();
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri(FC_GETMAP_URI)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let recorded = calls.lock().unwrap().clone();
+    assert_eq!(
+        recorded,
+        vec![None],
+        "omitting DIM_REFERENCE_TIME must query the latest run (None)"
+    );
+}
+
+/// `GetMap` with a valid `DIM_REFERENCE_TIME` selects that run — the engine is
+/// called with the pinned reference time.
+#[tokio::test]
+async fn getmap_selects_pinned_reference_time() {
+    let (app, calls) = build_forecast_router();
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri(format!(
+                    "{FC_GETMAP_URI}&DIM_REFERENCE_TIME=2026-06-07T00:00:00Z"
+                ))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let recorded = calls.lock().unwrap().clone();
+    assert_eq!(
+        recorded,
+        vec![Some(forecast_runs()[0])],
+        "DIM_REFERENCE_TIME must select the pinned run"
+    );
+}
+
+/// The compact EDR instance-id form (`20260607T0000Z`) is also accepted as a
+/// `DIM_REFERENCE_TIME` value, resolving to the same run.
+#[tokio::test]
+async fn getmap_accepts_compact_instance_id_reference_time() {
+    let (app, calls) = build_forecast_router();
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri(format!("{FC_GETMAP_URI}&DIM_REFERENCE_TIME=20260607T0000Z"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let recorded = calls.lock().unwrap().clone();
+    assert_eq!(recorded, vec![Some(forecast_runs()[0])]);
+}
+
+/// A `DIM_REFERENCE_TIME` that doesn't match an advertised run is a 400
+/// `InvalidDimensionValue` ServiceException — not a rendered (red) tile.
+#[tokio::test]
+async fn getmap_unknown_reference_time_returns_400() {
+    let (app, calls) = build_forecast_router();
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri(format!(
+                    "{FC_GETMAP_URI}&DIM_REFERENCE_TIME=2000-01-01T00:00:00Z"
+                ))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    let body = resp.into_body().collect().await.unwrap().to_bytes();
+    let xml = String::from_utf8(body.to_vec()).unwrap();
+    assert!(
+        xml.contains("InvalidDimensionValue"),
+        "unknown run must yield InvalidDimensionValue; got:\n{xml}"
+    );
+    // The engine must not have been asked to render an invalid run.
+    assert!(
+        calls.lock().unwrap().is_empty(),
+        "engine must not be called for an invalid reference_time"
+    );
+}
+
+/// An unparseable `DIM_REFERENCE_TIME` is also a 400 `InvalidDimensionValue`.
+#[tokio::test]
+async fn getmap_unparseable_reference_time_returns_400() {
+    let (app, _calls) = build_forecast_router();
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri(format!("{FC_GETMAP_URI}&DIM_REFERENCE_TIME=not-a-time"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+/// `DIM_REFERENCE_TIME` against a non-forecast layer (no advertised runs) is a
+/// 400 `InvalidDimensionValue` — the dimension doesn't exist for that layer.
+#[tokio::test]
+async fn getmap_reference_time_against_non_forecast_layer_returns_400() {
+    let app = build_populated_router(); // "radar" has empty reference_times
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri(format!(
+                    "{GETMAP_URI}&DIM_REFERENCE_TIME=2026-06-07T00:00:00Z"
+                ))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    let body = resp.into_body().collect().await.unwrap().to_bytes();
+    let xml = String::from_utf8(body.to_vec()).unwrap();
+    assert!(
+        xml.contains("InvalidDimensionValue"),
+        "reference_time on a non-forecast layer must be InvalidDimensionValue; got:\n{xml}"
+    );
+}

--- a/crates/api-wms/tests/integration.rs
+++ b/crates/api-wms/tests/integration.rs
@@ -1263,7 +1263,7 @@ fn build_forecast_router() -> (axum::Router, RunRecorder) {
 }
 
 const FC_GETMAP_URI: &str = "/?SERVICE=WMS&REQUEST=GetMap&VERSION=1.3.0&LAYERS=ecmwf-fc\
-                             &CRS=CRS:84&BBOX=10,55,30,70&WIDTH=64&HEIGHT=64\
+                             &STYLES=&CRS=CRS:84&BBOX=10,55,30,70&WIDTH=64&HEIGHT=64\
                              &FORMAT=image/png";
 
 /// A forecast collection advertises a custom `reference_time` dimension (the

--- a/crates/api-wms/tests/integration.rs
+++ b/crates/api-wms/tests/integration.rs
@@ -1439,6 +1439,67 @@ async fn getmap_accepts_compact_instance_id_reference_time() {
     assert_eq!(recorded, vec![Some(forecast_runs()[0])]);
 }
 
+/// The Web Mercator (EPSG:3857) meta-tile render path propagates the pinned run
+/// in two independent places — `TileKeyPrefix.reference_time` and the
+/// `get_raster_tile` closure inside `render_metatiled` — neither of which the
+/// CRS:84 direct-path tests above exercise. Pin a non-latest run (so it isn't
+/// normalised to `None`) and assert every tile render saw it.
+#[tokio::test]
+async fn getmap_metatile_path_selects_pinned_reference_time() {
+    let (app, calls) = build_forecast_router();
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri(
+                    "/?SERVICE=WMS&REQUEST=GetMap&VERSION=1.3.0&LAYERS=ecmwf-fc\
+                     &STYLES=&CRS=EPSG:3857&BBOX=1113194,6982997,3339584,9100048\
+                     &WIDTH=256&HEIGHT=256&FORMAT=image/png\
+                     &DIM_REFERENCE_TIME=2026-06-07T00:00:00Z",
+                )
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let recorded = calls.lock().unwrap().clone();
+    assert!(
+        !recorded.is_empty(),
+        "meta-tile path must call the engine at least once"
+    );
+    assert!(
+        recorded.iter().all(|rt| *rt == Some(forecast_runs()[0])),
+        "every meta-tile get_raster_tile must carry the pinned run; got {recorded:?}"
+    );
+}
+
+/// Explicitly pinning the *current latest* run is normalised to `None` so it
+/// shares cache entries (and the engine's latest-run path) with requests that
+/// omit the dimension — both render identical pixels. The engine therefore sees
+/// `None`, not `Some(latest)`.
+#[tokio::test]
+async fn getmap_explicit_latest_run_normalizes_to_none() {
+    let (app, calls) = build_forecast_router();
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri(format!(
+                    "{FC_GETMAP_URI}&DIM_REFERENCE_TIME=2026-06-07T12:00:00Z"
+                ))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let recorded = calls.lock().unwrap().clone();
+    assert_eq!(
+        recorded,
+        vec![None],
+        "pinning the current latest run must collapse to None (cache unified with no-dimension)"
+    );
+}
+
 /// A `DIM_REFERENCE_TIME` that doesn't match an advertised run is a 400
 /// `InvalidDimensionValue` ServiceException — not a rendered (red) tile.
 #[tokio::test]

--- a/crates/core/src/map_engine.rs
+++ b/crates/core/src/map_engine.rs
@@ -140,10 +140,13 @@ pub struct RasterInfo {
     /// parent-layer tree can still tell siblings apart. `None` for standalone
     /// collections.
     pub layer_subtitle: Option<String>,
-    /// Available forecast model runs (reference times), ascending. Empty for
-    /// non-forecast collections. WMS surfaces these as a custom `reference_time`
-    /// dimension and `get_raster_tile`'s `reference_time` argument selects one
-    /// (`None` ⇒ latest); see [`crate::instances`].
+    /// Available forecast model runs (reference times). **Contract: sorted
+    /// ascending, so the latest run is `.last()`** — engines build this from a
+    /// reference-time-keyed `BTreeMap`, and consumers depend on the ordering
+    /// (WMS advertises `.last()` as the `reference_time` dimension's `default`).
+    /// Empty for non-forecast collections. WMS surfaces these as a custom
+    /// `reference_time` dimension and `get_raster_tile`'s `reference_time`
+    /// argument selects one (`None` ⇒ latest); see [`crate::instances`].
     pub reference_times: Vec<DateTime<Utc>>,
 }
 

--- a/crates/render/src/lib.rs
+++ b/crates/render/src/lib.rs
@@ -86,6 +86,10 @@ pub struct CacheKey {
     /// Optional vertical level, quantized to millidegrees/milli-units so the
     /// key stays `Hash`/`Eq`. Use [`quantize_z`] to build it.
     pub z: Option<i64>,
+    /// Optional forecast model run (reference time). Distinct cache entries for
+    /// the same (layer, time, bbox, …) when a client pins a non-latest run via
+    /// the WMS `reference_time` dimension. `None` = the engine's latest run.
+    pub reference_time: Option<DateTime<Utc>>,
 }
 
 /// Quantize a vertical level for use in a [`CacheKey`] — millidegrees /
@@ -154,6 +158,19 @@ impl CacheKey {
             Some(z) => {
                 fnv1a_mix(&mut h, &[1u8]);
                 fnv1a_mix(&mut h, &z.to_le_bytes());
+            }
+            None => fnv1a_mix(&mut h, &[0u8]),
+        }
+        match self.reference_time {
+            Some(rt) => {
+                fnv1a_mix(&mut h, &[1u8]);
+                // Mirror the `time` mixing: nanos when in range, else a
+                // saturating millis fallback so the ETag stays deterministic
+                // for pathological dates rather than panicking.
+                let ts = rt
+                    .timestamp_nanos_opt()
+                    .unwrap_or_else(|| rt.timestamp_millis().saturating_mul(1_000_000));
+                fnv1a_mix(&mut h, &ts.to_le_bytes());
             }
             None => fnv1a_mix(&mut h, &[0u8]),
         }
@@ -534,6 +551,7 @@ mod tests {
             ),
             parameter: None,
             z: None,
+            reference_time: None,
         };
         let mut later = base.clone();
         later.time = Some(
@@ -557,6 +575,7 @@ mod tests {
             time: None,
             parameter: Some("2t".into()),
             z: None,
+            reference_time: None,
         };
         let mut other = base.clone();
         other.parameter = Some("10u".into());
@@ -564,6 +583,41 @@ mod tests {
 
         let mut absent = base.clone();
         absent.parameter = None;
+        assert_ne!(base.etag(), absent.etag());
+    }
+
+    #[test]
+    fn cache_key_etag_changes_when_reference_time_changes() {
+        // Two requests identical except for the forecast run (WMS
+        // `reference_time` dimension) must not collide in the rendered cache —
+        // different runs produce different pixels under the same valid TIME.
+        let base = CacheKey {
+            layer: "ecmwf-fc".into(),
+            style: "default".into(),
+            format: 0,
+            crs: "EPSG:3857".into(),
+            bbox: [0, 0, 1, 1],
+            width: 256,
+            height: 256,
+            time: None,
+            parameter: None,
+            z: None,
+            reference_time: Some(
+                chrono::DateTime::parse_from_rfc3339("2026-01-01T00:00:00Z")
+                    .unwrap()
+                    .with_timezone(&chrono::Utc),
+            ),
+        };
+        let mut other = base.clone();
+        other.reference_time = Some(
+            chrono::DateTime::parse_from_rfc3339("2026-01-01T12:00:00Z")
+                .unwrap()
+                .with_timezone(&chrono::Utc),
+        );
+        assert_ne!(base.etag(), other.etag());
+
+        let mut absent = base.clone();
+        absent.reference_time = None;
         assert_ne!(base.etag(), absent.etag());
     }
 
@@ -584,9 +638,10 @@ mod tests {
             time: None,
             parameter: None,
             z: None,
+            reference_time: None,
         };
-        // Pinned after introducing the `z` field (cache-bust event).
-        assert_eq!(key.etag(), "\"95776756a198bd3a\"");
+        // Pinned after introducing the `reference_time` field (cache-bust event).
+        assert_eq!(key.etag(), "\"92a1d2349689898e\"");
     }
 
     #[test]

--- a/crates/render/src/metatile.rs
+++ b/crates/render/src/metatile.rs
@@ -119,6 +119,9 @@ pub struct TileKeyPrefix {
     pub time: Option<DateTime<Utc>>,
     /// Vertical level, pre-quantized via [`crate::quantize_z`].
     pub z: Option<i64>,
+    /// Forecast model run (reference time); `None` = the engine's latest run.
+    /// Keeps tiles for distinct runs from colliding in the meta-tile cache.
+    pub reference_time: Option<DateTime<Utc>>,
 }
 
 /// Cache key for one rendered+colorized meta-tile.
@@ -129,6 +132,7 @@ pub struct TileKey {
     style: String,
     time: Option<DateTime<Utc>>,
     z: Option<i64>,
+    reference_time: Option<DateTime<Utc>>,
     level: i32,
     col: i64,
     row: i64,
@@ -327,6 +331,7 @@ where
                 style: prefix.style.clone(),
                 time: prefix.time,
                 z: prefix.z,
+                reference_time: prefix.reference_time,
                 level,
                 col,
                 row,
@@ -585,6 +590,7 @@ mod tests {
             style: "default".into(),
             time: None,
             z: None,
+            reference_time: None,
         };
         // A modest viewport around Helsinki at ~zoom 6.
         let bbox = [20.0, 58.0, 30.0, 64.0];
@@ -650,6 +656,7 @@ mod tests {
             style: "default".into(),
             time: None,
             z: None,
+            reference_time: None,
         };
         let empty_tile = |_b: [f64; 4], w: u32, h: u32| {
             Ok(RasterTile {
@@ -681,6 +688,7 @@ mod tests {
             style: "default".into(),
             time: None,
             z: None,
+            reference_time: None,
         };
         // Whole-world bbox at a tiny resolution forces > MAX_TILES → fallback.
         let out = render_metatiled(
@@ -718,6 +726,7 @@ mod tests {
             style: "default".into(),
             time: None,
             z: None,
+            reference_time: None,
         };
         // ~1 µm/px viewport (tiny bbox, large image).
         let out = render_metatiled(
@@ -818,6 +827,7 @@ mod tests {
             style: "default".into(),
             time: None,
             z: None,
+            reference_time: None,
         };
 
         // --- X axis: value = mercator-X, constant down each column. ---


### PR DESCRIPTION
## What

Phase 2 of #337 (model-run support). WMS now exposes the forecast **model run** (forecast *reference time* / init / analysis time) as a custom `reference_time` dimension, alongside the standard `TIME` (valid-time) axis — the de-facto ncWMS/THREDDS convention. Default = latest run, matching the existing no-instance EDR behaviour.

## Changes

**`api-wms`**
- **GetCapabilities** advertises `<Dimension name="reference_time" units="ISO8601">` for any layer whose engine reports a non-empty `RasterInfo.reference_times` (GRIB, QueryData today), with `default=` the latest run and every run listed as RFC 3339. Placed among the existing `<Dimension>`s, before `<Attribution>` (WMS 1.3.0 schema order). **No `nearestValue`** — the run must match an advertised value exactly.
- **GetMap** parses `DIM_REFERENCE_TIME=<run>` (RFC 3339 / lenient ISO, or the compact EDR instance-id stamp `20260607T0600Z`). The handler validates it against the advertised runs and returns `InvalidDimensionValue` (HTTP 400) for:
  - an unknown run, and
  - a `DIM_REFERENCE_TIME` against a non-forecast layer.
  
  This is the correct WMS response — without it the engine's `ReferenceTimeNotFound` would render a red 200 tile. Mirrors the existing parameter/`ELEVATION` validation.
- The selected run flows through `get_raster_tile` (both the direct and Web-Mercator meta-tile paths).

**`ds-render`**
- `CacheKey.reference_time` and `TileKeyPrefix`/`TileKey.reference_time` so distinct runs don't collide in the rendered-image and meta-tile caches. ETag golden re-pinned (cache-bust event).

**`api-maps` / `api-tiles`**
- Pass `reference_time: None` for the new cache-key field. Their `reference_time` query parameter is the remaining **Phase 4** follow-up; the engines already honour the selector.

## Tests

`crates/api-wms/tests/integration.rs` — a two-run forecast mock engine that records the `reference_time` it's asked to render:
- capabilities emit the `reference_time` dimension (default = latest, both runs listed, no `nearestValue`) and omit it for non-forecast layers;
- GetMap default → engine queried with `None` (latest); explicit run (RFC 3339 **and** compact instance-id) → engine queried with that run;
- unknown run / unparseable value / run on a non-forecast layer → 400 `InvalidDimensionValue` (and the engine is not called for an invalid run).

Plus a `ds-render` test that the ETag changes with `reference_time`.

`cargo test --workspace` green; `cargo clippy --workspace --tests` clean; `cargo fmt` applied.

## Remaining for #337

- [ ] OGC API - Maps/Tiles `reference_time` query parameter (Phase 4)
- [ ] Zarr forecast-reference/lead → instances (Phase 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)