### PR TITLE
feat(api-3dtiles): bundled CesiumJS viewer with collection picker

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -243,10 +243,14 @@ framework-free `ds-3dtiles` crate encodes it to a `.pnts` tile + `tileset.json`;
   `PolarVolumeSiteView`; the cloud is bounded by `MAX_POINTS` (8M, truncate +
   WARN). Unknown quantity ⇒ `InvalidParameter` (→ 400).
 - **Routes** (mounted at `/3dtiles`): `GET /collections/{id}/tileset.json`
-  (`?quantity=&datetime=`) and `GET /collections/{id}/content.pnts`
+  (`?quantity=&datetime=&min_value=`) and `GET /collections/{id}/content.pnts`
   (`?quantity=&datetime=&min_value=`), plus `/` · `/collections` ·
-  `/collections/{id}`. The tileset's `content.uri` embeds the resolved quantity
-  (+ pinned time) so the `.pnts` fetch is deterministic.
+  `/collections/{id}` · **`/viewer`** (a bundled CesiumJS page with a
+  collection + quantity picker, `include_str!`-baked from
+  `crates/api-3dtiles/viewer/index.html`; same-origin API base by default, so it
+  works on any deployment, with a `?base=` override). The tileset's
+  `content.uri` embeds the resolved quantity (+ pinned time + `min_value`) so
+  the `.pnts` fetch is deterministic.
 - **Concurrency:** `read_point_cloud` is sync (blocking HDF5 I/O + a long CPU
   loop), so the handler bounds it with the shared render semaphore and runs it
   via `spawn_blocking` — never inline on a request worker (the same pattern the

--- a/crates/api-3dtiles/src/handlers.rs
+++ b/crates/api-3dtiles/src/handlers.rs
@@ -169,7 +169,12 @@ pub async fn get_tileset(
         query.push_str(&format!("&datetime={}", dt.format("%Y-%m-%dT%H:%M:%SZ")));
     }
     if let Some(min) = params.min_value {
-        // f64 Display is URL-safe for a dBZ-range value (digits, `.`, `-`).
+        // `serde_urlencoded` parses "NaN"/"inf" as valid f64; a non-finite
+        // threshold filters every point → a silently-empty tile. Reject → 400.
+        if !min.is_finite() {
+            return Err(Tiles3dError::BadRequest("min_value must be finite".into()));
+        }
+        // f64 Display is URL-safe for a finite value (digits, `.`, `-`).
         query.push_str(&format!("&min_value={min}"));
     }
     let content_uri = format!("content.pnts?{query}");
@@ -204,6 +209,10 @@ pub async fn get_content(
     let time = params.datetime.as_deref().map(parse_datetime).transpose()?;
     let quantity = params.quantity.clone();
     let min_value = params.min_value;
+    // A non-finite threshold (parsed from "NaN"/"inf") would drop every point.
+    if min_value.is_some_and(|m| !m.is_finite()) {
+        return Err(Tiles3dError::BadRequest("min_value must be finite".into()));
+    }
 
     // Sample + encode off the request worker: `read_point_cloud` does blocking
     // HDF5 I/O and a long CPU loop (CLAUDE.md concurrency rules), so bound it

--- a/crates/api-3dtiles/src/handlers.rs
+++ b/crates/api-3dtiles/src/handlers.rs
@@ -64,6 +64,9 @@ pub struct TilesetParams {
     pub quantity: Option<String>,
     /// Valid time (RFC 3339). `None` → latest.
     pub datetime: Option<String>,
+    /// Drop points below this physical value (e.g. a dBZ floor); carried into
+    /// the tileset's `content.uri` so the `.pnts` fetch applies it.
+    pub min_value: Option<f64>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -111,6 +114,16 @@ fn etag_of(bytes: &[u8]) -> String {
     format!("\"{h:016x}\"")
 }
 
+/// The bundled CesiumJS viewer page (collection + quantity picker), baked into
+/// the binary and served at `GET /3dtiles/viewer`.
+const VIEWER_HTML: &str = include_str!("../viewer/index.html");
+
+/// `GET /viewer` — interactive CesiumJS viewer. It calls this same API
+/// (same-origin by default), so it works on any deployment.
+pub async fn get_viewer() -> axum::response::Html<&'static str> {
+    axum::response::Html(VIEWER_HTML)
+}
+
 // ---------------------------------------------------------------------------
 // Tileset
 // ---------------------------------------------------------------------------
@@ -154,6 +167,10 @@ pub async fn get_tileset(
     if let Some(dt_str) = &params.datetime {
         let dt = parse_datetime(dt_str)?;
         query.push_str(&format!("&datetime={}", dt.format("%Y-%m-%dT%H:%M:%SZ")));
+    }
+    if let Some(min) = params.min_value {
+        // f64 Display is URL-safe for a dBZ-range value (digits, `.`, `-`).
+        query.push_str(&format!("&min_value={min}"));
     }
     let content_uri = format!("content.pnts?{query}");
 
@@ -259,6 +276,7 @@ pub async fn landing_page(State(state): State<AppState>) -> Json<serde_json::Val
         "links": [
             { "href": format!("{base}/3dtiles/"), "rel": "self", "type": "application/json", "title": "This document" },
             { "href": format!("{base}/3dtiles/collections"), "rel": "data", "type": "application/json", "title": "Collections" },
+            { "href": format!("{base}/3dtiles/viewer"), "rel": "alternate", "type": "text/html", "title": "Interactive 3D Tiles viewer" },
         ]
     }))
 }

--- a/crates/api-3dtiles/src/lib.rs
+++ b/crates/api-3dtiles/src/lib.rs
@@ -24,6 +24,7 @@ use axum::Router;
 pub fn router(state: AppState) -> Router {
     Router::new()
         .route("/", get(handlers::landing_page))
+        .route("/viewer", get(handlers::get_viewer))
         .route("/collections", get(handlers::collections))
         .route("/collections/{id}", get(handlers::collection))
         .route("/collections/{id}/tileset.json", get(handlers::get_tileset))

--- a/crates/api-3dtiles/tests/integration.rs
+++ b/crates/api-3dtiles/tests/integration.rs
@@ -232,6 +232,32 @@ async fn if_none_match_wildcard_is_304() {
 }
 
 #[tokio::test]
+async fn viewer_page_is_served() {
+    let (status, body, headers) = get("/viewer").await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(headers[axum::http::header::CONTENT_TYPE]
+        .to_str()
+        .unwrap()
+        .starts_with("text/html"));
+    let html = String::from_utf8(body).unwrap();
+    assert!(html.contains("Cesium"), "viewer loads CesiumJS");
+    assert!(
+        html.contains("/collections"),
+        "viewer calls the collections API"
+    );
+}
+
+#[tokio::test]
+async fn tileset_carries_min_value_into_content_uri() {
+    let (status, body, _h) =
+        get("/collections/radar-fivih/tileset.json?quantity=DBZH&min_value=5").await;
+    assert_eq!(status, StatusCode::OK);
+    let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let uri = v["root"]["content"]["uri"].as_str().unwrap();
+    assert_eq!(uri, "content.pnts?quantity=DBZH&min_value=5");
+}
+
+#[tokio::test]
 async fn collections_list_and_doc() {
     let (status, body, _h) = get("/collections").await;
     assert_eq!(status, StatusCode::OK);

--- a/crates/api-3dtiles/tests/integration.rs
+++ b/crates/api-3dtiles/tests/integration.rs
@@ -248,6 +248,22 @@ async fn viewer_page_is_served() {
 }
 
 #[tokio::test]
+async fn non_finite_min_value_is_400() {
+    for v in ["NaN", "inf", "-inf"] {
+        let (ts, _b, _h) = get(&format!(
+            "/collections/radar-fivih/tileset.json?min_value={v}"
+        ))
+        .await;
+        assert_eq!(ts, StatusCode::BAD_REQUEST, "tileset rejects min_value={v}");
+        let (cs, _b, _h) = get(&format!(
+            "/collections/radar-fivih/content.pnts?min_value={v}"
+        ))
+        .await;
+        assert_eq!(cs, StatusCode::BAD_REQUEST, "content rejects min_value={v}");
+    }
+}
+
+#[tokio::test]
 async fn tileset_carries_min_value_into_content_uri() {
     let (status, body, _h) =
         get("/collections/radar-fivih/tileset.json?quantity=DBZH&min_value=5").await;

--- a/crates/api-3dtiles/viewer/index.html
+++ b/crates/api-3dtiles/viewer/index.html
@@ -6,7 +6,10 @@
 <title>MeteoCore — 3D Tiles viewer</title>
 <!-- Subresource Integrity on the version-pinned CesiumJS entry point: a CDN
      compromise/MITM can't silently swap the bundle. (Cesium then loads workers/
-     WASM from the CDN without SRI — full mitigation would self-host CesiumJS.) -->
+     WASM from the CDN without SRI — full mitigation would self-host CesiumJS.)
+     MANDATORY when bumping the CesiumJS version below: recompute these two
+     sha384 hashes with `scripts/check-cesium-sri.sh` — a stale hash makes
+     browsers silently refuse to load CesiumJS (blank viewer for everyone). -->
 <script src="https://cesium.com/downloads/cesiumjs/releases/1.124/Build/Cesium/Cesium.js"
         crossorigin="anonymous"
         integrity="sha384-5oazsHA45lZs9jgvxUv40qbMATfjwmtR/wQePfqDAeIDIhGmSK2V0gpRoCpZVBzJ"></script>
@@ -65,7 +68,15 @@ const sameOrigin = here.endsWith("/viewer")
 // Only accept an http(s) ?base override (reject javascript:/data:/etc.); it's
 // fetched + parsed by CesiumJS, so keep it to a plain absolute URL.
 const rawBase = params.get("base");
-const override = rawBase && /^https?:\/\//i.test(rawBase) ? rawBase.replace(/\/+$/, "") : null;
+let override = null;
+if (rawBase) {
+  try {
+    // new URL() normalises (resolves any `..`) and throws on malformed input;
+    // only accept an http(s) absolute URL (it's fetched + parsed by CesiumJS).
+    const u = new URL(rawBase);
+    if (u.protocol === "http:" || u.protocol === "https:") override = u.href.replace(/\/+$/, "");
+  } catch { /* ignore a malformed ?base override */ }
+}
 const BASE = override || sameOrigin || "https://meteocore.app.meteo.fi/3dtiles";
 
 const $coll = document.getElementById("coll");

--- a/crates/api-3dtiles/viewer/index.html
+++ b/crates/api-3dtiles/viewer/index.html
@@ -4,8 +4,15 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>MeteoCore — 3D Tiles viewer</title>
-<script src="https://cesium.com/downloads/cesiumjs/releases/1.124/Build/Cesium/Cesium.js"></script>
-<link href="https://cesium.com/downloads/cesiumjs/releases/1.124/Build/Cesium/Widgets/widgets.css" rel="stylesheet">
+<!-- Subresource Integrity on the version-pinned CesiumJS entry point: a CDN
+     compromise/MITM can't silently swap the bundle. (Cesium then loads workers/
+     WASM from the CDN without SRI — full mitigation would self-host CesiumJS.) -->
+<script src="https://cesium.com/downloads/cesiumjs/releases/1.124/Build/Cesium/Cesium.js"
+        crossorigin="anonymous"
+        integrity="sha384-5oazsHA45lZs9jgvxUv40qbMATfjwmtR/wQePfqDAeIDIhGmSK2V0gpRoCpZVBzJ"></script>
+<link href="https://cesium.com/downloads/cesiumjs/releases/1.124/Build/Cesium/Widgets/widgets.css" rel="stylesheet"
+      crossorigin="anonymous"
+      integrity="sha384-ghEeMdcWWzRv/BPeUcX835vcKDGrxvROXisl/Btpv3GeekBUXTSPVcFJpI1Tcrgp">
 <style>
   html, body, #cesium { width: 100%; height: 100%; margin: 0; overflow: hidden; }
   #cesium { position: absolute; inset: 0; }
@@ -42,8 +49,14 @@
 <script>
 "use strict";
 
-// API base: ?base=… override, else same-origin (when served at /3dtiles/viewer),
-// else the public deployment.
+// API base, in priority order:
+//   1. ?base=…              explicit override (local dev / cross-origin)
+//   2. same origin          when served at /3dtiles/viewer (the normal path) —
+//                           so it works on any deployment with no config.
+//   3. the public instance  last resort, e.g. when this file is opened directly
+//                           from disk. Intentional (the page targets the public
+//                           API by default); note it's a third-party trust
+//                           boundary if this ever fires from a served page.
 const params = new URLSearchParams(location.search);
 const here = location.pathname.replace(/\/+$/, "");
 const sameOrigin = here.endsWith("/viewer")

--- a/crates/api-3dtiles/viewer/index.html
+++ b/crates/api-3dtiles/viewer/index.html
@@ -42,7 +42,7 @@
   <div class="brand">MeteoCore <span>· 3D Tiles</span></div>
   <div class="field"><label for="coll">Collection</label><select id="coll"></select></div>
   <div class="field"><label for="qty">Quantity</label><select id="qty"></select></div>
-  <div class="field"><label for="min">min</label><input id="min" type="number" value="5" step="1"> dBZ</div>
+  <div class="field"><label for="min">min value</label><input id="min" type="number" value="5" step="1"></div>
   <div id="status"></div>
 </div>
 <div id="cesium"></div>
@@ -137,6 +137,10 @@ async function loadTileset() {
   if (!id || !q) return;
   const token = ++loadToken;
   setStatus(`loading ${id} · ${q}…`);
+  // `scene.primitives` has destroyPrimitives:true (default), so remove() also
+  // destroys the old tileset and frees its GPU buffers — no explicit destroy()
+  // (that would double-destroy and throw). The superseded-load path below DOES
+  // call destroy() because that tileset was never added to the collection.
   if (current) { viewer.scene.primitives.remove(current); current = null; }
 
   let url = `${BASE}/collections/${encodeURIComponent(id)}/tileset.json?quantity=${encodeURIComponent(q)}`;

--- a/crates/api-3dtiles/viewer/index.html
+++ b/crates/api-3dtiles/viewer/index.html
@@ -1,0 +1,148 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>MeteoCore — 3D Tiles viewer</title>
+<script src="https://cesium.com/downloads/cesiumjs/releases/1.124/Build/Cesium/Cesium.js"></script>
+<link href="https://cesium.com/downloads/cesiumjs/releases/1.124/Build/Cesium/Widgets/widgets.css" rel="stylesheet">
+<style>
+  html, body, #cesium { width: 100%; height: 100%; margin: 0; overflow: hidden; }
+  #cesium { position: absolute; inset: 0; }
+  #bar {
+    position: absolute; top: 0; left: 0; right: 0; z-index: 10;
+    display: flex; flex-wrap: wrap; gap: 14px; align-items: center;
+    padding: 9px 14px; box-sizing: border-box;
+    background: rgba(10, 13, 20, 0.82); -webkit-backdrop-filter: blur(6px); backdrop-filter: blur(6px);
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+    color: #e8eef6; font: 13px/1.3 system-ui, -apple-system, sans-serif;
+  }
+  #bar .brand { font-weight: 650; letter-spacing: .2px; margin-right: 4px; }
+  #bar .brand span { opacity: .55; font-weight: 400; }
+  #bar .field { display: flex; align-items: center; gap: 6px; }
+  #bar label { opacity: .6; }
+  #bar select, #bar input {
+    background: #161b25; color: #e8eef6; border: 1px solid #2a3340;
+    border-radius: 6px; padding: 5px 8px; font: 13px system-ui; max-width: 320px;
+  }
+  #bar input[type=number] { width: 58px; }
+  #status { margin-left: auto; opacity: .6; font-size: 12px; white-space: nowrap; }
+  #status.err { color: #ff8a8a; opacity: .95; }
+</style>
+</head>
+<body>
+<div id="bar">
+  <div class="brand">MeteoCore <span>· 3D Tiles</span></div>
+  <div class="field"><label for="coll">Collection</label><select id="coll"></select></div>
+  <div class="field"><label for="qty">Quantity</label><select id="qty"></select></div>
+  <div class="field"><label for="min">min</label><input id="min" type="number" value="5" step="1"> dBZ</div>
+  <div id="status"></div>
+</div>
+<div id="cesium"></div>
+<script>
+"use strict";
+
+// API base: ?base=… override, else same-origin (when served at /3dtiles/viewer),
+// else the public deployment.
+const params = new URLSearchParams(location.search);
+const here = location.pathname.replace(/\/+$/, "");
+const sameOrigin = here.endsWith("/viewer")
+  ? location.origin + here.slice(0, -"/viewer".length)
+  : null;
+const BASE = params.get("base") || sameOrigin || "https://meteocore.app.meteo.fi/3dtiles";
+
+const $coll = document.getElementById("coll");
+const $qty = document.getElementById("qty");
+const $min = document.getElementById("min");
+const $status = document.getElementById("status");
+const setStatus = (msg, err) => { $status.textContent = msg; $status.className = err ? "err" : ""; };
+
+// Token-free CesiumJS: CARTO Dark Matter basemap, no Cesium Ion.
+const viewer = new Cesium.Viewer("cesium", {
+  baseLayer: new Cesium.ImageryLayer(new Cesium.UrlTemplateImageryProvider({
+    url: "https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png",
+    subdomains: "abcd", maximumLevel: 19,
+    credit: "© OpenStreetMap contributors © CARTO",
+  })),
+  baseLayerPicker: false, timeline: false, animation: false, geocoder: false,
+  homeButton: false, sceneModePicker: false, navigationHelpButton: false, infoBox: false, selectionIndicator: false,
+});
+viewer.scene.backgroundColor = Cesium.Color.BLACK;
+viewer.scene.globe.depthTestAgainstTerrain = false;
+
+let current = null;       // active tileset
+let loadToken = 0;        // guards against out-of-order async loads
+
+async function loadCollections() {
+  setStatus("loading collections…");
+  try {
+    const data = await (await fetch(`${BASE}/collections`)).json();
+    const cols = data.collections || [];
+    $coll.innerHTML = "";
+    for (const c of cols) {
+      const o = document.createElement("option");
+      o.value = c.id; o.textContent = c.title || c.id;
+      $coll.appendChild(o);
+    }
+    if (!cols.length) { setStatus("no 3D-Tiles collections at " + BASE, true); return; }
+    await loadQuantities();
+  } catch (e) {
+    setStatus("can't reach " + BASE + " — " + e, true);
+  }
+}
+
+async function loadQuantities() {
+  const id = $coll.value;
+  if (!id) return;
+  try {
+    const data = await (await fetch(`${BASE}/collections/${encodeURIComponent(id)}`)).json();
+    const qs = data.quantities || [];
+    $qty.innerHTML = "";
+    for (const q of qs) {
+      const o = document.createElement("option");
+      o.value = q.id; o.textContent = q.label || q.id;
+      $qty.appendChild(o);
+    }
+    // Prefer a reflectivity quantity for the default view.
+    for (const pref of ["DBZH", "TH"]) {
+      const i = [...$qty.options].findIndex(o => o.value === pref);
+      if (i >= 0) { $qty.selectedIndex = i; break; }
+    }
+    await loadTileset();
+  } catch (e) {
+    setStatus("error loading quantities — " + e, true);
+  }
+}
+
+async function loadTileset() {
+  const id = $coll.value, q = $qty.value;
+  const min = $min.value.trim();
+  if (!id || !q) return;
+  const token = ++loadToken;
+  setStatus(`loading ${id} · ${q}…`);
+  if (current) { viewer.scene.primitives.remove(current); current = null; }
+
+  let url = `${BASE}/collections/${encodeURIComponent(id)}/tileset.json?quantity=${encodeURIComponent(q)}`;
+  if (min !== "") url += `&min_value=${encodeURIComponent(min)}`;
+  try {
+    const ts = await Cesium.Cesium3DTileset.fromUrl(url, { maximumScreenSpaceError: 1 });
+    if (token !== loadToken) return; // a newer load superseded this one
+    current = ts;
+    viewer.scene.primitives.add(ts);
+    ts.style = new Cesium.Cesium3DTileStyle({ pointSize: 5.0 });
+    await viewer.zoomTo(ts, new Cesium.HeadingPitchRange(
+      Cesium.Math.toRadians(210), Cesium.Math.toRadians(-28), 300000));
+    setStatus(`${id} · ${q}`);
+  } catch (e) {
+    if (token === loadToken) setStatus("no data for this selection", true);
+    console.error(e);
+  }
+}
+
+$coll.addEventListener("change", loadQuantities);
+$qty.addEventListener("change", loadTileset);
+$min.addEventListener("change", loadTileset);
+loadCollections();
+</script>
+</body>
+</html>

--- a/crates/api-3dtiles/viewer/index.html
+++ b/crates/api-3dtiles/viewer/index.html
@@ -139,7 +139,7 @@ async function loadTileset() {
   if (min !== "") url += `&min_value=${encodeURIComponent(min)}`;
   try {
     const ts = await Cesium.Cesium3DTileset.fromUrl(url, { maximumScreenSpaceError: 1 });
-    if (token !== loadToken) return; // a newer load superseded this one
+    if (token !== loadToken) { ts.destroy(); return; } // superseded — free its GPU buffers
     current = ts;
     viewer.scene.primitives.add(ts);
     ts.style = new Cesium.Cesium3DTileStyle({ pointSize: 5.0 });

--- a/crates/api-3dtiles/viewer/index.html
+++ b/crates/api-3dtiles/viewer/index.html
@@ -62,7 +62,11 @@ const here = location.pathname.replace(/\/+$/, "");
 const sameOrigin = here.endsWith("/viewer")
   ? location.origin + here.slice(0, -"/viewer".length)
   : null;
-const BASE = params.get("base") || sameOrigin || "https://meteocore.app.meteo.fi/3dtiles";
+// Only accept an http(s) ?base override (reject javascript:/data:/etc.); it's
+// fetched + parsed by CesiumJS, so keep it to a plain absolute URL.
+const rawBase = params.get("base");
+const override = rawBase && /^https?:\/\//i.test(rawBase) ? rawBase.replace(/\/+$/, "") : null;
+const BASE = override || sameOrigin || "https://meteocore.app.meteo.fi/3dtiles";
 
 const $coll = document.getElementById("coll");
 const $qty = document.getElementById("qty");

--- a/scripts/check-cesium-sri.sh
+++ b/scripts/check-cesium-sri.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Verify the Subresource Integrity (SRI) hashes pinned in the 3D Tiles viewer
+# match the live CesiumJS CDN. Re-run after bumping the CesiumJS version in
+# crates/api-3dtiles/viewer/index.html (a wrong hash makes browsers silently
+# refuse to load CesiumJS → a blank viewer). Requires network + openssl.
+#
+#   scripts/check-cesium-sri.sh
+set -euo pipefail
+
+html="$(git rev-parse --show-toplevel)/crates/api-3dtiles/viewer/index.html"
+ver="$(grep -oE 'cesiumjs/releases/[0-9.]+' "$html" | head -1 | grep -oE '[0-9.]+')"
+base="https://cesium.com/downloads/cesiumjs/releases/${ver}/Build/Cesium"
+
+# Pinned hashes, in file order (1 = Cesium.js, 2 = widgets.css). `sed -n Np`
+# instead of `mapfile` so this runs on the bash 3.2 macOS ships.
+pinned_js="$(grep -oE 'sha384-[A-Za-z0-9+/=]+' "$html" | sed -n '1p')"
+pinned_css="$(grep -oE 'sha384-[A-Za-z0-9+/=]+' "$html" | sed -n '2p')"
+
+check() {
+  url="$1"; name="$2"; want="$3"
+  got="sha384-$(curl -fsSL "$url" | openssl dgst -sha384 -binary | openssl base64 -A)"
+  if [ "$want" = "$got" ]; then
+    echo "OK    $name"
+  else
+    echo "FAIL  $name"
+    echo "  pinned: $want"
+    echo "  live:   $got"
+    exit 1
+  fi
+}
+
+echo "Checking CesiumJS $ver SRI hashes…"
+check "${base}/Cesium.js" "Cesium.js" "$pinned_js"
+check "${base}/Widgets/widgets.css" "widgets.css" "$pinned_css"
+echo "All SRI hashes match."


### PR DESCRIPTION
A committed, server-served CesiumJS viewer for the 3D Tiles API — the throwaway test page from the live demo, now a proper bundled page with a **collection + quantity picker**.

## What's here
- **`crates/api-3dtiles/viewer/index.html`** — a self-contained CesiumJS page: a top bar with a **Collection** dropdown (populated from `/3dtiles/collections`), a **Quantity** dropdown (from the collection doc, reflectivity-first), and a **min dBZ** threshold. CARTO Dark Matter basemap, token-free (no Cesium Ion). Out-of-order load guard for rapid switching.
- **Served at `GET /3dtiles/viewer`** (`include_str!`-baked into the binary). So once deployed it's live at e.g. **`https://meteocore.app.meteo.fi/3dtiles/viewer`**.
- **Same-origin API base by default** (derives `…/3dtiles` from its own URL, so it works on any host), with a **`?base=`** override for local dev (`/3dtiles/viewer?base=http://127.0.0.1:8131/3dtiles`).
- **`tileset.json` now accepts `min_value`** and carries it into the `content.uri`, so the viewer's threshold control actually reaches the `.pnts` fetch (cuts clutter + tile size).
- Landing page links the viewer (`rel=alternate`, `text/html`).

## Verified
- `GET /3dtiles/viewer` → `200 text/html` against the running server; landing advertises it.
- Tests: viewer page is served as HTML and references CesiumJS + the collections API; `tileset.json?...&min_value=5` → `content.pnts?quantity=DBZH&min_value=5`.

## Checks
`clippy` clean; api-3dtiles 1 unit + 11 integration green. CLAUDE.md documents the endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
