### PR TITLE
feat(3dtiles): ds-core VolumeEngine + ds-3dtiles encoder crate (#348)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -999,6 +999,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ds-3dtiles"
+version = "0.1.0"
+dependencies = [
+ "ds-core",
+ "ds-render",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "ds-core"
 version = "0.1.0"
 dependencies = [
@@ -1141,7 +1151,9 @@ version = "0.1.0"
 dependencies = [
  "arc-swap",
  "chrono",
+ "ds-3dtiles",
  "ds-core",
+ "ds-render",
  "ds-storage",
  "hdf5-reader",
  "ndarray",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "crates/storage",
     "crates/render",
     "crates/ds-mvt",
+    "crates/ds-3dtiles",
     "crates/api-edr",
     "crates/api-features",
     "crates/api-wms",

--- a/crates/core/src/geo.rs
+++ b/crates/core/src/geo.rs
@@ -5,6 +5,24 @@ const WGS84_A: f64 = 6_378_137.0; // semi-major axis (meters)
 const WGS84_F: f64 = 1.0 / 298.257223563; // flattening
 const WGS84_E2: f64 = 2.0 * WGS84_F - WGS84_F * WGS84_F; // eccentricity squared
 
+/// Convert WGS84 geodetic coordinates to Earth-Centered, Earth-Fixed (ECEF)
+/// metres (EPSG:4978). `lon_deg`/`lat_deg` are degrees, `h` is metres above
+/// the WGS84 ellipsoid. Used to place 3D content (e.g. OGC 3D Tiles volumes)
+/// at its true global position; the inverse is not needed here.
+pub fn geodetic_to_ecef(lon_deg: f64, lat_deg: f64, h: f64) -> [f64; 3] {
+    let lon = lon_deg.to_radians();
+    let lat = lat_deg.to_radians();
+    let (sin_lat, cos_lat) = lat.sin_cos();
+    let (sin_lon, cos_lon) = lon.sin_cos();
+    // Radius of curvature in the prime vertical.
+    let n = WGS84_A / (1.0 - WGS84_E2 * sin_lat * sin_lat).sqrt();
+    [
+        (n + h) * cos_lat * cos_lon,
+        (n + h) * cos_lat * sin_lon,
+        (n * (1.0 - WGS84_E2) + h) * sin_lat,
+    ]
+}
+
 /// Coordinate reference system.
 ///
 /// Stores projection parameters and provides forward/inverse transforms
@@ -1848,5 +1866,25 @@ mod tests {
         let (rlon, rlat) = crs.forward(24.0, 60.0);
         assert!((rlon - 24.0).abs() < 0.01, "rlon={rlon}");
         assert!((rlat - 60.0).abs() < 0.01, "rlat={rlat}");
+    }
+
+    #[test]
+    fn ecef_known_points() {
+        // (0,0,0): on the equator at the prime meridian, ECEF = (a, 0, 0).
+        let [x, y, z] = geodetic_to_ecef(0.0, 0.0, 0.0);
+        assert!((x - WGS84_A).abs() < 1e-3, "x={x}");
+        assert!(y.abs() < 1e-6 && z.abs() < 1e-6, "y={y} z={z}");
+
+        // North pole: x=y=0, z = polar radius b = a(1-f) (+height).
+        let b = WGS84_A * (1.0 - WGS84_F);
+        let [x, y, z] = geodetic_to_ecef(123.0, 90.0, 0.0);
+        assert!(x.abs() < 1e-6 && y.abs() < 1e-6, "x={x} y={y}");
+        assert!((z - b).abs() < 1e-3, "z={z} b={b}");
+
+        // 90°E on the equator: ECEF = (0, a, 0); height adds along the radial.
+        let [x, y, z] = geodetic_to_ecef(90.0, 0.0, 100.0);
+        assert!(x.abs() < 1e-6, "x={x}");
+        assert!((y - (WGS84_A + 100.0)).abs() < 1e-3, "y={y}");
+        assert!(z.abs() < 1e-6, "z={z}");
     }
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -14,3 +14,4 @@ pub mod ogc_extent;
 pub mod openapi;
 pub mod resample;
 pub mod vertical;
+pub mod volume;

--- a/crates/core/src/volume.rs
+++ b/crates/core/src/volume.rs
@@ -76,7 +76,10 @@ pub trait VolumeEngine: Send + Sync {
     ///
     /// - `quantity`: which parameter to sample (`None` → the default).
     /// - `time`: select the retained volume **nearest** this valid time
-    ///   (`None` → latest).
+    ///   (`None` → latest). There is **no staleness cap** — the nearest
+    ///   retained volume is always returned regardless of age (matching the
+    ///   `MapEngine` raster path); a caller needing freshness must check the
+    ///   returned time, or the engine config must bound retention.
     /// - `min_value`: drop points whose physical value is below this (`None` →
     ///   keep every non-nodata sample). E.g. a dBZ floor to cut clutter.
     /// - `reference_time`: forecast model run (`None` → latest; ignored by

--- a/crates/core/src/volume.rs
+++ b/crates/core/src/volume.rs
@@ -74,7 +74,8 @@ pub trait VolumeEngine: Send + Sync {
     /// Sample the collection into a 3-D point cloud.
     ///
     /// - `quantity`: which parameter to sample (`None` → the default).
-    /// - `time`: valid time to select (`None` → latest).
+    /// - `time`: select the retained volume **nearest** this valid time
+    ///   (`None` → latest).
     /// - `min_value`: drop points whose physical value is below this (`None` →
     ///   keep every non-nodata sample). E.g. a dBZ floor to cut clutter.
     /// - `reference_time`: forecast model run (`None` → latest; ignored by

--- a/crates/core/src/volume.rs
+++ b/crates/core/src/volume.rs
@@ -1,0 +1,96 @@
+//! Volumetric domain types and the [`VolumeEngine`] trait for OGC 3D Tiles
+//! delivery.
+//!
+//! Engines that hold genuinely 3-D data (radar polar volumes today) sample it
+//! into a [`VolumePointCloud`] — a georeferenced set of points, one per source
+//! cell — which the framework-free `ds-3dtiles` crate encodes into a `.pnts`
+//! tile + `tileset.json`. The point-cloud representation matches both the
+//! `.pnts` tile format and the native polar sampling of a radar volume. A
+//! dense, regular voxel grid (for the draft `EXT_primitive_voxels` path) is a
+//! separate representation tracked in #351.
+//!
+//! Like the other engine traits, `VolumeEngine` returns domain types only —
+//! colorization and byte encoding live in `ds-3dtiles`, not here.
+
+use crate::error::DataServerError;
+use chrono::{DateTime, Utc};
+
+/// One sample in a [`VolumePointCloud`]: an ECEF offset (metres) from the
+/// cloud's [`VolumePointCloud::rtc_center`], plus the physical value measured
+/// there.
+///
+/// The offset is `f32`: storing positions relative to a nearby center (rather
+/// than absolute ECEF, which is ~6.4e6 m and would lose sub-metre precision in
+/// `f32`) keeps the cloud compact while staying well within radar accuracy.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct VolumePoint {
+    /// ECEF offset (metres) from `rtc_center`, in true ECEF axes (no glTF
+    /// Y-up/Z-up convention — `.pnts` is ECEF-native).
+    pub offset: [f32; 3],
+    /// Physical value at this point (e.g. dBZ).
+    pub value: f64,
+}
+
+/// A georeferenced volumetric point cloud, ready for OGC 3D Tiles encoding.
+#[derive(Debug, Clone)]
+pub struct VolumePointCloud {
+    /// ECEF (EPSG:4978) metres of the local origin all [`VolumePoint::offset`]s
+    /// are relative to — typically the radar antenna. Becomes the `.pnts`
+    /// `RTC_CENTER`.
+    pub rtc_center: [f64; 3],
+    /// Geodetic bounding region `[west, south, east, north, min_height,
+    /// max_height]` — lon/lat in **radians**, heights in metres. This is the
+    /// 3D Tiles `region` bounding-volume layout (EPSG:4979).
+    pub region: [f64; 6],
+    /// The samples.
+    pub points: Vec<VolumePoint>,
+    /// Quantity id sampled (e.g. `"DBZH"`).
+    pub quantity: String,
+    /// Physical unit of [`VolumePoint::value`] (e.g. `"dBZ"`).
+    pub unit: String,
+}
+
+/// Metadata describing a collection's volumetric content, for the API layer
+/// (3D Tiles tileset listing, capabilities). Cheap to build from a snapshot.
+#[derive(Debug, Clone, Default)]
+pub struct VolumeInfo {
+    /// `(id, label)` for each renderable quantity.
+    pub quantities: Vec<(String, String)>,
+    /// Distinct volume valid-times, ascending.
+    pub times: Vec<DateTime<Utc>>,
+    /// Default quantity id (used when a request names none).
+    pub default_quantity: String,
+    /// Unit of the default quantity.
+    pub default_unit: String,
+}
+
+/// An engine that samples a collection's data into a volumetric point cloud
+/// for OGC 3D Tiles delivery.
+///
+/// Separate from `MapEngine`/`EdrEngine`/`FeatureEngine`: only engines with
+/// genuinely 3-D data implement it. The API state keeps a registry of
+/// `Arc<dyn VolumeEngine>` keyed by collection id, like the other traits.
+pub trait VolumeEngine: Send + Sync {
+    /// Sample the collection into a 3-D point cloud.
+    ///
+    /// - `quantity`: which parameter to sample (`None` → the default).
+    /// - `time`: valid time to select (`None` → latest).
+    /// - `min_value`: drop points whose physical value is below this (`None` →
+    ///   keep every non-nodata sample). E.g. a dBZ floor to cut clutter.
+    /// - `reference_time`: forecast model run (`None` → latest; ignored by
+    ///   non-forecast engines such as radar).
+    ///
+    /// Returns [`DataServerError::LocationNotFound`] when the selection yields
+    /// no data (matching the other engines' "no data ⇒ 404" convention), so
+    /// callers never have to encode an empty cloud.
+    fn read_point_cloud(
+        &self,
+        quantity: Option<&str>,
+        time: Option<DateTime<Utc>>,
+        min_value: Option<f64>,
+        reference_time: Option<DateTime<Utc>>,
+    ) -> Result<VolumePointCloud, DataServerError>;
+
+    /// Metadata for the volumetric collection (quantities, valid times).
+    fn volume_info(&self) -> VolumeInfo;
+}

--- a/crates/core/src/volume.rs
+++ b/crates/core/src/volume.rs
@@ -14,6 +14,7 @@
 
 use crate::error::DataServerError;
 use chrono::{DateTime, Utc};
+use std::sync::Arc;
 
 /// One sample in a [`VolumePointCloud`]: an ECEF offset (metres) from the
 /// cloud's [`VolumePointCloud::rtc_center`], plus the physical value measured
@@ -93,5 +94,10 @@ pub trait VolumeEngine: Send + Sync {
     ) -> Result<VolumePointCloud, DataServerError>;
 
     /// Metadata for the volumetric collection (quantities, valid times).
-    fn volume_info(&self) -> VolumeInfo;
+    ///
+    /// Returns a shared snapshot so it stays **O(1) on a per-request path** (no
+    /// recompute, no `Vec` clone) — engines should serve a cached
+    /// `Arc<VolumeInfo>` rebuilt on data refresh, per the `RasterInfo` rule
+    /// (#211).
+    fn volume_info(&self) -> Arc<VolumeInfo>;
 }

--- a/crates/ds-3dtiles/Cargo.toml
+++ b/crates/ds-3dtiles/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "ds-3dtiles"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+ds-core = { path = "../core" }
+ds-render = { path = "../render" }
+serde_json = "1"
+thiserror = "2"

--- a/crates/ds-3dtiles/Cargo.toml
+++ b/crates/ds-3dtiles/Cargo.toml
@@ -2,6 +2,9 @@
 name = "ds-3dtiles"
 version = "0.1.0"
 edition = "2021"
+# Uses `u*::is_multiple_of` (stable 1.87) and `Option::is_none_or` (1.82) — both
+# clippy-preferred idioms. Declared so an older toolchain fails clearly.
+rust-version = "1.87"
 
 [dependencies]
 ds-core = { path = "../core" }

--- a/crates/ds-3dtiles/src/lib.rs
+++ b/crates/ds-3dtiles/src/lib.rs
@@ -264,6 +264,14 @@ mod tests {
             tileset_json(&cloud, "content.pnts"),
             Err(Tiles3dError::NonFinite("region"))
         ));
+
+        // A non-finite point offset is caught in the encode loop.
+        let mut cloud = sample_cloud();
+        cloud.points[1].offset[2] = f32::NAN;
+        assert!(matches!(
+            encode_pnts(&cloud, &dbz_map()),
+            Err(Tiles3dError::NonFinite("point offset"))
+        ));
     }
 
     #[test]

--- a/crates/ds-3dtiles/src/lib.rs
+++ b/crates/ds-3dtiles/src/lib.rs
@@ -142,7 +142,10 @@ pub fn encode_pnts(
 }
 
 /// Build the `tileset.json` for a point cloud. `content_uri` is the relative
-/// URI of the `.pnts` tile (e.g. `"content.pnts"`).
+/// URI of the `.pnts` tile (e.g. `"content.pnts"`). It is JSON-escaped by
+/// `serde_json`, so there is no injection risk, but callers **must** supply a
+/// server-controlled relative path — never user input or unvalidated config —
+/// since CesiumJS will fetch whatever URL it resolves to.
 ///
 /// The `region` bounding volume is geodetic, so no tile `transform` is needed
 /// (the `.pnts` `RTC_CENTER` already places points in ECEF). The top-level

--- a/crates/ds-3dtiles/src/lib.rs
+++ b/crates/ds-3dtiles/src/lib.rs
@@ -136,7 +136,7 @@ pub fn tileset_json(cloud: &VolumePointCloud, content_uri: &str) -> Result<Strin
     if cloud.region.iter().any(|v| !v.is_finite()) {
         return Err(Tiles3dError::NonFinite("region"));
     }
-    let region: Vec<f64> = cloud.region.to_vec();
+    // `[f64; 6]` serializes directly to a JSON array — no `Vec` needed.
     // `asset.version` is intentionally "1.1" even though `.pnts` is a 1.0
     // content type: CesiumJS keys its tileset loader off this version, and a
     // 1.1 tileset happily references legacy `.pnts` content. Do not "fix" this
@@ -145,7 +145,7 @@ pub fn tileset_json(cloud: &VolumePointCloud, content_uri: &str) -> Result<Strin
         "asset": { "version": "1.1" },
         "geometricError": TILESET_GEOMETRIC_ERROR,
         "root": {
-            "boundingVolume": { "region": region },
+            "boundingVolume": { "region": cloud.region },
             "geometricError": ROOT_GEOMETRIC_ERROR,
             "refine": "ADD",
             "content": { "uri": content_uri },

--- a/crates/ds-3dtiles/src/lib.rs
+++ b/crates/ds-3dtiles/src/lib.rs
@@ -39,6 +39,11 @@ pub enum Tiles3dError {
     /// 4 GiB. Fail loudly instead of truncating to a corrupt file.
     #[error("pnts {0} exceeds u32 range (4 GiB)")]
     TooLarge(&'static str),
+    /// The point cloud is empty. The 3D Tiles 1.0 Point Cloud spec requires
+    /// `POINTS_LENGTH >= 1`; `VolumeEngine` maps "no data" to a 404 before
+    /// encoding, so an empty cloud reaching here is a caller bug.
+    #[error("cannot encode an empty point cloud (POINTS_LENGTH must be >= 1)")]
+    Empty,
 }
 
 /// Encode a point cloud as a 3D Tiles **`.pnts`** tile (the 3D Tiles 1.0 Point
@@ -47,6 +52,11 @@ pub enum Tiles3dError {
 ///
 /// `colormap` maps each point's physical value to RGB (alpha is ignored;
 /// `.pnts` `RGB` is opaque). Returns the complete tile bytes.
+///
+/// `cloud.points` must be non-empty — the 3D Tiles 1.0 Point Cloud format
+/// requires `POINTS_LENGTH >= 1`. An empty cloud is rejected with
+/// [`Tiles3dError::Empty`]; `VolumeEngine` callers already map "no data" to a
+/// 404 before reaching here.
 pub fn encode_pnts(
     cloud: &VolumePointCloud,
     colormap: &dyn ColorMap,
@@ -56,6 +66,9 @@ pub fn encode_pnts(
     }
 
     let count = cloud.points.len();
+    if count == 0 {
+        return Err(Tiles3dError::Empty);
+    }
 
     // Feature-table binary: POSITION (count * 3 * f32) then RGB (count * 3 * u8).
     let pos_bytes = count * 12;
@@ -124,6 +137,10 @@ pub fn tileset_json(cloud: &VolumePointCloud, content_uri: &str) -> Result<Strin
         return Err(Tiles3dError::NonFinite("region"));
     }
     let region: Vec<f64> = cloud.region.to_vec();
+    // `asset.version` is intentionally "1.1" even though `.pnts` is a 1.0
+    // content type: CesiumJS keys its tileset loader off this version, and a
+    // 1.1 tileset happily references legacy `.pnts` content. Do not "fix" this
+    // to "1.0" — it would change which loader path CesiumJS takes.
     let tileset = json!({
         "asset": { "version": "1.1" },
         "geometricError": TILESET_GEOMETRIC_ERROR,
@@ -235,15 +252,13 @@ mod tests {
     }
 
     #[test]
-    fn empty_cloud_encodes_to_a_valid_empty_tile() {
+    fn empty_cloud_is_rejected() {
+        // The 3D Tiles 1.0 Point Cloud spec requires POINTS_LENGTH >= 1.
         let mut cloud = sample_cloud();
         cloud.points.clear();
-        let bytes = encode_pnts(&cloud, &dbz_map()).expect("encode empty");
-        assert_eq!(&bytes[0..4], b"pnts");
-        let u32_at = |o: usize| u32::from_le_bytes(bytes[o..o + 4].try_into().unwrap());
-        assert_eq!(u32_at(8) as usize, bytes.len());
-        let ft: serde_json::Value =
-            serde_json::from_slice(&bytes[28..28 + u32_at(12) as usize]).unwrap();
-        assert_eq!(ft["POINTS_LENGTH"], 0);
+        assert!(matches!(
+            encode_pnts(&cloud, &dbz_map()),
+            Err(Tiles3dError::Empty)
+        ));
     }
 }

--- a/crates/ds-3dtiles/src/lib.rs
+++ b/crates/ds-3dtiles/src/lib.rs
@@ -1,0 +1,249 @@
+//! OGC 3D Tiles encoder: turns a [`ds_core::volume::VolumePointCloud`] into a
+//! `.pnts` point-cloud tile plus a `tileset.json`. Framework-free (only
+//! `ds-core` + `ds-render`), mirroring how `ds-render` encodes PNG and `ds-mvt`
+//! encodes vector tiles — engines produce the domain type, this crate turns it
+//! into bytes.
+//!
+//! The hard-won invariants from the Phase-1 demo (#347) are enforced here so
+//! every caller gets them for free:
+//!
+//! - The tileset's top-level `geometricError` is **> 0** — otherwise CesiumJS
+//!   never refines to the root and never even requests the content tile.
+//! - `.pnts` `POSITION` is **ECEF-native** (offsets from `RTC_CENTER`); there
+//!   is no glTF Y-up→Z-up flip.
+//! - The `region` bounding volume is geodetic (EPSG:4979) and ignores any tile
+//!   transform.
+//! - `u32` header fields are bounds-checked, and **non-finite geometry is
+//!   rejected** rather than silently emitted as `NaN`/`Infinity` (invalid JSON
+//!   / a corrupt tile that loads as nothing).
+
+use ds_core::volume::VolumePointCloud;
+use ds_render::ColorMap;
+use serde_json::json;
+
+/// Top-level tileset geometric error. Must be > 0 (see module docs); the value
+/// only needs to exceed the root's so CesiumJS refines to the content.
+const TILESET_GEOMETRIC_ERROR: f64 = 1.0e5;
+/// Leaf (root content) geometric error. Also > 0.
+const ROOT_GEOMETRIC_ERROR: f64 = 1.0e3;
+
+/// Errors from encoding a [`VolumePointCloud`].
+#[derive(Debug, thiserror::Error)]
+pub enum Tiles3dError {
+    /// A coordinate that must be finite (an RTC-center component, a point
+    /// offset, or a region bound) was `NaN`/±∞. Encoding refuses rather than
+    /// emit a corrupt tile / invalid JSON.
+    #[error("non-finite value in {0}")]
+    NonFinite(&'static str),
+    /// A `.pnts` header field (each a `u32`) would overflow — the tile exceeds
+    /// 4 GiB. Fail loudly instead of truncating to a corrupt file.
+    #[error("pnts {0} exceeds u32 range (4 GiB)")]
+    TooLarge(&'static str),
+}
+
+/// Encode a point cloud as a 3D Tiles **`.pnts`** tile (the 3D Tiles 1.0 Point
+/// Cloud format, still rendered by CesiumJS in 1.1 — the path where per-point
+/// RGB and `pointSize` styling actually work).
+///
+/// `colormap` maps each point's physical value to RGB (alpha is ignored;
+/// `.pnts` `RGB` is opaque). Returns the complete tile bytes.
+pub fn encode_pnts(
+    cloud: &VolumePointCloud,
+    colormap: &dyn ColorMap,
+) -> Result<Vec<u8>, Tiles3dError> {
+    if cloud.rtc_center.iter().any(|c| !c.is_finite()) {
+        return Err(Tiles3dError::NonFinite("rtc_center"));
+    }
+
+    let count = cloud.points.len();
+
+    // Feature-table binary: POSITION (count * 3 * f32) then RGB (count * 3 * u8).
+    let pos_bytes = count * 12;
+    let rgb_off = pos_bytes;
+    let mut body = Vec::with_capacity(pos_bytes + count * 3);
+    for p in &cloud.points {
+        for v in p.offset {
+            if !v.is_finite() {
+                return Err(Tiles3dError::NonFinite("point offset"));
+            }
+            body.extend_from_slice(&v.to_le_bytes());
+        }
+    }
+    for p in &cloud.points {
+        let c = colormap.color(Some(p.value));
+        body.extend_from_slice(&[c[0], c[1], c[2]]);
+    }
+    // The feature-table binary must end on an 8-byte boundary.
+    while !body.len().is_multiple_of(8) {
+        body.push(0);
+    }
+
+    // Feature-table JSON. rtc_center is finite (checked above); serde_json
+    // would otherwise serialize a non-finite f64 as `null` silently.
+    let [cx, cy, cz] = cloud.rtc_center;
+    let ft = json!({
+        "POINTS_LENGTH": count,
+        "RTC_CENTER": [cx, cy, cz],
+        "POSITION": { "byteOffset": 0 },
+        "RGB": { "byteOffset": rgb_off },
+    });
+    let mut ft_json = serde_json::to_vec(&ft).expect("feature table serializes");
+    while !ft_json.len().is_multiple_of(8) {
+        ft_json.push(b' ');
+    }
+
+    const HEADER_LEN: usize = 28;
+    let total = HEADER_LEN + ft_json.len() + body.len();
+    let total = u32::try_from(total).map_err(|_| Tiles3dError::TooLarge("byteLength"))?;
+    let ft_json_len =
+        u32::try_from(ft_json.len()).map_err(|_| Tiles3dError::TooLarge("featureTableJSON"))?;
+    let body_len =
+        u32::try_from(body.len()).map_err(|_| Tiles3dError::TooLarge("featureTableBinary"))?;
+
+    let mut pnts = Vec::with_capacity(total as usize);
+    pnts.extend_from_slice(b"pnts");
+    pnts.extend_from_slice(&1u32.to_le_bytes()); // version
+    pnts.extend_from_slice(&total.to_le_bytes());
+    pnts.extend_from_slice(&ft_json_len.to_le_bytes());
+    pnts.extend_from_slice(&body_len.to_le_bytes());
+    pnts.extend_from_slice(&0u32.to_le_bytes()); // batch-table JSON length
+    pnts.extend_from_slice(&0u32.to_le_bytes()); // batch-table binary length
+    pnts.extend_from_slice(&ft_json);
+    pnts.extend_from_slice(&body);
+    Ok(pnts)
+}
+
+/// Build the `tileset.json` for a point cloud. `content_uri` is the relative
+/// URI of the `.pnts` tile (e.g. `"content.pnts"`).
+///
+/// The `region` bounding volume is geodetic, so no tile `transform` is needed
+/// (the `.pnts` `RTC_CENTER` already places points in ECEF). The top-level
+/// `geometricError` is non-zero (load-bearing — see module docs).
+pub fn tileset_json(cloud: &VolumePointCloud, content_uri: &str) -> Result<String, Tiles3dError> {
+    if cloud.region.iter().any(|v| !v.is_finite()) {
+        return Err(Tiles3dError::NonFinite("region"));
+    }
+    let region: Vec<f64> = cloud.region.to_vec();
+    let tileset = json!({
+        "asset": { "version": "1.1" },
+        "geometricError": TILESET_GEOMETRIC_ERROR,
+        "root": {
+            "boundingVolume": { "region": region },
+            "geometricError": ROOT_GEOMETRIC_ERROR,
+            "refine": "ADD",
+            "content": { "uri": content_uri },
+        }
+    });
+    Ok(serde_json::to_string_pretty(&tileset).expect("tileset serializes"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ds_core::volume::{VolumePoint, VolumePointCloud};
+    use ds_render::{BuiltinColormap, LutColorMap};
+
+    fn sample_cloud() -> VolumePointCloud {
+        VolumePointCloud {
+            rtc_center: [3_000_000.0, 1_000_000.0, 5_000_000.0],
+            region: [0.42, 1.05, 0.44, 1.07, 100.0, 12_000.0],
+            points: vec![
+                VolumePoint {
+                    offset: [0.0, 0.0, 0.0],
+                    value: 10.0,
+                },
+                VolumePoint {
+                    offset: [100.0, -50.0, 250.0],
+                    value: 45.0,
+                },
+                VolumePoint {
+                    offset: [-200.0, 75.0, 1000.0],
+                    value: 60.0,
+                },
+            ],
+            quantity: "DBZH".into(),
+            unit: "dBZ".into(),
+        }
+    }
+
+    fn dbz_map() -> LutColorMap {
+        LutColorMap::from_builtin(BuiltinColormap::RadarDbz, -32.0, 95.0)
+    }
+
+    #[test]
+    fn pnts_header_is_wellformed() {
+        let cloud = sample_cloud();
+        let bytes = encode_pnts(&cloud, &dbz_map()).expect("encode");
+
+        assert_eq!(&bytes[0..4], b"pnts", "magic");
+        let u32_at = |o: usize| u32::from_le_bytes(bytes[o..o + 4].try_into().unwrap());
+        assert_eq!(u32_at(4), 1, "version");
+        assert_eq!(
+            u32_at(8) as usize,
+            bytes.len(),
+            "byteLength == actual length"
+        );
+        let ft_json_len = u32_at(12) as usize;
+        let ft_bin_len = u32_at(16) as usize;
+        assert_eq!(u32_at(20), 0, "no batch-table JSON");
+        assert_eq!(u32_at(24), 0, "no batch-table binary");
+        // Sections are 8-byte aligned, and the three lengths tile the file.
+        assert_eq!(ft_json_len % 8, 0);
+        assert_eq!(ft_bin_len % 8, 0);
+        assert_eq!(28 + ft_json_len + ft_bin_len, bytes.len());
+
+        // Feature-table JSON parses and carries the right point count + RTC.
+        let ft: serde_json::Value =
+            serde_json::from_slice(&bytes[28..28 + ft_json_len]).expect("FT JSON parses");
+        assert_eq!(ft["POINTS_LENGTH"], 3);
+        assert_eq!(ft["RTC_CENTER"][0], 3_000_000.0);
+        // RGB starts after the 3 positions (3 * 12 = 36 bytes).
+        assert_eq!(ft["RGB"]["byteOffset"], 36);
+    }
+
+    #[test]
+    fn tileset_has_positive_geometric_error_and_region() {
+        let cloud = sample_cloud();
+        let json: serde_json::Value =
+            serde_json::from_str(&tileset_json(&cloud, "content.pnts").expect("tileset")).unwrap();
+        assert!(
+            json["geometricError"].as_f64().unwrap() > 0.0,
+            "load-bearing"
+        );
+        assert!(json["root"]["geometricError"].as_f64().unwrap() > 0.0);
+        assert_eq!(json["root"]["content"]["uri"], "content.pnts");
+        let region = json["root"]["boundingVolume"]["region"].as_array().unwrap();
+        assert_eq!(region.len(), 6);
+        assert_eq!(region[0].as_f64().unwrap(), 0.42);
+    }
+
+    #[test]
+    fn non_finite_geometry_is_rejected() {
+        let mut cloud = sample_cloud();
+        cloud.rtc_center[1] = f64::NAN;
+        assert!(matches!(
+            encode_pnts(&cloud, &dbz_map()),
+            Err(Tiles3dError::NonFinite("rtc_center"))
+        ));
+
+        let mut cloud = sample_cloud();
+        cloud.region[3] = f64::INFINITY;
+        assert!(matches!(
+            tileset_json(&cloud, "content.pnts"),
+            Err(Tiles3dError::NonFinite("region"))
+        ));
+    }
+
+    #[test]
+    fn empty_cloud_encodes_to_a_valid_empty_tile() {
+        let mut cloud = sample_cloud();
+        cloud.points.clear();
+        let bytes = encode_pnts(&cloud, &dbz_map()).expect("encode empty");
+        assert_eq!(&bytes[0..4], b"pnts");
+        let u32_at = |o: usize| u32::from_le_bytes(bytes[o..o + 4].try_into().unwrap());
+        assert_eq!(u32_at(8) as usize, bytes.len());
+        let ft: serde_json::Value =
+            serde_json::from_slice(&bytes[28..28 + u32_at(12) as usize]).unwrap();
+        assert_eq!(ft["POINTS_LENGTH"], 0);
+    }
+}

--- a/crates/ds-3dtiles/src/lib.rs
+++ b/crates/ds-3dtiles/src/lib.rs
@@ -69,6 +69,9 @@ pub fn encode_pnts(
     if count == 0 {
         return Err(Tiles3dError::Empty);
     }
+    // `POINTS_LENGTH` is a u32 in the feature table; reject before the body
+    // build (the byte-length guards below would only catch this at ~4 GiB).
+    let points_len = u32::try_from(count).map_err(|_| Tiles3dError::TooLarge("POINTS_LENGTH"))?;
 
     // Feature-table binary: POSITION (count * 3 * f32) then RGB (count * 3 * u8).
     let pos_bytes = count * 12;
@@ -95,7 +98,7 @@ pub fn encode_pnts(
     // would otherwise serialize a non-finite f64 as `null` silently.
     let [cx, cy, cz] = cloud.rtc_center;
     let ft = json!({
-        "POINTS_LENGTH": count,
+        "POINTS_LENGTH": points_len,
         "RTC_CENTER": [cx, cy, cz],
         "POSITION": { "byteOffset": 0 },
         "RGB": { "byteOffset": rgb_off },

--- a/crates/ds-3dtiles/src/lib.rs
+++ b/crates/ds-3dtiles/src/lib.rs
@@ -44,6 +44,12 @@ pub enum Tiles3dError {
     /// encoding, so an empty cloud reaching here is a caller bug.
     #[error("cannot encode an empty point cloud (POINTS_LENGTH must be >= 1)")]
     Empty,
+    /// `content_uri` is not a safe server-relative path (empty, absolute,
+    /// scheme-qualified, or containing a `..` segment). CesiumJS fetches
+    /// whatever URL the tileset names, so the encoder rejects anything that
+    /// could traverse or redirect — defence-in-depth for a `pub` API.
+    #[error("invalid content URI: {0:?}")]
+    InvalidUri(String),
 }
 
 /// Encode a point cloud as a 3D Tiles **`.pnts`** tile (the 3D Tiles 1.0 Point
@@ -82,7 +88,9 @@ pub fn encode_pnts(
         .and_then(|n| n.checked_add(7))
         .is_none_or(|n| u32::try_from(n).is_err())
     {
-        return Err(Tiles3dError::TooLarge("featureTableBinary"));
+        // Distinct label from the post-build check below so the two guards are
+        // distinguishable in logs.
+        return Err(Tiles3dError::TooLarge("point data size"));
     }
 
     // Feature-table binary: POSITION (count * 3 * f32) then RGB (count * 3 * u8).
@@ -142,15 +150,23 @@ pub fn encode_pnts(
 }
 
 /// Build the `tileset.json` for a point cloud. `content_uri` is the relative
-/// URI of the `.pnts` tile (e.g. `"content.pnts"`). It is JSON-escaped by
-/// `serde_json`, so there is no injection risk, but callers **must** supply a
-/// server-controlled relative path — never user input or unvalidated config —
-/// since CesiumJS will fetch whatever URL it resolves to.
+/// URI of the `.pnts` tile (e.g. `"content.pnts"`). CesiumJS fetches whatever
+/// URL it resolves to, so the encoder **validates** it as a safe server-relative
+/// path — rejecting empty, absolute (`/…`), scheme-qualified (`…://…`), and
+/// `..`-traversing values with [`Tiles3dError::InvalidUri`] — rather than
+/// relying on the caller (defence-in-depth for a `pub` API).
 ///
 /// The `region` bounding volume is geodetic, so no tile `transform` is needed
 /// (the `.pnts` `RTC_CENTER` already places points in ECEF). The top-level
 /// `geometricError` is non-zero (load-bearing — see module docs).
 pub fn tileset_json(cloud: &VolumePointCloud, content_uri: &str) -> Result<String, Tiles3dError> {
+    if content_uri.is_empty()
+        || content_uri.starts_with('/')
+        || content_uri.contains("://")
+        || content_uri.split('/').any(|s| s == "..")
+    {
+        return Err(Tiles3dError::InvalidUri(content_uri.to_string()));
+    }
     if cloud.region.iter().any(|v| !v.is_finite()) {
         return Err(Tiles3dError::NonFinite("region"));
     }
@@ -275,6 +291,26 @@ mod tests {
             encode_pnts(&cloud, &dbz_map()),
             Err(Tiles3dError::NonFinite("point offset"))
         ));
+    }
+
+    #[test]
+    fn unsafe_content_uri_is_rejected() {
+        let cloud = sample_cloud();
+        for bad in [
+            "",
+            "/abs.pnts",
+            "http://evil/x.pnts",
+            "../../secret",
+            "a/../b.pnts",
+        ] {
+            assert!(
+                matches!(tileset_json(&cloud, bad), Err(Tiles3dError::InvalidUri(_))),
+                "expected InvalidUri for {bad:?}"
+            );
+        }
+        // A plain relative path is accepted.
+        assert!(tileset_json(&cloud, "content.pnts").is_ok());
+        assert!(tileset_json(&cloud, "tiles/0/content.pnts").is_ok());
     }
 
     #[test]

--- a/crates/ds-3dtiles/src/lib.rs
+++ b/crates/ds-3dtiles/src/lib.rs
@@ -73,6 +73,18 @@ pub fn encode_pnts(
     // build (the byte-length guards below would only catch this at ~4 GiB).
     let points_len = u32::try_from(count).map_err(|_| Tiles3dError::TooLarge("POINTS_LENGTH"))?;
 
+    // Front-load the body byte-budget check too: reject an oversized cloud
+    // *before* allocating the body (POSITION 12 B + RGB 3 B per point, + ≤7 B
+    // tail padding), so a caller bypassing the engine's MAX_POINTS cap can't
+    // force a multi-GB allocation that only errors afterward.
+    if count
+        .checked_mul(15)
+        .and_then(|n| n.checked_add(7))
+        .is_none_or(|n| u32::try_from(n).is_err())
+    {
+        return Err(Tiles3dError::TooLarge("featureTableBinary"));
+    }
+
     // Feature-table binary: POSITION (count * 3 * f32) then RGB (count * 3 * u8).
     let pos_bytes = count * 12;
     let rgb_off = pos_bytes;

--- a/crates/engine-odim/Cargo.toml
+++ b/crates/engine-odim/Cargo.toml
@@ -20,3 +20,6 @@ thiserror = "2"
 [dev-dependencies]
 tempfile = "3"
 chrono = { version = "0.4", features = ["serde"] }
+# 3D Tiles encoding for the gen_3dtiles example + VolumeEngine integration test.
+ds-3dtiles = { path = "../ds-3dtiles" }
+ds-render = { path = "../render" }

--- a/crates/engine-odim/examples/gen_3dtiles.rs
+++ b/crates/engine-odim/examples/gen_3dtiles.rs
@@ -1,121 +1,28 @@
-//! Phase-1 PoC: turn a polar volume into an OGC 3D Tiles point cloud that
-//! loads in stock CesiumJS. Every valid echo cell becomes a point at its true
-//! 3D position, computed with the engine's 4/3-Earth beam model, and colored by
-//! an NWS-style reflectivity ramp.
-//!
-//! Content is the `.pnts` (Point Cloud) tile format. It is the 3D Tiles 1.0
-//! point-cloud format (still rendered by CesiumJS in 1.1) and the path where
-//! `pointSize`/attenuation styling and per-point RGB actually work — a `.glb`
-//! with POINTS mode goes through the Model renderer, which draws fixed 1px
-//! white points and ignores both the style and vertex colors. A production
-//! feature would move to glTF voxels (EXT_primitive_voxels, cylinder shape);
-//! pnts is the right call for a "see it now" geometry PoC. Either way this
-//! exercises the hard part: (slant_range, elevation, azimuth) -> geographic ->
-//! ECEF, via an RTC center.
+//! Phase-1 demo, now a **thin driver** over the real stack (#348): build a
+//! `PolarVolumeEngine` over a directory of ODIM polar volumes, sample a site
+//! into a `ds_core::volume::VolumePointCloud` via `VolumeEngine`, and encode it
+//! to an OGC 3D Tiles `.pnts` tile + `tileset.json` with `ds-3dtiles`. The
+//! geometry (4/3-Earth beam model → ECEF) and the `.pnts`/tileset encoding now
+//! live in the engine and `ds-3dtiles`; this example only wires them together
+//! and writes a token-free CesiumJS viewer.
 //!
 //! Usage:
-//!   cargo run -p engine-odim --example gen_3dtiles -- <file.h5> [out_dir] [min_dbz]
-//!     out_dir  default target/3dtiles-fivih
-//!     min_dbz  default 5.0  (skip cells below this reflectivity)
+//!   cargo run -p engine-odim --example gen_3dtiles -- [file.h5] [out_dir] [min_dbz]
+//!     file.h5  default: the (uncommitted) FMI Vihti fixture
+//!     out_dir  default: target/3dtiles-fivih
+//!     min_dbz  default: 5.0  (drop cells below this reflectivity)
 
-use engine_odim::pvol::read_moment_pixels;
-use engine_odim::pvol::read_polar_volume;
-use std::f64::consts::PI;
+use ds_core::config::OdimConfig;
+use ds_core::edr_engine::EdrEngine;
+use ds_core::volume::VolumeEngine;
+use ds_render::{BuiltinColormap, LutColorMap};
+use engine_odim::PolarVolumeEngine;
 use std::fs;
-use std::path::PathBuf;
-
-// WGS84 ellipsoid.
-const WGS84_A: f64 = 6_378_137.0;
-const WGS84_E2: f64 = 6.694_379_990_14e-3;
-// 4/3-Earth effective radius for beam propagation (matches volume_engine.rs).
-const FOUR_THIRDS_EARTH_M: f64 = 4.0 / 3.0 * 6_371_000.0;
-// Sphere radius for the great-circle "destination point" along the ground.
-const EARTH_SPHERE_M: f64 = 6_371_000.0;
-
-/// (lon_deg, lat_deg, height_m above ellipsoid) -> ECEF (x, y, z) metres.
-fn geodetic_to_ecef(lon_deg: f64, lat_deg: f64, h: f64) -> [f64; 3] {
-    let lon = lon_deg.to_radians();
-    let lat = lat_deg.to_radians();
-    let (sl, cl) = lat.sin_cos();
-    let (so, co) = lon.sin_cos();
-    let n = WGS84_A / (1.0 - WGS84_E2 * sl * sl).sqrt();
-    [
-        (n + h) * cl * co,
-        (n + h) * cl * so,
-        (n * (1.0 - WGS84_E2) + h) * sl,
-    ]
-}
-
-/// Great-circle destination from (lon0,lat0) travelling `dist` m along
-/// `bearing` (deg clockwise from north). Spherical — matches the engine.
-fn destination_point(lon0: f64, lat0: f64, dist: f64, bearing_deg: f64) -> (f64, f64) {
-    let ad = dist / EARTH_SPHERE_M;
-    let br = bearing_deg.to_radians();
-    let lat1 = lat0.to_radians();
-    let lon1 = lon0.to_radians();
-    let lat2 = (lat1.sin() * ad.cos() + lat1.cos() * ad.sin() * br.cos()).asin();
-    let lon2 = lon1 + (br.sin() * ad.sin() * lat1.cos()).atan2(ad.cos() - lat1.sin() * lat2.sin());
-    let mut lon = lon2.to_degrees();
-    lon = (lon + 540.0) % 360.0 - 180.0; // normalise to [-180, 180)
-    (lon, lat2.to_degrees())
-}
-
-/// 4/3-Earth beam model: slant range + elevation angle -> (ground arc
-/// distance, height above antenna). Same formula as volume_engine.rs.
-fn slant_to_ground_height(r: f64, elangle_deg: f64) -> (f64, f64) {
-    let el = elangle_deg.to_radians();
-    let rp = FOUR_THIRDS_EARTH_M;
-    let h = (r * r + rp * rp + 2.0 * r * rp * el.sin()).sqrt() - rp;
-    let s = rp * (r * el.cos() / (r * el.sin() + rp)).atan();
-    (s, h)
-}
-
-/// NWS-style reflectivity colour ramp. dBZ -> (r,g,b).
-fn dbz_color(dbz: f64) -> [u8; 3] {
-    const STOPS: &[(f64, [u8; 3])] = &[
-        (5.0, [4, 233, 231]),
-        (10.0, [1, 159, 244]),
-        (15.0, [3, 0, 244]),
-        (20.0, [2, 253, 2]),
-        (25.0, [1, 197, 1]),
-        (30.0, [0, 142, 0]),
-        (35.0, [253, 248, 2]),
-        (40.0, [229, 188, 0]),
-        (45.0, [253, 149, 0]),
-        (50.0, [253, 0, 0]),
-        (55.0, [212, 0, 0]),
-        (60.0, [188, 0, 0]),
-        (65.0, [248, 0, 253]),
-        (70.0, [152, 84, 198]),
-    ];
-    if dbz <= STOPS[0].0 {
-        return STOPS[0].1;
-    }
-    let last = STOPS.len() - 1;
-    if dbz >= STOPS[last].0 {
-        return STOPS[last].1;
-    }
-    for w in STOPS.windows(2) {
-        let (lo, c0) = w[0];
-        let (hi, c1) = w[1];
-        if dbz >= lo && dbz <= hi {
-            let t = (dbz - lo) / (hi - lo);
-            return [
-                (c0[0] as f64 + t * (c1[0] as f64 - c0[0] as f64)).round() as u8,
-                (c0[1] as f64 + t * (c1[1] as f64 - c0[1] as f64)).round() as u8,
-                (c0[2] as f64 + t * (c1[2] as f64 - c0[2] as f64)).round() as u8,
-            ];
-        }
-    }
-    STOPS[last].1
-}
+use std::path::{Path, PathBuf};
 
 fn main() {
     let mut args = std::env::args().skip(1);
-    // Default to the FMI Vihti polar volume the integration tests use. Like
-    // those tests, this 15 MB fixture is NOT committed to git (see the demo
-    // README) — pass any ODIM polar volume (.h5) as the first arg instead.
-    let path = args.next().unwrap_or_else(|| {
+    let file = args.next().unwrap_or_else(|| {
         format!(
             "{}/../../testdata/radar-fmi-pvol/202605191050_fivih_PVOL.h5",
             env!("CARGO_MANIFEST_DIR")
@@ -130,216 +37,115 @@ fn main() {
         .map(|s| s.parse().expect("min_dbz must be a number"))
         .unwrap_or(5.0);
 
-    let bytes = match fs::read(&path) {
-        Ok(b) => b,
-        Err(err) => {
-            eprintln!("cannot read {path}: {err}");
-            eprintln!(
-                "The default FMI Vihti PVOL fixture is not committed to git (15 MB). \
-                 Pass a path to an ODIM polar volume (.h5), or place one under \
-                 testdata/radar-fmi-pvol/."
-            );
-            std::process::exit(1);
-        }
-    };
-    let vol = read_polar_volume(&bytes).expect("parse volume");
-    let site = &vol.site;
-    // Non-finite antenna coordinates would poison both the ECEF projection
-    // (NaN positions) and the generated viewer (`f64::INFINITY` formats as the
-    // invalid-JS literal `inf`). Refuse a corrupt volume up front.
-    if !(site.lon.is_finite() && site.lat.is_finite() && site.height.is_finite()) {
+    let file = Path::new(&file);
+    if !file.exists() {
+        eprintln!("cannot find {}", file.display());
         eprintln!(
-            "non-finite antenna coordinates (lon={}, lat={}, h={}) — refusing to encode",
-            site.lon, site.lat, site.height
+            "The default FMI Vihti PVOL fixture is not committed to git (15 MB). \
+             Pass a path to an ODIM polar volume (.h5), or place one under \
+             testdata/radar-fmi-pvol/."
         );
         std::process::exit(1);
     }
-    eprintln!(
-        "site {:?} ({:?})  lon={:.4} lat={:.4} h={:.0}m  sweeps={}  time={}",
-        site.nod,
-        site.plc,
-        site.lon,
-        site.lat,
-        site.height,
-        vol.sweeps.len(),
-        vol.time
-    );
+    let data_dir = file
+        .parent()
+        .and_then(Path::to_str)
+        .expect("file has a UTF-8 parent directory");
 
-    // RTC center = ECEF of the antenna. pnts POSITION values are raw ECEF
-    // offsets from this center (no Y-up/Z-up flip — pnts is ECEF-native).
-    let center = geodetic_to_ecef(site.lon, site.lat, site.height);
+    // The PVOL engine scans a directory and expands it into one collection per
+    // radar site. `odim-volume` ignores parameter/unit/overrides.
+    let config = OdimConfig {
+        filename_template: None,
+        filename_pattern: None,
+        timestamp_format: None,
+        parameter: None,
+        unit: None,
+        nodata: None,
+        gain: None,
+        offset: None,
+        poll_interval_secs: 30,
+        max_files: None,
+        endpoint: None,
+        bucket: None,
+        prefix_pattern: None,
+        time_window: None,
+        discovery: None,
+        cadence_secs: None,
+    };
+    let engine = PolarVolumeEngine::new("3dtiles-demo", Some(data_dir), &config)
+        .expect("build PolarVolumeEngine over the directory");
 
-    let mut positions: Vec<[f32; 3]> = Vec::new();
-    let mut colors: Vec<[u8; 3]> = Vec::new();
-    // Geodetic bbox for the `region` bounding volume.
-    let (mut w, mut s, mut e, mut n) = (PI, PI / 2.0, -PI, -PI / 2.0);
-    let (mut min_h, mut max_h) = (f64::INFINITY, f64::NEG_INFINITY);
-
-    for sw in &vol.sweeps {
-        let Some(mom) = sw
-            .moments
-            .iter()
-            .find(|m| m.quantity == "DBZH")
-            .or_else(|| sw.moments.iter().find(|m| m.quantity == "TH"))
-        else {
-            continue;
-        };
-        let px = match read_moment_pixels(&bytes, &mom.dataset_path, sw.nrays, sw.nbins) {
-            Ok(p) => p,
-            Err(err) => {
-                eprintln!("  skip sweep {:.2}: {err:?}", sw.elangle);
-                continue;
-            }
-        };
-        let deg_per_ray = 360.0 / sw.nrays as f64;
-        for ray in 0..sw.nrays {
-            let bearing = (ray as f64 + 0.5) * deg_per_ray;
-            for bin in 0..sw.nbins {
-                let Some(dbz) = px.sample(
-                    ray,
-                    bin,
-                    mom.gain,
-                    mom.offset,
-                    mom.nodata,
-                    Some(mom.undetect),
-                ) else {
-                    continue;
-                };
-                if dbz < min_dbz {
-                    continue;
-                }
-                let r = sw.rstart + (bin as f64 + 0.5) * sw.rscale;
-                let (ground, h_above) = slant_to_ground_height(r, sw.elangle);
-                let (lon, lat) = destination_point(site.lon, site.lat, ground, bearing);
-                let alt = site.height + h_above;
-                let ecef = geodetic_to_ecef(lon, lat, alt);
-                positions.push([
-                    (ecef[0] - center[0]) as f32,
-                    (ecef[1] - center[1]) as f32,
-                    (ecef[2] - center[2]) as f32,
-                ]);
-                colors.push(dbz_color(dbz));
-
-                let lonr = lon.to_radians();
-                let latr = lat.to_radians();
-                w = w.min(lonr);
-                e = e.max(lonr);
-                s = s.min(latr);
-                n = n.max(latr);
-                min_h = min_h.min(alt);
-                max_h = max_h.max(alt);
-            }
-        }
-    }
-
-    let count = positions.len();
-    if count == 0 {
-        eprintln!("no cells >= {min_dbz} dBZ — nothing to write");
+    let sites = engine.sites();
+    let Some((nod, _label)) = sites.first() else {
+        eprintln!("no radar sites found in {data_dir}");
         std::process::exit(1);
-    }
-    eprintln!("points: {count}  (>= {min_dbz} dBZ)");
+    };
+    let view = engine.site_view(nod, &format!("3dtiles-demo-{nod}"));
+
+    // For the demo, render a reflectivity quantity (the engine's own default is
+    // the first advertised quantity, which may be a classification field like
+    // CSP). Prefer DBZH, then TH, else whatever the site advertises first.
+    let info = view.volume_info();
+    let quantity = ["DBZH", "TH"]
+        .into_iter()
+        .find(|q| info.quantities.iter().any(|(id, _)| id == q))
+        .map(str::to_string)
+        .or_else(|| info.quantities.first().map(|(id, _)| id.clone()))
+        .expect("site advertises at least one quantity");
+
+    // Sample the whole volume into a point cloud — the production code path.
+    let cloud = view
+        .read_point_cloud(Some(&quantity), None, Some(min_dbz), None)
+        .expect("sample the volume into a point cloud");
+    eprintln!(
+        "site {nod} — {} points (>= {min_dbz} dBZ), quantity {}",
+        cloud.points.len(),
+        cloud.quantity
+    );
 
     fs::create_dir_all(&out_dir).expect("mkdir out_dir");
 
-    // ---- content.pnts ----
-    // Binary body: POSITION (n*12, f32) then RGB (n*3, u8).
-    let pos_bytes = count * 12;
-    let rgb_off = pos_bytes;
-    let mut body = Vec::with_capacity(pos_bytes + count * 3);
-    for p in &positions {
-        for v in p {
-            body.extend_from_slice(&v.to_le_bytes());
-        }
-    }
-    for c in &colors {
-        body.extend_from_slice(c);
-    }
-    while body.len() % 8 != 0 {
-        body.push(0);
-    }
+    // Encode via ds-3dtiles (the same path the API layer will use, #349).
+    let colormap = LutColorMap::from_builtin(BuiltinColormap::RadarDbz, -32.0, 95.0);
+    let pnts = ds_3dtiles::encode_pnts(&cloud, &colormap).expect("encode pnts");
+    fs::write(out_dir.join("content.pnts"), &pnts).expect("write content.pnts");
+    let tileset = ds_3dtiles::tileset_json(&cloud, "content.pnts").expect("build tileset.json");
+    fs::write(out_dir.join("tileset.json"), tileset).expect("write tileset.json");
 
-    let [cx, cy, cz] = center;
-    let ft_json = format!(
-        r#"{{"POINTS_LENGTH":{count},"RTC_CENTER":[{cx},{cy},{cz}],"POSITION":{{"byteOffset":0}},"RGB":{{"byteOffset":{rgb_off}}}}}"#
-    );
-    let mut ft_json = ft_json.into_bytes();
-    while ft_json.len() % 8 != 0 {
-        ft_json.push(b' ');
-    }
-
-    let header_len = 28;
-    let total = header_len + ft_json.len() + body.len();
-    // The pnts header fields are u32: fail loudly rather than silently
-    // truncate (a >4 GB tile would otherwise produce a corrupt file).
-    let total_u32 = u32::try_from(total).expect("pnts file exceeds 4 GB");
-    let ft_json_u32 = u32::try_from(ft_json.len()).expect("pnts feature-table JSON exceeds 4 GB");
-    let body_u32 = u32::try_from(body.len()).expect("pnts feature-table binary exceeds 4 GB");
-    let mut pnts = Vec::with_capacity(total);
-    pnts.extend_from_slice(b"pnts");
-    pnts.extend_from_slice(&1u32.to_le_bytes()); // version
-    pnts.extend_from_slice(&total_u32.to_le_bytes());
-    pnts.extend_from_slice(&ft_json_u32.to_le_bytes()); // FT JSON len
-    pnts.extend_from_slice(&body_u32.to_le_bytes()); // FT binary len
-    pnts.extend_from_slice(&0u32.to_le_bytes()); // batch table JSON len
-    pnts.extend_from_slice(&0u32.to_le_bytes()); // batch table binary len
-    pnts.extend_from_slice(&ft_json);
-    pnts.extend_from_slice(&body);
-    fs::write(out_dir.join("content.pnts"), &pnts).expect("write pnts");
-
-    // ---- tileset.json ----
-    // Region bounding volume is geodetic (EPSG:4979); RTC_CENTER inside the
-    // pnts places points in ECEF, so no tile transform is needed.
-    let region = format!("[{w},{s},{e},{n},{min_h},{max_h}]");
-    // A non-zero top-level geometricError is load-bearing: with the tileset
-    // geometricError at 0, CesiumJS never refines to the root and the content
-    // tile is never even requested (it draws nothing). Give the tileset a
-    // large error and the single content tile a positive leaf error.
-    let tileset = format!(
-        r#"{{
-  "asset": {{ "version": "1.1" }},
-  "geometricError": 100000,
-  "root": {{
-    "boundingVolume": {{ "region": {region} }},
-    "geometricError": 1000,
-    "refine": "ADD",
-    "content": {{ "uri": "content.pnts" }}
-  }}
-}}
-"#
-    );
-    fs::write(out_dir.join("tileset.json"), tileset).expect("write tileset");
-
-    // Self-describing HUD/title from the actual volume, not hardcoded.
-    let site_label = match (&site.plc, &site.nod) {
-        (Some(plc), Some(nod)) => format!("{plc} ({nod})"),
-        (Some(name), None) | (None, Some(name)) => name.clone(),
-        (None, None) => "radar".to_string(),
-    };
+    // Antenna position (for camera framing) + a self-describing HUD.
+    let antenna = view
+        .get_locations()
+        .ok()
+        .and_then(|locs| locs.into_iter().next());
+    let (lon, lat) = antenna
+        .as_ref()
+        .map(|l| (l.longitude, l.latitude))
+        .unwrap_or((0.0, 0.0));
+    let site_label = antenna
+        .as_ref()
+        .map(|l| l.label.clone())
+        .unwrap_or_else(|| nod.clone());
+    let time_str = info
+        .times
+        .last()
+        .map(|t| t.format("%Y-%m-%d %H:%MZ").to_string())
+        .unwrap_or_default();
     let hud = format!(
-        "{site_label} polar volume — {} · DBZH ≥ {min_dbz:.0} dBZ",
-        vol.time.format("%Y-%m-%d %H:%MZ")
+        "{site_label} ({nod}) polar volume — {time_str} · {} ≥ {min_dbz:.0} dBZ",
+        cloud.quantity
     );
-    write_viewer(&out_dir, site.lon, site.lat, site.height, &hud);
+    write_viewer(&out_dir, lon, lat, &hud);
 
     eprintln!(
-        "wrote {}/  (tileset.json, content.pnts, index.html)",
-        out_dir.display()
-    );
-    eprintln!(
-        "pnts {:.1} MB  region lon[{:.3},{:.3}] lat[{:.3},{:.3}] alt[{:.0},{:.0}]m",
-        pnts.len() as f64 / 1e6,
-        w.to_degrees(),
-        e.to_degrees(),
-        s.to_degrees(),
-        n.to_degrees(),
-        min_h,
-        max_h
+        "wrote {}/  (tileset.json, content.pnts, index.html) — {:.1} MB pnts",
+        out_dir.display(),
+        pnts.len() as f64 / 1e6
     );
 }
 
-/// Write a self-contained CesiumJS viewer. `hud` describes the actual volume
-/// (site/time/threshold) so the page is correct for any input, not just fivih.
-fn write_viewer(out_dir: &std::path::Path, lon: f64, lat: f64, h: f64, hud: &str) {
+/// Write a self-contained, token-free CesiumJS viewer (CARTO Dark Matter
+/// basemap). `hud`/`lon`/`lat` describe the actual volume.
+fn write_viewer(out_dir: &Path, lon: f64, lat: f64, hud: &str) {
     // `hud` carries HDF5-sourced site metadata (PLC/NOD) verbatim; escape it
     // before it lands in the HTML <title>/<div> so a crafted .h5 can't inject
     // markup/script into the generated viewer.
@@ -350,9 +156,6 @@ fn write_viewer(out_dir: &std::path::Path, lon: f64, lat: f64, h: f64, hud: &str
             .replace('"', "&quot;")
     }
     let hud = html_escape(hud);
-    // Camera sits ~90 km above the antenna's own elevation, south of it, so the
-    // framing tracks the site rather than assuming sea level.
-    let cam_alt = h + 90_000.0;
     let html = format!(
         r#"<!doctype html>
 <html><head><meta charset="utf-8"><title>{hud} — 3D Tiles</title>
@@ -380,7 +183,7 @@ Cesium.Cesium3DTileset.fromUrl("tileset.json", {{ maximumScreenSpaceError: 1 }})
   ts.style = new Cesium.Cesium3DTileStyle({{ pointSize: 5.0 }});
   // Frame the volume from the SW, elevated, to reveal vertical structure.
   viewer.camera.flyTo({{
-    destination: Cesium.Cartesian3.fromDegrees({lon}, {lat_s}, {cam_alt}),
+    destination: Cesium.Cartesian3.fromDegrees({lon}, {lat_s}, 90000),
     orientation: {{ heading: 0, pitch: Cesium.Math.toRadians(-30), roll: 0 }},
     duration: 0
   }});

--- a/crates/engine-odim/examples/gen_3dtiles.rs
+++ b/crates/engine-odim/examples/gen_3dtiles.rs
@@ -134,7 +134,11 @@ fn main() {
         "{site_label} ({nod}) polar volume — {time_str} · {} ≥ {min_dbz:.0} dBZ",
         cloud.quantity
     );
-    write_viewer(&out_dir, lon, lat, &hud);
+    // Frame relative to the site's elevation, not sea level: the region's min
+    // height ≈ the antenna altitude (lowest sweep near the radar). Matters for
+    // alpine sites; negligible for the Finnish fixture.
+    let base_alt = cloud.region[4];
+    write_viewer(&out_dir, lon, lat, base_alt, &hud);
 
     eprintln!(
         "wrote {}/  (tileset.json, content.pnts, index.html) — {:.1} MB pnts",
@@ -144,8 +148,9 @@ fn main() {
 }
 
 /// Write a self-contained, token-free CesiumJS viewer (CARTO Dark Matter
-/// basemap). `hud`/`lon`/`lat` describe the actual volume.
-fn write_viewer(out_dir: &Path, lon: f64, lat: f64, hud: &str) {
+/// basemap). `hud`/`lon`/`lat`/`base_alt` describe the actual volume;
+/// `base_alt` is the site's ground elevation (metres) the camera frames above.
+fn write_viewer(out_dir: &Path, lon: f64, lat: f64, base_alt: f64, hud: &str) {
     // `hud` carries HDF5-sourced site metadata (PLC/NOD) verbatim; escape it
     // before it lands in the HTML <title>/<div> so a crafted .h5 can't inject
     // markup/script into the generated viewer.
@@ -156,6 +161,7 @@ fn write_viewer(out_dir: &Path, lon: f64, lat: f64, hud: &str) {
             .replace('"', "&quot;")
     }
     let hud = html_escape(hud);
+    let cam_alt = base_alt + 90_000.0;
     let html = format!(
         r#"<!doctype html>
 <html><head><meta charset="utf-8"><title>{hud} — 3D Tiles</title>
@@ -183,7 +189,7 @@ Cesium.Cesium3DTileset.fromUrl("tileset.json", {{ maximumScreenSpaceError: 1 }})
   ts.style = new Cesium.Cesium3DTileStyle({{ pointSize: 5.0 }});
   // Frame the volume from the SW, elevated, to reveal vertical structure.
   viewer.camera.flyTo({{
-    destination: Cesium.Cartesian3.fromDegrees({lon}, {lat_s}, 90000),
+    destination: Cesium.Cartesian3.fromDegrees({lon}, {lat_s}, {cam_alt}),
     orientation: {{ heading: 0, pitch: Cesium.Math.toRadians(-30), roll: 0 }},
     duration: 0
   }});

--- a/crates/engine-odim/src/volume_engine.rs
+++ b/crates/engine-odim/src/volume_engine.rs
@@ -3056,12 +3056,22 @@ fn volume_point_cloud(
 
     // Hard memory bound: a pathologically dense volume must not allocate an
     // unbounded cloud once this is reachable from an HTTP handler (#349).
-    // 8M points × ~15 B ≈ 120 MB; real volumes are far smaller (the fivih demo
-    // is ~0.38M). On overflow we stop and warn rather than fail the request.
+    // `VolumePoint` is [f32; 3] + f64 = 24 B, so 8M points ≈ 192 MB; real
+    // volumes are far smaller (the fivih demo is ~0.38M). On overflow we stop
+    // and warn rather than fail the request.
     const MAX_POINTS: usize = 8_000_000;
     let mut truncated = false;
 
-    let mut points: Vec<VolumePoint> = Vec::new();
+    // Reserve the true upper bound (every cell of every sweep carrying the
+    // quantity), capped at MAX_POINTS, so the fill loop never reallocates.
+    let upper_bound = volume
+        .sweeps
+        .iter()
+        .filter(|s| s.moments.iter().any(|m| m.quantity == quantity))
+        .map(|s| s.nrays.saturating_mul(s.nbins))
+        .fold(0usize, usize::saturating_add)
+        .min(MAX_POINTS);
+    let mut points: Vec<VolumePoint> = Vec::with_capacity(upper_bound);
     // Geodetic region accumulators: lon/lat in radians, height in metres.
     let (mut west, mut east) = (f64::INFINITY, f64::NEG_INFINITY);
     let (mut south, mut north) = (f64::INFINITY, f64::NEG_INFINITY);

--- a/crates/engine-odim/src/volume_engine.rs
+++ b/crates/engine-odim/src/volume_engine.rs
@@ -1268,11 +1268,11 @@ fn derive_site_meta(list: &[VolumeEntry]) -> Option<SiteMeta> {
         (!levels.is_empty()).then(|| VerticalDimension::new(VerticalKind::ElevationAngle, levels));
 
     // Pre-build the 3D Tiles metadata snapshot once per catalog rebuild so the
-    // per-request `volume_info()` is an O(1) Arc clone (#211).
-    let default_quantity = parameters
-        .first()
-        .map(|(id, _)| id.clone())
-        .unwrap_or_default();
+    // per-request `volume_info()` is an O(1) Arc clone (#211). The default
+    // quantity is `quantities.first()` — the *same* source `read_point_cloud`
+    // and `get_raster_tile` default to, so the advertised default matches what
+    // an unqualified request actually renders.
+    let default_quantity = quantities.first().cloned().unwrap_or_default();
     let default_unit = quantities::quantity_unit(&default_quantity).to_string();
     let volume_info = Arc::new(VolumeInfo {
         quantities: parameters.clone(),
@@ -3195,15 +3195,16 @@ impl VolumeEngine for PolarVolumeSiteView {
     ) -> Result<VolumePointCloud, DataServerError> {
         let catalog = self.catalog.load();
 
-        // Default to the site's primary (first advertised) quantity, like
-        // `get_raster_tile`.
+        // Default to the same quantity `volume_info()` advertises (the cached
+        // `default_quantity`), so an unqualified request renders exactly what
+        // the metadata says is the default.
         let quantity = match quantity {
             Some(q) => q.to_string(),
             None => catalog
                 .by_site_meta
                 .get(&self.nod)
-                .and_then(|m| m.quantities.first())
-                .cloned()
+                .map(|m| m.volume_info.default_quantity.clone())
+                .filter(|q| !q.is_empty())
                 .ok_or_else(|| {
                     DataServerError::InvalidParameter(format!(
                         "[{}] PVOL collection has no quantities to render",
@@ -3268,6 +3269,9 @@ impl VolumeEngine for PolarVolumeSiteView {
 
     fn volume_info(&self) -> Arc<VolumeInfo> {
         // O(1): clone the pre-built snapshot's `Arc`, not its `Vec`s (#211).
+        // An unknown NOD (site dropped from the catalog since registration —
+        // a reload race) degrades to empty metadata, matching how the query
+        // methods report no data; no per-request log to avoid spam.
         self.catalog
             .load()
             .by_site_meta

--- a/crates/engine-odim/src/volume_engine.rs
+++ b/crates/engine-odim/src/volume_engine.rs
@@ -583,6 +583,10 @@ struct SiteMeta {
     coverage_radius_m: Option<f64>,
     /// This site's sweep elevation angles (degrees).
     vertical: Option<VerticalDimension>,
+    /// Pre-built 3D Tiles metadata snapshot, so `VolumeEngine::volume_info`
+    /// is an O(1) `Arc` clone on the request path (no per-call `Vec` clone),
+    /// per the `RasterInfo` rule (#211). Rebuilt on each catalog swap.
+    volume_info: Arc<VolumeInfo>,
 }
 
 /// The engine's catalog: per-site time-sorted volume lists, plus the
@@ -1263,6 +1267,20 @@ fn derive_site_meta(list: &[VolumeEntry]) -> Option<SiteMeta> {
     let vertical =
         (!levels.is_empty()).then(|| VerticalDimension::new(VerticalKind::ElevationAngle, levels));
 
+    // Pre-build the 3D Tiles metadata snapshot once per catalog rebuild so the
+    // per-request `volume_info()` is an O(1) Arc clone (#211).
+    let default_quantity = parameters
+        .first()
+        .map(|(id, _)| id.clone())
+        .unwrap_or_default();
+    let default_unit = quantities::quantity_unit(&default_quantity).to_string();
+    let volume_info = Arc::new(VolumeInfo {
+        quantities: parameters.clone(),
+        times: times.clone(),
+        default_quantity,
+        default_unit,
+    });
+
     Some(SiteMeta {
         lon: site.lon,
         lat: site.lat,
@@ -1275,6 +1293,7 @@ fn derive_site_meta(list: &[VolumeEntry]) -> Option<SiteMeta> {
         spatial_extent,
         coverage_radius_m,
         vertical,
+        volume_info,
     })
 }
 
@@ -3082,6 +3101,7 @@ fn volume_point_cloud(
             || sweep.nbins == 0
             || !sweep.rscale.is_finite()
             || sweep.rscale <= 0.0
+            || !sweep.rstart.is_finite()
             || !sweep.elangle.is_finite()
         {
             continue;
@@ -3246,26 +3266,14 @@ impl VolumeEngine for PolarVolumeSiteView {
         Ok(cloud)
     }
 
-    fn volume_info(&self) -> VolumeInfo {
-        // NOTE: clones `parameters` + `times` per call, mirroring the sibling
-        // `raster_info()` above. Not yet on a per-request hot path (the 3D
-        // Tiles API is #349); when it is wired, cache a snapshot in an
-        // `ArcSwap` rebuilt on catalog swap for *both* accessors together,
-        // matching the #211 `RasterInfo` fix.
-        let catalog = self.catalog.load();
-        let meta = catalog.by_site_meta.get(&self.nod);
-        let quantities = meta.map(|m| m.parameters.clone()).unwrap_or_default();
-        let default_quantity = quantities
-            .first()
-            .map(|(id, _)| id.clone())
-            .unwrap_or_default();
-        let default_unit = quantities::quantity_unit(&default_quantity).to_string();
-        VolumeInfo {
-            quantities,
-            times: meta.map(|m| m.times.clone()).unwrap_or_default(),
-            default_quantity,
-            default_unit,
-        }
+    fn volume_info(&self) -> Arc<VolumeInfo> {
+        // O(1): clone the pre-built snapshot's `Arc`, not its `Vec`s (#211).
+        self.catalog
+            .load()
+            .by_site_meta
+            .get(&self.nod)
+            .map(|m| Arc::clone(&m.volume_info))
+            .unwrap_or_default()
     }
 }
 
@@ -5686,6 +5694,7 @@ mod tests {
                 spatial_extent: None,
                 coverage_radius_m: None,
                 vertical: None,
+                volume_info: Arc::default(),
             }
         }
         let nods = vec!["fivih".to_string()];

--- a/crates/engine-odim/src/volume_engine.rs
+++ b/crates/engine-odim/src/volume_engine.rs
@@ -3061,7 +3061,11 @@ fn volume_point_cloud(
     let (mut min_h, mut max_h) = (f64::INFINITY, f64::NEG_INFINITY);
 
     for sweep in &volume.sweeps {
-        if sweep.nrays == 0 || sweep.nbins == 0 || !sweep.rscale.is_finite() || sweep.rscale <= 0.0
+        if sweep.nrays == 0
+            || sweep.nbins == 0
+            || !sweep.rscale.is_finite()
+            || sweep.rscale <= 0.0
+            || !sweep.elangle.is_finite()
         {
             continue;
         }

--- a/crates/engine-odim/src/volume_engine.rs
+++ b/crates/engine-odim/src/volume_engine.rs
@@ -3054,13 +3054,20 @@ fn volume_point_cloud(
     let site = &volume.site;
     let center = geodetic_to_ecef(site.lon, site.lat, site.height);
 
+    // Hard memory bound: a pathologically dense volume must not allocate an
+    // unbounded cloud once this is reachable from an HTTP handler (#349).
+    // 8M points × ~15 B ≈ 120 MB; real volumes are far smaller (the fivih demo
+    // is ~0.38M). On overflow we stop and warn rather than fail the request.
+    const MAX_POINTS: usize = 8_000_000;
+    let mut truncated = false;
+
     let mut points: Vec<VolumePoint> = Vec::new();
     // Geodetic region accumulators: lon/lat in radians, height in metres.
     let (mut west, mut east) = (f64::INFINITY, f64::NEG_INFINITY);
     let (mut south, mut north) = (f64::INFINITY, f64::NEG_INFINITY);
     let (mut min_h, mut max_h) = (f64::INFINITY, f64::NEG_INFINITY);
 
-    for sweep in &volume.sweeps {
+    'sweeps: for sweep in &volume.sweeps {
         if sweep.nrays == 0
             || sweep.nbins == 0
             || !sweep.rscale.is_finite()
@@ -3079,6 +3086,10 @@ fn volume_point_cloud(
         for ray in 0..sweep.nrays {
             let bearing = (ray as f64 + 0.5) * deg_per_ray;
             for bin in 0..sweep.nbins {
+                if points.len() >= MAX_POINTS {
+                    truncated = true;
+                    break 'sweeps;
+                }
                 let Some(v) = pixels.sample(
                     ray,
                     bin,
@@ -3114,6 +3125,14 @@ fn volume_point_cloud(
                 max_h = max_h.max(alt);
             }
         }
+    }
+
+    if truncated {
+        tracing::warn!(
+            "[PVOL] point cloud for site `{}` capped at {MAX_POINTS} points \
+             (dense volume); remaining cells dropped",
+            site.nod.as_deref().unwrap_or("?")
+        );
     }
 
     // Empty point set ⇒ zeroed region; the caller maps "no points" to a 404

--- a/crates/engine-odim/src/volume_engine.rs
+++ b/crates/engine-odim/src/volume_engine.rs
@@ -3199,7 +3199,23 @@ impl VolumeEngine for PolarVolumeSiteView {
         // `default_quantity`), so an unqualified request renders exactly what
         // the metadata says is the default.
         let quantity = match quantity {
-            Some(q) => q.to_string(),
+            Some(q) => {
+                // Reject an unknown quantity as InvalidParameter (→ 400), not a
+                // "no echoes" LocationNotFound (→ 404) — consistent with
+                // `get_raster_tile`/`polar_sample`, and so the #349 handler
+                // gets the right status for free.
+                let known = catalog
+                    .by_site_meta
+                    .get(&self.nod)
+                    .is_some_and(|m| m.quantities.iter().any(|x| x == q));
+                if !known {
+                    return Err(DataServerError::InvalidParameter(format!(
+                        "[{}] unknown quantity `{q}` for radar site `{}`",
+                        self.collection_id, self.nod
+                    )));
+                }
+                q.to_string()
+            }
             None => catalog
                 .by_site_meta
                 .get(&self.nod)

--- a/crates/engine-odim/src/volume_engine.rs
+++ b/crates/engine-odim/src/volume_engine.rs
@@ -62,12 +62,14 @@ use ds_core::feature::{
     Feature, FeaturePage, FeatureQuery, Geometry, PropertyValue,
 };
 use ds_core::feature_engine::FeatureEngine;
+use ds_core::geo::geodetic_to_ecef;
 use ds_core::map_engine::{MapEngine, OutputCrs, RasterInfo, RasterTile};
 use ds_core::model::{
     CoverageResponse, DomainDescription, Location, NdArray, ParameterDescription, QueryResult,
     VerticalCoord,
 };
 use ds_core::vertical::{VerticalDimension, VerticalKind};
+use ds_core::volume::{VolumeEngine, VolumeInfo, VolumePoint, VolumePointCloud};
 use tokio::sync::Notify;
 
 use ds_storage::discovery::{expand_prefix_for_dates, expand_prefix_pattern, TimeWindow};
@@ -3027,6 +3029,187 @@ impl MapEngine for PolarVolumeSiteView {
             // layer's title and flat clients can tell the sites apart.
             layer_subtitle: meta.map(|m| m.plc.clone().unwrap_or_else(|| self.nod.clone())),
             reference_times: Vec::new(),
+        }
+    }
+}
+
+/// Build a 3-D point cloud from one polar volume: every valid cell of every
+/// sweep that carries `quantity`, placed at its true ECEF position via the
+/// 4/3-Earth beam model (slant range → ground distance + height above the
+/// antenna), then offset from the antenna's ECEF position.
+///
+/// This is the cross-section sampler ([`volume_section`]) generalized from a
+/// 1-D path to the full `(sweep, ray, bin)` lattice. It uses real slant→ground
+/// geometry — unlike the 2-D [`polar_sample`], which renders with the
+/// ground-range interim. Azimuth is uniform `360/nrays` spacing (north-first,
+/// clockwise — matching the 2-D sampler); reading per-ray `how/startazA` for
+/// sector scans is a reader follow-up (#348).
+fn volume_point_cloud(
+    volume: &PolarVolume,
+    file_id: &str,
+    pix: Pixels,
+    quantity: &str,
+    min_value: Option<f64>,
+) -> VolumePointCloud {
+    let site = &volume.site;
+    let center = geodetic_to_ecef(site.lon, site.lat, site.height);
+
+    let mut points: Vec<VolumePoint> = Vec::new();
+    // Geodetic region accumulators: lon/lat in radians, height in metres.
+    let (mut west, mut east) = (f64::INFINITY, f64::NEG_INFINITY);
+    let (mut south, mut north) = (f64::INFINITY, f64::NEG_INFINITY);
+    let (mut min_h, mut max_h) = (f64::INFINITY, f64::NEG_INFINITY);
+
+    for sweep in &volume.sweeps {
+        if sweep.nrays == 0 || sweep.nbins == 0 || !sweep.rscale.is_finite() || sweep.rscale <= 0.0
+        {
+            continue;
+        }
+        let Some(moment) = sweep.moments.iter().find(|m| m.quantity == quantity) else {
+            continue;
+        };
+        let Some(pixels) = pix.moment(file_id, moment, sweep.nrays, sweep.nbins) else {
+            continue;
+        };
+        let deg_per_ray = 360.0 / sweep.nrays as f64;
+        for ray in 0..sweep.nrays {
+            let bearing = (ray as f64 + 0.5) * deg_per_ray;
+            for bin in 0..sweep.nbins {
+                let Some(v) = pixels.sample(
+                    ray,
+                    bin,
+                    moment.gain,
+                    moment.offset,
+                    moment.nodata,
+                    Some(moment.undetect),
+                ) else {
+                    continue;
+                };
+                if min_value.is_some_and(|min| v < min) {
+                    continue;
+                }
+                let r = sweep.rstart + (bin as f64 + 0.5) * sweep.rscale;
+                let (ground, h_above) = slant_to_ground_height(r, sweep.elangle);
+                let (lon, lat) = destination_point(site.lon, site.lat, ground, bearing);
+                let alt = site.height + h_above;
+                let ecef = geodetic_to_ecef(lon, lat, alt);
+                points.push(VolumePoint {
+                    offset: [
+                        (ecef[0] - center[0]) as f32,
+                        (ecef[1] - center[1]) as f32,
+                        (ecef[2] - center[2]) as f32,
+                    ],
+                    value: v,
+                });
+                let (lonr, latr) = (lon.to_radians(), lat.to_radians());
+                west = west.min(lonr);
+                east = east.max(lonr);
+                south = south.min(latr);
+                north = north.max(latr);
+                min_h = min_h.min(alt);
+                max_h = max_h.max(alt);
+            }
+        }
+    }
+
+    // Empty point set ⇒ zeroed region; the caller maps "no points" to a 404
+    // before this cloud is ever encoded, so the region is never used.
+    let region = if points.is_empty() {
+        [0.0; 6]
+    } else {
+        [west, south, east, north, min_h, max_h]
+    };
+    VolumePointCloud {
+        rtc_center: center,
+        region,
+        points,
+        quantity: quantity.to_string(),
+        unit: quantities::quantity_unit(quantity).to_string(),
+    }
+}
+
+impl VolumeEngine for PolarVolumeSiteView {
+    fn read_point_cloud(
+        &self,
+        quantity: Option<&str>,
+        time: Option<DateTime<Utc>>,
+        min_value: Option<f64>,
+        _reference_time: Option<DateTime<Utc>>,
+    ) -> Result<VolumePointCloud, DataServerError> {
+        let catalog = self.catalog.load();
+
+        // Default to the site's primary (first advertised) quantity, like
+        // `get_raster_tile`.
+        let quantity = match quantity {
+            Some(q) => q.to_string(),
+            None => catalog
+                .by_site_meta
+                .get(&self.nod)
+                .and_then(|m| m.quantities.first())
+                .cloned()
+                .ok_or_else(|| {
+                    DataServerError::InvalidParameter(format!(
+                        "[{}] PVOL collection has no quantities to render",
+                        self.collection_id
+                    ))
+                })?,
+        };
+
+        let site_volumes = catalog.by_site.get(&self.nod).ok_or_else(|| {
+            DataServerError::LocationNotFound(format!(
+                "[{}] radar site `{}` has no current volumes",
+                self.collection_id, self.nod
+            ))
+        })?;
+
+        // Select the volume nearest `time` (latest if `None`) — same rule as
+        // `get_raster_tile`.
+        let entry = match time {
+            Some(target) => site_volumes
+                .iter()
+                .min_by_key(|e| (e.volume.time - target).num_seconds().abs()),
+            None => site_volumes.last(),
+        }
+        .ok_or_else(|| {
+            DataServerError::LocationNotFound(format!(
+                "[{}] radar site `{}` has no volumes",
+                self.collection_id, self.nod
+            ))
+        })?;
+
+        let handle = blocking_pixel_handle();
+        let pix = Pixels {
+            source: &self.source,
+            handle: handle.as_ref(),
+        };
+        let cloud = volume_point_cloud(&entry.volume, &entry.id, pix, &quantity, min_value);
+
+        // No echoes (every cell nodata, or below `min_value`) ⇒ 404, matching
+        // the other engines' "no data in window" convention, so the API layer
+        // never has to encode an empty tileset.
+        if cloud.points.is_empty() {
+            return Err(DataServerError::LocationNotFound(format!(
+                "[{}] no `{}` echoes in the selected volume of site `{}`",
+                self.collection_id, quantity, self.nod
+            )));
+        }
+        Ok(cloud)
+    }
+
+    fn volume_info(&self) -> VolumeInfo {
+        let catalog = self.catalog.load();
+        let meta = catalog.by_site_meta.get(&self.nod);
+        let quantities = meta.map(|m| m.parameters.clone()).unwrap_or_default();
+        let default_quantity = quantities
+            .first()
+            .map(|(id, _)| id.clone())
+            .unwrap_or_default();
+        let default_unit = quantities::quantity_unit(&default_quantity).to_string();
+        VolumeInfo {
+            quantities,
+            times: meta.map(|m| m.times.clone()).unwrap_or_default(),
+            default_quantity,
+            default_unit,
         }
     }
 }

--- a/crates/engine-odim/src/volume_engine.rs
+++ b/crates/engine-odim/src/volume_engine.rs
@@ -3177,6 +3177,19 @@ impl VolumeEngine for PolarVolumeSiteView {
             ))
         })?;
 
+        // A corrupt file with non-finite antenna coordinates would poison the
+        // ECEF projection (`geodetic_to_ecef` → NaN center → every offset NaN).
+        // Reject up front with antenna context, rather than surfacing an opaque
+        // `NonFinite("point offset")` from the encoder.
+        let antenna = &entry.volume.site;
+        if !(antenna.lon.is_finite() && antenna.lat.is_finite() && antenna.height.is_finite()) {
+            return Err(DataServerError::Engine(format!(
+                "[{}] radar site `{}` has non-finite antenna coordinates \
+                 (lon={}, lat={}, height={})",
+                self.collection_id, self.nod, antenna.lon, antenna.lat, antenna.height
+            )));
+        }
+
         let handle = blocking_pixel_handle();
         let pix = Pixels {
             source: &self.source,
@@ -3197,6 +3210,11 @@ impl VolumeEngine for PolarVolumeSiteView {
     }
 
     fn volume_info(&self) -> VolumeInfo {
+        // NOTE: clones `parameters` + `times` per call, mirroring the sibling
+        // `raster_info()` above. Not yet on a per-request hot path (the 3D
+        // Tiles API is #349); when it is wired, cache a snapshot in an
+        // `ArcSwap` rebuilt on catalog swap for *both* accessors together,
+        // matching the #211 `RasterInfo` fix.
         let catalog = self.catalog.load();
         let meta = catalog.by_site_meta.get(&self.nod);
         let quantities = meta.map(|m| m.parameters.clone()).unwrap_or_default();

--- a/crates/engine-odim/src/volume_engine.rs
+++ b/crates/engine-odim/src/volume_engine.rs
@@ -3145,8 +3145,12 @@ fn volume_point_cloud(
         );
     }
 
-    // Empty point set ⇒ zeroed region; the caller maps "no points" to a 404
-    // before this cloud is ever encoded, so the region is never used.
+    // The region bounds the *included* points — exactly the tile's content,
+    // which is what a 3D Tiles bounding volume must enclose. Correct for both
+    // the full and the truncated (MAX_POINTS) cases: dropped cells are not in
+    // the tile, so excluding them from the bounds is right, and a tighter
+    // bound is better for frustum culling. An empty set ⇒ zeroed region, but
+    // the caller maps "no points" to a 404 before encoding, so it's never used.
     let region = if points.is_empty() {
         [0.0; 6]
     } else {

--- a/crates/engine-odim/tests/integration.rs
+++ b/crates/engine-odim/tests/integration.rs
@@ -644,6 +644,16 @@ fn pvol_volume_engine_emits_point_cloud() {
         tileset.contains("\"region\""),
         "tileset has a region bounding volume"
     );
+
+    // An unknown quantity is a clear InvalidParameter (→ 400), not a
+    // "no echoes" LocationNotFound (→ 404).
+    assert!(
+        matches!(
+            view.read_point_cloud(Some("NOSUCHQ"), None, None, None),
+            Err(ds_core::error::DataServerError::InvalidParameter(_))
+        ),
+        "unknown quantity must be InvalidParameter"
+    );
 }
 
 /// End-to-end `FeatureEngine` surface on the real FMI Vihti volume: the

--- a/crates/engine-odim/tests/integration.rs
+++ b/crates/engine-odim/tests/integration.rs
@@ -530,6 +530,122 @@ fn pvol_engine_renders_fmi_vihti_volume() {
     );
 }
 
+/// `VolumeEngine` surface on the real FMI Vihti volume: sample the polar
+/// volume into a 3-D point cloud and encode it as a 3D Tiles `.pnts` tile +
+/// `tileset.json` via `ds-3dtiles`. Skips when the uncommitted fixture is
+/// absent (CI stays green).
+#[test]
+fn pvol_volume_engine_emits_point_cloud() {
+    use ds_core::volume::VolumeEngine;
+
+    let fixture = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../testdata/radar-fmi-pvol/202605191050_fivih_PVOL.h5");
+    if !fixture.exists() {
+        eprintln!("skipping pvol_volume_engine_emits_point_cloud: fixture absent at {fixture:?}");
+        return;
+    }
+    let data_dir = fixture
+        .parent()
+        .expect("fixture has a parent directory")
+        .to_str()
+        .expect("utf8 fixture dir");
+
+    let config = OdimConfig {
+        filename_template: None,
+        filename_pattern: None,
+        timestamp_format: None,
+        parameter: None,
+        unit: None,
+        nodata: None,
+        gain: None,
+        offset: None,
+        poll_interval_secs: 30,
+        max_files: None,
+        endpoint: None,
+        bucket: None,
+        prefix_pattern: None,
+        time_window: None,
+        discovery: None,
+        cadence_secs: None,
+    };
+    let engine = engine_odim::PolarVolumeEngine::new("fivih-vol-test", Some(data_dir), &config)
+        .expect("PolarVolumeEngine::new over the PVOL directory");
+    let view = engine.site_view("fivih", "fivih-vol-test-fivih");
+
+    // Metadata surface.
+    let vinfo = view.volume_info();
+    assert!(
+        !vinfo.quantities.is_empty(),
+        "PVOL site must advertise quantities"
+    );
+    assert!(!vinfo.times.is_empty(), "PVOL site must have a valid time");
+    assert!(!vinfo.default_quantity.is_empty());
+
+    // Sample the full volume into a point cloud (default quantity, latest
+    // time, a 5 dBZ floor).
+    let cloud = view
+        .read_point_cloud(None, None, Some(5.0), None)
+        .expect("read_point_cloud over the real volume");
+    assert!(
+        !cloud.points.is_empty(),
+        "a real volume must yield echo points"
+    );
+
+    // RTC center is the antenna's ECEF position (geocentric radius ~6.36e6 m
+    // at 60.6°N); the per-point offsets are small and finite.
+    let rtc_mag =
+        (cloud.rtc_center[0].powi(2) + cloud.rtc_center[1].powi(2) + cloud.rtc_center[2].powi(2))
+            .sqrt();
+    assert!(
+        (6.0e6..6.6e6).contains(&rtc_mag),
+        "RTC center near Earth radius, got {rtc_mag}"
+    );
+    for p in &cloud.points {
+        assert!(p.offset.iter().all(|c| c.is_finite()), "finite offsets");
+        let d = (p.offset[0].powi(2) + p.offset[1].powi(2) + p.offset[2].powi(2)).sqrt();
+        assert!(d < 350_000.0, "point within sweep range, got {d} m");
+        assert!(p.value >= 5.0, "min_value floor honoured, got {}", p.value);
+    }
+
+    // Region is a sane geodetic box (radians/metres) around Vihti.
+    let [w, s, e, n, min_h, max_h] = cloud.region;
+    assert!(w < e && s < n, "region ordered: {:?}", cloud.region);
+    assert!(
+        (0.40..0.60).contains(&e),
+        "east edge near ~25-29°E, got {e}"
+    );
+    assert!(
+        (1.00..1.15).contains(&n),
+        "north edge near ~58-63°N, got {n}"
+    );
+    assert!(
+        min_h > 0.0 && min_h < max_h && max_h < 25_000.0,
+        "heights sane: {min_h}..{max_h}"
+    );
+
+    // Encode through ds-3dtiles: a valid .pnts tile + a tileset.json.
+    let cmap =
+        ds_render::LutColorMap::from_builtin(ds_render::BuiltinColormap::RadarDbz, -32.0, 95.0);
+    let pnts = ds_3dtiles::encode_pnts(&cloud, &cmap).expect("encode pnts");
+    assert_eq!(&pnts[0..4], b"pnts", "pnts magic");
+    let byte_len = u32::from_le_bytes(pnts[8..12].try_into().unwrap()) as usize;
+    assert_eq!(
+        byte_len,
+        pnts.len(),
+        "pnts byteLength matches actual length"
+    );
+
+    let tileset = ds_3dtiles::tileset_json(&cloud, "content.pnts").expect("tileset json");
+    assert!(
+        tileset.contains("\"content.pnts\""),
+        "tileset names content"
+    );
+    assert!(
+        tileset.contains("\"region\""),
+        "tileset has a region bounding volume"
+    );
+}
+
 /// End-to-end `FeatureEngine` surface on the real FMI Vihti volume: the
 /// owning `PolarVolumeEngine` exposes its sites as a Features collection (one
 /// Point Feature per site). Skips when the uncommitted 15 MB fixture is absent.


### PR DESCRIPTION
Phase 2 of the **OGC 3D Tiles** epic (#346). Closes #348. Promotes the Phase-1 demo's hand-rolled geometry + encoding (#347) into the codebase's normal shape: engines return a domain type, a framework-free crate turns it into bytes — exactly how `ds-render` does PNG and `ds-mvt` does MVT.

## What's here

- **ds-core**
  - `geo::geodetic_to_ecef` — WGS84 → ECEF (EPSG:4978), with tests pinning known points (equator, pole, 90°E).
  - new `volume` module — `VolumePoint` / `VolumePointCloud` domain types + the **`VolumeEngine`** trait (`read_point_cloud`, `volume_info`). Framework-free (chrono only), alongside the other engine traits.
- **ds-3dtiles** (new crate; deps `ds-core` + `ds-render`)
  - `encode_pnts(cloud, colormap) -> Vec<u8>` and `tileset_json(cloud, uri) -> String`.
  - Bakes in the Phase-1 invariants so every caller gets them: tileset **`geometricError > 0`** (or CesiumJS never requests the content), **ECEF-native `.pnts` POSITION** (RTC_CENTER, no Y-up flip), geodetic **`region`**, **`u32` bounds-checks**, and **rejection of non-finite geometry** (JSON built via `serde_json`, not `format!`). 4 unit tests.
- **engine-odim** — `impl VolumeEngine for PolarVolumeSiteView`: the cross-section sampler generalized from a 1-D path to the full `(sweep, ray, bin)` lattice, using the true **slant→ground 4/3-Earth** geometry (the 2-D render path uses the ground-range interim). Drops nodata cells (honours the surveyed envelope) and a `min_value` floor.
- **gen_3dtiles example** is now a **thin driver** over `PolarVolumeEngine` + `ds-3dtiles` — the hand-rolled projection/encoding is gone. Still renders the fivih volume in CesiumJS (verified end-to-end, 377k DBZH points; screenshot reproduced locally).
- **Integration test** samples the real fixture into a cloud and round-trips it through `ds-3dtiles` (same fixture-absent skip guard as the sibling PVOL tests, so CI stays green).

## Design notes

- The domain type is a **point cloud** (`VolumePointCloud`), which matches the `.pnts` format and radar's native polar sampling (one point per cell). A dense, regular **voxel grid** is the Tier-B `EXT_primitive_voxels` path, tracked in #351 — I named the type for what it is rather than the issue's tentative "VoxelGrid".
- **Deferred follow-ups** (neither modelled by the engine today): multi-quantity batch-table properties (carry DBZH/VRADH/ZDR/RHOHV together), and per-ray azimuths (`how/startazA`) for sector scans — the `Sweep` struct assumes uniform `360/nrays` spacing, as does the existing 2-D/EDR path.
- **Server/API wiring is #349** — no routes touched here; this is the library + engine + tests layer.

## Checks
`cargo clippy --workspace --all-targets` clean; `ds-3dtiles` (4), `ds-core` (195, incl. new ECEF test), `engine-odim` (134 unit + 28 integration, incl. the new VolumeEngine test) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
