### PR TITLE
feat(engine-odim): 3D Tiles point-cloud demo for radar polar volumes

### DIFF
--- a/crates/engine-odim/examples/README.md
+++ b/crates/engine-odim/examples/README.md
@@ -1,0 +1,84 @@
+# engine-odim examples — 3D Tiles radar-volume demo
+
+Proof-of-concept tooling for **OGC 3D Tiles** delivery of radar polar volumes
+(epic [#346], Phase 1 = [#347]). These are standalone `cargo run` examples — they
+do **not** change any engine trait; they validate the geometry pipeline
+end-to-end before the `VolumeEngine` trait + `ds-3dtiles` encoder are built
+([#348]).
+
+## `gen_3dtiles` — polar volume → 3D Tiles point cloud
+
+Reads an ODIM polar volume, projects **every** echo cell through the engine's
+4/3-Earth beam model → geodetic → ECEF, and writes a 3D Tiles point cloud plus a
+token-free CesiumJS viewer.
+
+```bash
+# Uses the default FMI Vihti fixture (see "Fixture" below):
+cargo run -p engine-odim --example gen_3dtiles
+
+# Or point it at any ODIM polar volume, with an output dir + min dBZ threshold:
+cargo run -p engine-odim --example gen_3dtiles -- path/to/volume.h5 target/3dtiles 5.0
+```
+
+Output (default `target/3dtiles-fivih/`):
+
+| File | What |
+|------|------|
+| `content.pnts` | the point cloud (3D Tiles 1.0 Point Cloud format) |
+| `tileset.json` | the tileset (single tile, `region` bounding volume) |
+| `index.html`   | a self-contained CesiumJS viewer (CARTO Dark Matter basemap) |
+
+### Viewing
+
+CesiumJS needs the files served over HTTP (not `file://`):
+
+```bash
+cd target/3dtiles-fivih && python3 -m http.server 8777
+# then open http://localhost:8777/index.html
+```
+
+The colours are an NWS-style reflectivity ramp; the dark basemap makes them pop.
+You'll see the conical sweep structure, the echo tops, and the "cone of silence"
+directly above the antenna.
+
+## `volume_stats` — reflectivity probe
+
+Prints per-sweep + whole-volume reflectivity stats (coverage, max dBZ, convective
+fraction, approximate echo top). Used to pick a demo timestep with interesting
+weather.
+
+```bash
+cargo run -p engine-odim --example volume_stats -- path/to/volume.h5 [QUANTITY]
+```
+
+## Why `.pnts` and not `.glb` (and other gotchas)
+
+Hard-won while building the PoC — these inform how `ds-3dtiles` should encode:
+
+- **Use `.pnts`, not a `.glb` with POINTS-mode.** A glb point primitive routes
+  through CesiumJS's `Model` renderer, which draws fixed **1px** points and
+  **ignores both `pointSize` styling and vertex `COLOR_0`** (renders faint
+  white). The `.pnts` FeatureTable (POSITION + RGB) honours `pointSize` and
+  per-point colour.
+- **The tileset's top-level `geometricError` must be `> 0`.** With it `0`,
+  CesiumJS never refines to the root and **never even requests the content
+  tile** — nothing renders, no error. (This example uses tileset `100000`,
+  root `1000`.)
+- **`.pnts` `POSITION` is ECEF-native** (offsets from `RTC_CENTER`) — no glTF
+  Y-up→Z-up flip. A glb path *would* need to bake `(x, z, -y)`.
+- **`region` bounding volume** is geodetic (EPSG:4979) and ignores the tile
+  transform, sidestepping local-frame confusion.
+- The Cesium Ion default imagery needs a token → black globe; the viewer uses
+  CARTO Dark Matter via `UrlTemplateImageryProvider` (token-free).
+
+## Fixture
+
+The default input — `testdata/radar-fmi-pvol/202605191050_fivih_PVOL.h5` (FMI
+Vihti, 2026-05-19 10:50Z) — is the same volume the integration tests use and is
+**not committed to git** (15 MB). Provide your own ODIM polar volume, or drop one
+under `testdata/radar-fmi-pvol/`. It's the best fivih volume we measured for a
+demo: 59 dBZ peak, 35.7% coverage, discrete convective cores.
+
+[#346]: https://github.com/mrauhala/meteocore/issues/346
+[#347]: https://github.com/mrauhala/meteocore/issues/347
+[#348]: https://github.com/mrauhala/meteocore/issues/348

--- a/crates/engine-odim/examples/gen_3dtiles.rs
+++ b/crates/engine-odim/examples/gen_3dtiles.rs
@@ -1,0 +1,353 @@
+//! Phase-1 PoC: turn a polar volume into an OGC 3D Tiles point cloud that
+//! loads in stock CesiumJS. Every valid echo cell becomes a point at its true
+//! 3D position, computed with the engine's 4/3-Earth beam model, and colored by
+//! an NWS-style reflectivity ramp.
+//!
+//! Content is the `.pnts` (Point Cloud) tile format. It is the 3D Tiles 1.0
+//! point-cloud format (still rendered by CesiumJS in 1.1) and the path where
+//! `pointSize`/attenuation styling and per-point RGB actually work — a `.glb`
+//! with POINTS mode goes through the Model renderer, which draws fixed 1px
+//! white points and ignores both the style and vertex colors. A production
+//! feature would move to glTF voxels (EXT_primitive_voxels, cylinder shape);
+//! pnts is the right call for a "see it now" geometry PoC. Either way this
+//! exercises the hard part: (slant_range, elevation, azimuth) -> geographic ->
+//! ECEF, via an RTC center.
+//!
+//! Usage:
+//!   cargo run -p engine-odim --example gen_3dtiles -- <file.h5> [out_dir] [min_dbz]
+//!     out_dir  default target/3dtiles-fivih
+//!     min_dbz  default 5.0  (skip cells below this reflectivity)
+
+use engine_odim::pvol::read_moment_pixels;
+use engine_odim::pvol::read_polar_volume;
+use std::f64::consts::PI;
+use std::fs;
+use std::path::PathBuf;
+
+// WGS84 ellipsoid.
+const WGS84_A: f64 = 6_378_137.0;
+const WGS84_E2: f64 = 6.694_379_990_14e-3;
+// 4/3-Earth effective radius for beam propagation (matches volume_engine.rs).
+const FOUR_THIRDS_EARTH_M: f64 = 4.0 / 3.0 * 6_371_000.0;
+// Sphere radius for the great-circle "destination point" along the ground.
+const EARTH_SPHERE_M: f64 = 6_371_000.0;
+
+/// (lon_deg, lat_deg, height_m above ellipsoid) -> ECEF (x, y, z) metres.
+fn geodetic_to_ecef(lon_deg: f64, lat_deg: f64, h: f64) -> [f64; 3] {
+    let lon = lon_deg.to_radians();
+    let lat = lat_deg.to_radians();
+    let (sl, cl) = lat.sin_cos();
+    let (so, co) = lon.sin_cos();
+    let n = WGS84_A / (1.0 - WGS84_E2 * sl * sl).sqrt();
+    [
+        (n + h) * cl * co,
+        (n + h) * cl * so,
+        (n * (1.0 - WGS84_E2) + h) * sl,
+    ]
+}
+
+/// Great-circle destination from (lon0,lat0) travelling `dist` m along
+/// `bearing` (deg clockwise from north). Spherical — matches the engine.
+fn destination_point(lon0: f64, lat0: f64, dist: f64, bearing_deg: f64) -> (f64, f64) {
+    let ad = dist / EARTH_SPHERE_M;
+    let br = bearing_deg.to_radians();
+    let lat1 = lat0.to_radians();
+    let lon1 = lon0.to_radians();
+    let lat2 = (lat1.sin() * ad.cos() + lat1.cos() * ad.sin() * br.cos()).asin();
+    let lon2 = lon1 + (br.sin() * ad.sin() * lat1.cos()).atan2(ad.cos() - lat1.sin() * lat2.sin());
+    let mut lon = lon2.to_degrees();
+    lon = (lon + 540.0) % 360.0 - 180.0; // normalise to (-180, 180]
+    (lon, lat2.to_degrees())
+}
+
+/// 4/3-Earth beam model: slant range + elevation angle -> (ground arc
+/// distance, height above antenna). Same formula as volume_engine.rs.
+fn slant_to_ground_height(r: f64, elangle_deg: f64) -> (f64, f64) {
+    let el = elangle_deg.to_radians();
+    let rp = FOUR_THIRDS_EARTH_M;
+    let h = (r * r + rp * rp + 2.0 * r * rp * el.sin()).sqrt() - rp;
+    let s = rp * (r * el.cos() / (r * el.sin() + rp)).atan();
+    (s, h)
+}
+
+/// NWS-style reflectivity colour ramp. dBZ -> (r,g,b).
+fn dbz_color(dbz: f64) -> [u8; 3] {
+    const STOPS: &[(f64, [u8; 3])] = &[
+        (5.0, [4, 233, 231]),
+        (10.0, [1, 159, 244]),
+        (15.0, [3, 0, 244]),
+        (20.0, [2, 253, 2]),
+        (25.0, [1, 197, 1]),
+        (30.0, [0, 142, 0]),
+        (35.0, [253, 248, 2]),
+        (40.0, [229, 188, 0]),
+        (45.0, [253, 149, 0]),
+        (50.0, [253, 0, 0]),
+        (55.0, [212, 0, 0]),
+        (60.0, [188, 0, 0]),
+        (65.0, [248, 0, 253]),
+        (70.0, [152, 84, 198]),
+    ];
+    if dbz <= STOPS[0].0 {
+        return STOPS[0].1;
+    }
+    let last = STOPS.len() - 1;
+    if dbz >= STOPS[last].0 {
+        return STOPS[last].1;
+    }
+    for w in STOPS.windows(2) {
+        let (lo, c0) = w[0];
+        let (hi, c1) = w[1];
+        if dbz >= lo && dbz <= hi {
+            let t = (dbz - lo) / (hi - lo);
+            return [
+                (c0[0] as f64 + t * (c1[0] as f64 - c0[0] as f64)).round() as u8,
+                (c0[1] as f64 + t * (c1[1] as f64 - c0[1] as f64)).round() as u8,
+                (c0[2] as f64 + t * (c1[2] as f64 - c0[2] as f64)).round() as u8,
+            ];
+        }
+    }
+    STOPS[last].1
+}
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    // Default to the FMI Vihti polar volume the integration tests use. Like
+    // those tests, this 15 MB fixture is NOT committed to git (see the demo
+    // README) — pass any ODIM polar volume (.h5) as the first arg instead.
+    let path = args.next().unwrap_or_else(|| {
+        format!(
+            "{}/../../testdata/radar-fmi-pvol/202605191050_fivih_PVOL.h5",
+            env!("CARGO_MANIFEST_DIR")
+        )
+    });
+    let out_dir = PathBuf::from(
+        args.next()
+            .unwrap_or_else(|| "target/3dtiles-fivih".to_string()),
+    );
+    let min_dbz: f64 = args
+        .next()
+        .map(|s| s.parse().expect("min_dbz must be a number"))
+        .unwrap_or(5.0);
+
+    let bytes = match fs::read(&path) {
+        Ok(b) => b,
+        Err(err) => {
+            eprintln!("cannot read {path}: {err}");
+            eprintln!(
+                "The default FMI Vihti PVOL fixture is not committed to git (15 MB). \
+                 Pass a path to an ODIM polar volume (.h5), or place one under \
+                 testdata/radar-fmi-pvol/."
+            );
+            std::process::exit(1);
+        }
+    };
+    let vol = read_polar_volume(&bytes).expect("parse volume");
+    let site = &vol.site;
+    eprintln!(
+        "site {:?} ({:?})  lon={:.4} lat={:.4} h={:.0}m  sweeps={}  time={}",
+        site.nod,
+        site.plc,
+        site.lon,
+        site.lat,
+        site.height,
+        vol.sweeps.len(),
+        vol.time
+    );
+
+    // RTC center = ECEF of the antenna. pnts POSITION values are raw ECEF
+    // offsets from this center (no Y-up/Z-up flip — pnts is ECEF-native).
+    let center = geodetic_to_ecef(site.lon, site.lat, site.height);
+
+    let mut positions: Vec<[f32; 3]> = Vec::new();
+    let mut colors: Vec<[u8; 3]> = Vec::new();
+    // Geodetic bbox for the `region` bounding volume.
+    let (mut w, mut s, mut e, mut n) = (PI, PI / 2.0, -PI, -PI / 2.0);
+    let (mut min_h, mut max_h) = (f64::INFINITY, f64::NEG_INFINITY);
+
+    for sw in &vol.sweeps {
+        let Some(mom) = sw
+            .moments
+            .iter()
+            .find(|m| m.quantity == "DBZH")
+            .or_else(|| sw.moments.iter().find(|m| m.quantity == "TH"))
+        else {
+            continue;
+        };
+        let px = match read_moment_pixels(&bytes, &mom.dataset_path, sw.nrays, sw.nbins) {
+            Ok(p) => p,
+            Err(err) => {
+                eprintln!("  skip sweep {:.2}: {err:?}", sw.elangle);
+                continue;
+            }
+        };
+        let deg_per_ray = 360.0 / sw.nrays as f64;
+        for ray in 0..sw.nrays {
+            let bearing = (ray as f64 + 0.5) * deg_per_ray;
+            for bin in 0..sw.nbins {
+                let Some(dbz) = px.sample(
+                    ray,
+                    bin,
+                    mom.gain,
+                    mom.offset,
+                    mom.nodata,
+                    Some(mom.undetect),
+                ) else {
+                    continue;
+                };
+                if dbz < min_dbz {
+                    continue;
+                }
+                let r = sw.rstart + (bin as f64 + 0.5) * sw.rscale;
+                let (ground, h_above) = slant_to_ground_height(r, sw.elangle);
+                let (lon, lat) = destination_point(site.lon, site.lat, ground, bearing);
+                let alt = site.height + h_above;
+                let ecef = geodetic_to_ecef(lon, lat, alt);
+                positions.push([
+                    (ecef[0] - center[0]) as f32,
+                    (ecef[1] - center[1]) as f32,
+                    (ecef[2] - center[2]) as f32,
+                ]);
+                colors.push(dbz_color(dbz));
+
+                let lonr = lon.to_radians();
+                let latr = lat.to_radians();
+                w = w.min(lonr);
+                e = e.max(lonr);
+                s = s.min(latr);
+                n = n.max(latr);
+                min_h = min_h.min(alt);
+                max_h = max_h.max(alt);
+            }
+        }
+    }
+
+    let count = positions.len();
+    assert!(count > 0, "no cells >= {min_dbz} dBZ — nothing to write");
+    eprintln!("points: {count}  (>= {min_dbz} dBZ)");
+
+    fs::create_dir_all(&out_dir).expect("mkdir out_dir");
+
+    // ---- content.pnts ----
+    // Binary body: POSITION (n*12, f32) then RGB (n*3, u8).
+    let pos_bytes = count * 12;
+    let rgb_off = pos_bytes;
+    let mut body = Vec::with_capacity(pos_bytes + count * 3);
+    for p in &positions {
+        for v in p {
+            body.extend_from_slice(&v.to_le_bytes());
+        }
+    }
+    for c in &colors {
+        body.extend_from_slice(c);
+    }
+    while body.len() % 8 != 0 {
+        body.push(0);
+    }
+
+    let [cx, cy, cz] = center;
+    let ft_json = format!(
+        r#"{{"POINTS_LENGTH":{count},"RTC_CENTER":[{cx},{cy},{cz}],"POSITION":{{"byteOffset":0}},"RGB":{{"byteOffset":{rgb_off}}}}}"#
+    );
+    let mut ft_json = ft_json.into_bytes();
+    while ft_json.len() % 8 != 0 {
+        ft_json.push(b' ');
+    }
+
+    let header_len = 28;
+    let total = header_len + ft_json.len() + body.len();
+    let mut pnts = Vec::with_capacity(total);
+    pnts.extend_from_slice(b"pnts");
+    pnts.extend_from_slice(&1u32.to_le_bytes()); // version
+    pnts.extend_from_slice(&(total as u32).to_le_bytes());
+    pnts.extend_from_slice(&(ft_json.len() as u32).to_le_bytes()); // FT JSON len
+    pnts.extend_from_slice(&(body.len() as u32).to_le_bytes()); // FT binary len
+    pnts.extend_from_slice(&0u32.to_le_bytes()); // batch table JSON len
+    pnts.extend_from_slice(&0u32.to_le_bytes()); // batch table binary len
+    pnts.extend_from_slice(&ft_json);
+    pnts.extend_from_slice(&body);
+    fs::write(out_dir.join("content.pnts"), &pnts).expect("write pnts");
+
+    // ---- tileset.json ----
+    // Region bounding volume is geodetic (EPSG:4979); RTC_CENTER inside the
+    // pnts places points in ECEF, so no tile transform is needed.
+    let region = format!("[{w},{s},{e},{n},{min_h},{max_h}]");
+    // A non-zero top-level geometricError is load-bearing: with the tileset
+    // geometricError at 0, CesiumJS never refines to the root and the content
+    // tile is never even requested (it draws nothing). Give the tileset a
+    // large error and the single content tile a positive leaf error.
+    let tileset = format!(
+        r#"{{
+  "asset": {{ "version": "1.1" }},
+  "geometricError": 100000,
+  "root": {{
+    "boundingVolume": {{ "region": {region} }},
+    "geometricError": 1000,
+    "refine": "ADD",
+    "content": {{ "uri": "content.pnts" }}
+  }}
+}}
+"#
+    );
+    fs::write(out_dir.join("tileset.json"), tileset).expect("write tileset");
+
+    write_viewer(&out_dir, site.lon, site.lat, site.height);
+
+    eprintln!(
+        "wrote {}/  (tileset.json, content.pnts, index.html)",
+        out_dir.display()
+    );
+    eprintln!(
+        "pnts {:.1} MB  region lon[{:.3},{:.3}] lat[{:.3},{:.3}] alt[{:.0},{:.0}]m",
+        pnts.len() as f64 / 1e6,
+        w.to_degrees(),
+        e.to_degrees(),
+        s.to_degrees(),
+        n.to_degrees(),
+        min_h,
+        max_h
+    );
+}
+
+fn write_viewer(out_dir: &std::path::Path, lon: f64, lat: f64, h: f64) {
+    let html = format!(
+        r#"<!doctype html>
+<html><head><meta charset="utf-8"><title>fivih radar volume — 3D Tiles PoC</title>
+<script src="https://cesium.com/downloads/cesiumjs/releases/1.124/Build/Cesium/Cesium.js"></script>
+<link href="https://cesium.com/downloads/cesiumjs/releases/1.124/Build/Cesium/Widgets/widgets.css" rel="stylesheet">
+<style>html,body,#c{{width:100%;height:100%;margin:0;overflow:hidden}}
+#hud{{position:absolute;top:8px;left:8px;z-index:9;font:13px sans-serif;color:#fff;background:rgba(0,0,0,.55);padding:6px 9px;border-radius:5px}}</style></head>
+<body><div id="c"></div><div id="hud">fivih (Vihti) polar volume — 2026-05-19 10:50Z · DBZH ≥ 5 dBZ</div><script>
+// Token-free: CARTO Dark Matter basemap (dark backdrop makes the dBZ
+// colours pop), no Cesium Ion terrain/imagery.
+const viewer = new Cesium.Viewer("c", {{
+  baseLayer: new Cesium.ImageryLayer(
+    new Cesium.UrlTemplateImageryProvider({{
+      url: "https://{{s}}.basemaps.cartocdn.com/dark_all/{{z}}/{{x}}/{{y}}.png",
+      subdomains: "abcd",
+      maximumLevel: 19,
+      credit: "© OpenStreetMap contributors © CARTO",
+    }})),
+  baseLayerPicker: false, timeline: false, animation: false, geocoder: false,
+}});
+viewer.scene.backgroundColor = Cesium.Color.BLACK;
+viewer.scene.globe.depthTestAgainstTerrain = false;
+Cesium.Cesium3DTileset.fromUrl("tileset.json", {{ maximumScreenSpaceError: 1 }}).then(ts => {{
+  viewer.scene.primitives.add(ts);
+  ts.style = new Cesium.Cesium3DTileStyle({{ pointSize: 5.0 }});
+  // Frame the volume from the SW, elevated, to reveal vertical structure.
+  viewer.camera.flyTo({{
+    destination: Cesium.Cartesian3.fromDegrees({lon}, {lat_s}, 90000),
+    orientation: {{ heading: 0, pitch: Cesium.Math.toRadians(-30), roll: 0 }},
+    duration: 0
+  }});
+  console.log("pnts tileset ready");
+}}).catch(e => console.error("tileset error", e));
+</script></body></html>
+"#,
+        lon = lon,
+        lat_s = lat - 0.9,
+    );
+    let _ = h;
+    let _ = fs::write(out_dir.join("index.html"), html);
+}

--- a/crates/engine-odim/examples/gen_3dtiles.rs
+++ b/crates/engine-odim/examples/gen_3dtiles.rs
@@ -144,6 +144,16 @@ fn main() {
     };
     let vol = read_polar_volume(&bytes).expect("parse volume");
     let site = &vol.site;
+    // Non-finite antenna coordinates would poison both the ECEF projection
+    // (NaN positions) and the generated viewer (`f64::INFINITY` formats as the
+    // invalid-JS literal `inf`). Refuse a corrupt volume up front.
+    if !(site.lon.is_finite() && site.lat.is_finite() && site.height.is_finite()) {
+        eprintln!(
+            "non-finite antenna coordinates (lon={}, lat={}, h={}) — refusing to encode",
+            site.lon, site.lat, site.height
+        );
+        std::process::exit(1);
+    }
     eprintln!(
         "site {:?} ({:?})  lon={:.4} lat={:.4} h={:.0}m  sweeps={}  time={}",
         site.nod,
@@ -259,12 +269,17 @@ fn main() {
 
     let header_len = 28;
     let total = header_len + ft_json.len() + body.len();
+    // The pnts header fields are u32: fail loudly rather than silently
+    // truncate (a >4 GB tile would otherwise produce a corrupt file).
+    let total_u32 = u32::try_from(total).expect("pnts file exceeds 4 GB");
+    let ft_json_u32 = u32::try_from(ft_json.len()).expect("pnts feature-table JSON exceeds 4 GB");
+    let body_u32 = u32::try_from(body.len()).expect("pnts feature-table binary exceeds 4 GB");
     let mut pnts = Vec::with_capacity(total);
     pnts.extend_from_slice(b"pnts");
     pnts.extend_from_slice(&1u32.to_le_bytes()); // version
-    pnts.extend_from_slice(&(total as u32).to_le_bytes());
-    pnts.extend_from_slice(&(ft_json.len() as u32).to_le_bytes()); // FT JSON len
-    pnts.extend_from_slice(&(body.len() as u32).to_le_bytes()); // FT binary len
+    pnts.extend_from_slice(&total_u32.to_le_bytes());
+    pnts.extend_from_slice(&ft_json_u32.to_le_bytes()); // FT JSON len
+    pnts.extend_from_slice(&body_u32.to_le_bytes()); // FT binary len
     pnts.extend_from_slice(&0u32.to_le_bytes()); // batch table JSON len
     pnts.extend_from_slice(&0u32.to_le_bytes()); // batch table binary len
     pnts.extend_from_slice(&ft_json);

--- a/crates/engine-odim/examples/gen_3dtiles.rs
+++ b/crates/engine-odim/examples/gen_3dtiles.rs
@@ -325,6 +325,16 @@ fn main() {
 /// Write a self-contained CesiumJS viewer. `hud` describes the actual volume
 /// (site/time/threshold) so the page is correct for any input, not just fivih.
 fn write_viewer(out_dir: &std::path::Path, lon: f64, lat: f64, h: f64, hud: &str) {
+    // `hud` carries HDF5-sourced site metadata (PLC/NOD) verbatim; escape it
+    // before it lands in the HTML <title>/<div> so a crafted .h5 can't inject
+    // markup/script into the generated viewer.
+    fn html_escape(s: &str) -> String {
+        s.replace('&', "&amp;")
+            .replace('<', "&lt;")
+            .replace('>', "&gt;")
+            .replace('"', "&quot;")
+    }
+    let hud = html_escape(hud);
     // Camera sits ~90 km above the antenna's own elevation, south of it, so the
     // framing tracks the site rather than assuming sea level.
     let cam_alt = h + 90_000.0;

--- a/crates/engine-odim/examples/gen_3dtiles.rs
+++ b/crates/engine-odim/examples/gen_3dtiles.rs
@@ -56,7 +56,7 @@ fn destination_point(lon0: f64, lat0: f64, dist: f64, bearing_deg: f64) -> (f64,
     let lat2 = (lat1.sin() * ad.cos() + lat1.cos() * ad.sin() * br.cos()).asin();
     let lon2 = lon1 + (br.sin() * ad.sin() * lat1.cos()).atan2(ad.cos() - lat1.sin() * lat2.sin());
     let mut lon = lon2.to_degrees();
-    lon = (lon + 540.0) % 360.0 - 180.0; // normalise to (-180, 180]
+    lon = (lon + 540.0) % 360.0 - 180.0; // normalise to [-180, 180)
     (lon, lat2.to_degrees())
 }
 

--- a/crates/engine-odim/examples/gen_3dtiles.rs
+++ b/crates/engine-odim/examples/gen_3dtiles.rs
@@ -223,7 +223,10 @@ fn main() {
     }
 
     let count = positions.len();
-    assert!(count > 0, "no cells >= {min_dbz} dBZ — nothing to write");
+    if count == 0 {
+        eprintln!("no cells >= {min_dbz} dBZ — nothing to write");
+        std::process::exit(1);
+    }
     eprintln!("points: {count}  (>= {min_dbz} dBZ)");
 
     fs::create_dir_all(&out_dir).expect("mkdir out_dir");
@@ -291,7 +294,17 @@ fn main() {
     );
     fs::write(out_dir.join("tileset.json"), tileset).expect("write tileset");
 
-    write_viewer(&out_dir, site.lon, site.lat, site.height);
+    // Self-describing HUD/title from the actual volume, not hardcoded.
+    let site_label = match (&site.plc, &site.nod) {
+        (Some(plc), Some(nod)) => format!("{plc} ({nod})"),
+        (Some(name), None) | (None, Some(name)) => name.clone(),
+        (None, None) => "radar".to_string(),
+    };
+    let hud = format!(
+        "{site_label} polar volume — {} · DBZH ≥ {min_dbz:.0} dBZ",
+        vol.time.format("%Y-%m-%d %H:%MZ")
+    );
+    write_viewer(&out_dir, site.lon, site.lat, site.height, &hud);
 
     eprintln!(
         "wrote {}/  (tileset.json, content.pnts, index.html)",
@@ -309,15 +322,20 @@ fn main() {
     );
 }
 
-fn write_viewer(out_dir: &std::path::Path, lon: f64, lat: f64, h: f64) {
+/// Write a self-contained CesiumJS viewer. `hud` describes the actual volume
+/// (site/time/threshold) so the page is correct for any input, not just fivih.
+fn write_viewer(out_dir: &std::path::Path, lon: f64, lat: f64, h: f64, hud: &str) {
+    // Camera sits ~90 km above the antenna's own elevation, south of it, so the
+    // framing tracks the site rather than assuming sea level.
+    let cam_alt = h + 90_000.0;
     let html = format!(
         r#"<!doctype html>
-<html><head><meta charset="utf-8"><title>fivih radar volume — 3D Tiles PoC</title>
+<html><head><meta charset="utf-8"><title>{hud} — 3D Tiles</title>
 <script src="https://cesium.com/downloads/cesiumjs/releases/1.124/Build/Cesium/Cesium.js"></script>
 <link href="https://cesium.com/downloads/cesiumjs/releases/1.124/Build/Cesium/Widgets/widgets.css" rel="stylesheet">
 <style>html,body,#c{{width:100%;height:100%;margin:0;overflow:hidden}}
 #hud{{position:absolute;top:8px;left:8px;z-index:9;font:13px sans-serif;color:#fff;background:rgba(0,0,0,.55);padding:6px 9px;border-radius:5px}}</style></head>
-<body><div id="c"></div><div id="hud">fivih (Vihti) polar volume — 2026-05-19 10:50Z · DBZH ≥ 5 dBZ</div><script>
+<body><div id="c"></div><div id="hud">{hud}</div><script>
 // Token-free: CARTO Dark Matter basemap (dark backdrop makes the dBZ
 // colours pop), no Cesium Ion terrain/imagery.
 const viewer = new Cesium.Viewer("c", {{
@@ -337,7 +355,7 @@ Cesium.Cesium3DTileset.fromUrl("tileset.json", {{ maximumScreenSpaceError: 1 }})
   ts.style = new Cesium.Cesium3DTileStyle({{ pointSize: 5.0 }});
   // Frame the volume from the SW, elevated, to reveal vertical structure.
   viewer.camera.flyTo({{
-    destination: Cesium.Cartesian3.fromDegrees({lon}, {lat_s}, 90000),
+    destination: Cesium.Cartesian3.fromDegrees({lon}, {lat_s}, {cam_alt}),
     orientation: {{ heading: 0, pitch: Cesium.Math.toRadians(-30), roll: 0 }},
     duration: 0
   }});
@@ -345,9 +363,7 @@ Cesium.Cesium3DTileset.fromUrl("tileset.json", {{ maximumScreenSpaceError: 1 }})
 }}).catch(e => console.error("tileset error", e));
 </script></body></html>
 "#,
-        lon = lon,
         lat_s = lat - 0.9,
     );
-    let _ = h;
-    let _ = fs::write(out_dir.join("index.html"), html);
+    fs::write(out_dir.join("index.html"), html).expect("write index.html");
 }

--- a/crates/engine-odim/examples/volume_stats.rs
+++ b/crates/engine-odim/examples/volume_stats.rs
@@ -27,7 +27,7 @@ fn main() {
     println!();
     println!(
         "{:>3}  {:>6}  {:>5}x{:>4}  {:>7}  {:>6}  {:>6}  {:>6}  {:>6}",
-        "sw", "elang", "rays", "bins", "valid%", "maxdBZ", ">20%", ">35%", ">50%"
+        "sw", "elang", "rays", "bins", "valid%", "maxdBZ", ">=20%", ">=35%", ">=50%"
     );
 
     // Volume-wide accumulators.
@@ -121,9 +121,10 @@ fn main() {
 
     println!();
     println!("VOLUME SUMMARY ({want}):");
-    if vtot == 0 {
-        // No readable sweeps: avoid -inf max and 0/0 = NaN coverage.
-        println!("  no readable {want}/TH sweeps");
+    if vvalid == 0 {
+        // No valid samples (no readable sweeps, or every cell nodata):
+        // vmax is still -inf and coverage would be 0/0 = NaN.
+        println!("  no valid {want}/TH samples ({vtot} cells, all nodata/undetect)");
         return;
     }
     println!("  max reflectivity : {vmax:.1} dBZ");

--- a/crates/engine-odim/examples/volume_stats.rs
+++ b/crates/engine-odim/examples/volume_stats.rs
@@ -34,6 +34,7 @@ fn main() {
     let mut vmax = f64::NEG_INFINITY;
     let mut vtot: u64 = 0;
     let mut vvalid: u64 = 0;
+    let mut v20: u64 = 0;
     let mut v35: u64 = 0;
     let mut v50: u64 = 0;
     // Approximate echo top: highest beam-center altitude with a >=35 dBZ cell.
@@ -115,6 +116,7 @@ fn main() {
         vmax = vmax.max(smax);
         vtot += total;
         vvalid += valid;
+        v20 += c20;
         v35 += c35;
         v50 += c50;
     }
@@ -132,6 +134,7 @@ fn main() {
         "  valid coverage   : {:.1}% of {vtot} cells",
         100.0 * vvalid as f64 / vtot as f64
     );
+    println!("  precip (>=20)    : {v20} cells");
     println!("  convective (>=35): {v35} cells");
     println!("  heavy core (>=50): {v50} cells");
     println!(

--- a/crates/engine-odim/examples/volume_stats.rs
+++ b/crates/engine-odim/examples/volume_stats.rs
@@ -1,0 +1,135 @@
+//! Quick reflectivity-content probe for a polar volume, to judge which
+//! fixture timestep has "interesting" weather worth a 3D-tiles demo.
+//!
+//! Usage: cargo run -p engine-odim --example volume_stats -- <file.h5> [QUANTITY]
+//! QUANTITY defaults to DBZH (falls back to TH if a sweep lacks DBZH).
+
+use engine_odim::pvol::{read_moment_pixels, read_polar_volume};
+use std::fs;
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let path = args
+        .next()
+        .expect("usage: volume_stats <file.h5> [QUANTITY]");
+    let want = args.next().unwrap_or_else(|| "DBZH".to_string());
+
+    let bytes = fs::read(&path).expect("read file");
+    let vol = read_polar_volume(&bytes).expect("parse volume");
+
+    println!("file:   {path}");
+    println!(
+        "site:   nod={:?} plc={:?}  lon={:.4} lat={:.4} h={:.0}m",
+        vol.site.nod, vol.site.plc, vol.site.lon, vol.site.lat, vol.site.height
+    );
+    println!("time:   {}  object={}", vol.time, vol.object);
+    println!("sweeps: {}", vol.sweeps.len());
+    println!();
+    println!(
+        "{:>3}  {:>6}  {:>5}x{:>4}  {:>7}  {:>6}  {:>6}  {:>6}  {:>6}",
+        "sw", "elang", "rays", "bins", "valid%", "maxdBZ", ">20%", ">35%", ">50%"
+    );
+
+    // Volume-wide accumulators.
+    let mut vmax = f64::NEG_INFINITY;
+    let mut vtot: u64 = 0;
+    let mut vvalid: u64 = 0;
+    let mut v35: u64 = 0;
+    let mut v50: u64 = 0;
+    // Approximate echo top: highest beam-center altitude with a >=35 dBZ cell.
+    let mut echo_top_m = 0.0_f64;
+    const FOUR_THIRDS_EARTH_M: f64 = 4.0 / 3.0 * 6_371_000.0;
+
+    for (i, sw) in vol.sweeps.iter().enumerate() {
+        // Pick the requested quantity, fall back to TH.
+        let mom = sw
+            .moments
+            .iter()
+            .find(|m| m.quantity == want)
+            .or_else(|| sw.moments.iter().find(|m| m.quantity == "TH"));
+        let Some(mom) = mom else {
+            println!("{i:>3}  {:>6.2}  (no {want}/TH)", sw.elangle);
+            continue;
+        };
+        let px = match read_moment_pixels(&bytes, &mom.dataset_path, sw.nrays, sw.nbins) {
+            Ok(p) => p,
+            Err(e) => {
+                println!("{i:>3}  {:>6.2}  read err: {e:?}", sw.elangle);
+                continue;
+            }
+        };
+
+        let mut smax = f64::NEG_INFINITY;
+        let mut valid: u64 = 0;
+        let mut c20: u64 = 0;
+        let mut c35: u64 = 0;
+        let mut c50: u64 = 0;
+        let total = (sw.nrays * sw.nbins) as u64;
+        for ray in 0..sw.nrays {
+            for bin in 0..sw.nbins {
+                if let Some(v) = px.sample(
+                    ray,
+                    bin,
+                    mom.gain,
+                    mom.offset,
+                    mom.nodata,
+                    Some(mom.undetect),
+                ) {
+                    valid += 1;
+                    if v > smax {
+                        smax = v;
+                    }
+                    if v >= 20.0 {
+                        c20 += 1;
+                    }
+                    if v >= 35.0 {
+                        c35 += 1;
+                        // Beam-center height for this bin (4/3-earth model).
+                        let r = sw.rstart + (bin as f64 + 0.5) * sw.rscale;
+                        let el = sw.elangle.to_radians();
+                        let rp = FOUR_THIRDS_EARTH_M;
+                        let h = (r * r + rp * rp + 2.0 * r * rp * el.sin()).sqrt() - rp;
+                        if h > echo_top_m {
+                            echo_top_m = h;
+                        }
+                    }
+                    if v >= 50.0 {
+                        c50 += 1;
+                    }
+                }
+            }
+        }
+        let pct = |c: u64| 100.0 * c as f64 / total as f64;
+        println!(
+            "{i:>3}  {:>6.2}  {:>5}x{:>4}  {:>6.1}%  {:>6.1}  {:>5.2}%  {:>5.2}%  {:>5.2}%",
+            sw.elangle,
+            sw.nrays,
+            sw.nbins,
+            100.0 * valid as f64 / total as f64,
+            if smax.is_finite() { smax } else { f64::NAN },
+            pct(c20),
+            pct(c35),
+            pct(c50),
+        );
+
+        vmax = vmax.max(smax);
+        vtot += total;
+        vvalid += valid;
+        v35 += c35;
+        v50 += c50;
+    }
+
+    println!();
+    println!("VOLUME SUMMARY ({want}):");
+    println!("  max reflectivity : {vmax:.1} dBZ");
+    println!(
+        "  valid coverage   : {:.1}% of {vtot} cells",
+        100.0 * vvalid as f64 / vtot as f64
+    );
+    println!("  convective (>=35): {v35} cells");
+    println!("  heavy core (>=50): {v50} cells");
+    println!(
+        "  approx echo top  : {:.1} km (highest >=35 dBZ beam center)",
+        echo_top_m / 1000.0
+    );
+}

--- a/crates/engine-odim/examples/volume_stats.rs
+++ b/crates/engine-odim/examples/volume_stats.rs
@@ -121,6 +121,11 @@ fn main() {
 
     println!();
     println!("VOLUME SUMMARY ({want}):");
+    if vtot == 0 {
+        // No readable sweeps: avoid -inf max and 0/0 = NaN coverage.
+        println!("  no readable {want}/TH sweeps");
+        return;
+    }
     println!("  max reflectivity : {vmax:.1} dBZ");
     println!(
         "  valid coverage   : {:.1}% of {vtot} cells",


### PR DESCRIPTION
Phase 1 of the **OGC 3D Tiles for volumetric weather** epic (#346). Closes #347.

Standalone `cargo run` examples that turn an ODIM **polar volume** into an OGC
3D Tiles `.pnts` point cloud loadable in CesiumJS — validating the
`(slant_range, elevation, azimuth) → geodetic → ECEF` geometry pipeline before
the `VolumeEngine` trait + `ds-3dtiles` encoder (#348) are built. No engine
trait changes; nothing wired into the server.

## What's here
- **`examples/gen_3dtiles.rs`** — reads a PVOL, projects every echo cell via the
  engine's 4/3-Earth beam model → ECEF, writes `content.pnts` + `tileset.json` +
  a token-free **CARTO Dark Matter** CesiumJS viewer. Colours by an NWS dBZ ramp.
- **`examples/volume_stats.rs`** — per-sweep/volume reflectivity probe (coverage,
  max dBZ, convective fraction, echo top) for picking a demo timestep.
- **`examples/README.md`** — usage + the gotchas below.

## Try it
```bash
cargo run -p engine-odim --example gen_3dtiles            # default FMI Vihti fixture
cd target/3dtiles-fivih && python3 -m http.server 8777    # open localhost:8777
```

Renders the fivih (Vihti) 2026-05-19 10:50Z volume — 377k points: the radial
sweep fans, echo tops, convective cells, and the cone of silence above the
antenna, all against a dark basemap.

## Gotchas captured (these will inform `ds-3dtiles`, #348)
- **Use `.pnts`, not glb-with-POINTS** — a glb POINTS primitive goes through
  Cesium's `Model` renderer, draws fixed 1px points and **ignores both
  `pointSize` styling and vertex `COLOR_0`** (faint white). `.pnts` honours both.
- **Tileset top-level `geometricError` must be `> 0`** — at `0`, Cesium never
  refines to the root and **never requests the content tile** (nothing renders).
- **`.pnts` `POSITION` is ECEF-native** (offset from `RTC_CENTER`) — no glTF
  Y-up→Z-up flip.
- `region` bounding volume is geodetic and ignores the tile transform.

## Notes
- Default input is the FMI Vihti volume the integration tests already use; like
  those tests it is **not committed** (15 MB) and the example exits gracefully
  when absent. CI is unaffected (examples build under clippy but aren't run).
- `cargo fmt` + `cargo clippy -p engine-odim --examples` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
