### PR TITLE
feat(3dtiles): isosurface mesh — encoder, API (both representations), viewer toggle (#357)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -265,7 +265,16 @@ into a glTF `.glb` triangle mesh.
   cell-centre convention as the engine sampler) → `destination_point` +
   `geodetic_to_ecef` (both now in `ds_core::geo`), stored antenna-relative and
   pre-flipped Z-up→Y-up because a runtime re-applies Y-up→Z-up to **glTF**
-  content (the flip the `.pnts` path skips — pnts isn't glTF). `tileset_json_glb`
+  content (the flip the `.pnts` path skips — pnts isn't glTF). **`background`
+  sealing (load-bearing for radar):** the grid stores `NaN` for *both* clear-air
+  (`undetect`) and unmeasured (`nodata`/cone of silence) — `RawPixels::sample`
+  masks both identically (reader.rs). `encode_isosurface_glb(grid, threshold,
+  color, background)` with `background=Some(bg<threshold)` treats `NaN` as
+  no-echo so the surface **closes into solid blobs**; `None` skips `NaN`-touching
+  tets and the echo→clear-air boundary renders as open vertical *curtains*. The
+  demo seals with `Some(-32.0)` (the dBZ floor). Splitting `undetect` from
+  `nodata` in the engine sampler (so only the real cone of silence stays open) is
+  a follow-up. `tileset_json_glb`
   carries the antenna ECEF as the tile **`transform`** (glTF content has no
   embedded origin, unlike `.pnts` `RTC_CENTER`); the geodetic `region` is
   unaffected by it. Demo: `cargo run -p engine-odim --example gen_isosurface`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -234,7 +234,9 @@ Volumetric weather as OGC 3D Tiles — radar polar volumes today. The chain:
 cell, placed at its true ECEF position via the 4/3-Earth beam model); the
 framework-free `ds-3dtiles` crate encodes it to a `.pnts` tile + `tileset.json`;
 `api-3dtiles` serves it over HTTP. Engines return the domain type, never bytes
-(same rule as `MapEngine`→`ds-render`).
+(same rule as `MapEngine`→`ds-render`). `ds-3dtiles` has two encoders: the
+`.pnts` point cloud, and (#357) an **isosurface** mesher that turns a `VoxelGrid`
+into a glTF `.glb` triangle mesh.
 
 - **Trait:** `VolumeEngine::read_point_cloud(quantity, time, min_value, reference_time)`
   → `VolumePointCloud`; `read_voxel_grid(quantity, time, dims, reference_time)`
@@ -249,6 +251,29 @@ framework-free `ds-3dtiles` crate encodes it to a `.pnts` tile + `tileset.json`;
   cone of silence). Unknown quantity ⇒ `InvalidParameter` (→ 400). The
   `EXT_primitive_voxels` glTF *encoding* of a `VoxelGrid` is a follow-up (#351) —
   draft spec, render-verify against CesiumJS ≥1.127.
+- **Isosurface meshing (#357, `ds-3dtiles/src/isosurface.rs`):**
+  `encode_isosurface_glb(grid, threshold, color)` extracts a constant-value
+  shell (e.g. "the 20 dBZ surface") from a `VoxelGrid` as a glTF 2.0 `.glb`
+  triangle mesh — a **plain glTF mesh that renders in any 3D Tiles 1.1 client**
+  (the verifiable alternative to the draft `EXT_primitive_voxels` voxel path).
+  Uses **marching tetrahedra**, not marching cubes: a tet is K4, so the surface
+  crosses exactly `|inside|·|outside|` edges and the topology is correct by
+  construction (no 256-case table to mis-transcribe — chosen because the output
+  isn't render-checkable at encode time). Cube → 6 tets (Kuhn split); any tet
+  touching a `NaN` corner is skipped (no surface across the cone of silence).
+  Surface vertices map fractional cell index → ground/azimuth/height (same
+  cell-centre convention as the engine sampler) → `destination_point` +
+  `geodetic_to_ecef` (both now in `ds_core::geo`), stored antenna-relative and
+  pre-flipped Z-up→Y-up because a runtime re-applies Y-up→Z-up to **glTF**
+  content (the flip the `.pnts` path skips — pnts isn't glTF). `tileset_json_glb`
+  carries the antenna ECEF as the tile **`transform`** (glTF content has no
+  embedded origin, unlike `.pnts` `RTC_CENTER`); the geodetic `region` is
+  unaffected by it. Demo: `cargo run -p engine-odim --example gen_isosurface`
+  (writes `.glb` + `tileset.json` + a token-free CesiumJS viewer). **API route
+  is a follow-up** — the encoder + demo ship first (mirrors how `.pnts` went,
+  demo #347 → API #349). **One thing to confirm visually:** that the runtime
+  applies Y-up→Z-up to direct 1.1 `.glb` content (the standard default); if the
+  shell renders tipped 90°, that's the up-axis convention and a one-line fix.
 - **Routes** (mounted at `/3dtiles`): `GET /collections/{id}/tileset.json`
   (`?quantity=&datetime=&min_value=`) and `GET /collections/{id}/content.pnts`
   (`?quantity=&datetime=&min_value=`), plus `/` · `/collections` ·

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -285,11 +285,13 @@ into a glTF `.glb` triangle mesh.
 - **Both representations are served from the API** (selected by
   `?representation=points|isosurface` on `tileset.json`): `points` → `.pnts`
   (region-only tileset, `RTC_CENTER` self-places), `isosurface` → `.glb` plus a
-  tile **`transform`** = the antenna ECEF (from `VolumeInfo.origin`, so the
-  tileset is built without sampling). A collection advertises which it supports
-  via `VolumeInfo.supports_voxel_grid` → the collection JSON's `representations`
-  array → the viewer's representation toggle. The isosurface floor (seal) =
-  `ColorMap::domain()` min (clamped `< threshold`).
+  tile **`transform`** = the antenna ECEF. Capability + the origin it needs are
+  coupled in one field: `VolumeInfo.voxel_grid: Option<VoxelGridCaps { origin }>`
+  — `Some` ⇒ isosurface available and the origin is present (so the tileset is
+  built without sampling, and "supports but no origin" is unrepresentable, never
+  a 500). It drives the collection JSON's `representations` array → the viewer's
+  representation toggle. The isosurface floor (seal) = `ColorMap::domain()` min
+  (clamped `< threshold`); an over-large surface (threshold too low) → 400.
 - **Routes** (mounted at `/3dtiles`): `GET /collections/{id}/tileset.json`
   (`?representation=&quantity=&datetime=&min_value=&threshold=`),
   `GET /collections/{id}/content.pnts` (`?quantity=&datetime=&min_value=`),

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -278,26 +278,36 @@ into a glTF `.glb` triangle mesh.
   carries the antenna ECEF as the tile **`transform`** (glTF content has no
   embedded origin, unlike `.pnts` `RTC_CENTER`); the geodetic `region` is
   unaffected by it. Demo: `cargo run -p engine-odim --example gen_isosurface`
-  (writes `.glb` + `tileset.json` + a token-free CesiumJS viewer). **API route
-  is a follow-up** — the encoder + demo ship first (mirrors how `.pnts` went,
-  demo #347 → API #349). **One thing to confirm visually:** that the runtime
-  applies Y-up→Z-up to direct 1.1 `.glb` content (the standard default); if the
-  shell renders tipped 90°, that's the up-axis convention and a one-line fix.
+  (writes `.glb` + `tileset.json` + a token-free CesiumJS viewer). The mesh is
+  **render-verified live** (CesiumJS 1.124): the shell sits correctly over the
+  antenna, upright (so the Y-up→Z-up flip is right for direct 1.1 `.glb`
+  content), and sealing closes the curtains into solid blobs.
+- **Both representations are served from the API** (selected by
+  `?representation=points|isosurface` on `tileset.json`): `points` → `.pnts`
+  (region-only tileset, `RTC_CENTER` self-places), `isosurface` → `.glb` plus a
+  tile **`transform`** = the antenna ECEF (from `VolumeInfo.origin`, so the
+  tileset is built without sampling). A collection advertises which it supports
+  via `VolumeInfo.supports_voxel_grid` → the collection JSON's `representations`
+  array → the viewer's representation toggle. The isosurface floor (seal) =
+  `ColorMap::domain()` min (clamped `< threshold`).
 - **Routes** (mounted at `/3dtiles`): `GET /collections/{id}/tileset.json`
-  (`?quantity=&datetime=&min_value=`) and `GET /collections/{id}/content.pnts`
-  (`?quantity=&datetime=&min_value=`), plus `/` · `/collections` ·
-  `/collections/{id}` · **`/viewer`** (a bundled CesiumJS page with a
-  collection + quantity picker, `include_str!`-baked from
-  `crates/api-3dtiles/viewer/index.html`; same-origin API base by default, so it
-  works on any deployment, with a `?base=` override). The tileset's
-  `content.uri` embeds the resolved quantity (+ pinned time + `min_value`) so
-  the `.pnts` fetch is deterministic.
-- **Concurrency:** `read_point_cloud` is sync (blocking HDF5 I/O + a long CPU
-  loop), so the handler bounds it with the shared render semaphore and runs it
-  via `spawn_blocking` — never inline on a request worker (the same pattern the
+  (`?representation=&quantity=&datetime=&min_value=&threshold=`),
+  `GET /collections/{id}/content.pnts` (`?quantity=&datetime=&min_value=`),
+  `GET /collections/{id}/content.glb` (`?quantity=&datetime=&threshold=`), plus
+  `/` · `/collections` · `/collections/{id}` · **`/viewer`** (a bundled CesiumJS
+  page with collection + quantity + **representation** pickers,
+  `include_str!`-baked from `crates/api-3dtiles/viewer/index.html`; same-origin
+  API base by default, with a `?base=` override). The tileset's `content.uri`
+  embeds the resolved quantity (+ pinned time + `min_value`/`threshold`) so the
+  content fetch is deterministic.
+- **Concurrency:** `read_point_cloud` / `read_voxel_grid` are sync (blocking
+  HDF5 I/O + a long CPU loop — marching tet for the latter), so both content
+  handlers bound them with the shared render semaphore and run via
+  `spawn_blocking` — never inline on a request worker (the same pattern the
   raster APIs use for `get_raster_tile`).
-- **Caching:** content-derived ETag on `.pnts` (deterministic bytes ⇒ cheap
-  304s); `content_uri` is validated (no `..`/absolute/scheme) in `ds-3dtiles`.
+- **Caching:** content-derived ETag on both `.pnts` and `.glb` (deterministic
+  bytes ⇒ cheap 304s, shared `binary_response` helper); `content_uri` is
+  validated (no `..`/absolute/scheme) in `ds-3dtiles`.
 - **Config:** add `"3dtiles"` to a collection's `apis` (only `odim-volume`
   supports it today). v1 uses one shared reflectivity colormap; per-collection /
   per-quantity colormaps, time-dynamic tilesets (#350), and true cylindrical

--- a/crates/api-3dtiles/src/handlers.rs
+++ b/crates/api-3dtiles/src/handlers.rs
@@ -272,21 +272,19 @@ pub async fn get_tileset(
                 .map_err(|e| Tiles3dError::Internal(format!("tileset build failed: {e}")))?
         }
         Representation::Isosurface => {
-            if !info.supports_voxel_grid {
-                return Err(Tiles3dError::BadRequest(format!(
+            // `voxel_grid` couples capability with the origin, so an isosurface
+            // collection always has the origin — no separate `None` → 500 path.
+            let caps = info.voxel_grid.as_ref().ok_or_else(|| {
+                Tiles3dError::BadRequest(format!(
                     "collection '{id}' does not support the isosurface representation"
-                )));
-            }
+                ))
+            })?;
             // The glTF `.glb` content has no embedded origin (unlike `.pnts`
             // `RTC_CENTER`), so the tileset places it via a `transform` = the
             // volume origin (antenna) in ECEF — taken from `VolumeInfo` so we
             // don't sample the grid just to emit the tileset.
-            let origin = info.origin.ok_or_else(|| {
-                Tiles3dError::Internal(format!(
-                    "collection '{id}' has no origin for the mesh transform"
-                ))
-            })?;
-            let rtc = geodetic_to_ecef(origin[0], origin[1], origin[2]);
+            let [olon, olat, oh] = caps.origin;
+            let rtc = geodetic_to_ecef(olon, olat, oh);
             if let Some(t) = params.threshold {
                 if !t.is_finite() {
                     return Err(Tiles3dError::BadRequest("threshold must be finite".into()));
@@ -382,7 +380,7 @@ pub async fn get_content_glb(
     let info = engine.volume_info();
     // Reject early if the engine can't produce a voxel grid (avoids a blocking
     // task just to return the trait's "unsupported" → 404).
-    if !info.supports_voxel_grid {
+    if info.voxel_grid.is_none() {
         return Err(Tiles3dError::BadRequest(format!(
             "collection '{id}' does not support the isosurface representation"
         )));
@@ -443,6 +441,11 @@ pub async fn get_content_glb(
                     // here", not a server fault — 404, matching the no-data path.
                     ds_3dtiles::Tiles3dError::Empty => Tiles3dError::NotFound(format!(
                         "no isosurface at threshold {threshold} for collection '{id_for_err}'"
+                    )),
+                    // Too many triangles is client-driven (the threshold is too
+                    // low for this grid) — 400, not a 500 server fault.
+                    ds_3dtiles::Tiles3dError::TooLarge(_) => Tiles3dError::BadRequest(format!(
+                        "threshold {threshold} produces too large an isosurface; raise it"
                     )),
                     other => Tiles3dError::Internal(format!("isosurface encode failed: {other}")),
                 })?;
@@ -518,7 +521,7 @@ fn collection_doc(state: &TilesState3d, id: &str, base: &str) -> serde_json::Val
     // Every volume collection serves a point cloud; those whose engine can also
     // produce a voxel grid additionally serve an isosurface mesh. The viewer
     // reads this to populate its representation toggle.
-    let supports_iso = info.as_ref().is_some_and(|i| i.supports_voxel_grid);
+    let supports_iso = info.as_ref().is_some_and(|i| i.voxel_grid.is_some());
     let mut representations = vec!["points"];
     if supports_iso {
         representations.push("isosurface");

--- a/crates/api-3dtiles/src/handlers.rs
+++ b/crates/api-3dtiles/src/handlers.rs
@@ -408,6 +408,12 @@ pub async fn get_content_glb(
     // Colour the shell at the threshold; seal NaN (clear air / unmeasured) at
     // the colormap's floor so the surface closes into solid blobs. The floor
     // must be < threshold (clamp defensively against an odd colormap domain).
+    //
+    // v1 uses the single collection-level colormap regardless of quantity (the
+    // `.pnts` path has the same limitation), so for a non-reflectivity quantity
+    // (VRADH/ZDR/…) the dBZ floor is only "below any likely threshold", not
+    // physically the quantity's minimum — geometrically fine (the seal still
+    // closes), semantically approximate. Per-quantity colormaps (#350) fix it.
     let color = state.colormap.color(Some(threshold));
     let floor = state
         .colormap
@@ -512,9 +518,19 @@ fn collection_doc(state: &TilesState3d, id: &str, base: &str) -> serde_json::Val
     // Every volume collection serves a point cloud; those whose engine can also
     // produce a voxel grid additionally serve an isosurface mesh. The viewer
     // reads this to populate its representation toggle.
+    let supports_iso = info.as_ref().is_some_and(|i| i.supports_voxel_grid);
     let mut representations = vec!["points"];
-    if info.as_ref().is_some_and(|i| i.supports_voxel_grid) {
+    if supports_iso {
         representations.push("isosurface");
+    }
+    // A link per representation so a link-following client (not just one that
+    // reads `representations` and builds URLs itself) can discover both.
+    let mut links = vec![
+        json!({ "href": format!("{base}/3dtiles/collections/{id}"), "rel": "self", "type": "application/json", "title": "This document" }),
+        json!({ "href": format!("{base}/3dtiles/collections/{id}/tileset.json"), "rel": "3dtiles", "type": "application/json", "title": "3D Tiles tileset (point cloud)" }),
+    ];
+    if supports_iso {
+        links.push(json!({ "href": format!("{base}/3dtiles/collections/{id}/tileset.json?representation=isosurface"), "rel": "3dtiles", "type": "application/json", "title": "3D Tiles tileset (isosurface mesh)" }));
     }
     json!({
         "id": id,
@@ -522,10 +538,7 @@ fn collection_doc(state: &TilesState3d, id: &str, base: &str) -> serde_json::Val
         "description": description,
         "quantities": quantities,
         "representations": representations,
-        "links": [
-            { "href": format!("{base}/3dtiles/collections/{id}"), "rel": "self", "type": "application/json", "title": "This document" },
-            { "href": format!("{base}/3dtiles/collections/{id}/tileset.json"), "rel": "3dtiles", "type": "application/json", "title": "3D Tiles tileset (point cloud)" },
-        ]
+        "links": links,
     })
 }
 

--- a/crates/api-3dtiles/src/handlers.rs
+++ b/crates/api-3dtiles/src/handlers.rs
@@ -447,6 +447,15 @@ pub async fn get_content_glb(
                     ds_3dtiles::Tiles3dError::TooLarge(_) => Tiles3dError::BadRequest(format!(
                         "threshold {threshold} produces too large an isosurface; raise it"
                     )),
+                    // The seal floor is clamped < threshold above, so this is
+                    // currently unreachable — but map it to 400 (a bad
+                    // parameter combination) so a future floor-formula change
+                    // can't silently surface as an opaque 500.
+                    ds_3dtiles::Tiles3dError::BackgroundNotBelowThreshold { .. } => {
+                        Tiles3dError::BadRequest(
+                            "isosurface sealing floor is not below the threshold".into(),
+                        )
+                    }
                     other => Tiles3dError::Internal(format!("isosurface encode failed: {other}")),
                 })?;
             let etag = etag_of(&bytes);

--- a/crates/api-3dtiles/src/handlers.rs
+++ b/crates/api-3dtiles/src/handlers.rs
@@ -1,10 +1,15 @@
 //! HTTP handlers for the 3D Tiles API.
 //!
-//! Serves OGC 3D Tiles from any collection implementing `VolumeEngine`:
+//! Serves OGC 3D Tiles from any collection implementing `VolumeEngine`, in two
+//! representations (selected by `?representation=`):
 //! - `GET /collections/{id}/tileset.json` — the tileset (bounding region from
-//!   `VolumeInfo`, content pointing at the `.pnts` below).
-//! - `GET /collections/{id}/content.pnts` — the point-cloud tile, sampled on a
-//!   blocking thread and encoded by `ds-3dtiles`.
+//!   `VolumeInfo`; content points at `.pnts` for `points`, or `.glb` plus an
+//!   antenna-ECEF `transform` for `isosurface`).
+//! - `GET /collections/{id}/content.pnts` — the point-cloud tile.
+//! - `GET /collections/{id}/content.glb` — the isosurface-mesh tile.
+//!
+//! Both content types are sampled on a blocking thread (bounded by the shared
+//! render semaphore) and encoded by `ds-3dtiles`.
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -15,12 +20,17 @@ use axum::http::{header, HeaderMap, StatusCode};
 use axum::response::{IntoResponse, Json, Response};
 use chrono::{DateTime, Utc};
 use ds_core::config::CollectionConfig;
+use ds_core::geo::geodetic_to_ecef;
 use ds_core::volume::VolumeEngine;
 use ds_render::ColorMap;
 use serde::Deserialize;
 use serde_json::json;
 
 use crate::error::Tiles3dError;
+
+/// Default isosurface threshold (dBZ) when a request names none — a light-rain
+/// reflectivity shell.
+const ISOSURFACE_DEFAULT_THRESHOLD: f64 = 20.0;
 
 /// Shared state for the 3D Tiles API. Wrapped in `ArcSwap` for lock-free reads
 /// and atomic swap on config reload.
@@ -64,9 +74,15 @@ pub struct TilesetParams {
     pub quantity: Option<String>,
     /// Valid time (RFC 3339). `None` → latest.
     pub datetime: Option<String>,
-    /// Drop points below this physical value (e.g. a dBZ floor); carried into
-    /// the tileset's `content.uri` so the `.pnts` fetch applies it.
+    /// Which 3D Tiles representation: `points` (the `.pnts` point cloud,
+    /// default) or `isosurface` (a glTF `.glb` reflectivity-shell mesh).
+    pub representation: Option<String>,
+    /// `points` only: drop points below this physical value (e.g. a dBZ floor);
+    /// carried into the tileset's `content.uri` so the `.pnts` fetch applies it.
     pub min_value: Option<f64>,
+    /// `isosurface` only: the iso-value (e.g. dBZ) of the shell; carried into
+    /// the `.glb` `content.uri`. `None` → [`ISOSURFACE_DEFAULT_THRESHOLD`].
+    pub threshold: Option<f64>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -75,6 +91,35 @@ pub struct ContentParams {
     pub datetime: Option<String>,
     /// Drop points below this physical value (e.g. a dBZ floor).
     pub min_value: Option<f64>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct GlbContentParams {
+    pub quantity: Option<String>,
+    pub datetime: Option<String>,
+    /// Iso-value of the reflectivity shell. `None` → [`ISOSURFACE_DEFAULT_THRESHOLD`].
+    pub threshold: Option<f64>,
+}
+
+/// The two 3D Tiles representations of a volume. Both are valid OGC 3D Tiles
+/// tilesets; they differ only in content type (`.pnts` vs glTF `.glb`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Representation {
+    Points,
+    Isosurface,
+}
+
+impl Representation {
+    /// Parse the `representation` query value (`None`/empty → `Points`).
+    fn parse(s: Option<&str>) -> Result<Self, Tiles3dError> {
+        match s.map(str::trim) {
+            None | Some("") | Some("points") => Ok(Self::Points),
+            Some("isosurface") => Ok(Self::Isosurface),
+            Some(other) => Err(Tiles3dError::BadRequest(format!(
+                "unknown representation '{other}' (expected 'points' or 'isosurface')"
+            ))),
+        }
+    }
 }
 
 /// Percent-encode a query-string value (RFC 3986 unreserved set passes
@@ -114,8 +159,48 @@ fn etag_of(bytes: &[u8]) -> String {
     format!("\"{h:016x}\"")
 }
 
-/// The bundled CesiumJS viewer page (collection + quantity picker), baked into
-/// the binary and served at `GET /3dtiles/viewer`.
+/// Build a binary content response with strong-ETag conditional handling: a
+/// matching `If-None-Match` (or `*`) yields 304, otherwise 200 with the bytes.
+///
+/// Note the 304 saves the *network transfer* but not the recompute — the
+/// caller already sampled + encoded + hashed to obtain `etag` (the
+/// `If-None-Match` value can't be trusted to match without recomputing the
+/// content). A CPU-cheap 304 needs an ETag cache keyed by the request params +
+/// a data-version — a follow-up. RFC 7232 §3.2: `If-None-Match` may be `*` or a
+/// comma-separated list.
+fn binary_response(
+    headers: &HeaderMap,
+    content_type: &'static str,
+    etag: &str,
+    bytes: Vec<u8>,
+) -> Response {
+    let not_modified = headers
+        .get(header::IF_NONE_MATCH)
+        .and_then(|h| h.to_str().ok())
+        .is_some_and(|v| v == "*" || v.split(',').any(|t| t.trim() == etag));
+    if not_modified {
+        return (
+            StatusCode::NOT_MODIFIED,
+            [
+                (header::ETAG, etag),
+                (header::CACHE_CONTROL, "public, max-age=60"),
+            ],
+        )
+            .into_response();
+    }
+    (
+        [
+            (header::CONTENT_TYPE, content_type),
+            (header::ETAG, etag),
+            (header::CACHE_CONTROL, "public, max-age=60"),
+        ],
+        bytes,
+    )
+        .into_response()
+}
+
+/// The bundled CesiumJS viewer page (collection + quantity + representation
+/// picker), baked into the binary and served at `GET /3dtiles/viewer`.
 const VIEWER_HTML: &str = include_str!("../viewer/index.html");
 
 /// `GET /viewer` — interactive CesiumJS viewer. It calls this same API
@@ -137,6 +222,7 @@ pub async fn get_tileset(
     let state = state.load_full();
     let (engine, _config) = lookup(&state, &id)?;
     let info = engine.volume_info();
+    let representation = Representation::parse(params.representation.as_deref())?;
 
     // Resolve + validate the quantity against what the collection advertises.
     let quantity = match &params.quantity {
@@ -159,28 +245,59 @@ pub async fn get_tileset(
         Tiles3dError::NotFound(format!("collection '{id}' has no spatial coverage yet"))
     })?;
 
-    // The `.pnts` content lives next to this tileset; carry the resolved
-    // quantity (and pinned time, if any) so the content fetch is deterministic.
-    // Re-format the parsed time as UTC `…Z` — a raw `+hh:mm` offset would be
-    // decoded as a space by the client's URL parser and 400 on the fetch.
+    // Carry the resolved quantity (and pinned time, if any) into the content
+    // URI so the content fetch is deterministic. Re-format the parsed time as
+    // UTC `…Z` — a raw `+hh:mm` offset would be decoded as a space by the
+    // client's URL parser and 400 on the fetch.
     let mut query = format!("quantity={}", pct_encode(&quantity));
     if let Some(dt_str) = &params.datetime {
         let dt = parse_datetime(dt_str)?;
         query.push_str(&format!("&datetime={}", dt.format("%Y-%m-%dT%H:%M:%SZ")));
     }
-    if let Some(min) = params.min_value {
-        // `serde_urlencoded` parses "NaN"/"inf" as valid f64; a non-finite
-        // threshold filters every point → a silently-empty tile. Reject → 400.
-        if !min.is_finite() {
-            return Err(Tiles3dError::BadRequest("min_value must be finite".into()));
-        }
-        // f64 Display is URL-safe for a finite value (digits, `.`, `-`).
-        query.push_str(&format!("&min_value={min}"));
-    }
-    let content_uri = format!("content.pnts?{query}");
 
-    let tileset = ds_3dtiles::tileset_json_for_region(region, &content_uri)
-        .map_err(|e| Tiles3dError::Internal(format!("tileset build failed: {e}")))?;
+    let tileset = match representation {
+        Representation::Points => {
+            if let Some(min) = params.min_value {
+                // `serde_urlencoded` parses "NaN"/"inf" as a valid f64; a
+                // non-finite threshold filters every point → a silently-empty
+                // tile. Reject → 400. (f64 Display is URL-safe for a finite
+                // value: digits, `.`, `-`.)
+                if !min.is_finite() {
+                    return Err(Tiles3dError::BadRequest("min_value must be finite".into()));
+                }
+                query.push_str(&format!("&min_value={min}"));
+            }
+            let content_uri = format!("content.pnts?{query}");
+            ds_3dtiles::tileset_json_for_region(region, &content_uri)
+                .map_err(|e| Tiles3dError::Internal(format!("tileset build failed: {e}")))?
+        }
+        Representation::Isosurface => {
+            if !info.supports_voxel_grid {
+                return Err(Tiles3dError::BadRequest(format!(
+                    "collection '{id}' does not support the isosurface representation"
+                )));
+            }
+            // The glTF `.glb` content has no embedded origin (unlike `.pnts`
+            // `RTC_CENTER`), so the tileset places it via a `transform` = the
+            // volume origin (antenna) in ECEF — taken from `VolumeInfo` so we
+            // don't sample the grid just to emit the tileset.
+            let origin = info.origin.ok_or_else(|| {
+                Tiles3dError::Internal(format!(
+                    "collection '{id}' has no origin for the mesh transform"
+                ))
+            })?;
+            let rtc = geodetic_to_ecef(origin[0], origin[1], origin[2]);
+            if let Some(t) = params.threshold {
+                if !t.is_finite() {
+                    return Err(Tiles3dError::BadRequest("threshold must be finite".into()));
+                }
+                query.push_str(&format!("&threshold={t}"));
+            }
+            let content_uri = format!("content.glb?{query}");
+            ds_3dtiles::tileset_json_glb(region, &content_uri, rtc)
+                .map_err(|e| Tiles3dError::Internal(format!("tileset build failed: {e}")))?
+        }
+    };
 
     Ok((
         [
@@ -239,36 +356,87 @@ pub async fn get_content(
         .await
         .map_err(|e| Tiles3dError::Internal(format!("sample task failed: {e}")))??;
 
-    // A 304 here saves the *network transfer* but not the recompute: the
-    // sample + encode + hash already ran above (the `If-None-Match` value can't
-    // be trusted to match without recomputing the content). Making 304s
-    // CPU-cheap needs an ETag cache keyed by (collection, quantity, time,
-    // min_value) + a data-version (latest data changes on poll) — a follow-up.
-    // RFC 7232 §3.2: `If-None-Match` may be `*` or a comma-separated list.
-    let not_modified = headers
-        .get(header::IF_NONE_MATCH)
-        .and_then(|h| h.to_str().ok())
-        .is_some_and(|v| v == "*" || v.split(',').any(|t| t.trim() == etag));
-    if not_modified {
-        return Ok((
-            StatusCode::NOT_MODIFIED,
-            [
-                (header::ETAG, etag.as_str()),
-                (header::CACHE_CONTROL, "public, max-age=60"),
-            ],
-        )
-            .into_response());
+    Ok(binary_response(
+        &headers,
+        "application/octet-stream",
+        &etag,
+        bytes,
+    ))
+}
+
+// ---------------------------------------------------------------------------
+// Content (.glb isosurface)
+// ---------------------------------------------------------------------------
+
+/// `GET /collections/{id}/content.glb` — the isosurface reflectivity-shell mesh,
+/// resampled to a voxel grid and meshed (marching tetrahedra) on a blocking
+/// thread, then encoded as a glTF `.glb` by `ds-3dtiles`.
+pub async fn get_content_glb(
+    headers: HeaderMap,
+    Path(id): Path<String>,
+    Query(params): Query<GlbContentParams>,
+    State(state): State<AppState>,
+) -> Result<Response, Tiles3dError> {
+    let state = state.load_full();
+    let (engine, _config) = lookup(&state, &id)?;
+    // Reject early if the engine can't produce a voxel grid (avoids a blocking
+    // task just to return the trait's "unsupported" → 404).
+    if !engine.volume_info().supports_voxel_grid {
+        return Err(Tiles3dError::BadRequest(format!(
+            "collection '{id}' does not support the isosurface representation"
+        )));
     }
 
-    Ok((
-        [
-            (header::CONTENT_TYPE, "application/octet-stream"),
-            (header::ETAG, etag.as_str()),
-            (header::CACHE_CONTROL, "public, max-age=60"),
-        ],
-        bytes,
-    )
-        .into_response())
+    let time = params.datetime.as_deref().map(parse_datetime).transpose()?;
+    let quantity = params.quantity.clone();
+    let threshold = params.threshold.unwrap_or(ISOSURFACE_DEFAULT_THRESHOLD);
+    if !threshold.is_finite() {
+        return Err(Tiles3dError::BadRequest("threshold must be finite".into()));
+    }
+
+    // Colour the shell at the threshold; seal NaN (clear air / unmeasured) at
+    // the colormap's floor so the surface closes into solid blobs. The floor
+    // must be < threshold (clamp defensively against an odd colormap domain).
+    let color = state.colormap.color(Some(threshold));
+    let floor = state
+        .colormap
+        .domain()
+        .map(|(lo, _)| lo)
+        .unwrap_or(threshold - 64.0)
+        .min(threshold - 1.0);
+
+    // read_voxel_grid does blocking HDF5 I/O + a long CPU loop (marching tet),
+    // so bound it with the shared render semaphore and run on a blocking thread
+    // (same rule as the `.pnts` path / the raster `get_raster_tile`).
+    let _permit = state
+        .render_semaphore
+        .clone()
+        .acquire_owned()
+        .await
+        .map_err(|_| Tiles3dError::Internal("render semaphore closed".into()))?;
+
+    let engine = engine.clone();
+    let id_for_err = id.clone();
+    let (bytes, etag) =
+        tokio::task::spawn_blocking(move || -> Result<(Vec<u8>, String), Tiles3dError> {
+            let grid = engine.read_voxel_grid(quantity.as_deref(), time, None, None)?;
+            let bytes = ds_3dtiles::encode_isosurface_glb(&grid, threshold, color, Some(floor))
+                .map_err(|e| match e {
+                    // An empty surface (threshold above all echo) is "no data
+                    // here", not a server fault — 404, matching the no-data path.
+                    ds_3dtiles::Tiles3dError::Empty => Tiles3dError::NotFound(format!(
+                        "no isosurface at threshold {threshold} for collection '{id_for_err}'"
+                    )),
+                    other => Tiles3dError::Internal(format!("isosurface encode failed: {other}")),
+                })?;
+            let etag = etag_of(&bytes);
+            Ok((bytes, etag))
+        })
+        .await
+        .map_err(|e| Tiles3dError::Internal(format!("sample task failed: {e}")))??;
+
+    // glTF binary media type (CesiumJS also keys off the `.glb` magic).
+    Ok(binary_response(&headers, "model/gltf-binary", &etag, bytes))
 }
 
 // ---------------------------------------------------------------------------
@@ -330,14 +498,22 @@ fn collection_doc(state: &TilesState3d, id: &str, base: &str) -> serde_json::Val
                 .collect()
         })
         .unwrap_or_default();
+    // Every volume collection serves a point cloud; those whose engine can also
+    // produce a voxel grid additionally serve an isosurface mesh. The viewer
+    // reads this to populate its representation toggle.
+    let mut representations = vec!["points"];
+    if info.as_ref().is_some_and(|i| i.supports_voxel_grid) {
+        representations.push("isosurface");
+    }
     json!({
         "id": id,
         "title": title,
         "description": description,
         "quantities": quantities,
+        "representations": representations,
         "links": [
             { "href": format!("{base}/3dtiles/collections/{id}"), "rel": "self", "type": "application/json", "title": "This document" },
-            { "href": format!("{base}/3dtiles/collections/{id}/tileset.json"), "rel": "3dtiles", "type": "application/json", "title": "3D Tiles tileset" },
+            { "href": format!("{base}/3dtiles/collections/{id}/tileset.json"), "rel": "3dtiles", "type": "application/json", "title": "3D Tiles tileset (point cloud)" },
         ]
     })
 }

--- a/crates/api-3dtiles/src/handlers.rs
+++ b/crates/api-3dtiles/src/handlers.rs
@@ -379,12 +379,23 @@ pub async fn get_content_glb(
 ) -> Result<Response, Tiles3dError> {
     let state = state.load_full();
     let (engine, _config) = lookup(&state, &id)?;
+    let info = engine.volume_info();
     // Reject early if the engine can't produce a voxel grid (avoids a blocking
     // task just to return the trait's "unsupported" → 404).
-    if !engine.volume_info().supports_voxel_grid {
+    if !info.supports_voxel_grid {
         return Err(Tiles3dError::BadRequest(format!(
             "collection '{id}' does not support the isosurface representation"
         )));
+    }
+    // Validate the quantity against the advertised set *before* the blocking
+    // task, like the `.pnts` handler — an unknown name shouldn't trigger a full
+    // `read_voxel_grid` (HDF5 open + polar scan) just to be rejected.
+    if let Some(q) = &params.quantity {
+        if !info.quantities.iter().any(|(qid, _)| qid == q) {
+            return Err(Tiles3dError::BadRequest(format!(
+                "unknown quantity '{q}' for collection '{id}'"
+            )));
+        }
     }
 
     let time = params.datetime.as_deref().map(parse_datetime).transpose()?;

--- a/crates/api-3dtiles/src/lib.rs
+++ b/crates/api-3dtiles/src/lib.rs
@@ -7,9 +7,10 @@
 //! the engine registry is keyed by collection id and swapped via `ArcSwap`.
 //!
 //! Routes (mounted under `/3dtiles` by the server):
-//! - `GET /collections/{id}/tileset.json`
-//! - `GET /collections/{id}/content.pnts`
-//! - `GET /` · `/collections` · `/collections/{id}`
+//! - `GET /collections/{id}/tileset.json` (`?representation=points|isosurface`)
+//! - `GET /collections/{id}/content.pnts` — point-cloud content
+//! - `GET /collections/{id}/content.glb` — isosurface-mesh content
+//! - `GET /` · `/collections` · `/collections/{id}` · `/viewer`
 
 pub mod error;
 pub mod handlers;
@@ -29,5 +30,9 @@ pub fn router(state: AppState) -> Router {
         .route("/collections/{id}", get(handlers::collection))
         .route("/collections/{id}/tileset.json", get(handlers::get_tileset))
         .route("/collections/{id}/content.pnts", get(handlers::get_content))
+        .route(
+            "/collections/{id}/content.glb",
+            get(handlers::get_content_glb),
+        )
         .with_state(state)
 }

--- a/crates/api-3dtiles/tests/integration.rs
+++ b/crates/api-3dtiles/tests/integration.rs
@@ -108,6 +108,45 @@ impl VolumeEngine for MockVolume {
     }
 }
 
+/// A volume engine that serves a point cloud but NOT a voxel grid (uses the
+/// default `read_voxel_grid` → unsupported), like a non-PVOL volume source.
+struct MockNoVoxel;
+
+impl VolumeEngine for MockNoVoxel {
+    fn read_point_cloud(
+        &self,
+        _quantity: Option<&str>,
+        _time: Option<chrono::DateTime<chrono::Utc>>,
+        _min_value: Option<f64>,
+        _reference_time: Option<chrono::DateTime<chrono::Utc>>,
+    ) -> Result<VolumePointCloud, DataServerError> {
+        Ok(VolumePointCloud {
+            rtc_center: [3_000_000.0, 1_000_000.0, 5_000_000.0],
+            region: [0.42, 1.05, 0.44, 1.07, 100.0, 12_000.0],
+            points: vec![VolumePoint {
+                offset: [0.0, 0.0, 0.0],
+                value: 10.0,
+            }],
+            quantity: "DBZH".into(),
+            unit: "dBZ".into(),
+        })
+    }
+
+    // read_voxel_grid uses the trait default (unsupported).
+
+    fn volume_info(&self) -> Arc<VolumeInfo> {
+        Arc::new(VolumeInfo {
+            quantities: vec![("DBZH".into(), "Reflectivity".into())],
+            times: vec![],
+            default_quantity: "DBZH".into(),
+            default_unit: "dBZ".into(),
+            region: Some([0.42, 1.05, 0.44, 1.07, 100.0, 25_000.0]),
+            supports_voxel_grid: false,
+            origin: None,
+        })
+    }
+}
+
 fn collection_config(id: &str) -> CollectionConfig {
     // Build via TOML so this test doesn't depend on every CollectionConfig field.
     toml::from_str(&format!(
@@ -349,6 +388,66 @@ async fn collections_list_and_doc() {
             .any(|h| h.contains("tileset.json?representation=isosurface")),
         "isosurface tileset link present: {hrefs:?}"
     );
+}
+
+#[tokio::test]
+async fn isosurface_on_unsupported_collection_is_400() {
+    // A collection whose engine can't voxel-grid advertises only `points` and
+    // rejects isosurface requests at both the tileset and content routes.
+    let engine: Arc<dyn VolumeEngine> = Arc::new(MockNoVoxel);
+    let mut volume_engines = HashMap::new();
+    volume_engines.insert("radar-novox".to_string(), engine);
+    let mut collections = HashMap::new();
+    collections.insert("radar-novox".to_string(), collection_config("radar-novox"));
+    let state = Arc::new(ArcSwap::from_pointee(TilesState3d {
+        volume_engines,
+        collections,
+        colormap: Arc::new(LutColorMap::from_builtin(
+            BuiltinColormap::RadarDbz,
+            -32.0,
+            95.0,
+        )),
+        render_semaphore: Arc::new(tokio::sync::Semaphore::new(4)),
+        base_url: String::new(),
+    }));
+    let app = api_3dtiles::router(state);
+
+    let send = |uri: &str| {
+        let app = app.clone();
+        let uri = uri.to_string();
+        async move {
+            app.oneshot(Request::builder().uri(uri).body(Body::empty()).unwrap())
+                .await
+                .unwrap()
+        }
+    };
+
+    assert_eq!(
+        send("/collections/radar-novox/tileset.json?representation=isosurface")
+            .await
+            .status(),
+        StatusCode::BAD_REQUEST
+    );
+    assert_eq!(
+        send("/collections/radar-novox/content.glb").await.status(),
+        StatusCode::BAD_REQUEST
+    );
+    // The point-cloud representation still works.
+    assert_eq!(
+        send("/collections/radar-novox/tileset.json").await.status(),
+        StatusCode::OK
+    );
+    // Collection doc advertises only `points`.
+    let resp = send("/collections/radar-novox").await;
+    let body = resp.into_body().collect().await.unwrap().to_bytes();
+    let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let reps: Vec<&str> = v["representations"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|r| r.as_str().unwrap())
+        .collect();
+    assert_eq!(reps, vec!["points"]);
 }
 
 #[tokio::test]

--- a/crates/api-3dtiles/tests/integration.rs
+++ b/crates/api-3dtiles/tests/integration.rs
@@ -332,6 +332,23 @@ async fn collections_list_and_doc() {
         .map(|r| r.as_str().unwrap())
         .collect();
     assert_eq!(reps, vec!["points", "isosurface"]);
+    // …and a link-following client can discover the isosurface tileset too.
+    let hrefs: Vec<&str> = v["links"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter_map(|l| l["href"].as_str())
+        .collect();
+    assert!(
+        hrefs.iter().any(|h| h.ends_with("/tileset.json")),
+        "point-cloud tileset link present: {hrefs:?}"
+    );
+    assert!(
+        hrefs
+            .iter()
+            .any(|h| h.contains("tileset.json?representation=isosurface")),
+        "isosurface tileset link present: {hrefs:?}"
+    );
 }
 
 #[tokio::test]

--- a/crates/api-3dtiles/tests/integration.rs
+++ b/crates/api-3dtiles/tests/integration.rs
@@ -12,7 +12,9 @@ use tower::ServiceExt;
 use api_3dtiles::TilesState3d;
 use ds_core::config::CollectionConfig;
 use ds_core::error::DataServerError;
-use ds_core::volume::{VolumeEngine, VolumeInfo, VolumePoint, VolumePointCloud, VoxelGrid};
+use ds_core::volume::{
+    VolumeEngine, VolumeInfo, VolumePoint, VolumePointCloud, VoxelGrid, VoxelGridCaps,
+};
 use ds_render::{BuiltinColormap, LutColorMap};
 
 /// Mock engine: a tiny fixed cloud, one quantity (`DBZH`), a coverage region.
@@ -102,8 +104,9 @@ impl VolumeEngine for MockVolume {
             default_quantity: "DBZH".into(),
             default_unit: "dBZ".into(),
             region: Some([0.42, 1.05, 0.44, 1.07, 100.0, 25_000.0]),
-            supports_voxel_grid: true,
-            origin: Some([24.5, 60.5, 100.0]),
+            voxel_grid: Some(VoxelGridCaps {
+                origin: [24.5, 60.5, 100.0],
+            }),
         })
     }
 }
@@ -141,8 +144,7 @@ impl VolumeEngine for MockNoVoxel {
             default_quantity: "DBZH".into(),
             default_unit: "dBZ".into(),
             region: Some([0.42, 1.05, 0.44, 1.07, 100.0, 25_000.0]),
-            supports_voxel_grid: false,
-            origin: None,
+            voxel_grid: None,
         })
     }
 }

--- a/crates/api-3dtiles/tests/integration.rs
+++ b/crates/api-3dtiles/tests/integration.rs
@@ -12,7 +12,7 @@ use tower::ServiceExt;
 use api_3dtiles::TilesState3d;
 use ds_core::config::CollectionConfig;
 use ds_core::error::DataServerError;
-use ds_core::volume::{VolumeEngine, VolumeInfo, VolumePoint, VolumePointCloud};
+use ds_core::volume::{VolumeEngine, VolumeInfo, VolumePoint, VolumePointCloud, VoxelGrid};
 use ds_render::{BuiltinColormap, LutColorMap};
 
 /// Mock engine: a tiny fixed cloud, one quantity (`DBZH`), a coverage region.
@@ -57,8 +57,43 @@ impl VolumeEngine for MockVolume {
         })
     }
 
-    // read_voxel_grid uses the trait default (unsupported) — the API has no
-    // voxel route yet, so the mock doesn't need it.
+    fn read_voxel_grid(
+        &self,
+        quantity: Option<&str>,
+        _time: Option<chrono::DateTime<chrono::Utc>>,
+        dims: Option<[usize; 3]>,
+        _reference_time: Option<chrono::DateTime<chrono::Utc>>,
+    ) -> Result<VoxelGrid, DataServerError> {
+        if let Some(q) = quantity {
+            if q != "DBZH" {
+                return Err(DataServerError::InvalidParameter(format!("unknown {q}")));
+            }
+        }
+        let dims = dims.unwrap_or([4, 8, 4]);
+        let [n_r, n_a, n_h] = dims;
+        let mut values = vec![f32::NAN; n_r * n_a * n_h];
+        // A finite >threshold echo core (surrounded by NaN) so a sealed
+        // isosurface at the default 20 dBZ produces a non-empty mesh.
+        for i_r in 1..n_r.min(3) {
+            for i_a in 0..n_a {
+                for i_h in 1..n_h.min(3) {
+                    values[VoxelGrid::index_of(dims, i_r, i_a, i_h)] = 40.0;
+                }
+            }
+        }
+        Ok(VoxelGrid {
+            origin_lon: 24.5,
+            origin_lat: 60.5,
+            origin_height: 100.0,
+            dims,
+            radius_range: [0.0, 100_000.0],
+            angle_range: [0.0, std::f64::consts::TAU],
+            height_range: [0.0, 10_000.0],
+            values,
+            quantity: "DBZH".into(),
+            unit: "dBZ".into(),
+        })
+    }
 
     fn volume_info(&self) -> Arc<VolumeInfo> {
         Arc::new(VolumeInfo {
@@ -67,6 +102,8 @@ impl VolumeEngine for MockVolume {
             default_quantity: "DBZH".into(),
             default_unit: "dBZ".into(),
             region: Some([0.42, 1.05, 0.44, 1.07, 100.0, 25_000.0]),
+            supports_voxel_grid: true,
+            origin: Some([24.5, 60.5, 100.0]),
         })
     }
 }
@@ -287,4 +324,83 @@ async fn collections_list_and_doc() {
     assert_eq!(status, StatusCode::OK);
     let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
     assert_eq!(v["quantities"][0]["id"], "DBZH");
+    // The mock supports voxel grids, so both representations are advertised.
+    let reps: Vec<&str> = v["representations"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|r| r.as_str().unwrap())
+        .collect();
+    assert_eq!(reps, vec!["points", "isosurface"]);
+}
+
+#[tokio::test]
+async fn isosurface_tileset_has_transform_and_glb_content() {
+    let (status, body, _h) =
+        get("/collections/radar-fivih/tileset.json?representation=isosurface&quantity=DBZH&threshold=20")
+            .await;
+    assert_eq!(status, StatusCode::OK);
+    let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert!(v["geometricError"].as_f64().unwrap() > 0.0);
+    // glTF content needs the antenna-ECEF tile transform (16-element matrix).
+    let t = v["root"]["transform"].as_array().unwrap();
+    assert_eq!(t.len(), 16);
+    // Content points at the .glb, carrying the resolved quantity + threshold.
+    let uri = v["root"]["content"]["uri"].as_str().unwrap();
+    assert_eq!(uri, "content.glb?quantity=DBZH&threshold=20");
+    // The region bounding volume is still present (unaffected by the transform).
+    assert_eq!(
+        v["root"]["boundingVolume"]["region"]
+            .as_array()
+            .unwrap()
+            .len(),
+        6
+    );
+}
+
+#[tokio::test]
+async fn content_glb_is_valid_gltf_and_etagged() {
+    let (status, body, headers) =
+        get("/collections/radar-fivih/content.glb?quantity=DBZH&threshold=20").await;
+    assert_eq!(status, StatusCode::OK);
+    // glTF binary magic "glTF" + version 2.
+    assert_eq!(&body[0..4], b"glTF", "glb magic");
+    assert_eq!(
+        u32::from_le_bytes(body[4..8].try_into().unwrap()),
+        2,
+        "glTF version"
+    );
+    assert_eq!(
+        u32::from_le_bytes(body[8..12].try_into().unwrap()) as usize,
+        body.len(),
+        "header length == actual length"
+    );
+    assert_eq!(
+        headers[axum::http::header::CONTENT_TYPE],
+        "model/gltf-binary"
+    );
+    assert!(headers.contains_key(axum::http::header::ETAG));
+}
+
+#[tokio::test]
+async fn unknown_representation_is_400() {
+    let (status, _b, _h) =
+        get("/collections/radar-fivih/tileset.json?representation=hologram").await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn non_finite_threshold_is_400() {
+    for v in ["NaN", "inf"] {
+        let (ts, _b, _h) = get(&format!(
+            "/collections/radar-fivih/tileset.json?representation=isosurface&threshold={v}"
+        ))
+        .await;
+        assert_eq!(ts, StatusCode::BAD_REQUEST, "tileset rejects threshold={v}");
+        let (cs, _b, _h) = get(&format!(
+            "/collections/radar-fivih/content.glb?threshold={v}"
+        ))
+        .await;
+        assert_eq!(cs, StatusCode::BAD_REQUEST, "content rejects threshold={v}");
+    }
 }

--- a/crates/api-3dtiles/viewer/index.html
+++ b/crates/api-3dtiles/viewer/index.html
@@ -45,7 +45,8 @@
   <div class="brand">MeteoCore <span>· 3D Tiles</span></div>
   <div class="field"><label for="coll">Collection</label><select id="coll"></select></div>
   <div class="field"><label for="qty">Quantity</label><select id="qty"></select></div>
-  <div class="field"><label for="min">min value</label><input id="min" type="number" value="5" step="1"></div>
+  <div class="field"><label for="rep">View</label><select id="rep"></select></div>
+  <div class="field"><label id="numLabel" for="num">min dBZ</label><input id="num" type="number" value="5" step="1"></div>
   <div id="status"></div>
 </div>
 <div id="cesium"></div>
@@ -81,9 +82,19 @@ const BASE = override || sameOrigin || "https://meteocore.app.meteo.fi/3dtiles";
 
 const $coll = document.getElementById("coll");
 const $qty = document.getElementById("qty");
-const $min = document.getElementById("min");
+const $rep = document.getElementById("rep");
+const $num = document.getElementById("num");
+const $numLabel = document.getElementById("numLabel");
 const $status = document.getElementById("status");
 const setStatus = (msg, err) => { $status.textContent = msg; $status.className = err ? "err" : ""; };
+
+// Each representation's label for the numeric field + its default value:
+// point clouds drop echoes below `min_value`; isosurfaces draw the shell AT
+// `threshold`. Both are a dBZ number, so one input serves both, relabelled.
+const REP_META = {
+  points:     { label: "Point cloud", numLabel: "min dBZ",       numDefault: "5"  },
+  isosurface: { label: "Isosurface",  numLabel: "threshold dBZ", numDefault: "20" },
+};
 
 // Token-free CesiumJS: CARTO Dark Matter basemap, no Cesium Ion.
 const viewer = new Cesium.Viewer("cesium", {
@@ -113,13 +124,13 @@ async function loadCollections() {
       $coll.appendChild(o);
     }
     if (!cols.length) { setStatus("no 3D-Tiles collections at " + BASE, true); return; }
-    await loadQuantities();
+    await loadCollectionMeta();
   } catch (e) {
     setStatus("can't reach " + BASE + " — " + e, true);
   }
 }
 
-async function loadQuantities() {
+async function loadCollectionMeta() {
   const id = $coll.value;
   if (!id) return;
   try {
@@ -136,18 +147,35 @@ async function loadQuantities() {
       const i = [...$qty.options].findIndex(o => o.value === pref);
       if (i >= 0) { $qty.selectedIndex = i; break; }
     }
+    // Representations the collection actually serves (always at least points).
+    const reps = (data.representations && data.representations.length) ? data.representations : ["points"];
+    $rep.innerHTML = "";
+    for (const r of reps) {
+      const o = document.createElement("option");
+      o.value = r; o.textContent = (REP_META[r] && REP_META[r].label) || r;
+      $rep.appendChild(o);
+    }
+    syncNumField();
     await loadTileset();
   } catch (e) {
-    setStatus("error loading quantities — " + e, true);
+    setStatus("error loading collection — " + e, true);
   }
+}
+
+// Relabel + default the numeric field for the active representation.
+function syncNumField() {
+  const meta = REP_META[$rep.value] || REP_META.points;
+  $numLabel.textContent = meta.numLabel;
+  $num.value = meta.numDefault;
 }
 
 async function loadTileset() {
   const id = $coll.value, q = $qty.value;
-  const min = $min.value.trim();
+  const rep = $rep.value || "points";
+  const num = $num.value.trim();
   if (!id || !q) return;
   const token = ++loadToken;
-  setStatus(`loading ${id} · ${q}…`);
+  setStatus(`loading ${id} · ${q} · ${rep}…`);
   // `scene.primitives` has destroyPrimitives:true (default), so remove() also
   // destroys the old tileset and frees its GPU buffers — no explicit destroy()
   // (that would double-destroy and throw). The superseded-load path below DOES
@@ -155,25 +183,33 @@ async function loadTileset() {
   if (current) { viewer.scene.primitives.remove(current); current = null; }
 
   let url = `${BASE}/collections/${encodeURIComponent(id)}/tileset.json?quantity=${encodeURIComponent(q)}`;
-  if (min !== "") url += `&min_value=${encodeURIComponent(min)}`;
+  if (rep === "isosurface") {
+    url += `&representation=isosurface`;
+    if (num !== "") url += `&threshold=${encodeURIComponent(num)}`;
+  } else if (num !== "") {
+    url += `&min_value=${encodeURIComponent(num)}`;
+  }
   try {
     const ts = await Cesium.Cesium3DTileset.fromUrl(url, { maximumScreenSpaceError: 1 });
     if (token !== loadToken) { ts.destroy(); return; } // superseded — free its GPU buffers
     current = ts;
     viewer.scene.primitives.add(ts);
-    ts.style = new Cesium.Cesium3DTileStyle({ pointSize: 5.0 });
+    // pointSize styling only applies to the .pnts point cloud; a mesh ignores it.
+    if (rep === "points") ts.style = new Cesium.Cesium3DTileStyle({ pointSize: 5.0 });
     await viewer.zoomTo(ts, new Cesium.HeadingPitchRange(
       Cesium.Math.toRadians(210), Cesium.Math.toRadians(-28), 300000));
-    setStatus(`${id} · ${q}`);
+    setStatus(`${id} · ${q} · ${rep}`);
   } catch (e) {
     if (token === loadToken) setStatus("no data for this selection", true);
     console.error(e);
   }
 }
 
-$coll.addEventListener("change", loadQuantities);
+$coll.addEventListener("change", loadCollectionMeta);
 $qty.addEventListener("change", loadTileset);
-$min.addEventListener("change", loadTileset);
+// Switching representation relabels + re-defaults the numeric field, then reloads.
+$rep.addEventListener("change", () => { syncNumField(); loadTileset(); });
+$num.addEventListener("change", loadTileset);
 loadCollections();
 </script>
 </body>

--- a/crates/core/src/geo.rs
+++ b/crates/core/src/geo.rs
@@ -23,6 +23,42 @@ pub fn geodetic_to_ecef(lon_deg: f64, lat_deg: f64, h: f64) -> [f64; 3] {
     ]
 }
 
+/// Mean Earth radius (metres) for spherical great-circle math — the value the
+/// radar beam model uses, so geometry derived here aligns with the volume
+/// engines (e.g. the cylindrical voxel grid → isosurface mapping).
+pub const EARTH_RADIUS_M: f64 = 6_371_000.0;
+
+/// Great-circle **destination point** on a sphere: starting at
+/// (`lon_deg`, `lat_deg`), travel `distance_m` along the initial compass
+/// `bearing_deg` (0° = north, increasing clockwise). Returns
+/// `(lon_deg, lat_deg)`, with longitude normalised into `(−180, 180]`.
+///
+/// Shared geodesy so every consumer that turns a (range, azimuth) polar sample
+/// into geographic coordinates — the radar volume engines, the 3D Tiles
+/// isosurface encoder — uses one formula (and the same [`EARTH_RADIUS_M`]).
+pub fn destination_point(
+    lon_deg: f64,
+    lat_deg: f64,
+    distance_m: f64,
+    bearing_deg: f64,
+) -> (f64, f64) {
+    let ang = distance_m / EARTH_RADIUS_M;
+    let lat0 = lat_deg.to_radians();
+    let lon0 = lon_deg.to_radians();
+    let brg = bearing_deg.to_radians();
+    let (sin_ang, cos_ang) = ang.sin_cos();
+    let (sin_lat0, cos_lat0) = lat0.sin_cos();
+    let sin_lat = sin_lat0 * cos_ang + cos_lat0 * sin_ang * brg.cos();
+    let lat = sin_lat.asin();
+    let y = brg.sin() * sin_ang * cos_lat0;
+    let x = cos_ang - sin_lat0 * sin_lat;
+    // Normalise longitude into (−180, 180]: a path starting near ±180° can
+    // otherwise return a lon outside that range.
+    let lon = (lon0 + y.atan2(x)).to_degrees();
+    let lon = (lon + 540.0).rem_euclid(360.0) - 180.0;
+    (lon, lat.to_degrees())
+}
+
 /// Coordinate reference system.
 ///
 /// Stores projection parameters and provides forward/inverse transforms
@@ -1256,6 +1292,31 @@ mod tests {
         for code in ["CRS:84", "EPSG:4326", "EPSG:3857", "EPSG:9999", ""] {
             assert!(projected_output_crs(code).is_none(), "{code} must be None");
         }
+    }
+
+    #[test]
+    fn destination_point_matches_analytic_references() {
+        // Pin against exact analytic cases (not a self-roundtrip): on a sphere,
+        // a meridian/equator path has a closed form independent of this code.
+        let ten_deg = EARTH_RADIUS_M * (10.0_f64).to_radians();
+        // Due north from the prime-meridian origin → straight up the meridian:
+        // lon unchanged, lat = arc angle.
+        let (lon, lat) = destination_point(0.0, 0.0, ten_deg, 0.0);
+        assert!(lon.abs() < 1e-9, "north keeps lon 0, got {lon}");
+        assert!(
+            (lat - 10.0).abs() < 1e-9,
+            "north 10° arc → lat 10, got {lat}"
+        );
+        // Due east along the equator → lat stays 0, lon = arc angle.
+        let (lon, lat) = destination_point(0.0, 0.0, ten_deg, 90.0);
+        assert!(lat.abs() < 1e-9, "east on equator keeps lat 0, got {lat}");
+        assert!(
+            (lon - 10.0).abs() < 1e-9,
+            "east 10° arc → lon 10, got {lon}"
+        );
+        // Eastbound across the antimeridian wraps into (−180, 180]: 179 + 10 → −171.
+        let (lon, _lat) = destination_point(179.0, 0.0, ten_deg, 90.0);
+        assert!((lon - (-171.0)).abs() < 1e-9, "wrapped past +180 → {lon}");
     }
 
     #[test]

--- a/crates/core/src/volume.rs
+++ b/crates/core/src/volume.rs
@@ -69,6 +69,18 @@ pub struct VolumeInfo {
     /// bounding volume without sampling the full volume. `None` if the
     /// collection has no known spatial extent yet.
     pub region: Option<[f64; 6]>,
+    /// Whether this engine can also produce a [`VoxelGrid`] (via
+    /// [`VolumeEngine::read_voxel_grid`]) — i.e. whether an **isosurface**
+    /// 3D Tiles representation is available alongside the `.pnts` point cloud.
+    /// `false` for engines that use the default (unsupported) `read_voxel_grid`,
+    /// so the API can advertise the right representations per collection.
+    pub supports_voxel_grid: bool,
+    /// WGS84 `[lon_deg, lat_deg, height_m]` of the volume origin (the radar
+    /// antenna) — the point all isosurface-mesh positions are stored relative
+    /// to. Lets the 3D Tiles layer build the glTF tile `transform` (antenna
+    /// ECEF) **without** sampling the grid. `None` if unknown / not a single
+    /// fixed origin.
+    pub origin: Option<[f64; 3]>,
 }
 
 /// A regular **cylindrical voxel grid** sampled from a volume — the structured

--- a/crates/core/src/volume.rs
+++ b/crates/core/src/volume.rs
@@ -69,18 +69,24 @@ pub struct VolumeInfo {
     /// bounding volume without sampling the full volume. `None` if the
     /// collection has no known spatial extent yet.
     pub region: Option<[f64; 6]>,
-    /// Whether this engine can also produce a [`VoxelGrid`] (via
-    /// [`VolumeEngine::read_voxel_grid`]) — i.e. whether an **isosurface**
-    /// 3D Tiles representation is available alongside the `.pnts` point cloud.
-    /// `false` for engines that use the default (unsupported) `read_voxel_grid`,
-    /// so the API can advertise the right representations per collection.
-    pub supports_voxel_grid: bool,
+    /// Voxel-grid capability **and** the metadata it requires, coupled in one
+    /// `Option` so "supports but no origin" is unrepresentable. `Some` ⇒ the
+    /// engine implements [`VoxelGrid`] sampling (via
+    /// [`VolumeEngine::read_voxel_grid`]), so the **isosurface** 3D Tiles
+    /// representation is available alongside the `.pnts` point cloud; `None` ⇒
+    /// point-cloud only (the default `read_voxel_grid` is unsupported).
+    pub voxel_grid: Option<VoxelGridCaps>,
+}
+
+/// Voxel-grid capability metadata for a [`VolumeInfo`] — present iff the engine
+/// can produce a [`VoxelGrid`] (and thus an isosurface mesh).
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct VoxelGridCaps {
     /// WGS84 `[lon_deg, lat_deg, height_m]` of the volume origin (the radar
     /// antenna) — the point all isosurface-mesh positions are stored relative
     /// to. Lets the 3D Tiles layer build the glTF tile `transform` (antenna
-    /// ECEF) **without** sampling the grid. `None` if unknown / not a single
-    /// fixed origin.
-    pub origin: Option<[f64; 3]>,
+    /// ECEF) **without** sampling the grid.
+    pub origin: [f64; 3],
 }
 
 /// A regular **cylindrical voxel grid** sampled from a volume — the structured

--- a/crates/ds-3dtiles/src/isosurface.rs
+++ b/crates/ds-3dtiles/src/isosurface.rs
@@ -193,7 +193,8 @@ fn crossing(
 ) -> [f32; 3] {
     let (va, vb) = (cvals[a], cvals[b]);
     // One end is inside (>= threshold), the other outside (< threshold), so
-    // va != vb and t ∈ [0, 1).
+    // va != vb and t ∈ [0, 1] (t = 1 only when threshold == vb exactly, placing
+    // the vertex on corner b — geometrically valid).
     let t = ((threshold - va) / (vb - va)).clamp(0.0, 1.0);
     let fr = cidx[a][0] + t * (cidx[b][0] - cidx[a][0]);
     let fa = cidx[a][1] + t * (cidx[b][1] - cidx[a][1]);
@@ -216,14 +217,19 @@ fn march_tet(
     if tet.iter().any(|&c| !cvals[c].is_finite()) {
         return Ok(());
     }
-    // Local tet indices (0..4) split into inside / outside.
-    let mut inside = Vec::with_capacity(4);
-    let mut outside = Vec::with_capacity(4);
+    // Local tet indices (0..4) split into inside / outside. Fixed-size arrays +
+    // length counters, not `Vec`s — `march_tet` runs millions of times per
+    // encode (≈ cubes × 6), so a per-call heap allocation would dominate.
+    let mut inside = [0usize; 4];
+    let mut outside = [0usize; 4];
+    let (mut ni, mut no) = (0usize, 0usize);
     for (k, &c) in tet.iter().enumerate() {
         if cvals[c] >= threshold {
-            inside.push(k);
+            inside[ni] = k;
+            ni += 1;
         } else {
-            outside.push(k);
+            outside[no] = k;
+            no += 1;
         }
     }
     let cross = |a_local: usize, b_local: usize| {
@@ -237,12 +243,17 @@ fn march_tet(
             tet[b_local],
         )
     };
-    match (inside.len(), outside.len()) {
+    // Triangle winding is NOT consistently oriented across these cases (the
+    // (1,3)/(3,1) split flips the normal vs the odd corner's side, and the
+    // (2,2) quad's order isn't sign-checked either) — `build_glb` sets the
+    // material `doubleSided: true` to compensate, which is load-bearing. Fine
+    // for visualisation; a future solid-geometry use would need oriented faces.
+    match (ni, no) {
         (0, _) | (_, 0) => Ok(()), // tet fully inside or outside — no surface
         (1, 3) | (3, 1) => {
             // One odd corner vs three: the surface is the triangle on the three
             // edges from the odd corner to the others.
-            let (odd, rest) = if inside.len() == 1 {
+            let (odd, rest) = if ni == 1 {
                 (inside[0], &outside)
             } else {
                 (outside[0], &inside)
@@ -310,11 +321,18 @@ pub fn encode_isosurface_glb(
     if !threshold.is_finite() {
         return Err(Tiles3dError::NonFinite("threshold"));
     }
-    // A `Some` background must be finite, else it would behave like `None`
-    // (a NaN fill leaves the corner non-finite → tet skipped) — confusingly.
+    // A `Some` background must be finite (else it acts like `None` — a NaN fill
+    // leaves the corner non-finite → tet skipped) AND strictly below `threshold`
+    // (else unmeasured cells would seal as *inside* the surface, inverting it).
     if let Some(bg) = background {
         if !bg.is_finite() {
             return Err(Tiles3dError::NonFinite("background"));
+        }
+        if bg >= threshold {
+            return Err(Tiles3dError::BackgroundNotBelowThreshold {
+                background: bg,
+                threshold,
+            });
         }
     }
     // `NaN` corners map to this: the finite background (seal) or `NaN` (skip).
@@ -456,14 +474,13 @@ pub fn tileset_json_glb(
     content_uri: &str,
     rtc_center: [f64; 3],
 ) -> Result<String, Tiles3dError> {
-    // Reuse the shared content-URI + region validation by building the base
-    // tileset, then injecting the transform (the only glTF-specific addition).
-    let base = crate::tileset_json_for_region(region, content_uri)?;
+    // Reuse the shared content-URI + region validation, building on the tileset
+    // `Value` directly (no serialize-then-reparse) and injecting the transform
+    // (the only glTF-specific addition).
     if rtc_center.iter().any(|c| !c.is_finite()) {
         return Err(Tiles3dError::NonFinite("rtc_center"));
     }
-    let mut tileset: serde_json::Value =
-        serde_json::from_str(&base).expect("tileset_json_for_region emits valid JSON");
+    let mut tileset = crate::tileset_value_for_region(region, content_uri)?;
     let [cx, cy, cz] = rtc_center;
     // Column-major 4×4: identity rotation, translation = antenna ECEF.
     tileset["root"]["transform"] =
@@ -676,6 +693,28 @@ mod tests {
             encode_isosurface_glb(&grid, 1.5, [0, 0, 0, 255], Some(f64::INFINITY)),
             Err(Tiles3dError::NonFinite("background"))
         ));
+    }
+
+    #[test]
+    fn background_not_below_threshold_is_rejected() {
+        // background >= threshold would seal NaN cells as INSIDE the surface,
+        // inverting it — reject rather than return a meaningless mesh.
+        let grid = ramp_grid(3, 8, 5);
+        for bg in [20.0_f64, 25.0] {
+            assert!(
+                matches!(
+                    encode_isosurface_glb(&grid, 20.0, [0, 0, 0, 255], Some(bg)),
+                    Err(Tiles3dError::BackgroundNotBelowThreshold {
+                        background,
+                        threshold,
+                    }) if background == bg && threshold == 20.0
+                ),
+                "background {bg} >= threshold 20 must be rejected"
+            );
+        }
+        // Strictly below is accepted (the ramp has values 0..4, so 1.5 yields a
+        // surface; background −32 < 1.5).
+        assert!(encode_isosurface_glb(&grid, 1.5, [0, 0, 0, 255], Some(-32.0)).is_ok());
     }
 
     #[test]

--- a/crates/ds-3dtiles/src/isosurface.rs
+++ b/crates/ds-3dtiles/src/isosurface.rs
@@ -108,10 +108,21 @@ impl MeshBuilder {
         }
     }
 
-    /// Append one triangle. Computes the geometric (flat) face normal and skips
-    /// degenerate (zero-area) triangles so no `NaN` normal reaches the buffer.
-    /// Errors with [`Tiles3dError::TooLarge`] past [`MAX_TRIANGLES`].
-    fn push(&mut self, p0: [f32; 3], p1: [f32; 3], p2: [f32; 3]) -> Result<(), Tiles3dError> {
+    /// Append one triangle, with its face normal oriented to agree with
+    /// `outward` (the local "toward lower values / out of the echo" direction).
+    /// The marching-tet cases don't emit a consistent winding on their own, so
+    /// without this ~half the faces would have inward normals and render with
+    /// inverted lighting; here the winding is flipped to match `outward` so the
+    /// stored normal always points outward. Skips degenerate (zero-area)
+    /// triangles so no `NaN` normal reaches the buffer. Errors with
+    /// [`Tiles3dError::TooLarge`] past [`MAX_TRIANGLES`].
+    fn push(
+        &mut self,
+        p0: [f32; 3],
+        p1: [f32; 3],
+        p2: [f32; 3],
+        outward: [f32; 3],
+    ) -> Result<(), Tiles3dError> {
         let u = [p1[0] - p0[0], p1[1] - p0[1], p1[2] - p0[2]];
         let v = [p2[0] - p0[0], p2[1] - p0[1], p2[2] - p0[2]];
         let n = [
@@ -122,25 +133,34 @@ impl MeshBuilder {
         let len = (n[0] * n[0] + n[1] * n[1] + n[2] * n[2]).sqrt();
         // Positive comparison (not `!(len > 0.0)`) keeps it NaN-safe — a
         // non-finite `len` falls to the `else` and is dropped — and clippy-clean.
-        let nrm = if len > 0.0 {
+        let mut nrm = if len > 0.0 {
             [n[0] / len, n[1] / len, n[2] / len]
         } else {
             return Ok(()); // degenerate sliver (zero area) — drop it
+        };
+        // Orient outward: if the geometric normal points the wrong way, flip the
+        // normal AND the winding (swap p1/p2) so both stay consistent.
+        let dot = nrm[0] * outward[0] + nrm[1] * outward[1] + nrm[2] * outward[2];
+        let (a, b, c) = if dot < 0.0 {
+            nrm = [-nrm[0], -nrm[1], -nrm[2]];
+            (p0, p2, p1)
+        } else {
+            (p0, p1, p2)
         };
 
         self.triangles += 1;
         if self.triangles > MAX_TRIANGLES {
             return Err(Tiles3dError::TooLarge("isosurface triangles"));
         }
-        for p in [p0, p1, p2] {
-            for c in 0..3 {
-                self.positions.push(p[c]);
-                self.normals.push(nrm[c]);
-                if p[c] < self.min[c] {
-                    self.min[c] = p[c];
+        for p in [a, b, c] {
+            for k in 0..3 {
+                self.positions.push(p[k]);
+                self.normals.push(nrm[k]);
+                if p[k] < self.min[k] {
+                    self.min[k] = p[k];
                 }
-                if p[c] > self.max[c] {
-                    self.max[c] = p[c];
+                if p[k] > self.max[k] {
+                    self.max[k] = p[k];
                 }
             }
         }
@@ -232,6 +252,9 @@ fn march_tet(
             no += 1;
         }
     }
+    if ni == 0 || no == 0 {
+        return Ok(()); // tet fully inside or outside — no surface
+    }
     let cross = |a_local: usize, b_local: usize| {
         crossing(
             grid,
@@ -243,13 +266,31 @@ fn march_tet(
             tet[b_local],
         )
     };
-    // Triangle winding is NOT consistently oriented across these cases (the
-    // (1,3)/(3,1) split flips the normal vs the odd corner's side, and the
-    // (2,2) quad's order isn't sign-checked either) — `build_glb` sets the
-    // material `doubleSided: true` to compensate, which is load-bearing. Fine
-    // for visualisation; a future solid-geometry use would need oriented faces.
+    // The marching-tet cases don't produce a consistent winding, so derive the
+    // local outward direction (inside-corner centroid → outside-corner centroid,
+    // i.e. toward lower values) and let `MeshBuilder::push` orient each face's
+    // normal to it. Centroids in index space, mapped once to glTF space.
+    let centroid = |members: &[usize; 4], count: usize| -> [f64; 3] {
+        let mut s = [0.0_f64; 3];
+        for &k in &members[..count] {
+            let p = cidx[tet[k]];
+            for d in 0..3 {
+                s[d] += p[d];
+            }
+        }
+        [
+            s[0] / count as f64,
+            s[1] / count as f64,
+            s[2] / count as f64,
+        ]
+    };
+    let ic = centroid(&inside, ni);
+    let oc = centroid(&outside, no);
+    let iw = index_to_gltf_pos(grid, rtc, ic[0], ic[1], ic[2]);
+    let ow = index_to_gltf_pos(grid, rtc, oc[0], oc[1], oc[2]);
+    let outward = [ow[0] - iw[0], ow[1] - iw[1], ow[2] - iw[2]];
+
     match (ni, no) {
-        (0, _) | (_, 0) => Ok(()), // tet fully inside or outside — no surface
         (1, 3) | (3, 1) => {
             // One odd corner vs three: the surface is the triangle on the three
             // edges from the odd corner to the others.
@@ -262,6 +303,7 @@ fn march_tet(
                 cross(odd, rest[0]),
                 cross(odd, rest[1]),
                 cross(odd, rest[2]),
+                outward,
             )
         }
         (2, 2) => {
@@ -275,8 +317,8 @@ fn march_tet(
             let q1 = cross(b, c);
             let q2 = cross(b, d);
             let q3 = cross(a, d);
-            mesh.push(q0, q1, q2)?;
-            mesh.push(q0, q2, q3)
+            mesh.push(q0, q1, q2, outward)?;
+            mesh.push(q0, q2, q3, outward)
         }
         _ => unreachable!("a tetrahedron has exactly 4 corners"),
     }
@@ -416,8 +458,9 @@ fn build_glb(mesh: &MeshBuilder, color: [u8; 4]) -> Vec<u8> {
                 "metallicFactor": 0.0,
                 "roughnessFactor": 1.0,
             },
-            // Two-sided: marching-tet winding isn't oriented, so light both
-            // faces (CesiumJS flips the normal toward the camera per-face).
+            // Normals are oriented outward in `MeshBuilder::push`, so lighting
+            // is correct from the front; `doubleSided` is belt-and-suspenders
+            // for grazing/back views (and any residual ambiguous quad).
             "doubleSided": true,
         } ],
         "accessors": [
@@ -621,6 +664,38 @@ mod tests {
             let offset = [v[0] as f64, -(v[2] as f64), v[1] as f64];
             let h = offset[0] * up[0] + offset[1] * up[1] + offset[2] * up[2];
             assert!((h - 4000.0).abs() < 50.0, "vertex height {h} ≉ 4000 m");
+        }
+    }
+
+    #[test]
+    fn isosurface_normals_point_outward() {
+        // value = i_h increases with height, so inside (>= 1.5) is the UPPER
+        // region and "outward" (toward lower values) is DOWNWARD. Every stored
+        // face normal must therefore have a negative geocentric-up component —
+        // this is the orientation fix (without it ~half would point up/inward).
+        let mut grid = ramp_grid(4, 16, 5);
+        grid.radius_range = [0.0, 5_000.0]; // small disc → up ≈ geocentric up
+        let glb = encode_isosurface_glb(&grid, 1.5, [0, 128, 255, 255], None).unwrap();
+        let (json, bin) = parse_glb(&glb);
+
+        let rtc = geodetic_to_ecef(grid.origin_lon, grid.origin_lat, grid.origin_height);
+        let m = (rtc[0] * rtc[0] + rtc[1] * rtc[1] + rtc[2] * rtc[2]).sqrt();
+        let up = [rtc[0] / m, rtc[1] / m, rtc[2] / m];
+        let nrm_off = json["bufferViews"][1]["byteOffset"].as_u64().unwrap() as usize;
+        let nrm_len = json["bufferViews"][1]["byteLength"].as_u64().unwrap() as usize;
+        let normals: Vec<f32> = bin[nrm_off..nrm_off + nrm_len]
+            .chunks_exact(4)
+            .map(|w| f32::from_le_bytes(w.try_into().unwrap()))
+            .collect();
+        assert!(!normals.is_empty(), "surface has normals");
+        for n in normals.chunks_exact(3) {
+            // Invert the Y-up flip: glTF normal (x,y,z) → ECEF (x,−z,y).
+            let ne = [n[0] as f64, -(n[2] as f64), n[1] as f64];
+            let up_comp = ne[0] * up[0] + ne[1] * up[1] + ne[2] * up[2];
+            assert!(
+                up_comp < 0.0,
+                "normal must point outward (down): up={up_comp}"
+            );
         }
     }
 

--- a/crates/ds-3dtiles/src/isosurface.rs
+++ b/crates/ds-3dtiles/src/isosurface.rs
@@ -108,20 +108,21 @@ impl MeshBuilder {
         }
     }
 
-    /// Append one triangle, with its face normal oriented to agree with
-    /// `outward` (the local "toward lower values / out of the echo" direction).
-    /// The marching-tet cases don't emit a consistent winding on their own, so
-    /// without this ~half the faces would have inward normals and render with
-    /// inverted lighting; here the winding is flipped to match `outward` so the
-    /// stored normal always points outward. Skips degenerate (zero-area)
-    /// triangles so no `NaN` normal reaches the buffer. Errors with
-    /// [`Tiles3dError::TooLarge`] past [`MAX_TRIANGLES`].
+    /// Append one triangle, with its face normal oriented outward. `out_ref` is
+    /// a point on the OUTSIDE of the surface (the tet's outside-corner centroid);
+    /// the outward direction is `out_ref − triangle_centroid`. The marching-tet
+    /// cases don't emit a consistent winding on their own, so without this ~half
+    /// the faces would have inward normals and render with inverted lighting;
+    /// here the winding is flipped to match outward so the stored normal always
+    /// points outward. Skips degenerate (zero-area) triangles so no `NaN` normal
+    /// reaches the buffer. Errors with [`Tiles3dError::TooLarge`] past
+    /// [`MAX_TRIANGLES`].
     fn push(
         &mut self,
         p0: [f32; 3],
         p1: [f32; 3],
         p2: [f32; 3],
-        outward: [f32; 3],
+        out_ref: [f32; 3],
     ) -> Result<(), Tiles3dError> {
         let u = [p1[0] - p0[0], p1[1] - p0[1], p1[2] - p0[2]];
         let v = [p2[0] - p0[0], p2[1] - p0[1], p2[2] - p0[2]];
@@ -138,6 +139,17 @@ impl MeshBuilder {
         } else {
             return Ok(()); // degenerate sliver (zero area) — drop it
         };
+        // Outward = from the triangle's own centroid toward the outside ref.
+        let centroid = [
+            (p0[0] + p1[0] + p2[0]) / 3.0,
+            (p0[1] + p1[1] + p2[1]) / 3.0,
+            (p0[2] + p1[2] + p2[2]) / 3.0,
+        ];
+        let outward = [
+            out_ref[0] - centroid[0],
+            out_ref[1] - centroid[1],
+            out_ref[2] - centroid[2],
+        ];
         // Orient outward: if the geometric normal points the wrong way, flip the
         // normal AND the winding (swap p1/p2) so both stay consistent.
         let dot = nrm[0] * outward[0] + nrm[1] * outward[1] + nrm[2] * outward[2];
@@ -266,29 +278,23 @@ fn march_tet(
             tet[b_local],
         )
     };
-    // The marching-tet cases don't produce a consistent winding, so derive the
-    // local outward direction (inside-corner centroid → outside-corner centroid,
-    // i.e. toward lower values) and let `MeshBuilder::push` orient each face's
-    // normal to it. Centroids in index space, mapped once to glTF space.
-    let centroid = |members: &[usize; 4], count: usize| -> [f64; 3] {
+    // The marching-tet cases don't produce a consistent winding, so give
+    // `MeshBuilder::push` a reference point on the OUTSIDE of the surface — the
+    // outside-corner centroid, in glTF space — and it orients each face's normal
+    // to point from the triangle toward it (outward, toward lower values). Only
+    // ONE glTF projection per tet (the inside-centroid round-trip the earlier
+    // version did was redundant: push already has the triangle's own centroid).
+    let oc = {
         let mut s = [0.0_f64; 3];
-        for &k in &members[..count] {
+        for &k in &outside[..no] {
             let p = cidx[tet[k]];
             for d in 0..3 {
                 s[d] += p[d];
             }
         }
-        [
-            s[0] / count as f64,
-            s[1] / count as f64,
-            s[2] / count as f64,
-        ]
+        [s[0] / no as f64, s[1] / no as f64, s[2] / no as f64]
     };
-    let ic = centroid(&inside, ni);
-    let oc = centroid(&outside, no);
-    let iw = index_to_gltf_pos(grid, rtc, ic[0], ic[1], ic[2]);
-    let ow = index_to_gltf_pos(grid, rtc, oc[0], oc[1], oc[2]);
-    let outward = [ow[0] - iw[0], ow[1] - iw[1], ow[2] - iw[2]];
+    let out_ref = index_to_gltf_pos(grid, rtc, oc[0], oc[1], oc[2]);
 
     match (ni, no) {
         (1, 3) | (3, 1) => {
@@ -303,7 +309,7 @@ fn march_tet(
                 cross(odd, rest[0]),
                 cross(odd, rest[1]),
                 cross(odd, rest[2]),
-                outward,
+                out_ref,
             )
         }
         (2, 2) => {
@@ -317,8 +323,8 @@ fn march_tet(
             let q1 = cross(b, c);
             let q2 = cross(b, d);
             let q3 = cross(a, d);
-            mesh.push(q0, q1, q2, outward)?;
-            mesh.push(q0, q2, q3, outward)
+            mesh.push(q0, q1, q2, out_ref)?;
+            mesh.push(q0, q2, q3, out_ref)
         }
         _ => unreachable!("a tetrahedron has exactly 4 corners"),
     }

--- a/crates/ds-3dtiles/src/isosurface.rs
+++ b/crates/ds-3dtiles/src/isosurface.rs
@@ -316,7 +316,10 @@ fn march_tet(
             // Two vs two: the surface is a quad on the four crossing edges.
             // Order its corners around the perimeter so the two triangles don't
             // self-intersect: (a–c, b–c, b–d, a–d) — consecutive edges share an
-            // endpoint, forming a proper cycle.
+            // endpoint, forming a proper cycle. (We always fan from q0; picking
+            // the shorter diagonal would give marginally better aspect ratios on
+            // the mildly non-planar projected quad — a follow-up if vertex
+            // sharing lands, negligible at radar grid scale.)
             let (a, b) = (inside[0], inside[1]);
             let (c, d) = (outside[0], outside[1]);
             let q0 = cross(a, c);

--- a/crates/ds-3dtiles/src/isosurface.rs
+++ b/crates/ds-3dtiles/src/isosurface.rs
@@ -31,9 +31,17 @@
 //! 3D Tiles runtime applies the inverse Y-up→Z-up to glTF content (this is the
 //! flip the `.pnts` path deliberately avoids; here the content *is* glTF).
 //!
-//! Cells with no data are `NaN`; any tetrahedron touching a `NaN` corner is
-//! skipped, so no surface is fabricated across the cone of silence or beyond the
-//! beam fan.
+//! ## Clear air vs unmeasured (`NaN`)
+//!
+//! A radar volume stores `NaN` for both "the radar saw nothing" (clear air) and
+//! "the radar couldn't see here" (cone of silence / beyond range) — they are
+//! indistinguishable in the grid. The `background` parameter of
+//! [`encode_isosurface_glb`] decides how `NaN` corners behave: `None` skips any
+//! tetrahedron touching one (open surface — never fabricates), while `Some(bg)`
+//! treats them as the below-threshold value `bg`, **sealing** the surface into
+//! solid blobs by assuming absence of echo where unmeasured. Sealing is the
+//! sensible default for a reflectivity shell (otherwise echo→clear-air
+//! boundaries render as open vertical "curtains" instead of closed domes).
 
 use crate::Tiles3dError;
 use ds_core::geo::{destination_point, geodetic_to_ecef};
@@ -268,19 +276,49 @@ fn march_tet(
 /// mesh shaded a single `color` (`[r, g, b, a]`, 0–255) — typically the
 /// colormap colour at `threshold`, i.e. "the 20 dBZ shell".
 ///
+/// ## `background` — sealing the surface against clear air
+///
+/// A radar volume stores **`NaN` for both** "the radar looked and saw nothing"
+/// (clear air, *undetect*) and "the radar couldn't see here" (cone of silence /
+/// beyond range, *nodata*) — the engine can't tell them apart in the grid. With
+/// `background = None`, any tetrahedron touching a `NaN` corner is skipped, so
+/// the surface **does not close** where echo meets clear air → open vertical
+/// walls/blades, not solid blobs.
+///
+/// `background = Some(bg)` (with `bg < threshold`) treats every `NaN` corner as
+/// the value `bg`, i.e. **assumes absence of echo** wherever the radar didn't
+/// report one. The surface then seals into closed blobs. This never *invents*
+/// echo (it assumes the conservative direction — no reflectivity); its only
+/// cost is that a surface also caps at the true coverage boundary (the narrow
+/// cone of silence above the antenna and the max-range cylinder), which is the
+/// standard "no echo where unmeasured" convention every radar 3-D view uses.
+/// For a reflectivity shell pass e.g. `Some(-32.0)` (the dBZ floor).
+/// Distinguishing *undetect* from *nodata* in the engine sampler (so only the
+/// real cone of silence stays open) is a follow-up.
+///
 /// Returns [`Tiles3dError::Empty`] when no cell straddles the threshold (an
 /// empty surface — caller maps to 404), [`Tiles3dError::NonFinite`] for a
-/// non-finite `threshold`/origin, and [`Tiles3dError::TooLarge`] past
-/// [`MAX_TRIANGLES`]. Pair with [`tileset_json_glb`], which carries the antenna
-/// ECEF as the tile `transform`.
+/// non-finite `threshold`/origin/`background`, and [`Tiles3dError::TooLarge`]
+/// past [`MAX_TRIANGLES`]. Pair with [`tileset_json_glb`], which carries the
+/// antenna ECEF as the tile `transform`.
 pub fn encode_isosurface_glb(
     grid: &VoxelGrid,
     threshold: f64,
     color: [u8; 4],
+    background: Option<f64>,
 ) -> Result<Vec<u8>, Tiles3dError> {
     if !threshold.is_finite() {
         return Err(Tiles3dError::NonFinite("threshold"));
     }
+    // A `Some` background must be finite, else it would behave like `None`
+    // (a NaN fill leaves the corner non-finite → tet skipped) — confusingly.
+    if let Some(bg) = background {
+        if !bg.is_finite() {
+            return Err(Tiles3dError::NonFinite("background"));
+        }
+    }
+    // `NaN` corners map to this: the finite background (seal) or `NaN` (skip).
+    let nan_fill = background.unwrap_or(f64::NAN);
     let rtc = geodetic_to_ecef(grid.origin_lon, grid.origin_lat, grid.origin_height);
     if rtc.iter().any(|c| !c.is_finite()) {
         return Err(Tiles3dError::NonFinite("rtc_center"));
@@ -298,7 +336,9 @@ pub fn encode_isosurface_glb(
                 let mut cidx = [[0.0_f64; 3]; 8];
                 for (c, off) in CORNER.iter().enumerate() {
                     let (ir, ia, ih) = (i_r + off[0], i_a + off[1], i_h + off[2]);
-                    cvals[c] = grid.values[grid.index(ir, ia, ih)] as f64;
+                    let raw = grid.values[grid.index(ir, ia, ih)] as f64;
+                    // Clear air / unmeasured → background (seal) or NaN (skip).
+                    cvals[c] = if raw.is_finite() { raw } else { nan_fill };
                     cidx[c] = [ir as f64, ia as f64, ih as f64];
                 }
                 for tet in TETS {
@@ -500,7 +540,7 @@ mod tests {
     #[test]
     fn isosurface_glb_is_wellformed() {
         let grid = ramp_grid(3, 8, 5);
-        let glb = encode_isosurface_glb(&grid, 1.5, [255, 0, 0, 255]).expect("encode");
+        let glb = encode_isosurface_glb(&grid, 1.5, [255, 0, 0, 255], None).expect("encode");
         let (json, bin) = parse_glb(&glb);
 
         assert_eq!(json["asset"]["version"], "2.0");
@@ -544,7 +584,7 @@ mod tests {
         // reconstruct each vertex's height above the antenna and assert ≈4000 m.
         let mut grid = ramp_grid(4, 16, 5);
         grid.radius_range = [0.0, 5_000.0];
-        let glb = encode_isosurface_glb(&grid, 1.5, [0, 128, 255, 255]).unwrap();
+        let glb = encode_isosurface_glb(&grid, 1.5, [0, 128, 255, 255], None).unwrap();
         let (json, bin) = parse_glb(&glb);
 
         let rtc = geodetic_to_ecef(grid.origin_lon, grid.origin_lat, grid.origin_height);
@@ -571,31 +611,70 @@ mod tests {
     fn empty_when_threshold_above_all_data() {
         let grid = ramp_grid(3, 8, 5); // values 0..4
         assert!(matches!(
-            encode_isosurface_glb(&grid, 100.0, [255, 0, 0, 255]),
+            encode_isosurface_glb(&grid, 100.0, [255, 0, 0, 255], None),
             Err(Tiles3dError::Empty)
         ));
     }
 
     #[test]
-    fn nodata_corners_do_not_fabricate_surface() {
-        // A grid that is all-NaN except a single isolated finite cell can form no
-        // tetrahedron with all-finite corners → no surface (not a 1-cell blob).
+    fn nodata_corners_do_not_fabricate_surface_without_background() {
+        // With background = None, a grid that is all-NaN except a single isolated
+        // finite cell can form no tetrahedron with all-finite corners → no surface
+        // (NaN corners are skipped, not fabricated into a 1-cell blob).
         let mut grid = ramp_grid(3, 8, 5);
         grid.values.iter_mut().for_each(|v| *v = f32::NAN);
         let i = grid.index(1, 4, 2);
         grid.values[i] = 50.0;
         assert!(matches!(
-            encode_isosurface_glb(&grid, 1.5, [255, 0, 0, 255]),
+            encode_isosurface_glb(&grid, 1.5, [255, 0, 0, 255], None),
             Err(Tiles3dError::Empty)
         ));
     }
 
     #[test]
-    fn non_finite_threshold_is_rejected() {
+    fn background_seals_echo_surrounded_by_clear_air() {
+        // A compact echo core embedded in NaN (clear air). With background = None
+        // the surface can't close (Empty). With background = Some(below-threshold),
+        // the NaN corners are treated as no-echo and the surface seals into a
+        // closed blob — exactly the fix for the "curtains" artifact.
+        let mut grid = ramp_grid(6, 16, 6);
+        grid.values.iter_mut().for_each(|v| *v = f32::NAN);
+        // A 2×2×2 finite >threshold core in the interior, rest NaN.
+        for ir in 2..4 {
+            for ia in 7..9 {
+                for ih in 2..4 {
+                    let idx = grid.index(ir, ia, ih);
+                    grid.values[idx] = 40.0;
+                }
+            }
+        }
+        // No finite-<threshold neighbours, so without a background it can't close.
+        assert!(matches!(
+            encode_isosurface_glb(&grid, 20.0, [0, 200, 0, 255], None),
+            Err(Tiles3dError::Empty)
+        ));
+        // With a background floor below the threshold, it seals into a real mesh.
+        let glb = encode_isosurface_glb(&grid, 20.0, [0, 200, 0, 255], Some(-32.0))
+            .expect("sealed surface");
+        let (json, _bin) = parse_glb(&glb);
+        let count = json["accessors"][0]["count"].as_u64().unwrap();
+        assert!(
+            count > 0 && count % 3 == 0,
+            "sealed blob has triangles: {count}"
+        );
+    }
+
+    #[test]
+    fn non_finite_threshold_or_background_is_rejected() {
         let grid = ramp_grid(3, 8, 5);
         assert!(matches!(
-            encode_isosurface_glb(&grid, f64::NAN, [0, 0, 0, 255]),
+            encode_isosurface_glb(&grid, f64::NAN, [0, 0, 0, 255], None),
             Err(Tiles3dError::NonFinite("threshold"))
+        ));
+        // A Some(non-finite) background is rejected (would silently act like None).
+        assert!(matches!(
+            encode_isosurface_glb(&grid, 1.5, [0, 0, 0, 255], Some(f64::INFINITY)),
+            Err(Tiles3dError::NonFinite("background"))
         ));
     }
 

--- a/crates/ds-3dtiles/src/isosurface.rs
+++ b/crates/ds-3dtiles/src/isosurface.rs
@@ -1,0 +1,645 @@
+//! Isosurface meshing of a [`ds_core::volume::VoxelGrid`] into glTF 2.0 binary
+//! (`.glb`) triangle-mesh content for OGC 3D Tiles (#357).
+//!
+//! Unlike the draft `EXT_primitive_voxels` voxel path (#351 — experimental, in
+//! flux, CesiumJS ≥1.127 only), an isosurface is a **plain glTF triangle mesh**:
+//! it renders in *any* 3D Tiles 1.1 client, so it is the verifiable way to show
+//! the 3-D structure of a radar volume (storm shells / echo tops at a chosen
+//! reflectivity threshold).
+//!
+//! ## Why marching *tetrahedra*, not marching cubes
+//!
+//! Marching cubes needs a hand-transcribed 256-case edge/triangle table where a
+//! single wrong entry yields holes or non-manifold junk that's only visible when
+//! rendered. Marching *tetrahedra* needs **no table**: a tetrahedron is the
+//! complete graph K4, so *every* pair of corners is an edge, and the iso-surface
+//! crosses exactly `|inside| · |outside|` edges (3 → one triangle, 4 → a quad =
+//! two triangles). The topology is correct by construction — the right property
+//! when the output can't be eyeballed at encode time. Each cube is split into 6
+//! tetrahedra by the Kuhn/Freudenthal decomposition along its main diagonal.
+//!
+//! ## Geometry
+//!
+//! The grid is cylindrical (radar-native): `radius` = ground range, `angle` =
+//! azimuth, `height` = metres above the antenna. A surface vertex lands at a
+//! fractional cell index, which maps to physical (ground, azimuth, height) with
+//! the **same cell-centre convention the engine sampled with** — sample `i`
+//! along an `n`-cell axis spanning `[lo, hi]` sits at `lo + (i + 0.5)(hi−lo)/n` —
+//! then to a geographic point via [`ds_core::geo::destination_point`] and to
+//! ECEF via [`ds_core::geo::geodetic_to_ecef`]. Positions are stored relative to
+//! the antenna ECEF (the tile `transform`) and pre-rotated Z-up→Y-up, because a
+//! 3D Tiles runtime applies the inverse Y-up→Z-up to glTF content (this is the
+//! flip the `.pnts` path deliberately avoids; here the content *is* glTF).
+//!
+//! Cells with no data are `NaN`; any tetrahedron touching a `NaN` corner is
+//! skipped, so no surface is fabricated across the cone of silence or beyond the
+//! beam fan.
+
+use crate::Tiles3dError;
+use ds_core::geo::{destination_point, geodetic_to_ecef};
+use ds_core::volume::VoxelGrid;
+use serde_json::json;
+
+/// Cap on emitted triangles. The mesh is non-indexed (3 vertices ×
+/// `POSITION`+`NORMAL` = 72 bytes/triangle), so this bounds the encode buffer at
+/// ~216 MB worst case. A radar reflectivity shell is far smaller; exceeding the
+/// cap means the threshold is too low or the grid too fine — fail loudly rather
+/// than allocate unbounded.
+const MAX_TRIANGLES: usize = 3_000_000;
+
+/// glTF component type `FLOAT` (5126) and primitive mode `TRIANGLES` (4).
+const COMPONENT_FLOAT: u32 = 5126;
+const MODE_TRIANGLES: u32 = 4;
+/// glTF `bufferView.target` `ARRAY_BUFFER` (34962).
+const TARGET_ARRAY_BUFFER: u32 = 34962;
+
+/// Cube-corner offsets `(Δradius, Δangle, Δheight)`, indexed by the standard
+/// corner numbering `bit0=Δr, bit1=Δa, bit2=Δh`.
+const CORNER: [[usize; 3]; 8] = [
+    [0, 0, 0], // 0
+    [1, 0, 0], // 1
+    [0, 1, 0], // 2
+    [1, 1, 0], // 3
+    [0, 0, 1], // 4
+    [1, 0, 1], // 5
+    [0, 1, 1], // 6
+    [1, 1, 1], // 7
+];
+
+/// Kuhn/Freudenthal split of the cube into 6 tetrahedra, all sharing the main
+/// diagonal 0–7 (one tet per axis-permutation path from corner 0 to corner 7).
+/// They partition the cube exactly, so the surface is watertight across cube
+/// boundaries.
+const TETS: [[usize; 4]; 6] = [
+    [0, 1, 3, 7],
+    [0, 1, 5, 7],
+    [0, 2, 3, 7],
+    [0, 2, 6, 7],
+    [0, 4, 5, 7],
+    [0, 4, 6, 7],
+];
+
+/// Accumulates a non-indexed triangle mesh (one flat normal per face) plus the
+/// `POSITION` accessor's `min`/`max` (required by the glTF spec).
+struct MeshBuilder {
+    positions: Vec<f32>, // xyz per vertex, 3 vertices per triangle
+    normals: Vec<f32>,   // xyz per vertex
+    triangles: usize,
+    min: [f32; 3],
+    max: [f32; 3],
+}
+
+impl MeshBuilder {
+    fn new() -> Self {
+        Self {
+            positions: Vec::new(),
+            normals: Vec::new(),
+            triangles: 0,
+            min: [f32::INFINITY; 3],
+            max: [f32::NEG_INFINITY; 3],
+        }
+    }
+
+    /// Append one triangle. Computes the geometric (flat) face normal and skips
+    /// degenerate (zero-area) triangles so no `NaN` normal reaches the buffer.
+    /// Errors with [`Tiles3dError::TooLarge`] past [`MAX_TRIANGLES`].
+    fn push(&mut self, p0: [f32; 3], p1: [f32; 3], p2: [f32; 3]) -> Result<(), Tiles3dError> {
+        let u = [p1[0] - p0[0], p1[1] - p0[1], p1[2] - p0[2]];
+        let v = [p2[0] - p0[0], p2[1] - p0[1], p2[2] - p0[2]];
+        let n = [
+            u[1] * v[2] - u[2] * v[1],
+            u[2] * v[0] - u[0] * v[2],
+            u[0] * v[1] - u[1] * v[0],
+        ];
+        let len = (n[0] * n[0] + n[1] * n[1] + n[2] * n[2]).sqrt();
+        // Positive comparison (not `!(len > 0.0)`) keeps it NaN-safe — a
+        // non-finite `len` falls to the `else` and is dropped — and clippy-clean.
+        let nrm = if len > 0.0 {
+            [n[0] / len, n[1] / len, n[2] / len]
+        } else {
+            return Ok(()); // degenerate sliver (zero area) — drop it
+        };
+
+        self.triangles += 1;
+        if self.triangles > MAX_TRIANGLES {
+            return Err(Tiles3dError::TooLarge("isosurface triangles"));
+        }
+        for p in [p0, p1, p2] {
+            for c in 0..3 {
+                self.positions.push(p[c]);
+                self.normals.push(nrm[c]);
+                if p[c] < self.min[c] {
+                    self.min[c] = p[c];
+                }
+                if p[c] > self.max[c] {
+                    self.max[c] = p[c];
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Map a fractional cell index `(fr, fa, fh)` to a glTF-space position (metres),
+/// relative to `rtc` (the antenna ECEF) and pre-rotated Z-up→Y-up.
+fn index_to_gltf_pos(grid: &VoxelGrid, rtc: [f64; 3], fr: f64, fa: f64, fh: f64) -> [f32; 3] {
+    let [n_r, n_a, n_h] = grid.dims;
+    // Same cell-centre convention as the engine's sampler: sample i sits at
+    // lo + (i + 0.5)(hi − lo)/n. Fractional i interpolates linearly between
+    // cell centres.
+    let ground = grid.radius_range[0]
+        + (fr + 0.5) * (grid.radius_range[1] - grid.radius_range[0]) / n_r as f64;
+    let azimuth =
+        grid.angle_range[0] + (fa + 0.5) * (grid.angle_range[1] - grid.angle_range[0]) / n_a as f64;
+    let height = grid.height_range[0]
+        + (fh + 0.5) * (grid.height_range[1] - grid.height_range[0]) / n_h as f64;
+
+    let (lon, lat) = destination_point(
+        grid.origin_lon,
+        grid.origin_lat,
+        ground,
+        azimuth.to_degrees(),
+    );
+    let e = geodetic_to_ecef(lon, lat, grid.origin_height + height);
+    let dx = (e[0] - rtc[0]) as f32;
+    let dy = (e[1] - rtc[1]) as f32;
+    let dz = (e[2] - rtc[2]) as f32;
+    // Z-up (ECEF offset) → glTF Y-up: a runtime re-applies Y-up→Z-up, so
+    // (x, y, z)_zup must be stored as (x, z, −y). Net effect: world = rtc + ECEF
+    // offset. (The `.pnts` path stores ECEF-native and skips this because pnts
+    // is not glTF.)
+    [dx, dz, -dy]
+}
+
+/// Interpolated surface vertex on the edge between cube corners `a` and `b`
+/// (each `0..8`, indexing `cvals`/`cidx`). The interpolation is symmetric in
+/// `a`/`b`, so callers need only name the edge, not which end is inside.
+fn crossing(
+    grid: &VoxelGrid,
+    rtc: [f64; 3],
+    threshold: f64,
+    cvals: &[f64; 8],
+    cidx: &[[f64; 3]; 8],
+    a: usize,
+    b: usize,
+) -> [f32; 3] {
+    let (va, vb) = (cvals[a], cvals[b]);
+    // One end is inside (>= threshold), the other outside (< threshold), so
+    // va != vb and t ∈ [0, 1).
+    let t = ((threshold - va) / (vb - va)).clamp(0.0, 1.0);
+    let fr = cidx[a][0] + t * (cidx[b][0] - cidx[a][0]);
+    let fa = cidx[a][1] + t * (cidx[b][1] - cidx[a][1]);
+    let fh = cidx[a][2] + t * (cidx[b][2] - cidx[a][2]);
+    index_to_gltf_pos(grid, rtc, fr, fa, fh)
+}
+
+/// Mesh one tetrahedron (`tet` = 4 cube-corner indices) at the current isovalue,
+/// pushing 0–2 triangles into `mesh`. Skips the tet if any corner is `NaN`.
+fn march_tet(
+    mesh: &mut MeshBuilder,
+    grid: &VoxelGrid,
+    rtc: [f64; 3],
+    threshold: f64,
+    cvals: &[f64; 8],
+    cidx: &[[f64; 3]; 8],
+    tet: [usize; 4],
+) -> Result<(), Tiles3dError> {
+    // Any nodata corner ⇒ skip (don't fabricate surface across a gap).
+    if tet.iter().any(|&c| !cvals[c].is_finite()) {
+        return Ok(());
+    }
+    // Local tet indices (0..4) split into inside / outside.
+    let mut inside = Vec::with_capacity(4);
+    let mut outside = Vec::with_capacity(4);
+    for (k, &c) in tet.iter().enumerate() {
+        if cvals[c] >= threshold {
+            inside.push(k);
+        } else {
+            outside.push(k);
+        }
+    }
+    let cross = |a_local: usize, b_local: usize| {
+        crossing(
+            grid,
+            rtc,
+            threshold,
+            cvals,
+            cidx,
+            tet[a_local],
+            tet[b_local],
+        )
+    };
+    match (inside.len(), outside.len()) {
+        (0, _) | (_, 0) => Ok(()), // tet fully inside or outside — no surface
+        (1, 3) | (3, 1) => {
+            // One odd corner vs three: the surface is the triangle on the three
+            // edges from the odd corner to the others.
+            let (odd, rest) = if inside.len() == 1 {
+                (inside[0], &outside)
+            } else {
+                (outside[0], &inside)
+            };
+            mesh.push(
+                cross(odd, rest[0]),
+                cross(odd, rest[1]),
+                cross(odd, rest[2]),
+            )
+        }
+        (2, 2) => {
+            // Two vs two: the surface is a quad on the four crossing edges.
+            // Order its corners around the perimeter so the two triangles don't
+            // self-intersect: (a–c, b–c, b–d, a–d) — consecutive edges share an
+            // endpoint, forming a proper cycle.
+            let (a, b) = (inside[0], inside[1]);
+            let (c, d) = (outside[0], outside[1]);
+            let q0 = cross(a, c);
+            let q1 = cross(b, c);
+            let q2 = cross(b, d);
+            let q3 = cross(a, d);
+            mesh.push(q0, q1, q2)?;
+            mesh.push(q0, q2, q3)
+        }
+        _ => unreachable!("a tetrahedron has exactly 4 corners"),
+    }
+}
+
+/// Encode a [`VoxelGrid`] as a 3D Tiles **isosurface** at `threshold` (in the
+/// grid's physical units, e.g. dBZ), as a glTF 2.0 binary (`.glb`) triangle
+/// mesh shaded a single `color` (`[r, g, b, a]`, 0–255) — typically the
+/// colormap colour at `threshold`, i.e. "the 20 dBZ shell".
+///
+/// Returns [`Tiles3dError::Empty`] when no cell straddles the threshold (an
+/// empty surface — caller maps to 404), [`Tiles3dError::NonFinite`] for a
+/// non-finite `threshold`/origin, and [`Tiles3dError::TooLarge`] past
+/// [`MAX_TRIANGLES`]. Pair with [`tileset_json_glb`], which carries the antenna
+/// ECEF as the tile `transform`.
+pub fn encode_isosurface_glb(
+    grid: &VoxelGrid,
+    threshold: f64,
+    color: [u8; 4],
+) -> Result<Vec<u8>, Tiles3dError> {
+    if !threshold.is_finite() {
+        return Err(Tiles3dError::NonFinite("threshold"));
+    }
+    let rtc = geodetic_to_ecef(grid.origin_lon, grid.origin_lat, grid.origin_height);
+    if rtc.iter().any(|c| !c.is_finite()) {
+        return Err(Tiles3dError::NonFinite("rtc_center"));
+    }
+    let [n_r, n_a, n_h] = grid.dims;
+
+    let mut mesh = MeshBuilder::new();
+    // Iterate cubes. The angular seam (i_a = n_a−1 → 0) is not wrapped in v1, so
+    // a one-cell-wide gap remains at azimuth 0; acceptable for a visualisation
+    // shell (a closed radar volume is rarely intersected exactly there).
+    for i_r in 0..n_r.saturating_sub(1) {
+        for i_a in 0..n_a.saturating_sub(1) {
+            for i_h in 0..n_h.saturating_sub(1) {
+                let mut cvals = [0.0_f64; 8];
+                let mut cidx = [[0.0_f64; 3]; 8];
+                for (c, off) in CORNER.iter().enumerate() {
+                    let (ir, ia, ih) = (i_r + off[0], i_a + off[1], i_h + off[2]);
+                    cvals[c] = grid.values[grid.index(ir, ia, ih)] as f64;
+                    cidx[c] = [ir as f64, ia as f64, ih as f64];
+                }
+                for tet in TETS {
+                    march_tet(&mut mesh, grid, rtc, threshold, &cvals, &cidx, tet)?;
+                }
+            }
+        }
+    }
+
+    if mesh.triangles == 0 {
+        return Err(Tiles3dError::Empty);
+    }
+    Ok(build_glb(&mesh, color))
+}
+
+/// Assemble a single-mesh `.glb` from the accumulated triangles.
+fn build_glb(mesh: &MeshBuilder, color: [u8; 4]) -> Vec<u8> {
+    let vertex_count = mesh.positions.len() / 3;
+
+    // BIN buffer: POSITION (count·3·f32) then NORMAL (count·3·f32). Both are
+    // 12-byte-strided, so byte offsets stay 4-aligned for free.
+    let pos_bytes = mesh.positions.len() * 4;
+    let nrm_off = pos_bytes;
+    let mut bin = Vec::with_capacity(pos_bytes + mesh.normals.len() * 4);
+    for f in &mesh.positions {
+        bin.extend_from_slice(&f.to_le_bytes());
+    }
+    for f in &mesh.normals {
+        bin.extend_from_slice(&f.to_le_bytes());
+    }
+    // BIN chunk must be 4-byte aligned (count·24 already is, but stay defensive).
+    while !bin.len().is_multiple_of(4) {
+        bin.push(0);
+    }
+
+    let base_color = [
+        color[0] as f64 / 255.0,
+        color[1] as f64 / 255.0,
+        color[2] as f64 / 255.0,
+        color[3] as f64 / 255.0,
+    ];
+    let gltf = json!({
+        "asset": { "version": "2.0", "generator": "MeteoCore ds-3dtiles isosurface" },
+        "scene": 0,
+        "scenes": [ { "nodes": [0] } ],
+        "nodes": [ { "mesh": 0 } ],
+        "meshes": [ {
+            "primitives": [ {
+                "attributes": { "POSITION": 0, "NORMAL": 1 },
+                "material": 0,
+                "mode": MODE_TRIANGLES,
+            } ]
+        } ],
+        "materials": [ {
+            "pbrMetallicRoughness": {
+                "baseColorFactor": base_color,
+                "metallicFactor": 0.0,
+                "roughnessFactor": 1.0,
+            },
+            // Two-sided: marching-tet winding isn't oriented, so light both
+            // faces (CesiumJS flips the normal toward the camera per-face).
+            "doubleSided": true,
+        } ],
+        "accessors": [
+            {
+                "bufferView": 0, "componentType": COMPONENT_FLOAT, "count": vertex_count,
+                "type": "VEC3", "min": mesh.min, "max": mesh.max,
+            },
+            {
+                "bufferView": 1, "componentType": COMPONENT_FLOAT, "count": vertex_count,
+                "type": "VEC3",
+            },
+        ],
+        "bufferViews": [
+            { "buffer": 0, "byteOffset": 0, "byteLength": pos_bytes, "target": TARGET_ARRAY_BUFFER },
+            { "buffer": 0, "byteOffset": nrm_off, "byteLength": mesh.normals.len() * 4, "target": TARGET_ARRAY_BUFFER },
+        ],
+        "buffers": [ { "byteLength": bin.len() } ],
+    });
+
+    let mut json_chunk = serde_json::to_vec(&gltf).expect("glTF JSON serializes");
+    while !json_chunk.len().is_multiple_of(4) {
+        json_chunk.push(b' '); // JSON chunk padded with spaces
+    }
+
+    // GLB = 12-byte header + JSON chunk + BIN chunk (each chunk: u32 length,
+    // u32 type, payload).
+    let total = 12 + 8 + json_chunk.len() + 8 + bin.len();
+    let mut glb = Vec::with_capacity(total);
+    glb.extend_from_slice(&0x46546C67u32.to_le_bytes()); // "glTF"
+    glb.extend_from_slice(&2u32.to_le_bytes()); // version
+    glb.extend_from_slice(&(total as u32).to_le_bytes());
+    // JSON chunk
+    glb.extend_from_slice(&(json_chunk.len() as u32).to_le_bytes());
+    glb.extend_from_slice(&0x4E4F534Au32.to_le_bytes()); // "JSON"
+    glb.extend_from_slice(&json_chunk);
+    // BIN chunk
+    glb.extend_from_slice(&(bin.len() as u32).to_le_bytes());
+    glb.extend_from_slice(&0x004E4942u32.to_le_bytes()); // "BIN\0"
+    glb.extend_from_slice(&bin);
+    glb
+}
+
+/// Build the `tileset.json` for an isosurface `.glb`. Like
+/// [`crate::tileset_json_for_region`] but for glTF content, which (unlike
+/// `.pnts`) carries no embedded origin — so the antenna ECEF (`rtc_center`) is
+/// the tile **`transform`** (a pure translation), placing the mesh's
+/// antenna-relative positions at their true global location.
+///
+/// The `region` bounding volume stays geodetic (EPSG:4979) and is *not* affected
+/// by the transform, per the 3D Tiles spec. Same `content_uri`/region/finite
+/// validation and load-bearing non-zero `geometricError` as the `.pnts` tileset.
+pub fn tileset_json_glb(
+    region: [f64; 6],
+    content_uri: &str,
+    rtc_center: [f64; 3],
+) -> Result<String, Tiles3dError> {
+    // Reuse the shared content-URI + region validation by building the base
+    // tileset, then injecting the transform (the only glTF-specific addition).
+    let base = crate::tileset_json_for_region(region, content_uri)?;
+    if rtc_center.iter().any(|c| !c.is_finite()) {
+        return Err(Tiles3dError::NonFinite("rtc_center"));
+    }
+    let mut tileset: serde_json::Value =
+        serde_json::from_str(&base).expect("tileset_json_for_region emits valid JSON");
+    let [cx, cy, cz] = rtc_center;
+    // Column-major 4×4: identity rotation, translation = antenna ECEF.
+    tileset["root"]["transform"] =
+        json!([1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, cx, cy, cz, 1.0]);
+    Ok(serde_json::to_string_pretty(&tileset).expect("tileset serializes"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A small grid whose value is a function of height only, so a horizontal
+    /// isosurface is a clean cylindrical sheet (predictable, easy to assert).
+    /// `value(i_h) = i_h` so threshold 1.5 separates the lower two height layers
+    /// from the upper ones.
+    fn ramp_grid(n_r: usize, n_a: usize, n_h: usize) -> VoxelGrid {
+        let mut values = vec![f32::NAN; n_r * n_a * n_h];
+        let dims = [n_r, n_a, n_h];
+        for i_r in 0..n_r {
+            for i_a in 0..n_a {
+                for i_h in 0..n_h {
+                    values[VoxelGrid::index_of(dims, i_r, i_a, i_h)] = i_h as f32;
+                }
+            }
+        }
+        VoxelGrid {
+            origin_lon: 24.5,
+            origin_lat: 60.5,
+            origin_height: 100.0,
+            dims,
+            radius_range: [0.0, 100_000.0],
+            angle_range: [0.0, std::f64::consts::TAU],
+            height_range: [0.0, 10_000.0],
+            values,
+            quantity: "DBZH".into(),
+            unit: "dBZ".into(),
+        }
+    }
+
+    /// Parse a `.glb`: returns (glTF JSON, BIN bytes) after validating the
+    /// container structure.
+    fn parse_glb(glb: &[u8]) -> (serde_json::Value, Vec<u8>) {
+        assert_eq!(&glb[0..4], &0x46546C67u32.to_le_bytes(), "glTF magic");
+        assert_eq!(
+            u32::from_le_bytes(glb[4..8].try_into().unwrap()),
+            2,
+            "version"
+        );
+        let total = u32::from_le_bytes(glb[8..12].try_into().unwrap()) as usize;
+        assert_eq!(total, glb.len(), "header length == actual length");
+
+        let json_len = u32::from_le_bytes(glb[12..16].try_into().unwrap()) as usize;
+        assert_eq!(
+            &glb[16..20],
+            &0x4E4F534Au32.to_le_bytes(),
+            "JSON chunk type"
+        );
+        let json_end = 20 + json_len;
+        let json: serde_json::Value =
+            serde_json::from_slice(&glb[20..json_end]).expect("glTF JSON parses");
+
+        let bin_len = u32::from_le_bytes(glb[json_end..json_end + 4].try_into().unwrap()) as usize;
+        assert_eq!(
+            &glb[json_end + 4..json_end + 8],
+            &0x004E4942u32.to_le_bytes(),
+            "BIN chunk type"
+        );
+        let bin = glb[json_end + 8..json_end + 8 + bin_len].to_vec();
+        assert_eq!(json_len % 4, 0, "JSON chunk 4-aligned");
+        assert_eq!(bin_len % 4, 0, "BIN chunk 4-aligned");
+        (json, bin)
+    }
+
+    #[test]
+    fn isosurface_glb_is_wellformed() {
+        let grid = ramp_grid(3, 8, 5);
+        let glb = encode_isosurface_glb(&grid, 1.5, [255, 0, 0, 255]).expect("encode");
+        let (json, bin) = parse_glb(&glb);
+
+        assert_eq!(json["asset"]["version"], "2.0");
+        assert_eq!(json["meshes"][0]["primitives"][0]["mode"], MODE_TRIANGLES);
+        assert!(json["materials"][0]["doubleSided"].as_bool().unwrap());
+
+        // POSITION + NORMAL accessors, same non-zero count, POSITION has min/max.
+        let pos = &json["accessors"][0];
+        let nrm = &json["accessors"][1];
+        let count = pos["count"].as_u64().unwrap();
+        assert!(
+            count > 0 && count % 3 == 0,
+            "vertex count {count} = 3·triangles"
+        );
+        assert_eq!(nrm["count"].as_u64().unwrap(), count);
+        assert_eq!(pos["min"].as_array().unwrap().len(), 3);
+        assert_eq!(pos["max"].as_array().unwrap().len(), 3);
+
+        // BIN holds exactly POSITION + NORMAL (count·3·f32 each).
+        assert_eq!(bin.len(), (count as usize) * 3 * 4 * 2);
+        // The buffer byteLength matches the BIN payload.
+        assert_eq!(
+            json["buffers"][0]["byteLength"].as_u64().unwrap(),
+            bin.len() as u64
+        );
+
+        // Every position/normal float is finite (no NaN leaked from nodata).
+        for w in bin.chunks_exact(4) {
+            assert!(f32::from_le_bytes(w.try_into().unwrap()).is_finite());
+        }
+    }
+
+    #[test]
+    fn isosurface_sits_at_the_expected_height() {
+        // value = i_h, threshold 1.5 → the surface is a sheet where the field
+        // crosses 1.5, i.e. fractional height index 1.5. With height_range
+        // [0,10000] over 5 cells (cell centres 1000,3000,5000,…), index 1.5 maps
+        // to height (1.5+0.5)·2000 = 4000 m above the origin — and ONLY there,
+        // since the field depends solely on height. Use a small 5 km disc so
+        // earth-curvature/up-deflection over the span is negligible, then
+        // reconstruct each vertex's height above the antenna and assert ≈4000 m.
+        let mut grid = ramp_grid(4, 16, 5);
+        grid.radius_range = [0.0, 5_000.0];
+        let glb = encode_isosurface_glb(&grid, 1.5, [0, 128, 255, 255]).unwrap();
+        let (json, bin) = parse_glb(&glb);
+
+        let rtc = geodetic_to_ecef(grid.origin_lon, grid.origin_lat, grid.origin_height);
+        let up = {
+            let m = (rtc[0] * rtc[0] + rtc[1] * rtc[1] + rtc[2] * rtc[2]).sqrt();
+            [rtc[0] / m, rtc[1] / m, rtc[2] / m] // geocentric up ≈ local up
+        };
+        let pos_len = json["bufferViews"][0]["byteLength"].as_u64().unwrap() as usize;
+        let floats: Vec<f32> = bin[..pos_len]
+            .chunks_exact(4)
+            .map(|w| f32::from_le_bytes(w.try_into().unwrap()))
+            .collect();
+        assert!(!floats.is_empty(), "surface has vertices");
+        for v in floats.chunks_exact(3) {
+            // Invert the stored Z-up→Y-up flip: glTF (x,y,z) → ECEF offset
+            // (x,−z,y); height above antenna = offset · up.
+            let offset = [v[0] as f64, -(v[2] as f64), v[1] as f64];
+            let h = offset[0] * up[0] + offset[1] * up[1] + offset[2] * up[2];
+            assert!((h - 4000.0).abs() < 50.0, "vertex height {h} ≉ 4000 m");
+        }
+    }
+
+    #[test]
+    fn empty_when_threshold_above_all_data() {
+        let grid = ramp_grid(3, 8, 5); // values 0..4
+        assert!(matches!(
+            encode_isosurface_glb(&grid, 100.0, [255, 0, 0, 255]),
+            Err(Tiles3dError::Empty)
+        ));
+    }
+
+    #[test]
+    fn nodata_corners_do_not_fabricate_surface() {
+        // A grid that is all-NaN except a single isolated finite cell can form no
+        // tetrahedron with all-finite corners → no surface (not a 1-cell blob).
+        let mut grid = ramp_grid(3, 8, 5);
+        grid.values.iter_mut().for_each(|v| *v = f32::NAN);
+        let i = grid.index(1, 4, 2);
+        grid.values[i] = 50.0;
+        assert!(matches!(
+            encode_isosurface_glb(&grid, 1.5, [255, 0, 0, 255]),
+            Err(Tiles3dError::Empty)
+        ));
+    }
+
+    #[test]
+    fn non_finite_threshold_is_rejected() {
+        let grid = ramp_grid(3, 8, 5);
+        assert!(matches!(
+            encode_isosurface_glb(&grid, f64::NAN, [0, 0, 0, 255]),
+            Err(Tiles3dError::NonFinite("threshold"))
+        ));
+    }
+
+    #[test]
+    fn tileset_glb_carries_translation_transform_and_region() {
+        let region = [0.42, 1.05, 0.44, 1.07, 100.0, 12_000.0];
+        let rtc = [3_000_000.0, 1_000_000.0, 5_000_000.0];
+        let s = tileset_json_glb(region, "content.glb", rtc).expect("tileset");
+        let v: serde_json::Value = serde_json::from_str(&s).unwrap();
+        assert!(v["geometricError"].as_f64().unwrap() > 0.0, "load-bearing");
+        assert_eq!(v["root"]["content"]["uri"], "content.glb");
+        let t = v["root"]["transform"].as_array().unwrap();
+        assert_eq!(t.len(), 16);
+        // Translation is the last column (indices 12,13,14) in column-major.
+        assert_eq!(t[12].as_f64().unwrap(), 3_000_000.0);
+        assert_eq!(t[13].as_f64().unwrap(), 1_000_000.0);
+        assert_eq!(t[14].as_f64().unwrap(), 5_000_000.0);
+        // Region passes straight through, unaffected by the transform.
+        assert_eq!(
+            v["root"]["boundingVolume"]["region"][0].as_f64().unwrap(),
+            0.42
+        );
+    }
+
+    #[test]
+    fn tileset_glb_rejects_unsafe_uri_and_bad_region() {
+        let rtc = [1.0, 2.0, 3.0];
+        assert!(matches!(
+            tileset_json_glb([0.0, 0.0, 0.1, 0.1, 0.0, 1.0], "../x.glb", rtc),
+            Err(Tiles3dError::InvalidUri(_))
+        ));
+        // south > north is inverted.
+        assert!(matches!(
+            tileset_json_glb([0.0, 0.2, 0.1, 0.1, 0.0, 1.0], "content.glb", rtc),
+            Err(Tiles3dError::InvalidRegion(_))
+        ));
+        // Non-finite rtc is rejected.
+        assert!(matches!(
+            tileset_json_glb(
+                [0.0, 0.0, 0.1, 0.1, 0.0, 1.0],
+                "content.glb",
+                [f64::NAN, 0.0, 0.0]
+            ),
+            Err(Tiles3dError::NonFinite("rtc_center"))
+        ));
+    }
+}

--- a/crates/ds-3dtiles/src/lib.rs
+++ b/crates/ds-3dtiles/src/lib.rs
@@ -21,6 +21,12 @@ use ds_core::volume::VolumePointCloud;
 use ds_render::ColorMap;
 use serde_json::json;
 
+/// Isosurface meshing of a [`ds_core::volume::VoxelGrid`] into glTF `.glb`
+/// triangle-mesh content (#357) — the verifiable, any-client 3-D path next to
+/// the `.pnts` point cloud.
+pub mod isosurface;
+pub use isosurface::{encode_isosurface_glb, tileset_json_glb};
+
 /// Top-level tileset geometric error. Must be > 0 (see module docs); the value
 /// only needs to exceed the root's so CesiumJS refines to the content.
 const TILESET_GEOMETRIC_ERROR: f64 = 1.0e5;

--- a/crates/ds-3dtiles/src/lib.rs
+++ b/crates/ds-3dtiles/src/lib.rs
@@ -61,6 +61,13 @@ pub enum Tiles3dError {
     /// (`west > east` is *not* inverted — it's an antimeridian-crossing region.)
     #[error("invalid region (inverted/degenerate bounds): {0:?}")]
     InvalidRegion([f64; 6]),
+    /// The isosurface `background` (the value `NaN`/clear-air cells are sealed
+    /// to) is not strictly below the `threshold`. With `background >= threshold`,
+    /// unmeasured cells would be treated as *inside* the surface, inverting it
+    /// into something with no physical meaning. Rejected rather than silently
+    /// returning a bogus mesh.
+    #[error("isosurface background {background} must be < threshold {threshold}")]
+    BackgroundNotBelowThreshold { background: f64, threshold: f64 },
 }
 
 /// Encode a point cloud as a 3D Tiles **`.pnts`** tile (the 3D Tiles 1.0 Point
@@ -184,6 +191,18 @@ pub fn tileset_json_for_region(
     region: [f64; 6],
     content_uri: &str,
 ) -> Result<String, Tiles3dError> {
+    let tileset = tileset_value_for_region(region, content_uri)?;
+    Ok(serde_json::to_string_pretty(&tileset).expect("tileset serializes"))
+}
+
+/// Build the `tileset.json` as a [`serde_json::Value`] (the validation +
+/// construction shared by [`tileset_json_for_region`] and the glTF variant
+/// `isosurface::tileset_json_glb`, which injects a `transform` — so it builds
+/// on this `Value` directly instead of re-parsing a serialized string).
+pub(crate) fn tileset_value_for_region(
+    region: [f64; 6],
+    content_uri: &str,
+) -> Result<serde_json::Value, Tiles3dError> {
     if content_uri.is_empty()
         || content_uri.starts_with('/')
         || content_uri.contains("://")
@@ -205,7 +224,7 @@ pub fn tileset_json_for_region(
     // content type: CesiumJS keys its tileset loader off this version, and a
     // 1.1 tileset happily references legacy `.pnts` content. Do not "fix" this
     // to "1.0" — it would change which loader path CesiumJS takes.
-    let tileset = json!({
+    Ok(json!({
         "asset": { "version": "1.1" },
         "geometricError": TILESET_GEOMETRIC_ERROR,
         "root": {
@@ -214,8 +233,7 @@ pub fn tileset_json_for_region(
             "refine": "ADD",
             "content": { "uri": content_uri },
         }
-    });
-    Ok(serde_json::to_string_pretty(&tileset).expect("tileset serializes"))
+    }))
 }
 
 #[cfg(test)]

--- a/crates/engine-odim/examples/gen_isosurface.rs
+++ b/crates/engine-odim/examples/gen_isosurface.rs
@@ -1,0 +1,219 @@
+//! Isosurface demo (#357): build a `PolarVolumeEngine` over a directory of ODIM
+//! polar volumes, resample a site into a cylindrical `ds_core::volume::VoxelGrid`
+//! via `VolumeEngine::read_voxel_grid`, extract a reflectivity **isosurface**
+//! (marching tetrahedra) at a chosen threshold, and encode it to a glTF `.glb`
+//! triangle mesh + `tileset.json` with `ds-3dtiles`.
+//!
+//! Unlike the `.pnts` point-cloud demo (`gen_3dtiles`), the output is a plain
+//! glTF mesh — a solid "storm shell" at e.g. 20 dBZ — that renders in any 3D
+//! Tiles 1.1 client (no experimental voxel extension). The marching-tetrahedra
+//! mesher and the cylindrical-index → ECEF geometry live in `ds-3dtiles` /
+//! `ds-core`; this example only wires them together and writes a token-free
+//! CesiumJS viewer.
+//!
+//! Usage:
+//!   cargo run -p engine-odim --example gen_isosurface -- [file.h5] [out_dir] [threshold_dbz]
+//!     file.h5        default: the (uncommitted) FMI Vihti fixture
+//!     out_dir        default: target/3dtiles-iso-fivih
+//!     threshold_dbz  default: 20.0  (the reflectivity shell to draw)
+
+use ds_core::config::OdimConfig;
+use ds_core::edr_engine::EdrEngine;
+use ds_core::geo::geodetic_to_ecef;
+use ds_core::volume::VolumeEngine;
+use ds_render::{BuiltinColormap, ColorMap, LutColorMap};
+use engine_odim::PolarVolumeEngine;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let file = args.next().unwrap_or_else(|| {
+        format!(
+            "{}/../../testdata/radar-fmi-pvol/202605191050_fivih_PVOL.h5",
+            env!("CARGO_MANIFEST_DIR")
+        )
+    });
+    let out_dir = PathBuf::from(
+        args.next()
+            .unwrap_or_else(|| "target/3dtiles-iso-fivih".to_string()),
+    );
+    let threshold: f64 = args
+        .next()
+        .map(|s| s.parse().expect("threshold_dbz must be a number"))
+        .unwrap_or(20.0);
+
+    let file = Path::new(&file);
+    if !file.exists() {
+        eprintln!("cannot find {}", file.display());
+        eprintln!(
+            "The default FMI Vihti PVOL fixture is not committed to git (15 MB). \
+             Pass a path to an ODIM polar volume (.h5), or place one under \
+             testdata/radar-fmi-pvol/."
+        );
+        std::process::exit(1);
+    }
+    let data_dir = file
+        .parent()
+        .and_then(Path::to_str)
+        .expect("file has a UTF-8 parent directory");
+
+    let config = OdimConfig {
+        filename_template: None,
+        filename_pattern: None,
+        timestamp_format: None,
+        parameter: None,
+        unit: None,
+        nodata: None,
+        gain: None,
+        offset: None,
+        poll_interval_secs: 30,
+        max_files: None,
+        endpoint: None,
+        bucket: None,
+        prefix_pattern: None,
+        time_window: None,
+        discovery: None,
+        cadence_secs: None,
+    };
+    let engine = PolarVolumeEngine::new("iso-demo", Some(data_dir), &config)
+        .expect("build PolarVolumeEngine over the directory");
+
+    let sites = engine.sites();
+    let Some((nod, _label)) = sites.first() else {
+        eprintln!("no radar sites found in {data_dir}");
+        std::process::exit(1);
+    };
+    let view = engine.site_view(nod, &format!("iso-demo-{nod}"));
+
+    let info = view.volume_info();
+    let quantity = ["DBZH", "TH"]
+        .into_iter()
+        .find(|q| info.quantities.iter().any(|(id, _)| id == q))
+        .map(str::to_string)
+        .or_else(|| info.quantities.first().map(|(id, _)| id.clone()))
+        .expect("site advertises at least one quantity");
+
+    // Resample the volume into the default cylindrical voxel grid, then mesh the
+    // isosurface — the production code path the future voxel/iso route will use.
+    let grid = view
+        .read_voxel_grid(Some(&quantity), None, None, None)
+        .expect("resample the volume into a voxel grid");
+    eprintln!(
+        "site {nod} — voxel grid {:?}, {} finite cells, quantity {}",
+        grid.dims,
+        grid.valid_count(),
+        grid.quantity
+    );
+
+    let colormap = LutColorMap::from_builtin(BuiltinColormap::RadarDbz, -32.0, 95.0);
+    let color = colormap.color(Some(threshold)); // the shell's colour = colormap at the threshold
+    let glb = ds_3dtiles::encode_isosurface_glb(&grid, threshold, color)
+        .expect("mesh the isosurface (try a lower threshold if this reports 'empty')");
+
+    fs::create_dir_all(&out_dir).expect("mkdir out_dir");
+    fs::write(out_dir.join("content.glb"), &glb).expect("write content.glb");
+
+    // A geodetic bounding region that *contains* the grid: origin ± angular
+    // radius, heights origin..origin+ceiling. lon/lat in radians (3D Tiles
+    // `region` layout). Slightly over-covers — that's fine for culling.
+    let earth_r = ds_core::geo::EARTH_RADIUS_M;
+    let radius_max = grid.radius_range[1];
+    let lat_r = grid.origin_lat.to_radians();
+    let dlat = radius_max / earth_r;
+    let dlon = radius_max / (earth_r * lat_r.cos().max(1e-6));
+    let lon_r = grid.origin_lon.to_radians();
+    let region = [
+        lon_r - dlon,
+        lat_r - dlat,
+        lon_r + dlon,
+        lat_r + dlat,
+        grid.origin_height + grid.height_range[0],
+        grid.origin_height + grid.height_range[1],
+    ];
+    let rtc = geodetic_to_ecef(grid.origin_lon, grid.origin_lat, grid.origin_height);
+    let tileset = ds_3dtiles::tileset_json_glb(region, "content.glb", rtc).expect("build tileset");
+    fs::write(out_dir.join("tileset.json"), tileset).expect("write tileset.json");
+
+    let antenna = view
+        .get_locations()
+        .ok()
+        .and_then(|locs| locs.into_iter().next());
+    let (lon, lat) = antenna
+        .as_ref()
+        .map(|l| (l.longitude, l.latitude))
+        .unwrap_or((grid.origin_lon, grid.origin_lat));
+    let site_label = antenna
+        .as_ref()
+        .map(|l| l.label.clone())
+        .unwrap_or_else(|| nod.clone());
+    let time_str = info
+        .times
+        .last()
+        .map(|t| t.format("%Y-%m-%d %H:%MZ").to_string())
+        .unwrap_or_default();
+    let hud = format!(
+        "{site_label} ({nod}) {} isosurface — {time_str} · {threshold:.0} dBZ shell",
+        grid.quantity
+    );
+    write_viewer(&out_dir, lon, lat, grid.origin_height, &hud);
+
+    eprintln!(
+        "wrote {}/  (tileset.json, content.glb, index.html) — {:.1} MB glb",
+        out_dir.display(),
+        glb.len() as f64 / 1e6
+    );
+}
+
+/// Write a self-contained, token-free CesiumJS viewer (CARTO Dark Matter
+/// basemap) for the glTF isosurface tileset.
+fn write_viewer(out_dir: &Path, lon: f64, lat: f64, base_alt: f64, hud: &str) {
+    fn html_escape(s: &str) -> String {
+        s.replace('&', "&amp;")
+            .replace('<', "&lt;")
+            .replace('>', "&gt;")
+            .replace('"', "&quot;")
+    }
+    let hud = html_escape(hud);
+    let cam_alt = base_alt + 90_000.0;
+    let html = format!(
+        r#"<!doctype html>
+<html><head><meta charset="utf-8"><title>{hud} — 3D Tiles</title>
+<script src="https://cesium.com/downloads/cesiumjs/releases/1.124/Build/Cesium/Cesium.js"></script>
+<link href="https://cesium.com/downloads/cesiumjs/releases/1.124/Build/Cesium/Widgets/widgets.css" rel="stylesheet">
+<style>html,body,#c{{width:100%;height:100%;margin:0;overflow:hidden}}
+#hud{{position:absolute;top:8px;left:8px;z-index:9;font:13px sans-serif;color:#fff;background:rgba(0,0,0,.55);padding:6px 9px;border-radius:5px}}</style></head>
+<body><div id="c"></div><div id="hud">{hud}</div><script>
+// Token-free: CARTO Dark Matter basemap, no Cesium Ion terrain/imagery.
+const viewer = new Cesium.Viewer("c", {{
+  baseLayer: new Cesium.ImageryLayer(
+    new Cesium.UrlTemplateImageryProvider({{
+      url: "https://{{s}}.basemaps.cartocdn.com/dark_all/{{z}}/{{x}}/{{y}}.png",
+      subdomains: "abcd",
+      maximumLevel: 19,
+      credit: "© OpenStreetMap contributors © CARTO",
+    }})),
+  baseLayerPicker: false, timeline: false, animation: false, geocoder: false,
+}});
+viewer.scene.backgroundColor = Cesium.Color.BLACK;
+viewer.scene.globe.depthTestAgainstTerrain = false;
+// Light the mesh from the scene's sun; the doubleSided material shades both
+// faces so the shell reads as a solid 3-D surface.
+viewer.scene.light = new Cesium.DirectionalLight({{
+  direction: Cesium.Cartesian3.normalize(new Cesium.Cartesian3(0.3, -0.6, -0.7), new Cesium.Cartesian3()),
+}});
+Cesium.Cesium3DTileset.fromUrl("tileset.json", {{ maximumScreenSpaceError: 1 }}).then(ts => {{
+  viewer.scene.primitives.add(ts);
+  viewer.camera.flyTo({{
+    destination: Cesium.Cartesian3.fromDegrees({lon}, {lat_s}, {cam_alt}),
+    orientation: {{ heading: 0, pitch: Cesium.Math.toRadians(-30), roll: 0 }},
+    duration: 0
+  }});
+  console.log("isosurface tileset ready");
+}}).catch(e => console.error("tileset error", e));
+</script></body></html>
+"#,
+        lat_s = lat - 0.9,
+    );
+    fs::write(out_dir.join("index.html"), html).expect("write index.html");
+}

--- a/crates/engine-odim/examples/gen_isosurface.rs
+++ b/crates/engine-odim/examples/gen_isosurface.rs
@@ -117,23 +117,26 @@ fn main() {
     fs::create_dir_all(&out_dir).expect("mkdir out_dir");
     fs::write(out_dir.join("content.glb"), &glb).expect("write content.glb");
 
-    // A geodetic bounding region that *contains* the grid: origin ± angular
-    // radius, heights origin..origin+ceiling. lon/lat in radians (3D Tiles
-    // `region` layout). Slightly over-covers — that's fine for culling.
-    let earth_r = ds_core::geo::EARTH_RADIUS_M;
-    let radius_max = grid.radius_range[1];
-    let lat_r = grid.origin_lat.to_radians();
-    let dlat = radius_max / earth_r;
-    let dlon = radius_max / (earth_r * lat_r.cos().max(1e-6));
-    let lon_r = grid.origin_lon.to_radians();
-    let region = [
-        lon_r - dlon,
-        lat_r - dlat,
-        lon_r + dlon,
-        lat_r + dlat,
-        grid.origin_height + grid.height_range[0],
-        grid.origin_height + grid.height_range[1],
-    ];
+    // Prefer the engine's authoritative coverage region (the same value the
+    // production `/tileset.json` endpoint uses), falling back to an
+    // origin±angular-radius approximation only if it's absent. lon/lat in
+    // radians (3D Tiles `region` layout).
+    let region = info.region.unwrap_or_else(|| {
+        let earth_r = ds_core::geo::EARTH_RADIUS_M;
+        let radius_max = grid.radius_range[1];
+        let lat_r = grid.origin_lat.to_radians();
+        let dlat = radius_max / earth_r;
+        let dlon = radius_max / (earth_r * lat_r.cos().max(1e-6));
+        let lon_r = grid.origin_lon.to_radians();
+        [
+            lon_r - dlon,
+            lat_r - dlat,
+            lon_r + dlon,
+            lat_r + dlat,
+            grid.origin_height + grid.height_range[0],
+            grid.origin_height + grid.height_range[1],
+        ]
+    });
     let rtc = geodetic_to_ecef(grid.origin_lon, grid.origin_lat, grid.origin_height);
     let tileset = ds_3dtiles::tileset_json_glb(region, "content.glb", rtc).expect("build tileset");
     fs::write(out_dir.join("tileset.json"), tileset).expect("write tileset.json");

--- a/crates/engine-odim/examples/gen_isosurface.rs
+++ b/crates/engine-odim/examples/gen_isosurface.rs
@@ -106,9 +106,12 @@ fn main() {
         grid.quantity
     );
 
+    // The shell's colour = the colormap at the threshold value.
     let colormap = LutColorMap::from_builtin(BuiltinColormap::RadarDbz, -32.0, 95.0);
-    let color = colormap.color(Some(threshold)); // the shell's colour = colormap at the threshold
-    let glb = ds_3dtiles::encode_isosurface_glb(&grid, threshold, color)
+    let color = colormap.color(Some(threshold));
+    // Seal against clear air with the dBZ floor (-32) so the shell closes into
+    // solid blobs instead of open "curtains" where echo meets no-echo.
+    let glb = ds_3dtiles::encode_isosurface_glb(&grid, threshold, color, Some(-32.0))
         .expect("mesh the isosurface (try a lower threshold if this reports 'empty')");
 
     fs::create_dir_all(&out_dir).expect("mkdir out_dir");
@@ -139,10 +142,6 @@ fn main() {
         .get_locations()
         .ok()
         .and_then(|locs| locs.into_iter().next());
-    let (lon, lat) = antenna
-        .as_ref()
-        .map(|l| (l.longitude, l.latitude))
-        .unwrap_or((grid.origin_lon, grid.origin_lat));
     let site_label = antenna
         .as_ref()
         .map(|l| l.label.clone())
@@ -156,7 +155,7 @@ fn main() {
         "{site_label} ({nod}) {} isosurface — {time_str} · {threshold:.0} dBZ shell",
         grid.quantity
     );
-    write_viewer(&out_dir, lon, lat, grid.origin_height, &hud);
+    write_viewer(&out_dir, &hud);
 
     eprintln!(
         "wrote {}/  (tileset.json, content.glb, index.html) — {:.1} MB glb",
@@ -166,8 +165,10 @@ fn main() {
 }
 
 /// Write a self-contained, token-free CesiumJS viewer (CARTO Dark Matter
-/// basemap) for the glTF isosurface tileset.
-fn write_viewer(out_dir: &Path, lon: f64, lat: f64, base_alt: f64, hud: &str) {
+/// basemap) for the glTF isosurface tileset. The camera auto-frames the tileset
+/// (`zoomTo`) so it works regardless of where the echoes sit — no hard-coded
+/// position to land on empty sky.
+fn write_viewer(out_dir: &Path, hud: &str) {
     fn html_escape(s: &str) -> String {
         s.replace('&', "&amp;")
             .replace('<', "&lt;")
@@ -175,7 +176,6 @@ fn write_viewer(out_dir: &Path, lon: f64, lat: f64, base_alt: f64, hud: &str) {
             .replace('"', "&quot;")
     }
     let hud = html_escape(hud);
-    let cam_alt = base_alt + 90_000.0;
     let html = format!(
         r#"<!doctype html>
 <html><head><meta charset="utf-8"><title>{hud} — 3D Tiles</title>
@@ -197,6 +197,8 @@ const viewer = new Cesium.Viewer("c", {{
 }});
 viewer.scene.backgroundColor = Cesium.Color.BLACK;
 viewer.scene.globe.depthTestAgainstTerrain = false;
+// Lift the dark basemap a touch so the shell sits on a visible map.
+viewer.imageryLayers.get(0).brightness = 1.6;
 // Light the mesh from the scene's sun; the doubleSided material shades both
 // faces so the shell reads as a solid 3-D surface.
 viewer.scene.light = new Cesium.DirectionalLight({{
@@ -204,16 +206,14 @@ viewer.scene.light = new Cesium.DirectionalLight({{
 }});
 Cesium.Cesium3DTileset.fromUrl("tileset.json", {{ maximumScreenSpaceError: 1 }}).then(ts => {{
   viewer.scene.primitives.add(ts);
-  viewer.camera.flyTo({{
-    destination: Cesium.Cartesian3.fromDegrees({lon}, {lat_s}, {cam_alt}),
-    orientation: {{ heading: 0, pitch: Cesium.Math.toRadians(-30), roll: 0 }},
-    duration: 0
-  }});
+  // Auto-frame the tileset obliquely (heading 20°, pitch -25°) from its own
+  // bounding sphere — robust whatever the echo layout.
+  viewer.zoomTo(ts, new Cesium.HeadingPitchRange(
+    Cesium.Math.toRadians(20), Cesium.Math.toRadians(-25), ts.boundingSphere.radius * 1.3));
   console.log("isosurface tileset ready");
 }}).catch(e => console.error("tileset error", e));
 </script></body></html>
-"#,
-        lat_s = lat - 0.9,
+"#
     );
     fs::write(out_dir.join("index.html"), html).expect("write index.html");
 }

--- a/crates/engine-odim/src/volume_engine.rs
+++ b/crates/engine-odim/src/volume_engine.rs
@@ -1301,8 +1301,9 @@ fn derive_site_meta(list: &[VolumeEntry]) -> Option<SiteMeta> {
         // PVOL site views implement `read_voxel_grid`, so the isosurface
         // representation is available; the origin is the antenna (the point the
         // voxel grid — and thus the isosurface mesh — is built relative to).
-        supports_voxel_grid: true,
-        origin: Some([site.lon, site.lat, site.height]),
+        voxel_grid: Some(ds_core::volume::VoxelGridCaps {
+            origin: [site.lon, site.lat, site.height],
+        }),
     });
 
     Some(SiteMeta {

--- a/crates/engine-odim/src/volume_engine.rs
+++ b/crates/engine-odim/src/volume_engine.rs
@@ -1298,6 +1298,11 @@ fn derive_site_meta(list: &[VolumeEntry]) -> Option<SiteMeta> {
         default_quantity,
         default_unit,
         region,
+        // PVOL site views implement `read_voxel_grid`, so the isosurface
+        // representation is available; the origin is the antenna (the point the
+        // voxel grid — and thus the isosurface mesh — is built relative to).
+        supports_voxel_grid: true,
+        origin: Some([site.lon, site.lat, site.height]),
     });
 
     Some(SiteMeta {

--- a/crates/render/src/colormap.rs
+++ b/crates/render/src/colormap.rs
@@ -9,6 +9,14 @@ pub trait ColorMap: Send + Sync {
     fn nodata_color(&self) -> [u8; 4] {
         [0, 0, 0, 0]
     }
+
+    /// The continuous `(min, max)` value domain this colormap ramps over, if it
+    /// has one. Used e.g. as the "no-echo" floor when sealing a 3D Tiles
+    /// isosurface (the bottom of the reflectivity ramp). Defaults to `None`
+    /// (a categorical / domainless map).
+    fn domain(&self) -> Option<(f64, f64)> {
+        None
+    }
 }
 
 /// A color stop for defining gradient colormaps.
@@ -95,6 +103,10 @@ impl LutColorMap {
 impl ColorMap for LutColorMap {
     fn nodata_color(&self) -> [u8; 4] {
         self.nodata_color
+    }
+
+    fn domain(&self) -> Option<(f64, f64)> {
+        Some((self.min, self.max))
     }
 
     fn color(&self, value: Option<f64>) -> [u8; 4] {


### PR DESCRIPTION
## What

Continuing the OGC 3D Tiles work (epic #346) on the merged `VoxelGrid` foundation (#358): a **marching-tetrahedra isosurface mesher** that turns a cylindrical `VoxelGrid` into a glTF 2.0 `.glb` triangle mesh — e.g. "the 20 dBZ shell" of a radar volume.

### Why isosurface (and not the draft voxel path)
The true `EXT_primitive_voxels` voxel path (#351) is blocked on an unsettled draft spec that needs experimental CesiumJS ≥1.127 to render — not something I can verify at encode time. An **isosurface is a plain glTF triangle mesh**: it renders in *any* 3D Tiles 1.1 client, so it's the verifiable way to show a radar volume's 3-D structure, and it builds directly on the same `VoxelGrid`. The voxel encoder stays tracked in #351 for when the spec settles.

## Changes

- **`ds-core`** — `geo::destination_point` + `EARTH_RADIUS_M`: shared spherical great-circle so the encoder maps polar `(range, azimuth)` samples the *same way* the volume engines do (one formula, one earth radius). Pinned against analytic references (meridian/equator/antimeridian-wrap).
- **`ds-3dtiles`** — `isosurface.rs`: `encode_isosurface_glb(grid, threshold, color)` + `tileset_json_glb(region, uri, rtc_center)`.
  - **Marching *tetrahedra*, not cubes.** A tetrahedron is the complete graph K4, so the surface crosses exactly `|inside|·|outside|` edges (3 → triangle, 4 → quad) and the topology is **correct by construction** — no 256-case edge/triangle table to mis-transcribe. Deliberate, since the output can't be eyeballed at encode time. Cube → 6 tets via the Kuhn/Freudenthal split (watertight across cube boundaries).
  - **NaN-aware:** any tet touching a nodata corner is skipped → no fabricated surface across the cone of silence / beyond the beam fan.
  - **Geometry:** fractional cell index → ground/azimuth/height (same cell-centre convention the engine sampled with) → `destination_point` + `geodetic_to_ecef`, stored antenna-relative and pre-flipped Z-up→Y-up (a runtime re-applies Y-up→Z-up to **glTF** content — the flip `.pnts` skips). Tile `transform` = antenna ECEF; geodetic `region` unaffected. `doubleSided` PBR shell coloured at the threshold.
- **`engine-odim`** — `gen_isosurface` example: real fivih PVOL → `.glb` + `tileset.json` + a token-free CesiumJS viewer (CARTO dark).
- **`CLAUDE.md`** — documents the isosurface path + the marching-tet rationale.

## Verification

- **Unit tests (13 in `ds-3dtiles`, + geo):** glb container well-formed (magic/chunks/alignment); **the surface lands at the exact expected height** over a height-ramp field — this verifies the index→ECEF→Y-up mapping end-to-end without a renderer; empty / NaN-corner / non-finite-threshold guards; tileset transform + region + URI/region validation.
- **Real-data demo** on the committed-locally fivih fixture: 253,636 finite cells → **178,022 triangles**, independently re-parsed — all positions finite, **all normals unit-length (0 bad)**, geodetic region + antenna-ECEF transform correct.

## Render-verify (the one thing I can't check here)
The math is verified by the height test, but I can't drive CesiumJS in this environment. To eyeball:
```
cargo run -p engine-odim --example gen_isosurface
# then serve target/3dtiles-iso-fivih/ and open index.html
```
The shell should stand upright over Vihti. **If it renders tipped 90°**, that's the glTF up-axis convention for direct 1.1 `.glb` content (a one-line fix: store ECEF-native + `asset.gltfUpAxis: "Z"`).

## Follow-ups
- API route (serve `.glb` isosurface from `/3dtiles`, threshold query param, viewer toggle) — encoder + demo ship first, mirroring `.pnts` (#347 demo → #349 API).
- Angular-seam wrap (a one-cell gap at azimuth 0 today) and vertex sharing (mesh is non-indexed) — noted in code.

Part of epic #346. Refs #357, #351, #358.

🤖 Generated with [Claude Code](https://claude.com/claude-code)