### PR TITLE
feat(api-3dtiles): OGC 3D Tiles HTTP service (#349)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## What This Is
 
-Rust workspace implementing OGC API - EDR, OGC API - Features, OGC API - Maps, OGC API - Tiles, and OGC WMS 1.3.0 servers. Eighteen crates: `ds-core` (traits + types + shared utilities), `ds-storage` (S3/HTTP/local object store), `ds-render` (raster colorization + PNG encoding), `ds-mvt` (Mapbox Vector Tile encoder + LRU tile cache), `engine-csv` (CSV data engine), `engine-geojson` (GeoJSON data engine), `engine-geotiff` (GeoTIFF/COG data engine), `engine-grib` (GRIB2 NWP data engine), `engine-odim` (ODIM_H5 weather-radar engine), `engine-querydata` (FMI QueryData data engine), `engine-zarr` (Zarr V2/V3 multidimensional-array engine), `engine-postgis` (PostGIS/TimescaleDB observation data engine), `api-edr` (EDR HTTP layer), `api-features` (Features HTTP layer), `api-maps` (OGC API Maps HTTP layer), `api-tiles` (OGC API Tiles HTTP layer), `api-wms` (WMS 1.3.0 HTTP layer), `server` (binary).
+Rust workspace implementing OGC API - EDR, OGC API - Features, OGC API - Maps, OGC API - Tiles, OGC WMS 1.3.0, and OGC 3D Tiles servers. Twenty crates: `ds-core` (traits + types + shared utilities), `ds-storage` (S3/HTTP/local object store), `ds-render` (raster colorization + PNG encoding), `ds-mvt` (Mapbox Vector Tile encoder + LRU tile cache), `ds-3dtiles` (OGC 3D Tiles `.pnts`/`tileset.json` encoder), `engine-csv` (CSV data engine), `engine-geojson` (GeoJSON data engine), `engine-geotiff` (GeoTIFF/COG data engine), `engine-grib` (GRIB2 NWP data engine), `engine-odim` (ODIM_H5 weather-radar engine), `engine-querydata` (FMI QueryData data engine), `engine-zarr` (Zarr V2/V3 multidimensional-array engine), `engine-postgis` (PostGIS/TimescaleDB observation data engine), `api-edr` (EDR HTTP layer), `api-features` (Features HTTP layer), `api-maps` (OGC API Maps HTTP layer), `api-tiles` (OGC API Tiles HTTP layer), `api-wms` (WMS 1.3.0 HTTP layer), `api-3dtiles` (OGC 3D Tiles HTTP layer), `server` (binary).
 
 ## Build & Run
 
@@ -50,7 +50,7 @@ When completing work, close the relevant issue: `gh issue close <number>`.
 
 ## Architecture Rules
 
-- **Three core traits: `EdrEngine` (EDR), `FeatureEngine` (Features), and `MapEngine` (Maps/WMS/Tiles).** They are separate traits — not all engines need to support all APIs. Engines return domain types, never JSON/XML. Serialization belongs in the API crates.
+- **Four core traits: `EdrEngine` (EDR), `FeatureEngine` (Features), `MapEngine` (Maps/WMS/Tiles), and `VolumeEngine` (3D Tiles — volumetric point clouds).** They are separate traits — not all engines need to support all APIs. Engines return domain types, never JSON/XML. Serialization belongs in the API crates (`ds-3dtiles` is the framework-free byte encoder for the 3D Tiles path, mirroring `ds-render`/`ds-mvt`).
 - **ds-core has no framework dependencies.** Only chrono, serde, thiserror, toml. Keep it that way. Use `PropertyValue` enum instead of `serde_json::Value` for feature properties.
 - **CRS and GeoTransform live in ds-core** (`ds_core::geo`), shared by all engines.
 - **ds-render has no framework dependencies.** Only ds-core and `png`.
@@ -212,7 +212,7 @@ don't collide. **Maps/Tiles `reference_time` query parameter is still a follow-u
 | GeoTIFF | `EdrEngine` + `MapEngine` | EDR (position, area), WMS, Maps, Tiles |
 | GRIB | `EdrEngine` + `MapEngine` | EDR, WMS, Maps, Tiles |
 | ODIM COMP | `EdrEngine` + `MapEngine` | EDR (position, area), WMS, Maps, Tiles |
-| ODIM PVOL | `EdrEngine` + `MapEngine` (per-site views) + `FeatureEngine` (network engine) | EDR (position, locations, area, trajectory), WMS, Maps, Tiles, Features (site inventory) |
+| ODIM PVOL | `EdrEngine` + `MapEngine` + `VolumeEngine` (per-site views) + `FeatureEngine` (network engine) | EDR (position, locations, area, trajectory), WMS, Maps, Tiles, 3D Tiles, Features (site inventory) |
 | QueryData | `EdrEngine` + `MapEngine` | EDR (position only), WMS, Maps, Tiles |
 | Zarr | `EdrEngine` + `MapEngine` | EDR (position), WMS, Maps, Tiles; local + S3/HTTP |
 | PostGIS | `EdrEngine` + `FeatureEngine` | EDR (position, locations, area), Features |
@@ -226,6 +226,39 @@ don't collide. **Maps/Tiles `reference_time` query parameter is still a follow-u
 - **Labels come from the ODIM quantity dictionary.** The bare quantity stays the parameter *id* (URL short-name, WMS `<Name>`, CoverageJSON key), but the human-readable *label* and unit come from `engine-odim/src/quantities.rs` (acronym + name, e.g. `DBZH` → `"DBZH — Reflectivity (horizontal)"`, unit `dBZ`); unknown codes fall back to the bare string. WMS additionally prefixes each child layer's `<Title>` with the site place name (`RasterInfo.layer_subtitle`, ODIM `/what` PLC) so flat clients that ignore the parent-layer tree can tell the per-site layers apart.
 - **Auto-split happens in `server/src/admin.rs`** (`load_collections`, the `"odim-volume"` arm): build the engine once, enumerate `engine.sites()` (returns `(nod, label)` per site), and register one `PolarVolumeSiteView` per site (cloning the base `CollectionConfig` with a per-site id/title). Site discovery is a scan snapshot — sites added later surface on the next `POST /admin/collections/reload`.
 - **Cross-sections.** `query_trajectory` returns a CoverageJSON `Section` (composite `[t,x,y]` axis + numeric `z` = height above antenna, via the 4/3-Earth beam model). `z` selects the elevation-angle band. Vertical axis is elevation angle (`VerticalKind::ElevationAngle`).
+
+## OGC 3D Tiles (`api-3dtiles`, epic #346)
+
+Volumetric weather as OGC 3D Tiles — radar polar volumes today. The chain:
+`VolumeEngine` (in `ds-core`) returns a `VolumePointCloud` (one point per echo
+cell, placed at its true ECEF position via the 4/3-Earth beam model); the
+framework-free `ds-3dtiles` crate encodes it to a `.pnts` tile + `tileset.json`;
+`api-3dtiles` serves it over HTTP. Engines return the domain type, never bytes
+(same rule as `MapEngine`→`ds-render`).
+
+- **Trait:** `VolumeEngine::read_point_cloud(quantity, time, min_value, reference_time)`
+  → `VolumePointCloud`, and `volume_info() -> Arc<VolumeInfo>` (O(1) cached
+  snapshot, #211 — carries quantities, times, default quantity, and a coverage
+  `region` for the tileset bounding volume without sampling). Implemented by
+  `PolarVolumeSiteView`; the cloud is bounded by `MAX_POINTS` (8M, truncate +
+  WARN). Unknown quantity ⇒ `InvalidParameter` (→ 400).
+- **Routes** (mounted at `/3dtiles`): `GET /collections/{id}/tileset.json`
+  (`?quantity=&datetime=`) and `GET /collections/{id}/content.pnts`
+  (`?quantity=&datetime=&min_value=`), plus `/` · `/collections` ·
+  `/collections/{id}`. The tileset's `content.uri` embeds the resolved quantity
+  (+ pinned time) so the `.pnts` fetch is deterministic.
+- **Concurrency:** `read_point_cloud` is sync (blocking HDF5 I/O + a long CPU
+  loop), so the handler bounds it with the shared render semaphore and runs it
+  via `spawn_blocking` — never inline on a request worker (the same pattern the
+  raster APIs use for `get_raster_tile`).
+- **Caching:** content-derived ETag on `.pnts` (deterministic bytes ⇒ cheap
+  304s); `content_uri` is validated (no `..`/absolute/scheme) in `ds-3dtiles`.
+- **Config:** add `"3dtiles"` to a collection's `apis` (only `odim-volume`
+  supports it today). v1 uses one shared reflectivity colormap; per-collection /
+  per-quantity colormaps, time-dynamic tilesets (#350), and true cylindrical
+  voxels (#351) are follow-ups. **Encoder/CesiumJS gotchas** (load-bearing) live
+  in `ds-3dtiles`: tileset `geometricError > 0`, ECEF-native `.pnts` POSITION,
+  `.pnts` not glb-with-POINTS.
 
 ## GeoTIFF Engine Notes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,6 +65,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "api-3dtiles"
+version = "0.1.0"
+dependencies = [
+ "arc-swap",
+ "axum",
+ "bytes",
+ "chrono",
+ "ds-3dtiles",
+ "ds-core",
+ "ds-render",
+ "http-body-util",
+ "serde",
+ "serde_json",
+ "tokio",
+ "toml",
+ "tower",
+ "tracing",
+]
+
+[[package]]
 name = "api-edr"
 version = "0.1.0"
 dependencies = [
@@ -3986,6 +4006,7 @@ dependencies = [
 name = "server"
 version = "0.6.0"
 dependencies = [
+ "api-3dtiles",
  "api-edr",
  "api-features",
  "api-maps",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ members = [
     "crates/api-wms",
     "crates/api-maps",
     "crates/api-tiles",
+    "crates/api-3dtiles",
     "crates/server",
 ]
 exclude = ["fuzz"]

--- a/collections.d/radar-fi-volume-local-h5.toml
+++ b/collections.d/radar-fi-volume-local-h5.toml
@@ -21,7 +21,7 @@ id = "radar-fi-volume-local-h5"
 title = "FMI — radar polar volumes (local, ODIM_H5)"
 description = "Finnish radar polar volumes (ODIM_H5 PVOL) from local sample files — every elevation sweep and dual-polarisation moment. One collection per radar site."
 engine_type = "odim-volume"
-apis = ["edr", "wms", "maps", "tiles"]
+apis = ["edr", "wms", "maps", "tiles", "3dtiles"]
 data_path = "testdata/radar-fmi-pvol"
 
 [odim]

--- a/crates/api-3dtiles/Cargo.toml
+++ b/crates/api-3dtiles/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "api-3dtiles"
+version = "0.1.0"
+edition = "2021"
+rust-version = "1.87"
+
+[dependencies]
+ds-core = { path = "../core" }
+ds-3dtiles = { path = "../ds-3dtiles" }
+ds-render = { path = "../render" }
+arc-swap = "1"
+axum = "0.8"
+bytes = "1"
+chrono = { version = "0.4", features = ["serde"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tokio = { version = "1", features = ["sync", "rt"] }
+tracing = "0.1"
+
+[dev-dependencies]
+tower = "0.5"
+http-body-util = "0.1"
+toml = "0.8"

--- a/crates/api-3dtiles/src/error.rs
+++ b/crates/api-3dtiles/src/error.rs
@@ -1,0 +1,50 @@
+//! Error type for the 3D Tiles API, mapped to HTTP responses.
+
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+use serde_json::json;
+
+/// HTTP-facing error for the 3D Tiles API.
+#[derive(Debug)]
+pub enum Tiles3dError {
+    /// Unknown collection, or no data for the request → 404.
+    NotFound(String),
+    /// Bad request (e.g. unknown quantity, unparseable datetime) → 400.
+    BadRequest(String),
+    /// Server temporarily overloaded → 503.
+    ServiceUnavailable(String),
+    /// Internal failure → 500 (details logged, not leaked to the client).
+    Internal(String),
+}
+
+impl IntoResponse for Tiles3dError {
+    fn into_response(self) -> Response {
+        let (status, message) = match self {
+            Tiles3dError::NotFound(m) => (StatusCode::NOT_FOUND, m),
+            Tiles3dError::BadRequest(m) => (StatusCode::BAD_REQUEST, m),
+            Tiles3dError::ServiceUnavailable(m) => (StatusCode::SERVICE_UNAVAILABLE, m),
+            // Don't leak internal detail to the client (CLAUDE.md code style).
+            Tiles3dError::Internal(_) => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Internal server error".to_string(),
+            ),
+        };
+        (status, Json(json!({ "error": message }))).into_response()
+    }
+}
+
+impl From<ds_core::error::DataServerError> for Tiles3dError {
+    fn from(e: ds_core::error::DataServerError) -> Self {
+        use ds_core::error::DataServerError as E;
+        match e {
+            E::InvalidParameter(m) | E::InvalidBbox(m) | E::InvalidDatetime(m) => {
+                Tiles3dError::BadRequest(m)
+            }
+            E::CollectionNotFound(m) | E::LocationNotFound(m) | E::FeatureNotFound(m) => {
+                Tiles3dError::NotFound(m)
+            }
+            other => Tiles3dError::Internal(other.to_string()),
+        }
+    }
+}

--- a/crates/api-3dtiles/src/handlers.rs
+++ b/crates/api-3dtiles/src/handlers.rs
@@ -97,9 +97,11 @@ fn parse_datetime(s: &str) -> Result<DateTime<Utc>, Tiles3dError> {
         .map_err(|_| Tiles3dError::BadRequest(format!("invalid datetime: {s:?}")))
 }
 
-/// Weak content-derived ETag (quoted hex of a hash of the bytes). FNV-1a 64-bit
-/// — stable across Rust versions and instances (unlike `DefaultHasher`), so a
-/// toolchain upgrade or a mixed-version fleet doesn't silently invalidate ETags.
+/// Strong content-derived ETag — quoted hex with no `W/` prefix (the bytes are
+/// exact, so byte-equal responses are equivalent per RFC 7232 §2.1). FNV-1a
+/// 64-bit — stable across Rust versions and instances (unlike `DefaultHasher`),
+/// so a toolchain upgrade or a mixed-version fleet doesn't silently invalidate
+/// ETags.
 fn etag_of(bytes: &[u8]) -> String {
     let mut h: u64 = 0xcbf2_9ce4_8422_2325;
     for &b in bytes {
@@ -211,9 +213,12 @@ pub async fn get_content(
         .await
         .map_err(|e| Tiles3dError::Internal(format!("sample task failed: {e}")))??;
 
-    // Content-derived ETag → cheap 304s; the bytes are deterministic for a
-    // given (collection, quantity, time, min_value). RFC 7232 §3.2:
-    // `If-None-Match` may be `*` or a comma-separated list.
+    // A 304 here saves the *network transfer* but not the recompute: the
+    // sample + encode + hash already ran above (the `If-None-Match` value can't
+    // be trusted to match without recomputing the content). Making 304s
+    // CPU-cheap needs an ETag cache keyed by (collection, quantity, time,
+    // min_value) + a data-version (latest data changes on poll) — a follow-up.
+    // RFC 7232 §3.2: `If-None-Match` may be `*` or a comma-separated list.
     let not_modified = headers
         .get(header::IF_NONE_MATCH)
         .and_then(|h| h.to_str().ok())

--- a/crates/api-3dtiles/src/handlers.rs
+++ b/crates/api-3dtiles/src/handlers.rs
@@ -74,6 +74,23 @@ pub struct ContentParams {
     pub min_value: Option<f64>,
 }
 
+/// Percent-encode a query-string value (RFC 3986 unreserved set passes
+/// through). The `VolumeEngine` trait places no charset constraint on quantity
+/// names, so a name containing `&`/`+`/`#`/`%`/… must not break the tileset's
+/// `content.uri` — the same class of bug as the `+hh:mm` datetime offset.
+fn pct_encode(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for b in s.bytes() {
+        match b {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b'~' => {
+                out.push(b as char)
+            }
+            _ => out.push_str(&format!("%{b:02X}")),
+        }
+    }
+    out
+}
+
 fn parse_datetime(s: &str) -> Result<DateTime<Utc>, Tiles3dError> {
     DateTime::parse_from_rfc3339(s)
         .map(|dt| dt.with_timezone(&Utc))
@@ -131,7 +148,7 @@ pub async fn get_tileset(
     // quantity (and pinned time, if any) so the content fetch is deterministic.
     // Re-format the parsed time as UTC `…Z` — a raw `+hh:mm` offset would be
     // decoded as a space by the client's URL parser and 400 on the fetch.
-    let mut query = format!("quantity={quantity}");
+    let mut query = format!("quantity={}", pct_encode(&quantity));
     if let Some(dt_str) = &params.datetime {
         let dt = parse_datetime(dt_str)?;
         query.push_str(&format!("&datetime={}", dt.format("%Y-%m-%dT%H:%M:%SZ")));
@@ -291,4 +308,18 @@ fn collection_doc(state: &TilesState3d, id: &str, base: &str) -> serde_json::Val
             { "href": format!("{base}/3dtiles/collections/{id}/tileset.json"), "rel": "3dtiles", "type": "application/json", "title": "3D Tiles tileset" },
         ]
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::pct_encode;
+
+    #[test]
+    fn pct_encode_passes_unreserved_and_escapes_specials() {
+        assert_eq!(pct_encode("DBZH"), "DBZH");
+        assert_eq!(pct_encode("a-b_c.d~e"), "a-b_c.d~e");
+        // Chars that would break a query value are escaped.
+        assert_eq!(pct_encode("a&b+c#d%e"), "a%26b%2Bc%23d%25e");
+        assert_eq!(pct_encode("x y"), "x%20y");
+    }
 }

--- a/crates/api-3dtiles/src/handlers.rs
+++ b/crates/api-3dtiles/src/handlers.rs
@@ -6,9 +6,7 @@
 //! - `GET /collections/{id}/content.pnts` — the point-cloud tile, sampled on a
 //!   blocking thread and encoded by `ds-3dtiles`.
 
-use std::collections::hash_map::DefaultHasher;
 use std::collections::HashMap;
-use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 
 use arc_swap::ArcSwap;
@@ -82,11 +80,16 @@ fn parse_datetime(s: &str) -> Result<DateTime<Utc>, Tiles3dError> {
         .map_err(|_| Tiles3dError::BadRequest(format!("invalid datetime: {s:?}")))
 }
 
-/// Weak content-derived ETag (quoted hex of a hash of the bytes).
+/// Weak content-derived ETag (quoted hex of a hash of the bytes). FNV-1a 64-bit
+/// — stable across Rust versions and instances (unlike `DefaultHasher`), so a
+/// toolchain upgrade or a mixed-version fleet doesn't silently invalidate ETags.
 fn etag_of(bytes: &[u8]) -> String {
-    let mut h = DefaultHasher::new();
-    bytes.hash(&mut h);
-    format!("\"{:016x}\"", h.finish())
+    let mut h: u64 = 0xcbf2_9ce4_8422_2325;
+    for &b in bytes {
+        h ^= b as u64;
+        h = h.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    format!("\"{h:016x}\"")
 }
 
 // ---------------------------------------------------------------------------
@@ -120,20 +123,18 @@ pub async fn get_tileset(
             "collection '{id}' has no quantities"
         )));
     }
-    // Validate datetime if present (so the tileset never embeds a bad value).
-    if let Some(dt) = &params.datetime {
-        parse_datetime(dt)?;
-    }
-
     let region = info.region.ok_or_else(|| {
         Tiles3dError::NotFound(format!("collection '{id}' has no spatial coverage yet"))
     })?;
 
     // The `.pnts` content lives next to this tileset; carry the resolved
     // quantity (and pinned time, if any) so the content fetch is deterministic.
+    // Re-format the parsed time as UTC `…Z` — a raw `+hh:mm` offset would be
+    // decoded as a space by the client's URL parser and 400 on the fetch.
     let mut query = format!("quantity={quantity}");
-    if let Some(dt) = &params.datetime {
-        query.push_str(&format!("&datetime={dt}"));
+    if let Some(dt_str) = &params.datetime {
+        let dt = parse_datetime(dt_str)?;
+        query.push_str(&format!("&datetime={}", dt.format("%Y-%m-%dT%H:%M:%SZ")));
     }
     let content_uri = format!("content.pnts?{query}");
 
@@ -180,21 +181,27 @@ pub async fn get_content(
 
     let engine = engine.clone();
     let colormap = state.colormap.clone();
-    let bytes = tokio::task::spawn_blocking(move || -> Result<Vec<u8>, Tiles3dError> {
-        let cloud = engine.read_point_cloud(quantity.as_deref(), time, min_value, None)?;
-        ds_3dtiles::encode_pnts(&cloud, colormap.as_ref())
-            .map_err(|e| Tiles3dError::Internal(format!("pnts encode failed: {e}")))
-    })
-    .await
-    .map_err(|e| Tiles3dError::Internal(format!("sample task failed: {e}")))??;
+    // Sample, encode, and hash all on the blocking thread (the ETag hash over a
+    // multi-MB tile is real CPU — keep it off the async worker too).
+    let (bytes, etag) =
+        tokio::task::spawn_blocking(move || -> Result<(Vec<u8>, String), Tiles3dError> {
+            let cloud = engine.read_point_cloud(quantity.as_deref(), time, min_value, None)?;
+            let bytes = ds_3dtiles::encode_pnts(&cloud, colormap.as_ref())
+                .map_err(|e| Tiles3dError::Internal(format!("pnts encode failed: {e}")))?;
+            let etag = etag_of(&bytes);
+            Ok((bytes, etag))
+        })
+        .await
+        .map_err(|e| Tiles3dError::Internal(format!("sample task failed: {e}")))??;
 
     // Content-derived ETag → cheap 304s; the bytes are deterministic for a
-    // given (collection, quantity, time, min_value).
-    let etag = etag_of(&bytes);
-    let if_none_match = headers
+    // given (collection, quantity, time, min_value). RFC 7232 §3.2:
+    // `If-None-Match` may be `*` or a comma-separated list.
+    let not_modified = headers
         .get(header::IF_NONE_MATCH)
-        .and_then(|h| h.to_str().ok());
-    if if_none_match == Some(etag.as_str()) {
+        .and_then(|h| h.to_str().ok())
+        .is_some_and(|v| v == "*" || v.split(',').any(|t| t.trim() == etag));
+    if not_modified {
         return Ok((
             StatusCode::NOT_MODIFIED,
             [

--- a/crates/api-3dtiles/src/handlers.rs
+++ b/crates/api-3dtiles/src/handlers.rs
@@ -1,0 +1,287 @@
+//! HTTP handlers for the 3D Tiles API.
+//!
+//! Serves OGC 3D Tiles from any collection implementing `VolumeEngine`:
+//! - `GET /collections/{id}/tileset.json` — the tileset (bounding region from
+//!   `VolumeInfo`, content pointing at the `.pnts` below).
+//! - `GET /collections/{id}/content.pnts` — the point-cloud tile, sampled on a
+//!   blocking thread and encoded by `ds-3dtiles`.
+
+use std::collections::hash_map::DefaultHasher;
+use std::collections::HashMap;
+use std::hash::{Hash, Hasher};
+use std::sync::Arc;
+
+use arc_swap::ArcSwap;
+use axum::extract::{Path, Query, State};
+use axum::http::{header, HeaderMap, StatusCode};
+use axum::response::{IntoResponse, Json, Response};
+use chrono::{DateTime, Utc};
+use ds_core::config::CollectionConfig;
+use ds_core::volume::VolumeEngine;
+use ds_render::ColorMap;
+use serde::Deserialize;
+use serde_json::json;
+
+use crate::error::Tiles3dError;
+
+/// Shared state for the 3D Tiles API. Wrapped in `ArcSwap` for lock-free reads
+/// and atomic swap on config reload.
+#[derive(Clone)]
+pub struct TilesState3d {
+    /// Collections that can produce volumetric point clouds, keyed by id.
+    pub volume_engines: HashMap<String, Arc<dyn VolumeEngine>>,
+    /// Per-collection config (title/description/etc.), keyed by id.
+    pub collections: HashMap<String, CollectionConfig>,
+    /// Colour ramp applied to point values when encoding `.pnts` RGB. v1 uses
+    /// one shared ramp (reflectivity); per-collection/per-quantity colormaps
+    /// from config are a follow-up.
+    pub colormap: Arc<dyn ColorMap>,
+    /// Bounds concurrent sampling/encoding, shared with the raster render path.
+    pub render_semaphore: Arc<tokio::sync::Semaphore>,
+    /// Public base URL for absolute links.
+    pub base_url: String,
+}
+
+pub type AppState = Arc<ArcSwap<TilesState3d>>;
+
+/// Look up a collection's volume engine + config, 404 if absent.
+fn lookup<'a>(
+    state: &'a TilesState3d,
+    id: &str,
+) -> Result<(&'a Arc<dyn VolumeEngine>, &'a CollectionConfig), Tiles3dError> {
+    let engine = state
+        .volume_engines
+        .get(id)
+        .ok_or_else(|| Tiles3dError::NotFound(format!("Collection '{id}' not found")))?;
+    let config = state
+        .collections
+        .get(id)
+        .ok_or_else(|| Tiles3dError::Internal(format!("config missing for '{id}'")))?;
+    Ok((engine, config))
+}
+
+#[derive(Debug, Deserialize)]
+pub struct TilesetParams {
+    /// Quantity to render (`None` → the collection default).
+    pub quantity: Option<String>,
+    /// Valid time (RFC 3339). `None` → latest.
+    pub datetime: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ContentParams {
+    pub quantity: Option<String>,
+    pub datetime: Option<String>,
+    /// Drop points below this physical value (e.g. a dBZ floor).
+    pub min_value: Option<f64>,
+}
+
+fn parse_datetime(s: &str) -> Result<DateTime<Utc>, Tiles3dError> {
+    DateTime::parse_from_rfc3339(s)
+        .map(|dt| dt.with_timezone(&Utc))
+        .map_err(|_| Tiles3dError::BadRequest(format!("invalid datetime: {s:?}")))
+}
+
+/// Weak content-derived ETag (quoted hex of a hash of the bytes).
+fn etag_of(bytes: &[u8]) -> String {
+    let mut h = DefaultHasher::new();
+    bytes.hash(&mut h);
+    format!("\"{:016x}\"", h.finish())
+}
+
+// ---------------------------------------------------------------------------
+// Tileset
+// ---------------------------------------------------------------------------
+
+/// `GET /collections/{id}/tileset.json`
+pub async fn get_tileset(
+    Path(id): Path<String>,
+    Query(params): Query<TilesetParams>,
+    State(state): State<AppState>,
+) -> Result<Response, Tiles3dError> {
+    let state = state.load_full();
+    let (engine, _config) = lookup(&state, &id)?;
+    let info = engine.volume_info();
+
+    // Resolve + validate the quantity against what the collection advertises.
+    let quantity = match &params.quantity {
+        Some(q) => {
+            if !info.quantities.iter().any(|(qid, _)| qid == q) {
+                return Err(Tiles3dError::BadRequest(format!(
+                    "unknown quantity '{q}' for collection '{id}'"
+                )));
+            }
+            q.clone()
+        }
+        None => info.default_quantity.clone(),
+    };
+    if quantity.is_empty() {
+        return Err(Tiles3dError::NotFound(format!(
+            "collection '{id}' has no quantities"
+        )));
+    }
+    // Validate datetime if present (so the tileset never embeds a bad value).
+    if let Some(dt) = &params.datetime {
+        parse_datetime(dt)?;
+    }
+
+    let region = info.region.ok_or_else(|| {
+        Tiles3dError::NotFound(format!("collection '{id}' has no spatial coverage yet"))
+    })?;
+
+    // The `.pnts` content lives next to this tileset; carry the resolved
+    // quantity (and pinned time, if any) so the content fetch is deterministic.
+    let mut query = format!("quantity={quantity}");
+    if let Some(dt) = &params.datetime {
+        query.push_str(&format!("&datetime={dt}"));
+    }
+    let content_uri = format!("content.pnts?{query}");
+
+    let tileset = ds_3dtiles::tileset_json_for_region(region, &content_uri)
+        .map_err(|e| Tiles3dError::Internal(format!("tileset build failed: {e}")))?;
+
+    Ok((
+        [
+            (header::CONTENT_TYPE, "application/json"),
+            (header::CACHE_CONTROL, "public, max-age=60"),
+        ],
+        tileset,
+    )
+        .into_response())
+}
+
+// ---------------------------------------------------------------------------
+// Content (.pnts)
+// ---------------------------------------------------------------------------
+
+/// `GET /collections/{id}/content.pnts`
+pub async fn get_content(
+    headers: HeaderMap,
+    Path(id): Path<String>,
+    Query(params): Query<ContentParams>,
+    State(state): State<AppState>,
+) -> Result<Response, Tiles3dError> {
+    let state = state.load_full();
+    let (engine, _config) = lookup(&state, &id)?;
+
+    let time = params.datetime.as_deref().map(parse_datetime).transpose()?;
+    let quantity = params.quantity.clone();
+    let min_value = params.min_value;
+
+    // Sample + encode off the request worker: `read_point_cloud` does blocking
+    // HDF5 I/O and a long CPU loop (CLAUDE.md concurrency rules), so bound it
+    // with the shared render semaphore and run it on a blocking thread.
+    let _permit = state
+        .render_semaphore
+        .clone()
+        .acquire_owned()
+        .await
+        .map_err(|_| Tiles3dError::Internal("render semaphore closed".into()))?;
+
+    let engine = engine.clone();
+    let colormap = state.colormap.clone();
+    let bytes = tokio::task::spawn_blocking(move || -> Result<Vec<u8>, Tiles3dError> {
+        let cloud = engine.read_point_cloud(quantity.as_deref(), time, min_value, None)?;
+        ds_3dtiles::encode_pnts(&cloud, colormap.as_ref())
+            .map_err(|e| Tiles3dError::Internal(format!("pnts encode failed: {e}")))
+    })
+    .await
+    .map_err(|e| Tiles3dError::Internal(format!("sample task failed: {e}")))??;
+
+    // Content-derived ETag → cheap 304s; the bytes are deterministic for a
+    // given (collection, quantity, time, min_value).
+    let etag = etag_of(&bytes);
+    let if_none_match = headers
+        .get(header::IF_NONE_MATCH)
+        .and_then(|h| h.to_str().ok());
+    if if_none_match == Some(etag.as_str()) {
+        return Ok((
+            StatusCode::NOT_MODIFIED,
+            [
+                (header::ETAG, etag.as_str()),
+                (header::CACHE_CONTROL, "public, max-age=60"),
+            ],
+        )
+            .into_response());
+    }
+
+    Ok((
+        [
+            (header::CONTENT_TYPE, "application/octet-stream"),
+            (header::ETAG, etag.as_str()),
+            (header::CACHE_CONTROL, "public, max-age=60"),
+        ],
+        bytes,
+    )
+        .into_response())
+}
+
+// ---------------------------------------------------------------------------
+// Landing / collections
+// ---------------------------------------------------------------------------
+
+/// `GET /` — API landing document.
+pub async fn landing_page(State(state): State<AppState>) -> Json<serde_json::Value> {
+    let state = state.load_full();
+    let base = &state.base_url;
+    Json(json!({
+        "title": "MeteoCore — 3D Tiles",
+        "description": "Volumetric weather data as OGC 3D Tiles (radar polar volumes)",
+        "links": [
+            { "href": format!("{base}/3dtiles/"), "rel": "self", "type": "application/json", "title": "This document" },
+            { "href": format!("{base}/3dtiles/collections"), "rel": "data", "type": "application/json", "title": "Collections" },
+        ]
+    }))
+}
+
+/// `GET /collections` — list 3D-Tiles-capable collections.
+pub async fn collections(State(state): State<AppState>) -> Json<serde_json::Value> {
+    let state = state.load_full();
+    let base = &state.base_url;
+    let mut ids: Vec<&String> = state.volume_engines.keys().collect();
+    ids.sort();
+    let items: Vec<_> = ids
+        .iter()
+        .map(|id| collection_doc(&state, id, base))
+        .collect();
+    Json(json!({ "collections": items }))
+}
+
+/// `GET /collections/{id}` — one collection document.
+pub async fn collection(
+    Path(id): Path<String>,
+    State(state): State<AppState>,
+) -> Result<Json<serde_json::Value>, Tiles3dError> {
+    let state = state.load_full();
+    // 404 if not a volume collection.
+    lookup(&state, &id)?;
+    Ok(Json(collection_doc(&state, &id, &state.base_url)))
+}
+
+fn collection_doc(state: &TilesState3d, id: &str, base: &str) -> serde_json::Value {
+    let cfg = state.collections.get(id);
+    let title = cfg
+        .map(|c| c.title.clone())
+        .unwrap_or_else(|| id.to_string());
+    let description = cfg.map(|c| c.description.clone()).unwrap_or_default();
+    let info = state.volume_engines.get(id).map(|e| e.volume_info());
+    let quantities: Vec<_> = info
+        .as_ref()
+        .map(|i| {
+            i.quantities
+                .iter()
+                .map(|(qid, label)| json!({ "id": qid, "label": label }))
+                .collect()
+        })
+        .unwrap_or_default();
+    json!({
+        "id": id,
+        "title": title,
+        "description": description,
+        "quantities": quantities,
+        "links": [
+            { "href": format!("{base}/3dtiles/collections/{id}"), "rel": "self", "type": "application/json", "title": "This document" },
+            { "href": format!("{base}/3dtiles/collections/{id}/tileset.json"), "rel": "3dtiles", "type": "application/json", "title": "3D Tiles tileset" },
+        ]
+    })
+}

--- a/crates/api-3dtiles/src/lib.rs
+++ b/crates/api-3dtiles/src/lib.rs
@@ -1,0 +1,32 @@
+//! OGC 3D Tiles HTTP API (#349).
+//!
+//! Serves volumetric weather data — radar polar volumes today — as OGC 3D
+//! Tiles, from any collection implementing [`ds_core::volume::VolumeEngine`].
+//! Like the other API crates, it depends only on `ds-core` + the encoder
+//! (`ds-3dtiles`) and `ds-render` (for the colour ramp), never an engine crate;
+//! the engine registry is keyed by collection id and swapped via `ArcSwap`.
+//!
+//! Routes (mounted under `/3dtiles` by the server):
+//! - `GET /collections/{id}/tileset.json`
+//! - `GET /collections/{id}/content.pnts`
+//! - `GET /` · `/collections` · `/collections/{id}`
+
+pub mod error;
+pub mod handlers;
+
+pub use error::Tiles3dError;
+pub use handlers::{AppState, TilesState3d};
+
+use axum::routing::get;
+use axum::Router;
+
+/// Build the 3D Tiles API router.
+pub fn router(state: AppState) -> Router {
+    Router::new()
+        .route("/", get(handlers::landing_page))
+        .route("/collections", get(handlers::collections))
+        .route("/collections/{id}", get(handlers::collection))
+        .route("/collections/{id}/tileset.json", get(handlers::get_tileset))
+        .route("/collections/{id}/content.pnts", get(handlers::get_content))
+        .with_state(state)
+}

--- a/crates/api-3dtiles/tests/integration.rs
+++ b/crates/api-3dtiles/tests/integration.rs
@@ -194,6 +194,19 @@ async fn unknown_quantity_is_400() {
 }
 
 #[tokio::test]
+async fn datetime_offset_normalised_to_utc_z_in_content_uri() {
+    // A `+hh:mm` offset must be re-emitted as `…Z` so the client's URL parser
+    // doesn't decode the `+` as a space and 400 on the content fetch.
+    let (status, body, _h) =
+        get("/collections/radar-fivih/tileset.json?datetime=2024-01-01T12:00:00%2B05:30").await;
+    assert_eq!(status, StatusCode::OK);
+    let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let uri = v["root"]["content"]["uri"].as_str().unwrap();
+    assert!(!uri.contains('+'), "no raw + offset in content uri: {uri}");
+    assert!(uri.contains("datetime=2024-01-01T06:30:00Z"), "got {uri}");
+}
+
+#[tokio::test]
 async fn bad_datetime_is_400() {
     let (status, _b, _h) = get("/collections/radar-fivih/content.pnts?datetime=notadate").await;
     assert_eq!(status, StatusCode::BAD_REQUEST);

--- a/crates/api-3dtiles/tests/integration.rs
+++ b/crates/api-3dtiles/tests/integration.rs
@@ -208,8 +208,27 @@ async fn datetime_offset_normalised_to_utc_z_in_content_uri() {
 
 #[tokio::test]
 async fn bad_datetime_is_400() {
-    let (status, _b, _h) = get("/collections/radar-fivih/content.pnts?datetime=notadate").await;
-    assert_eq!(status, StatusCode::BAD_REQUEST);
+    // Both routes parse the datetime.
+    let (cs, _b, _h) = get("/collections/radar-fivih/content.pnts?datetime=notadate").await;
+    assert_eq!(cs, StatusCode::BAD_REQUEST, "content rejects bad datetime");
+    let (ts, _b, _h) = get("/collections/radar-fivih/tileset.json?datetime=notadate").await;
+    assert_eq!(ts, StatusCode::BAD_REQUEST, "tileset rejects bad datetime");
+}
+
+#[tokio::test]
+async fn if_none_match_wildcard_is_304() {
+    // RFC 7232 §3.2: `If-None-Match: *` matches any current representation.
+    let resp = router()
+        .oneshot(
+            Request::builder()
+                .uri("/collections/radar-fivih/content.pnts")
+                .header(axum::http::header::IF_NONE_MATCH, "*")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_MODIFIED);
 }
 
 #[tokio::test]

--- a/crates/api-3dtiles/tests/integration.rs
+++ b/crates/api-3dtiles/tests/integration.rs
@@ -1,0 +1,213 @@
+//! End-to-end tests for the 3D Tiles API over a mock `VolumeEngine`.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use arc_swap::ArcSwap;
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use http_body_util::BodyExt;
+use tower::ServiceExt;
+
+use api_3dtiles::TilesState3d;
+use ds_core::config::CollectionConfig;
+use ds_core::error::DataServerError;
+use ds_core::volume::{VolumeEngine, VolumeInfo, VolumePoint, VolumePointCloud};
+use ds_render::{BuiltinColormap, LutColorMap};
+
+/// Mock engine: a tiny fixed cloud, one quantity (`DBZH`), a coverage region.
+struct MockVolume;
+
+impl VolumeEngine for MockVolume {
+    fn read_point_cloud(
+        &self,
+        quantity: Option<&str>,
+        _time: Option<chrono::DateTime<chrono::Utc>>,
+        min_value: Option<f64>,
+        _reference_time: Option<chrono::DateTime<chrono::Utc>>,
+    ) -> Result<VolumePointCloud, DataServerError> {
+        // Mirror the engine contract: unknown quantity → InvalidParameter.
+        if let Some(q) = quantity {
+            if q != "DBZH" {
+                return Err(DataServerError::InvalidParameter(format!("unknown {q}")));
+            }
+        }
+        let mut points = vec![
+            VolumePoint {
+                offset: [0.0, 0.0, 0.0],
+                value: 10.0,
+            },
+            VolumePoint {
+                offset: [100.0, -50.0, 250.0],
+                value: 45.0,
+            },
+        ];
+        if let Some(min) = min_value {
+            points.retain(|p| p.value >= min);
+        }
+        if points.is_empty() {
+            return Err(DataServerError::LocationNotFound("no echoes".into()));
+        }
+        Ok(VolumePointCloud {
+            rtc_center: [3_000_000.0, 1_000_000.0, 5_000_000.0],
+            region: [0.42, 1.05, 0.44, 1.07, 100.0, 12_000.0],
+            points,
+            quantity: "DBZH".into(),
+            unit: "dBZ".into(),
+        })
+    }
+
+    fn volume_info(&self) -> Arc<VolumeInfo> {
+        Arc::new(VolumeInfo {
+            quantities: vec![("DBZH".into(), "Reflectivity".into())],
+            times: vec![],
+            default_quantity: "DBZH".into(),
+            default_unit: "dBZ".into(),
+            region: Some([0.42, 1.05, 0.44, 1.07, 100.0, 25_000.0]),
+        })
+    }
+}
+
+fn collection_config(id: &str) -> CollectionConfig {
+    // Build via TOML so this test doesn't depend on every CollectionConfig field.
+    toml::from_str(&format!(
+        r#"id = "{id}"
+title = "Mock Radar Volume"
+description = "test"
+engine_type = "odim-volume"
+apis = ["3dtiles"]
+"#
+    ))
+    .expect("collection config parses")
+}
+
+fn router() -> axum::Router {
+    let engine: Arc<dyn VolumeEngine> = Arc::new(MockVolume);
+    let mut volume_engines = HashMap::new();
+    volume_engines.insert("radar-fivih".to_string(), engine);
+    let mut collections = HashMap::new();
+    collections.insert("radar-fivih".to_string(), collection_config("radar-fivih"));
+
+    let state = Arc::new(ArcSwap::from_pointee(TilesState3d {
+        volume_engines,
+        collections,
+        colormap: Arc::new(LutColorMap::from_builtin(
+            BuiltinColormap::RadarDbz,
+            -32.0,
+            95.0,
+        )),
+        render_semaphore: Arc::new(tokio::sync::Semaphore::new(4)),
+        base_url: String::new(),
+    }));
+    api_3dtiles::router(state)
+}
+
+async fn get(uri: &str) -> (StatusCode, Vec<u8>, axum::http::HeaderMap) {
+    let resp = router()
+        .oneshot(Request::builder().uri(uri).body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    let status = resp.status();
+    let headers = resp.headers().clone();
+    let body = resp
+        .into_body()
+        .collect()
+        .await
+        .unwrap()
+        .to_bytes()
+        .to_vec();
+    (status, body, headers)
+}
+
+#[tokio::test]
+async fn tileset_json_has_region_and_content_uri() {
+    let (status, body, _h) = get("/collections/radar-fivih/tileset.json").await;
+    assert_eq!(status, StatusCode::OK);
+    let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert!(v["geometricError"].as_f64().unwrap() > 0.0);
+    assert_eq!(
+        v["root"]["boundingVolume"]["region"]
+            .as_array()
+            .unwrap()
+            .len(),
+        6
+    );
+    // Content URI carries the resolved default quantity and is relative.
+    let uri = v["root"]["content"]["uri"].as_str().unwrap();
+    assert_eq!(uri, "content.pnts?quantity=DBZH");
+}
+
+#[tokio::test]
+async fn content_pnts_is_valid_and_etagged() {
+    let (status, body, headers) = get("/collections/radar-fivih/content.pnts?quantity=DBZH").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(&body[0..4], b"pnts", "pnts magic");
+    let byte_len = u32::from_le_bytes(body[8..12].try_into().unwrap()) as usize;
+    assert_eq!(byte_len, body.len());
+    assert_eq!(
+        headers[axum::http::header::CONTENT_TYPE],
+        "application/octet-stream"
+    );
+    assert!(headers.contains_key(axum::http::header::ETAG));
+}
+
+#[tokio::test]
+async fn etag_round_trips_to_304() {
+    let (_s, _b, headers) = get("/collections/radar-fivih/content.pnts").await;
+    let etag = headers[axum::http::header::ETAG]
+        .to_str()
+        .unwrap()
+        .to_string();
+    let resp = router()
+        .oneshot(
+            Request::builder()
+                .uri("/collections/radar-fivih/content.pnts")
+                .header(axum::http::header::IF_NONE_MATCH, &etag)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_MODIFIED);
+}
+
+#[tokio::test]
+async fn unknown_collection_is_404() {
+    let (status, _b, _h) = get("/collections/nope/tileset.json").await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn unknown_quantity_is_400() {
+    let (ts, _b, _h) = get("/collections/radar-fivih/tileset.json?quantity=FOOBAR").await;
+    assert_eq!(
+        ts,
+        StatusCode::BAD_REQUEST,
+        "tileset rejects unknown quantity"
+    );
+    let (cs, _b, _h) = get("/collections/radar-fivih/content.pnts?quantity=FOOBAR").await;
+    assert_eq!(
+        cs,
+        StatusCode::BAD_REQUEST,
+        "content rejects unknown quantity"
+    );
+}
+
+#[tokio::test]
+async fn bad_datetime_is_400() {
+    let (status, _b, _h) = get("/collections/radar-fivih/content.pnts?datetime=notadate").await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn collections_list_and_doc() {
+    let (status, body, _h) = get("/collections").await;
+    assert_eq!(status, StatusCode::OK);
+    let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(v["collections"][0]["id"], "radar-fivih");
+
+    let (status, body, _h) = get("/collections/radar-fivih").await;
+    assert_eq!(status, StatusCode::OK);
+    let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(v["quantities"][0]["id"], "DBZH");
+}

--- a/crates/core/src/volume.rs
+++ b/crates/core/src/volume.rs
@@ -63,6 +63,12 @@ pub struct VolumeInfo {
     pub default_quantity: String,
     /// Unit of the default quantity.
     pub default_unit: String,
+    /// Coverage bounding region `[west, south, east, north, min_h, max_h]`
+    /// (lon/lat **radians**, heights metres) — a region guaranteed to *contain*
+    /// the collection's content, for building the 3D Tiles `tileset.json`
+    /// bounding volume without sampling the full volume. `None` if the
+    /// collection has no known spatial extent yet.
+    pub region: Option<[f64; 6]>,
 }
 
 /// An engine that samples a collection's data into a volumetric point cloud

--- a/crates/ds-3dtiles/src/lib.rs
+++ b/crates/ds-3dtiles/src/lib.rs
@@ -50,6 +50,11 @@ pub enum Tiles3dError {
     /// could traverse or redirect — defence-in-depth for a `pub` API.
     #[error("invalid content URI: {0:?}")]
     InvalidUri(String),
+    /// The geodetic `region` has inverted/degenerate bounds (`west > east`,
+    /// `south > north`, or `min_h > max_h`) — valid JSON that CesiumJS silently
+    /// refuses to load.
+    #[error("invalid region (inverted/degenerate bounds): {0:?}")]
+    InvalidRegion([f64; 6]),
 }
 
 /// Encode a point cloud as a 3D Tiles **`.pnts`** tile (the 3D Tiles 1.0 Point
@@ -183,6 +188,12 @@ pub fn tileset_json_for_region(
     if region.iter().any(|v| !v.is_finite()) {
         return Err(Tiles3dError::NonFinite("region"));
     }
+    // Reject inverted/degenerate bounds: `[west, south, east, north, minH, maxH]`
+    // must be ordered. An inverted box serializes to valid JSON that CesiumJS
+    // silently refuses to load, so fail loudly at encode time instead.
+    if region[0] > region[2] || region[1] > region[3] || region[4] > region[5] {
+        return Err(Tiles3dError::InvalidRegion(region));
+    }
     // `[f64; 6]` serializes directly to a JSON array — no `Vec` needed.
     // `asset.version` is intentionally "1.1" even though `.pnts` is a 1.0
     // content type: CesiumJS keys its tileset loader off this version, and a
@@ -279,6 +290,22 @@ mod tests {
         let region = json["root"]["boundingVolume"]["region"].as_array().unwrap();
         assert_eq!(region.len(), 6);
         assert_eq!(region[0].as_f64().unwrap(), 0.42);
+    }
+
+    #[test]
+    fn inverted_region_is_rejected() {
+        // west > east — an inverted box CesiumJS would silently refuse.
+        let region = [0.44, 1.05, 0.42, 1.07, 100.0, 12_000.0];
+        assert!(matches!(
+            tileset_json_for_region(region, "content.pnts"),
+            Err(Tiles3dError::InvalidRegion(_))
+        ));
+        // min_h > max_h is also rejected.
+        let region = [0.42, 1.05, 0.44, 1.07, 12_000.0, 100.0];
+        assert!(matches!(
+            tileset_json_for_region(region, "content.pnts"),
+            Err(Tiles3dError::InvalidRegion(_))
+        ));
     }
 
     #[test]

--- a/crates/ds-3dtiles/src/lib.rs
+++ b/crates/ds-3dtiles/src/lib.rs
@@ -160,6 +160,19 @@ pub fn encode_pnts(
 /// (the `.pnts` `RTC_CENTER` already places points in ECEF). The top-level
 /// `geometricError` is non-zero (load-bearing — see module docs).
 pub fn tileset_json(cloud: &VolumePointCloud, content_uri: &str) -> Result<String, Tiles3dError> {
+    tileset_json_for_region(cloud.region, content_uri)
+}
+
+/// Build the `tileset.json` from a geodetic bounding `region`
+/// (`[west, south, east, north, min_h, max_h]`, lon/lat radians + metres)
+/// directly — for the API layer, which has the collection's coverage region
+/// from `VolumeInfo` and need not sample the whole volume just to emit the
+/// tileset. The region must merely *contain* the content the `.pnts` will hold.
+/// Same `content_uri` validation and invariants as [`tileset_json`].
+pub fn tileset_json_for_region(
+    region: [f64; 6],
+    content_uri: &str,
+) -> Result<String, Tiles3dError> {
     if content_uri.is_empty()
         || content_uri.starts_with('/')
         || content_uri.contains("://")
@@ -167,7 +180,7 @@ pub fn tileset_json(cloud: &VolumePointCloud, content_uri: &str) -> Result<Strin
     {
         return Err(Tiles3dError::InvalidUri(content_uri.to_string()));
     }
-    if cloud.region.iter().any(|v| !v.is_finite()) {
+    if region.iter().any(|v| !v.is_finite()) {
         return Err(Tiles3dError::NonFinite("region"));
     }
     // `[f64; 6]` serializes directly to a JSON array — no `Vec` needed.
@@ -179,7 +192,7 @@ pub fn tileset_json(cloud: &VolumePointCloud, content_uri: &str) -> Result<Strin
         "asset": { "version": "1.1" },
         "geometricError": TILESET_GEOMETRIC_ERROR,
         "root": {
-            "boundingVolume": { "region": cloud.region },
+            "boundingVolume": { "region": region },
             "geometricError": ROOT_GEOMETRIC_ERROR,
             "refine": "ADD",
             "content": { "uri": content_uri },

--- a/crates/ds-3dtiles/src/lib.rs
+++ b/crates/ds-3dtiles/src/lib.rs
@@ -50,9 +50,9 @@ pub enum Tiles3dError {
     /// could traverse or redirect — defence-in-depth for a `pub` API.
     #[error("invalid content URI: {0:?}")]
     InvalidUri(String),
-    /// The geodetic `region` has inverted/degenerate bounds (`west > east`,
-    /// `south > north`, or `min_h > max_h`) — valid JSON that CesiumJS silently
-    /// refuses to load.
+    /// The geodetic `region` has inverted/degenerate bounds (`south > north`
+    /// or `min_h > max_h`) — valid JSON that CesiumJS silently refuses to load.
+    /// (`west > east` is *not* inverted — it's an antimeridian-crossing region.)
     #[error("invalid region (inverted/degenerate bounds): {0:?}")]
     InvalidRegion([f64; 6]),
 }
@@ -188,10 +188,10 @@ pub fn tileset_json_for_region(
     if region.iter().any(|v| !v.is_finite()) {
         return Err(Tiles3dError::NonFinite("region"));
     }
-    // Reject inverted/degenerate bounds: `[west, south, east, north, minH, maxH]`
-    // must be ordered. An inverted box serializes to valid JSON that CesiumJS
-    // silently refuses to load, so fail loudly at encode time instead.
-    if region[0] > region[2] || region[1] > region[3] || region[4] > region[5] {
+    // Reject truly inverted/degenerate bounds (south > north, min_h > max_h) —
+    // valid JSON that CesiumJS silently refuses to load. Note `west > east` is
+    // NOT inverted: 3D Tiles 1.1 uses it for antimeridian-crossing regions.
+    if region[1] > region[3] || region[4] > region[5] {
         return Err(Tiles3dError::InvalidRegion(region));
     }
     // `[f64; 6]` serializes directly to a JSON array — no `Vec` needed.
@@ -294,18 +294,21 @@ mod tests {
 
     #[test]
     fn inverted_region_is_rejected() {
-        // west > east — an inverted box CesiumJS would silently refuse.
-        let region = [0.44, 1.05, 0.42, 1.07, 100.0, 12_000.0];
+        // south > north is inverted.
+        let region = [0.42, 1.07, 0.44, 1.05, 100.0, 12_000.0];
         assert!(matches!(
             tileset_json_for_region(region, "content.pnts"),
             Err(Tiles3dError::InvalidRegion(_))
         ));
-        // min_h > max_h is also rejected.
+        // min_h > max_h is inverted.
         let region = [0.42, 1.05, 0.44, 1.07, 12_000.0, 100.0];
         assert!(matches!(
             tileset_json_for_region(region, "content.pnts"),
             Err(Tiles3dError::InvalidRegion(_))
         ));
+        // west > east is VALID — an antimeridian-crossing region (not inverted).
+        let region = [3.0, 1.05, -3.0, 1.07, 100.0, 12_000.0];
+        assert!(tileset_json_for_region(region, "content.pnts").is_ok());
     }
 
     #[test]

--- a/crates/engine-odim/src/volume_engine.rs
+++ b/crates/engine-odim/src/volume_engine.rs
@@ -1274,11 +1274,26 @@ fn derive_site_meta(list: &[VolumeEntry]) -> Option<SiteMeta> {
     // an unqualified request actually renders.
     let default_quantity = quantities.first().cloned().unwrap_or_default();
     let default_unit = quantities::quantity_unit(&default_quantity).to_string();
+    // 3D Tiles coverage region: the WGS84 coverage bbox (→ radians) plus a
+    // generous vertical span (antenna height up to a 25 km ceiling — above any
+    // radar echo and the `volume_point_cloud` height range). It only needs to
+    // *contain* the sampled cloud, so a slight over-estimate is fine.
+    let region = spatial_extent.map(|[w, s, e, n]| {
+        [
+            w.to_radians(),
+            s.to_radians(),
+            e.to_radians(),
+            n.to_radians(),
+            site.height,
+            site.height + 25_000.0,
+        ]
+    });
     let volume_info = Arc::new(VolumeInfo {
         quantities: parameters.clone(),
         times: times.clone(),
         default_quantity,
         default_unit,
+        region,
     });
 
     Some(SiteMeta {

--- a/crates/engine-odim/src/volume_engine.rs
+++ b/crates/engine-odim/src/volume_engine.rs
@@ -1278,6 +1278,10 @@ fn derive_site_meta(list: &[VolumeEntry]) -> Option<SiteMeta> {
     // generous vertical span (antenna height up to a 25 km ceiling — above any
     // radar echo and the `volume_point_cloud` height range). It only needs to
     // *contain* the sampled cloud, so a slight over-estimate is fine.
+    // Approximation: 3D Tiles heights are ellipsoidal but ODIM `site.height` is
+    // orthometric (above MSL); the geoid offset (~tens of m in Finland) is
+    // swamped by the 25 km ceiling, so this is harmless for culling — but the
+    // same approximation applies to the point altitudes in `volume_point_cloud`.
     let region = spatial_extent.map(|[w, s, e, n]| {
         [
             w.to_radians(),

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -23,6 +23,7 @@ api-features = { path = "../api-features" }
 api-wms = { path = "../api-wms" }
 api-maps = { path = "../api-maps" }
 api-tiles = { path = "../api-tiles" }
+api-3dtiles = { path = "../api-3dtiles" }
 ds-render = { path = "../render" }
 ds-mvt = { path = "../ds-mvt" }
 arc-swap = "1"

--- a/crates/server/src/admin.rs
+++ b/crates/server/src/admin.rs
@@ -440,6 +440,7 @@ pub struct ServerState {
     pub wms: Arc<ArcSwap<WmsState>>,
     pub maps: Arc<ArcSwap<MapsState>>,
     pub tiles: Arc<ArcSwap<TilesState>>,
+    pub tiles_3d: Arc<ArcSwap<api_3dtiles::TilesState3d>>,
     pub config_path: String,
     pub health: RwLock<Vec<CollectionHealth>>,
     pub geotiff_engines: RwLock<Vec<Arc<engine_geotiff::GeoTiffEngine>>>,
@@ -468,6 +469,7 @@ pub struct LoadResult {
     pub wms_state: WmsState,
     pub maps_state: MapsState,
     pub tiles_state: TilesState,
+    pub tiles_3d_state: api_3dtiles::TilesState3d,
     pub health: Vec<CollectionHealth>,
     pub geotiff_engines: Vec<Arc<engine_geotiff::GeoTiffEngine>>,
     pub querydata_engines: Vec<Arc<engine_querydata::QueryDataEngine>>,
@@ -510,6 +512,11 @@ pub fn load_collections(
         Arc<dyn ds_core::feature_engine::FeatureEngine>,
     > = HashMap::new();
     let mut tiles_feature_collections: HashMap<String, CollectionConfig> = HashMap::new();
+    // 3D Tiles sources: collections with `apis = [..., "3dtiles"]` whose engine
+    // implements `VolumeEngine`, keyed by collection id.
+    let mut volume_engines: HashMap<String, Arc<dyn ds_core::volume::VolumeEngine>> =
+        HashMap::new();
+    let mut volume_collections: HashMap<String, CollectionConfig> = HashMap::new();
     let mut geotiff_engines: Vec<Arc<engine_geotiff::GeoTiffEngine>> = Vec::new();
     let mut querydata_engines: Vec<Arc<engine_querydata::QueryDataEngine>> = Vec::new();
     let mut grib_engines: Vec<Arc<engine_grib::GribEngine>> = Vec::new();
@@ -542,7 +549,7 @@ pub fn load_collections(
             "grib" => &["edr", "wms", "maps", "tiles"],
             "zarr" => &["edr", "wms", "maps", "tiles"],
             "odim" => &["edr", "wms", "maps", "tiles"],
-            "odim-volume" => &["edr", "wms", "maps", "tiles", "features"],
+            "odim-volume" => &["edr", "wms", "maps", "tiles", "3dtiles", "features"],
             "postgis" => &["edr", "features", "tiles"],
             _ => &[],
         };
@@ -1511,6 +1518,13 @@ pub fn load_collections(
                             );
                         }
                     }
+                    if collection.apis.contains(&"3dtiles".to_string()) {
+                        volume_engines.insert(
+                            site_id.clone(),
+                            view.clone() as Arc<dyn ds_core::volume::VolumeEngine>,
+                        );
+                        volume_collections.insert(site_id.clone(), site_cfg.clone());
+                    }
 
                     info!(
                         "Collection '{}': wired per-site radar collection '{site_id}' ({label})",
@@ -1817,6 +1831,19 @@ pub fn load_collections(
             render_semaphore: render_semaphore.clone(),
             rendered_cache: rendered_cache.clone(),
             vector_tile_cache: vector_tile_cache.clone(),
+            base_url: base_url.to_string(),
+        },
+        tiles_3d_state: api_3dtiles::TilesState3d {
+            volume_engines,
+            collections: volume_collections,
+            // v1: one shared reflectivity ramp for all 3D-Tiles collections.
+            // Per-collection/per-quantity colormaps from config are a follow-up.
+            colormap: Arc::new(ds_render::LutColorMap::from_builtin(
+                ds_render::BuiltinColormap::RadarDbz,
+                -32.0,
+                95.0,
+            )),
+            render_semaphore: render_semaphore.clone(),
             base_url: base_url.to_string(),
         },
         health,
@@ -2453,6 +2480,7 @@ pub(crate) fn do_reload(state: &AdminState) -> Result<ReloadOutcome, ReloadError
     state.wms.store(Arc::new(result.wms_state));
     state.maps.store(Arc::new(result.maps_state));
     state.tiles.store(Arc::new(result.tiles_state));
+    state.tiles_3d.store(Arc::new(result.tiles_3d_state));
 
     // Update health
     update_health_gauges(&result.health);

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -290,6 +290,7 @@ async fn main() {
     let wms_swap = Arc::new(ArcSwap::from_pointee(result.wms_state));
     let maps_swap = Arc::new(ArcSwap::from_pointee(result.maps_state));
     let tiles_swap = Arc::new(ArcSwap::from_pointee(result.tiles_state));
+    let tiles_3d_swap = Arc::new(ArcSwap::from_pointee(result.tiles_3d_state));
 
     // Resolve admin token: ADMIN_TOKEN env var takes priority over config
     let admin_token = std::env::var("ADMIN_TOKEN")
@@ -338,6 +339,7 @@ async fn main() {
         wms: wms_swap.clone(),
         maps: maps_swap.clone(),
         tiles: tiles_swap.clone(),
+        tiles_3d: tiles_3d_swap.clone(),
         config_path,
         health: RwLock::new(result.health),
         geotiff_engines: RwLock::new(result.geotiff_engines),
@@ -382,7 +384,12 @@ async fn main() {
         .nest("/wms", api_wms::router(wms_swap.clone()))
         .nest("/maps", api_maps::router(maps_swap.clone()))
         .nest("/tiles", api_tiles::router(tiles_swap.clone()))
-        // Trailing-slash variants so /edr/, /features/, /maps/, and /tiles/ also work
+        .nest("/3dtiles", api_3dtiles::router(tiles_3d_swap.clone()))
+        // Trailing-slash variants so /edr/, /features/, /maps/, /tiles/, /3dtiles/ also work
+        .route(
+            "/3dtiles/",
+            get(api_3dtiles::handlers::landing_page).with_state(tiles_3d_swap),
+        )
         .route(
             "/edr/",
             get(api_edr::handlers::landing_page).with_state(edr_swap),
@@ -605,6 +612,12 @@ async fn root_landing_page(state: AdminState) -> impl IntoResponse {
                 "rel": "service-doc",
                 "type": "text/html",
                 "title": "Tiles API documentation"
+            },
+            {
+                "href": format!("{base}/3dtiles/"),
+                "rel": "child",
+                "type": "application/json",
+                "title": "3D Tiles API"
             },
             {
                 "href": format!("{base}/health"),

--- a/crates/server/src/preview.rs
+++ b/crates/server/src/preview.rs
@@ -949,6 +949,17 @@ mod tests {
             wms: Arc::new(ArcSwap::from_pointee(wms)),
             maps: Arc::new(ArcSwap::from_pointee(maps)),
             tiles: Arc::new(ArcSwap::from_pointee(tiles)),
+            tiles_3d: Arc::new(ArcSwap::from_pointee(api_3dtiles::TilesState3d {
+                volume_engines: std::collections::HashMap::new(),
+                collections: std::collections::HashMap::new(),
+                colormap: Arc::new(ds_render::LutColorMap::from_builtin(
+                    ds_render::BuiltinColormap::RadarDbz,
+                    -32.0,
+                    95.0,
+                )),
+                render_semaphore: Arc::new(tokio::sync::Semaphore::new(1)),
+                base_url: String::new(),
+            })),
             config_path: String::new(),
             health: RwLock::new(Vec::new()),
             geotiff_engines: RwLock::new(Vec::new()),

--- a/crates/server/src/watcher.rs
+++ b/crates/server/src/watcher.rs
@@ -165,6 +165,7 @@ mod tests {
             wms: Arc::new(ArcSwap::from_pointee(result.wms_state)),
             maps: Arc::new(ArcSwap::from_pointee(result.maps_state)),
             tiles: Arc::new(ArcSwap::from_pointee(result.tiles_state)),
+            tiles_3d: Arc::new(ArcSwap::from_pointee(result.tiles_3d_state)),
             config_path: config_path.to_str().unwrap().to_string(),
             health: RwLock::new(result.health),
             geotiff_engines: RwLock::new(result.geotiff_engines),


### PR DESCRIPTION
Phase 3 of the **OGC 3D Tiles** epic (#346). Closes #349. A new HTTP API crate serving 3D Tiles from any `VolumeEngine`-capable collection — mirroring how `api-tiles` serves raster tiles from `MapEngine`.

## What's here

- **`api-3dtiles`** (new crate; deps `ds-core` + `ds-3dtiles` + `ds-render`, **no engine crates**):
  - `GET /collections/{id}/tileset.json` (`?quantity=&datetime=`)
  - `GET /collections/{id}/content.pnts` (`?quantity=&datetime=&min_value=`)
  - `GET /` · `/collections` · `/collections/{id}`
  - The tileset's `content.uri` embeds the resolved quantity (+ pinned time) so the `.pnts` fetch is deterministic; content-derived **ETag → 304s**.
- **Concurrency (the load-bearing requirement from #348's review):** `read_point_cloud` does blocking HDF5 I/O + a long CPU loop, so the handler bounds it with the shared **render semaphore** and runs it via **`spawn_blocking`** — never inline on a request worker, the same pattern the raster APIs use.
- **`ds-core`:** `VolumeInfo` gains a coverage `region`, so `tileset.json` is **O(1)** (no volume sampling). **`ds-3dtiles`:** `tileset_json_for_region` for that path.
- **`engine-odim`:** `derive_site_meta` populates the region (coverage bbox → radians + a 25 km ceiling).
- **Server wiring:** a `volume_engines` registry, `"3dtiles"` added to the `odim-volume` `supported_apis` allowlist, `/3dtiles` nest + trailing slash + **reload swap** + root-landing link.

## Verified end-to-end

Enabled `"3dtiles"` on the runnable `radar-fi-volume-local-h5` example config and smoke-tested the live server:
- `tileset.json` → valid, region from `VolumeInfo` (radians + 181–25181 m), `geometricError 100000`, `content.uri = content.pnts?quantity=DBZH`
- `content.pnts?quantity=DBZH` → `200`, `application/octet-stream`, **13 MB**, `pnts` magic
- ETag → **304** round-trip; unknown quantity → **400**; permissive **CORS** present

Plus **7 integration tests** over a mock `VolumeEngine` (tileset, content, ETag/304, 404, 400 unknown-quantity on both routes, 400 bad-datetime, collections list/doc).

## Error semantics
Unknown quantity → 400, bad datetime → 400, unknown collection → 404, no coverage yet → 404.

## Scope / follow-ups
v1 uses **one shared reflectivity colormap**; per-collection/per-quantity colormaps from config, a **truncation flag/header** (#348-deferred — real radar doesn't hit the 8M cap), **time-dynamic tilesets** (#350), and **implicit-octree subtrees** (#351) are follow-ups.

## Checks
`cargo clippy --workspace --all-targets` clean; tests green: api-3dtiles 7, ds-3dtiles 5, ds-core 195, engine-odim 134+28. CLAUDE.md documents the new API + the four-trait architecture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
