### PR TITLE
feat(engine-odim): split radar undetect (clear air) from nodata in the voxel grid (#360)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -265,16 +265,18 @@ into a glTF `.glb` triangle mesh.
   cell-centre convention as the engine sampler) → `destination_point` +
   `geodetic_to_ecef` (both now in `ds_core::geo`), stored antenna-relative and
   pre-flipped Z-up→Y-up because a runtime re-applies Y-up→Z-up to **glTF**
-  content (the flip the `.pnts` path skips — pnts isn't glTF). **`background`
-  sealing (load-bearing for radar):** the grid stores `NaN` for *both* clear-air
-  (`undetect`) and unmeasured (`nodata`/cone of silence) — `RawPixels::sample`
-  masks both identically (reader.rs). `encode_isosurface_glb(grid, threshold,
-  color, background)` with `background=Some(bg<threshold)` treats `NaN` as
-  no-echo so the surface **closes into solid blobs**; `None` skips `NaN`-touching
-  tets and the echo→clear-air boundary renders as open vertical *curtains*. The
-  demo seals with `Some(-32.0)` (the dBZ floor). Splitting `undetect` from
-  `nodata` in the engine sampler (so only the real cone of silence stays open) is
-  a follow-up. `tileset_json_glb`
+  content (the flip the `.pnts` path skips — pnts isn't glTF). **Clear-air
+  sealing (load-bearing for radar):** the engine distinguishes clear air
+  (`undetect`) from unmeasured (`nodata`/cone of silence) — `RawPixels::sample_class`
+  (reader.rs) returns `Value`/`Undetect`/`Masked`, and `voxel_grid_from_volume`
+  fills `Undetect` cells with the finite `NO_ECHO_FLOOR` (−32 dBZ) and leaves
+  `Masked` cells `NaN` (#360). So the isosurface seals against clear air on its
+  own and callers pass `background=None`: the surface **closes into solid blobs**
+  where echo meets clear air, while genuinely-unmeasured cells stay `NaN` and are
+  left **open** (no fabricated cap over the cone of silence / below the lowest
+  beam / beyond range). The `background=Some(bg<threshold)` mode still exists (it
+  seals `NaN` too, capping the unmeasured boundary — the pre-#360 behaviour) for
+  callers that want a watertight shell. `tileset_json_glb`
   carries the antenna ECEF as the tile **`transform`** (glTF content has no
   embedded origin, unlike `.pnts` `RTC_CENTER`); the geodetic `region` is
   unaffected by it. Demo: `cargo run -p engine-odim --example gen_isosurface`
@@ -290,8 +292,9 @@ into a glTF `.glb` triangle mesh.
   — `Some` ⇒ isosurface available and the origin is present (so the tileset is
   built without sampling, and "supports but no origin" is unrepresentable, never
   a 500). It drives the collection JSON's `representations` array → the viewer's
-  representation toggle. The isosurface floor (seal) = `ColorMap::domain()` min
-  (clamped `< threshold`); an over-large surface (threshold too low) → 400.
+  representation toggle. The isosurface passes `background=None` (the engine's
+  `NO_ECHO_FLOOR` does the sealing, #360); an over-large surface (threshold too
+  low) → 400, an empty one (threshold above all echo) → 404.
 - **Routes** (mounted at `/3dtiles`): `GET /collections/{id}/tileset.json`
   (`?representation=&quantity=&datetime=&min_value=&threshold=`),
   `GET /collections/{id}/content.pnts` (`?quantity=&datetime=&min_value=`),

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -265,18 +265,19 @@ into a glTF `.glb` triangle mesh.
   cell-centre convention as the engine sampler) → `destination_point` +
   `geodetic_to_ecef` (both now in `ds_core::geo`), stored antenna-relative and
   pre-flipped Z-up→Y-up because a runtime re-applies Y-up→Z-up to **glTF**
-  content (the flip the `.pnts` path skips — pnts isn't glTF). **Clear-air
-  sealing (load-bearing for radar):** the engine distinguishes clear air
-  (`undetect`) from unmeasured (`nodata`/cone of silence) — `RawPixels::sample_class`
-  (reader.rs) returns `Value`/`Undetect`/`Masked`, and `voxel_grid_from_volume`
-  fills `Undetect` cells with the finite `NO_ECHO_FLOOR` (−32 dBZ) and leaves
-  `Masked` cells `NaN` (#360). So the isosurface seals against clear air on its
-  own and callers pass `background=None`: the surface **closes into solid blobs**
-  where echo meets clear air, while genuinely-unmeasured cells stay `NaN` and are
-  left **open** (no fabricated cap over the cone of silence / below the lowest
-  beam / beyond range). The `background=Some(bg<threshold)` mode still exists (it
-  seals `NaN` too, capping the unmeasured boundary — the pre-#360 behaviour) for
-  callers that want a watertight shell. `tileset_json_glb`
+  content (the flip the `.pnts` path skips — pnts isn't glTF). **Sealing
+  (load-bearing for radar):** `encode_isosurface_glb(grid, threshold, color,
+  background)` with `background=Some(bg<threshold)` treats every `NaN` corner as
+  no-echo, so the surface **closes into solid blobs** — the **default** the API +
+  demo use (`Some(-32.0)`), because leaving boundaries open renders as vertical
+  *curtains*. `None` skips `NaN`-touching tets (open surface). **#360 layer
+  (foundation, currently invisible under the sealed default):** the engine *does*
+  distinguish clear air (`undetect`) from genuinely-unmeasured (`nodata`/cone of
+  silence) — `RawPixels::sample_class` (reader.rs) → `Value`/`Undetect`/`Masked`,
+  and `voxel_grid_from_volume` fills `Undetect` with the finite `NO_ECHO_FLOOR`
+  (−32 dBZ) and leaves `Masked` `NaN`. With `Some` both seal alike (solid look);
+  with `None` clear air still seals but unmeasured stays open — an opt-in "honest
+  boundary" mode, and the substrate true voxels (#351) need. `tileset_json_glb`
   carries the antenna ECEF as the tile **`transform`** (glTF content has no
   embedded origin, unlike `.pnts` `RTC_CENTER`); the geodetic `region` is
   unaffected by it. Demo: `cargo run -p engine-odim --example gen_isosurface`
@@ -292,8 +293,8 @@ into a glTF `.glb` triangle mesh.
   — `Some` ⇒ isosurface available and the origin is present (so the tileset is
   built without sampling, and "supports but no origin" is unrepresentable, never
   a 500). It drives the collection JSON's `representations` array → the viewer's
-  representation toggle. The isosurface passes `background=None` (the engine's
-  `NO_ECHO_FLOOR` does the sealing, #360); an over-large surface (threshold too
+  representation toggle. The isosurface seals (`background=Some(-32)`, clamped
+  `< threshold`) for the solid-blob look; an over-large surface (threshold too
   low) → 400, an empty one (threshold above all echo) → 404.
 - **Routes** (mounted at `/3dtiles`): `GET /collections/{id}/tileset.json`
   (`?representation=&quantity=&datetime=&min_value=&threshold=`),

--- a/crates/api-3dtiles/src/handlers.rs
+++ b/crates/api-3dtiles/src/handlers.rs
@@ -403,22 +403,15 @@ pub async fn get_content_glb(
         return Err(Tiles3dError::BadRequest("threshold must be finite".into()));
     }
 
-    // Colour the shell at the threshold; seal NaN (clear air / unmeasured) at
-    // the colormap's floor so the surface closes into solid blobs. The floor
-    // must be < threshold (clamp defensively against an odd colormap domain).
-    //
-    // v1 uses the single collection-level colormap regardless of quantity (the
-    // `.pnts` path has the same limitation), so for a non-reflectivity quantity
-    // (VRADH/ZDR/…) the dBZ floor is only "below any likely threshold", not
-    // physically the quantity's minimum — geometrically fine (the seal still
-    // closes), semantically approximate. Per-quantity colormaps (#350) fix it.
+    // Colour the shell at the threshold. v1 uses the single collection-level
+    // colormap regardless of quantity (the `.pnts` path has the same
+    // limitation); per-quantity colormaps are #350.
     let color = state.colormap.color(Some(threshold));
-    let floor = state
-        .colormap
-        .domain()
-        .map(|(lo, _)| lo)
-        .unwrap_or(threshold - 64.0)
-        .min(threshold - 1.0);
+    // background = None: the engine fills clear air (undetect) with a finite
+    // floor (#360), so the surface seals against it on its own; genuinely
+    // unmeasured cells stay NaN and are left OPEN — no fabricated cap over the
+    // cone of silence.
+    let background = None;
 
     // read_voxel_grid does blocking HDF5 I/O + a long CPU loop (marching tet),
     // so bound it with the shared render semaphore and run on a blocking thread
@@ -435,7 +428,7 @@ pub async fn get_content_glb(
     let (bytes, etag) =
         tokio::task::spawn_blocking(move || -> Result<(Vec<u8>, String), Tiles3dError> {
             let grid = engine.read_voxel_grid(quantity.as_deref(), time, None, None)?;
-            let bytes = ds_3dtiles::encode_isosurface_glb(&grid, threshold, color, Some(floor))
+            let bytes = ds_3dtiles::encode_isosurface_glb(&grid, threshold, color, background)
                 .map_err(|e| match e {
                     // An empty surface (threshold above all echo) is "no data
                     // here", not a server fault — 404, matching the no-data path.

--- a/crates/api-3dtiles/src/handlers.rs
+++ b/crates/api-3dtiles/src/handlers.rs
@@ -408,7 +408,7 @@ pub async fn get_content_glb(
     let floor = f64::from(ds_core::volume::NO_ECHO_FLOOR_DBZ);
     if threshold <= floor {
         return Err(Tiles3dError::BadRequest(format!(
-            "threshold must be above the {floor} dBZ no-echo floor"
+            "threshold must be above the no-echo floor ({floor})"
         )));
     }
 

--- a/crates/api-3dtiles/src/handlers.rs
+++ b/crates/api-3dtiles/src/handlers.rs
@@ -407,11 +407,12 @@ pub async fn get_content_glb(
     // colormap regardless of quantity (the `.pnts` path has the same
     // limitation); per-quantity colormaps are #350.
     let color = state.colormap.color(Some(threshold));
-    // background = None: the engine fills clear air (undetect) with a finite
-    // floor (#360), so the surface seals against it on its own; genuinely
-    // unmeasured cells stay NaN and are left OPEN — no fabricated cap over the
-    // cone of silence.
-    let background = None;
+    // Seal NaN at the no-echo floor so the shell closes into solid blobs (the
+    // preferred look — leaving the unmeasured boundary open reads as "curtains").
+    // The engine fills clear air with the same -32 dBZ floor (#360), so clear
+    // air and unmeasured cells seal at one uniform level. Clamp < threshold so
+    // a (nonsensical) sub-floor threshold can't trip the encoder's guard.
+    let background = Some((-32.0_f64).min(threshold - 1.0));
 
     // read_voxel_grid does blocking HDF5 I/O + a long CPU loop (marching tet),
     // so bound it with the shared render semaphore and run on a blocking thread

--- a/crates/api-3dtiles/src/handlers.rs
+++ b/crates/api-3dtiles/src/handlers.rs
@@ -405,6 +405,8 @@ pub async fn get_content_glb(
     // The engine fills clear air with the no-echo floor; a threshold at/below it
     // would put clear air *inside* the surface (all clear air would render as
     // echo). Reject — a reflectivity shell below the −32 dBZ floor is meaningless.
+    // (v1: the floor is dBZ for every quantity; for a non-reflectivity quantity
+    // it's just "below any sane threshold" — per-quantity floors are #350.)
     let floor = f64::from(ds_core::volume::NO_ECHO_FLOOR_DBZ);
     if threshold <= floor {
         return Err(Tiles3dError::BadRequest(format!(

--- a/crates/api-3dtiles/src/handlers.rs
+++ b/crates/api-3dtiles/src/handlers.rs
@@ -402,17 +402,25 @@ pub async fn get_content_glb(
     if !threshold.is_finite() {
         return Err(Tiles3dError::BadRequest("threshold must be finite".into()));
     }
+    // The engine fills clear air with the no-echo floor; a threshold at/below it
+    // would put clear air *inside* the surface (all clear air would render as
+    // echo). Reject — a reflectivity shell below the −32 dBZ floor is meaningless.
+    let floor = f64::from(ds_core::volume::NO_ECHO_FLOOR_DBZ);
+    if threshold <= floor {
+        return Err(Tiles3dError::BadRequest(format!(
+            "threshold must be above the {floor} dBZ no-echo floor"
+        )));
+    }
 
     // Colour the shell at the threshold. v1 uses the single collection-level
     // colormap regardless of quantity (the `.pnts` path has the same
     // limitation); per-quantity colormaps are #350.
     let color = state.colormap.color(Some(threshold));
-    // Seal NaN at the no-echo floor so the shell closes into solid blobs (the
-    // preferred look — leaving the unmeasured boundary open reads as "curtains").
-    // The engine fills clear air with the same -32 dBZ floor (#360), so clear
-    // air and unmeasured cells seal at one uniform level. Clamp < threshold so
-    // a (nonsensical) sub-floor threshold can't trip the encoder's guard.
-    let background = Some((-32.0_f64).min(threshold - 1.0));
+    // Seal NaN at the same no-echo floor the engine fills clear air with, so the
+    // shell closes into solid blobs (the preferred look — an open unmeasured
+    // boundary reads as "curtains") and clear air + unmeasured seal at one
+    // uniform level. `floor < threshold` is guaranteed above.
+    let background = Some(floor);
 
     // read_voxel_grid does blocking HDF5 I/O + a long CPU loop (marching tet),
     // so bound it with the shared render semaphore and run on a blocking thread

--- a/crates/api-3dtiles/tests/integration.rs
+++ b/crates/api-3dtiles/tests/integration.rs
@@ -73,11 +73,11 @@ impl VolumeEngine for MockVolume {
         }
         let dims = dims.unwrap_or([4, 8, 4]);
         let [n_r, n_a, n_h] = dims;
-        // Clear air is a finite floor (−32 dBZ), matching the post-#360 engine
-        // fill, so an isosurface at the default 20 dBZ seals against it
-        // (background=None) and yields a non-empty mesh. A finite >threshold
-        // echo core sits in the middle.
-        let mut values = vec![-32.0_f32; n_r * n_a * n_h];
+        // Clear air is the finite no-echo floor (matching the post-#360 engine
+        // fill), with a finite >threshold echo core in the middle — so the
+        // isosurface (which the handler seals with `background=Some(floor)`)
+        // produces a non-empty mesh.
+        let mut values = vec![ds_core::volume::NO_ECHO_FLOOR_DBZ; n_r * n_a * n_h];
         for i_r in 1..n_r.min(3) {
             for i_a in 0..n_a {
                 for i_h in 1..n_h.min(3) {
@@ -500,6 +500,26 @@ async fn content_glb_is_valid_gltf_and_etagged() {
         "model/gltf-binary"
     );
     assert!(headers.contains_key(axum::http::header::ETAG));
+}
+
+#[tokio::test]
+async fn isosurface_threshold_at_or_below_floor_is_400() {
+    // A threshold at/below the −32 dBZ no-echo floor would place clear-air floor
+    // cells inside the surface (all clear air renders as echo) — rejected.
+    for t in ["-40", "-32"] {
+        let (cs, _b, _h) = get(&format!(
+            "/collections/radar-fivih/content.glb?threshold={t}"
+        ))
+        .await;
+        assert_eq!(
+            cs,
+            StatusCode::BAD_REQUEST,
+            "threshold {t} <= floor must 400"
+        );
+    }
+    // Just above the floor is accepted.
+    let (cs, _b, _h) = get("/collections/radar-fivih/content.glb?threshold=-30").await;
+    assert_eq!(cs, StatusCode::OK, "threshold above floor is fine");
 }
 
 #[tokio::test]

--- a/crates/api-3dtiles/tests/integration.rs
+++ b/crates/api-3dtiles/tests/integration.rs
@@ -504,9 +504,10 @@ async fn content_glb_is_valid_gltf_and_etagged() {
 
 #[tokio::test]
 async fn isosurface_threshold_at_or_below_floor_is_400() {
-    // A threshold at/below the −32 dBZ no-echo floor would place clear-air floor
-    // cells inside the surface (all clear air renders as echo) — rejected.
-    for t in ["-40", "-32"] {
+    // A threshold at/below the no-echo floor would place clear-air floor cells
+    // inside the surface (all clear air renders as echo) — rejected.
+    let floor = f64::from(ds_core::volume::NO_ECHO_FLOOR_DBZ);
+    for t in [floor - 8.0, floor] {
         let (cs, _b, _h) = get(&format!(
             "/collections/radar-fivih/content.glb?threshold={t}"
         ))
@@ -518,7 +519,11 @@ async fn isosurface_threshold_at_or_below_floor_is_400() {
         );
     }
     // Just above the floor is accepted.
-    let (cs, _b, _h) = get("/collections/radar-fivih/content.glb?threshold=-30").await;
+    let (cs, _b, _h) = get(&format!(
+        "/collections/radar-fivih/content.glb?threshold={}",
+        floor + 2.0
+    ))
+    .await;
     assert_eq!(cs, StatusCode::OK, "threshold above floor is fine");
 }
 

--- a/crates/api-3dtiles/tests/integration.rs
+++ b/crates/api-3dtiles/tests/integration.rs
@@ -73,9 +73,11 @@ impl VolumeEngine for MockVolume {
         }
         let dims = dims.unwrap_or([4, 8, 4]);
         let [n_r, n_a, n_h] = dims;
-        let mut values = vec![f32::NAN; n_r * n_a * n_h];
-        // A finite >threshold echo core (surrounded by NaN) so a sealed
-        // isosurface at the default 20 dBZ produces a non-empty mesh.
+        // Clear air is a finite floor (−32 dBZ), matching the post-#360 engine
+        // fill, so an isosurface at the default 20 dBZ seals against it
+        // (background=None) and yields a non-empty mesh. A finite >threshold
+        // echo core sits in the middle.
+        let mut values = vec![-32.0_f32; n_r * n_a * n_h];
         for i_r in 1..n_r.min(3) {
             for i_a in 0..n_a {
                 for i_h in 1..n_h.min(3) {

--- a/crates/core/src/volume.rs
+++ b/crates/core/src/volume.rs
@@ -89,6 +89,15 @@ pub struct VoxelGridCaps {
     pub origin: [f64; 3],
 }
 
+/// The physical value (dBZ) marking a radar voxel cell as **clear air / no
+/// echo**: the level a producer fills `undetect` cells with, and the level a
+/// 3D Tiles isosurface seals `NaN` corners at (`background`). Shared here so the
+/// *fill* (the radar engine) and the *seal* (the API/encoder) stay in lockstep
+/// — an isosurface threshold must be **above** this floor, or clear air would
+/// fall inside the surface. v1 uses one reflectivity floor regardless of
+/// quantity (per-quantity floors are a follow-up, tied to #350).
+pub const NO_ECHO_FLOOR_DBZ: f32 = -32.0;
+
 /// A regular **cylindrical voxel grid** sampled from a volume — the structured
 /// substrate for true 3D Tiles voxel content (`EXT_primitive_voxels`, #351) and
 /// isosurface meshing (#357). Cylinder axes match radar's native geometry:

--- a/crates/core/src/volume.rs
+++ b/crates/core/src/volume.rs
@@ -145,8 +145,12 @@ impl VoxelGrid {
         Self::index_of(self.dims, i_r, i_a, i_h)
     }
 
-    /// Count of cells with a **finite** sampled value (excludes `NaN` *and*
-    /// `±∞`) — for diagnostics / emptiness checks.
+    /// Count of cells with a **finite** value (excludes `NaN` *and* `±∞`) — for
+    /// diagnostics. Note this counts **every** finite cell, including a
+    /// producer's finite "clear air / no echo" floor (e.g. the radar engine's
+    /// `NO_ECHO_FLOOR`, #360) — so it is **not** equivalent to "has echo data":
+    /// a clear-air-only grid still has `valid_count() > 0`. Callers needing an
+    /// echo-emptiness check must use the engine's own echo count, not this.
     pub fn valid_count(&self) -> usize {
         self.values.iter().filter(|v| v.is_finite()).count()
     }

--- a/crates/engine-odim/examples/gen_isosurface.rs
+++ b/crates/engine-odim/examples/gen_isosurface.rs
@@ -109,12 +109,13 @@ fn main() {
     // The shell's colour = the colormap at the threshold value.
     let colormap = LutColorMap::from_builtin(BuiltinColormap::RadarDbz, -32.0, 95.0);
     let color = colormap.color(Some(threshold));
-    // Seal at the -32 dBZ floor so the shell closes into solid blobs (the
-    // preferred look). The engine fills clear air with the same floor (#360);
+    // Seal at the shared no-echo floor (the engine fills clear air with it too,
+    // #360) so the shell closes into solid blobs (the preferred look);
     // background=Some additionally seals the genuinely-unmeasured (NaN) cells, so
     // there are no open boundaries. (Pass None instead for honest open
     // boundaries — leaves the cone of silence / below-lowest-beam uncapped.)
-    let glb = ds_3dtiles::encode_isosurface_glb(&grid, threshold, color, Some(-32.0))
+    let background = Some(f64::from(ds_core::volume::NO_ECHO_FLOOR_DBZ));
+    let glb = ds_3dtiles::encode_isosurface_glb(&grid, threshold, color, background)
         .expect("mesh the isosurface (try a lower threshold if this reports 'empty')");
 
     fs::create_dir_all(&out_dir).expect("mkdir out_dir");

--- a/crates/engine-odim/examples/gen_isosurface.rs
+++ b/crates/engine-odim/examples/gen_isosurface.rs
@@ -109,11 +109,12 @@ fn main() {
     // The shell's colour = the colormap at the threshold value.
     let colormap = LutColorMap::from_builtin(BuiltinColormap::RadarDbz, -32.0, 95.0);
     let color = colormap.color(Some(threshold));
-    // background = None: the engine now fills clear air with a finite floor
-    // (#360), so the surface seals against clear air on its own; only genuinely
-    // unmeasured cells stay NaN, which we leave OPEN (no fabricated cap over the
-    // cone of silence).
-    let glb = ds_3dtiles::encode_isosurface_glb(&grid, threshold, color, None)
+    // Seal at the -32 dBZ floor so the shell closes into solid blobs (the
+    // preferred look). The engine fills clear air with the same floor (#360);
+    // background=Some additionally seals the genuinely-unmeasured (NaN) cells, so
+    // there are no open boundaries. (Pass None instead for honest open
+    // boundaries — leaves the cone of silence / below-lowest-beam uncapped.)
+    let glb = ds_3dtiles::encode_isosurface_glb(&grid, threshold, color, Some(-32.0))
         .expect("mesh the isosurface (try a lower threshold if this reports 'empty')");
 
     fs::create_dir_all(&out_dir).expect("mkdir out_dir");

--- a/crates/engine-odim/examples/gen_isosurface.rs
+++ b/crates/engine-odim/examples/gen_isosurface.rs
@@ -109,9 +109,11 @@ fn main() {
     // The shell's colour = the colormap at the threshold value.
     let colormap = LutColorMap::from_builtin(BuiltinColormap::RadarDbz, -32.0, 95.0);
     let color = colormap.color(Some(threshold));
-    // Seal against clear air with the dBZ floor (-32) so the shell closes into
-    // solid blobs instead of open "curtains" where echo meets no-echo.
-    let glb = ds_3dtiles::encode_isosurface_glb(&grid, threshold, color, Some(-32.0))
+    // background = None: the engine now fills clear air with a finite floor
+    // (#360), so the surface seals against clear air on its own; only genuinely
+    // unmeasured cells stay NaN, which we leave OPEN (no fabricated cap over the
+    // cone of silence).
+    let glb = ds_3dtiles::encode_isosurface_glb(&grid, threshold, color, None)
         .expect("mesh the isosurface (try a lower threshold if this reports 'empty')");
 
     fs::create_dir_all(&out_dir).expect("mkdir out_dir");

--- a/crates/engine-odim/src/reader.rs
+++ b/crates/engine-odim/src/reader.rs
@@ -198,12 +198,15 @@ impl RawPixels {
         // sentinels.
         //
         // NaN-aware: some PVOL producers declare `nodata`/`undetect`
-        // as NaN. `raw == nodata` is always false when `nodata` is
-        // NaN (IEEE-754), so a NaN raw is masked here unconditionally
-        // (a NaN physical value is never meaningful radar data); a NaN
-        // undetect sentinel therefore can't be told from nodata and
-        // its cells fall to `Masked` rather than `Undetect` — an
-        // acceptable edge (integer undetect codes are the norm).
+        // as NaN. A NaN raw is masked unconditionally below (a NaN
+        // physical value is never meaningful radar data), and `raw ==
+        // sentinel` is always false for a NaN sentinel (IEEE-754). So
+        // with a NaN `undetect`, the `!u.is_nan()` guard skips the
+        // undetect check entirely: a clear-air cell (which stores NaN)
+        // is classified `Masked` by the raw-is-NaN guard, never
+        // `Undetect`. An acceptable edge — integer undetect codes are
+        // the norm; a NaN-undetect producer's clear air just won't
+        // seal an isosurface (it stays open, like the cone of silence).
         if raw.is_nan() {
             return PixelClass::Masked;
         }

--- a/crates/engine-odim/src/reader.rs
+++ b/crates/engine-odim/src/reader.rs
@@ -101,6 +101,23 @@ pub enum RawPixels {
     F64(Array2<f64>),
 }
 
+/// Classification of a single sampled radar pixel, distinguishing the two
+/// kinds of "no value": clear air vs genuinely unmeasured. Returned by
+/// [`RawPixels::sample_class`]; the volume voxel-grid sampler uses it to seal
+/// an isosurface against clear air without fabricating across the cone of
+/// silence (#360).
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum PixelClass {
+    /// A real physical value (`raw * gain + offset`).
+    Value(f64),
+    /// In-coverage but below detection — the radar looked and saw nothing
+    /// (the ODIM `undetect` sentinel). "Clear air".
+    Undetect,
+    /// Out-of-range index, the ODIM `nodata` sentinel, or a non-finite raw —
+    /// genuinely unmeasured / outside coverage.
+    Masked,
+}
+
 impl RawPixels {
     /// Shape as `(height, width)` — same ordering ndarray uses
     /// internally. The first axis is rows (y), the second is columns
@@ -119,11 +136,12 @@ impl RawPixels {
     /// `None`.
     ///
     /// Both `nodata` ("outside coverage") and `undetect` ("radar
-    /// looked but saw nothing") are treated as masked in Phase 1 —
-    /// neither renders as a colored pixel. Splitting them into
-    /// distinct visible classes can be revisited if a use case asks
-    /// for it (e.g. precipitation accumulation overlays often want
-    /// undetect = 0 mm, not transparent).
+    /// looked but saw nothing") are masked here (→ `None`) — neither
+    /// renders as a colored pixel. The volume voxel-grid path needs to
+    /// tell them apart (to seal an isosurface against clear air without
+    /// fabricating across the cone of silence), so it uses
+    /// [`Self::sample_class`]; this thin wrapper preserves the
+    /// raster/EDR "both masked" behaviour.
     pub fn sample(
         &self,
         row: usize,
@@ -133,10 +151,41 @@ impl RawPixels {
         nodata: f64,
         undetect: Option<f64>,
     ) -> Option<f64> {
+        match self.sample_class(row, col, gain, offset, nodata, undetect) {
+            PixelClass::Value(v) => Some(v),
+            PixelClass::Undetect | PixelClass::Masked => None,
+        }
+    }
+
+    /// Read a single pixel at `(row, col)`, **classifying** it as a real
+    /// value, clear-air `Undetect` ("the radar looked and saw nothing"), or
+    /// `Masked` (out-of-range index, the `nodata` sentinel, or a non-finite
+    /// raw — i.e. genuinely unmeasured / outside coverage). `physical =
+    /// raw * gain + offset`. The distinction lets a consumer fill clear air
+    /// with a finite "no echo" floor while leaving unmeasured cells unknown
+    /// (#360).
+    pub fn sample_class(
+        &self,
+        row: usize,
+        col: usize,
+        gain: f64,
+        offset: f64,
+        nodata: f64,
+        undetect: Option<f64>,
+    ) -> PixelClass {
         let raw = match self {
-            RawPixels::U8(a) => a.get((row, col)).map(|v| *v as f64)?,
-            RawPixels::U16(a) => a.get((row, col)).map(|v| *v as f64)?,
-            RawPixels::F64(a) => a.get((row, col)).copied()?,
+            RawPixels::U8(a) => match a.get((row, col)) {
+                Some(v) => *v as f64,
+                None => return PixelClass::Masked,
+            },
+            RawPixels::U16(a) => match a.get((row, col)) {
+                Some(v) => *v as f64,
+                None => return PixelClass::Masked,
+            },
+            RawPixels::F64(a) => match a.get((row, col)) {
+                Some(v) => *v,
+                None => return PixelClass::Masked,
+            },
         };
         // Exact equality is intentional for nodata/undetect: ODIM
         // producers store integer sentinels (e.g. OPERA's
@@ -150,26 +199,23 @@ impl RawPixels {
         //
         // NaN-aware: some PVOL producers declare `nodata`/`undetect`
         // as NaN. `raw == nodata` is always false when `nodata` is
-        // NaN (IEEE-754), so it would never mask — and a NaN raw
-        // value would fall through to `raw * gain + offset = NaN`,
-        // which the colorizer renders as a stray pixel. Treat a NaN
-        // sentinel as "mask any NaN raw"; also mask a NaN raw value
-        // unconditionally, since a NaN physical value is never
-        // meaningful radar data.
+        // NaN (IEEE-754), so a NaN raw is masked here unconditionally
+        // (a NaN physical value is never meaningful radar data); a NaN
+        // undetect sentinel therefore can't be told from nodata and
+        // its cells fall to `Masked` rather than `Undetect` — an
+        // acceptable edge (integer undetect codes are the norm).
         if raw.is_nan() {
-            return None;
+            return PixelClass::Masked;
         }
-        if nodata.is_nan() {
-            // sentinel is NaN — only NaN raws (handled above) match it
-        } else if raw == nodata {
-            return None;
+        if !nodata.is_nan() && raw == nodata {
+            return PixelClass::Masked;
         }
         if let Some(u) = undetect {
             if !u.is_nan() && raw == u {
-                return None;
+                return PixelClass::Undetect;
             }
         }
-        Some(raw * gain + offset)
+        PixelClass::Value(raw * gain + offset)
     }
 
     /// Approximate heap footprint of the backing array, in bytes — element
@@ -795,5 +841,47 @@ mod tests {
             None,
             "undetect sentinel must mask"
         );
+    }
+
+    /// `sample_class` keeps the value/undetect/nodata distinction that `sample`
+    /// flattens (#360): a real value, clear-air `Undetect`, and genuinely
+    /// unmeasured `Masked` (nodata sentinel + out-of-range index) are separate.
+    #[test]
+    fn raw_pixels_sample_class_distinguishes_undetect_from_nodata() {
+        // [value, value, nodata, undetect]
+        let arr =
+            Array2::from_shape_vec((1, 4), vec![5.0_f64, 25.0, -9999000.0, -8888000.0]).unwrap();
+        let px = RawPixels::F64(arr);
+        let nodata = -9999000.0;
+        let undetect = Some(-8888000.0);
+
+        assert_eq!(
+            px.sample_class(0, 0, 1.0, 0.0, nodata, undetect),
+            PixelClass::Value(5.0)
+        );
+        assert_eq!(
+            px.sample_class(0, 2, 1.0, 0.0, nodata, undetect),
+            PixelClass::Masked,
+            "nodata → Masked (genuinely unmeasured)"
+        );
+        assert_eq!(
+            px.sample_class(0, 3, 1.0, 0.0, nodata, undetect),
+            PixelClass::Undetect,
+            "undetect → Undetect (clear air)"
+        );
+        // Out-of-range index is Masked, not Undetect.
+        assert_eq!(
+            px.sample_class(0, 99, 1.0, 0.0, nodata, undetect),
+            PixelClass::Masked
+        );
+        // A NaN raw is Masked regardless of sentinels.
+        let nanpx = RawPixels::F64(Array2::from_shape_vec((1, 1), vec![f64::NAN]).unwrap());
+        assert_eq!(
+            nanpx.sample_class(0, 0, 1.0, 0.0, nodata, undetect),
+            PixelClass::Masked
+        );
+        // And `sample` still flattens Undetect + Masked to None (unchanged).
+        assert_eq!(px.sample(0, 3, 1.0, 0.0, nodata, undetect), None);
+        assert_eq!(px.sample(0, 2, 1.0, 0.0, nodata, undetect), None);
     }
 }

--- a/crates/engine-odim/src/volume_engine.rs
+++ b/crates/engine-odim/src/volume_engine.rs
@@ -3258,14 +3258,10 @@ const DEFAULT_VOXEL_DIMS: [usize; 3] = [128, 360, 48];
 const MAX_VOXELS: usize = 32_000_000;
 /// Height ceiling (metres above antenna) for the voxel grid — above any echo.
 const VOXEL_HEIGHT_CEILING_M: f64 = 20_000.0;
-/// Physical value written for **clear-air** (`undetect`) voxel cells (#360): a
-/// finite floor well below any reflectivity threshold, so an isosurface seals
-/// against clear air (closed blobs) while genuinely-unmeasured cells stay `NaN`
-/// (and an isosurface leaves them open — no fabricated cap over the cone of
-/// silence). v1 uses the standard −32 dBZ radar floor regardless of quantity
-/// (consistent with the single reflectivity colormap); a per-quantity floor is
-/// a follow-up (tied to per-quantity colormaps, #350).
-const NO_ECHO_FLOOR: f32 = -32.0;
+/// Value written for **clear-air** (`undetect`) voxel cells (#360) — the shared
+/// no-echo floor (so the engine fill and the isosurface seal use one constant,
+/// not two hardcoded `-32`s). See [`ds_core::volume::NO_ECHO_FLOOR_DBZ`].
+const NO_ECHO_FLOOR: f32 = ds_core::volume::NO_ECHO_FLOOR_DBZ;
 
 /// Resample one polar volume into a regular cylindrical [`VoxelGrid`]: for each
 /// `(radius, azimuth, height)` cell centre, invert to `(slant_range, elevation)`

--- a/crates/engine-odim/src/volume_engine.rs
+++ b/crates/engine-odim/src/volume_engine.rs
@@ -3345,10 +3345,10 @@ fn voxel_grid_from_volume(
                     el,
                 ) {
                     PixelClass::Value(v) => {
-                        // Only finite samples count as data — a non-finite gain/
-                        // offset in a malformed file can yield `Value(NaN)`;
-                        // writing it would make `valid` (and the 404 guard)
-                        // disagree with the finite-only `valid_count()`.
+                        // Only a finite echo is written + counted — a non-finite
+                        // gain/offset in a malformed file can yield `Value(NaN)`;
+                        // writing it would leave a stray `NaN` cell counted as
+                        // neither echo (`valid`) nor clear-air floor.
                         let fv = v as f32;
                         if fv.is_finite() {
                             // One source of truth for the axis order (in flux #351).

--- a/crates/engine-odim/src/volume_engine.rs
+++ b/crates/engine-odim/src/volume_engine.rs
@@ -79,7 +79,7 @@ use crate::engine::EngineError;
 use crate::pixel_cache::PixelCache;
 use crate::pvol::{read_moment_pixels, read_polar_volume, PolarMoment, PolarVolume, Sweep};
 use crate::quantities;
-use crate::reader::RawPixels;
+use crate::reader::{PixelClass, RawPixels};
 
 /// Default lazy-pixel cache size (MB) when `MC_PVOL_PIXEL_CACHE_MB` is
 /// unset. One shared budget bounds resident decoded pixels across every
@@ -2267,9 +2267,45 @@ fn sample_polar_slant(
     azimuth_deg: f64,
     elangle_deg: f64,
 ) -> Option<f64> {
-    let sweep = nearest_sweep(volume, elangle_deg)?;
+    // Point-cloud / EDR path: only real values; clear-air `Undetect` and
+    // `Masked` both collapse to `None` (no point), unchanged from before #360.
+    match sample_polar_slant_class(
+        volume,
+        file_id,
+        pix,
+        envelope,
+        quantity,
+        slant_range_m,
+        azimuth_deg,
+        elangle_deg,
+    ) {
+        PixelClass::Value(v) => Some(v),
+        PixelClass::Undetect | PixelClass::Masked => None,
+    }
+}
+
+/// Like [`sample_polar_slant`] but **classifies** the cell (#360): an out-of-
+/// envelope / out-of-range / malformed target is `Masked` (genuinely
+/// unmeasured — the cone of silence, beyond max range, below the lowest beam),
+/// while a sampled gate that is clear air returns `Undetect`. The voxel-grid
+/// sampler uses this to fill clear air with a finite "no echo" floor (so an
+/// isosurface seals against it) while leaving `Masked` cells `NaN`.
+#[allow(clippy::too_many_arguments)]
+fn sample_polar_slant_class(
+    volume: &PolarVolume,
+    file_id: &str,
+    pix: Pixels,
+    envelope: (f64, f64),
+    quantity: &str,
+    slant_range_m: f64,
+    azimuth_deg: f64,
+    elangle_deg: f64,
+) -> PixelClass {
+    let Some(sweep) = nearest_sweep(volume, elangle_deg) else {
+        return PixelClass::Masked;
+    };
     if sweep.nrays == 0 || sweep.nbins == 0 {
-        return None;
+        return PixelClass::Masked;
     }
     // Reject targets outside the sweep envelope (see the constant's doc
     // for the rationale). Pre-computed envelope keeps this O(1) per cell.
@@ -2278,7 +2314,7 @@ fn sample_polar_slant(
         || elangle_deg < min_el - SWEEP_ENVELOPE_TOL_DEG
         || elangle_deg > max_el + SWEEP_ENVELOPE_TOL_DEG
     {
-        return None;
+        return PixelClass::Masked;
     }
     // A malformed sweep with `rscale <= 0` would silently mis-sample:
     // `rscale = 0` makes the divisor zero (a NaN cast to `i64` becomes
@@ -2288,16 +2324,20 @@ fn sample_polar_slant(
     // defensive guard here is cheap and keeps a corrupted file from
     // ever surfacing fabricated values.
     if !sweep.rscale.is_finite() || sweep.rscale <= 0.0 {
-        return None;
+        return PixelClass::Masked;
     }
-    let moment = sweep.moments.iter().find(|m| m.quantity == *quantity)?;
+    let Some(moment) = sweep.moments.iter().find(|m| m.quantity == *quantity) else {
+        return PixelClass::Masked;
+    };
     let bin = ((slant_range_m - sweep.rstart) / sweep.rscale).floor() as i64;
     if bin < 0 || bin >= sweep.nbins as i64 {
-        return None;
+        return PixelClass::Masked;
     }
     let ray = (azimuth_deg / (360.0 / sweep.nrays as f64)).floor() as usize % sweep.nrays;
-    let pixels = pix.moment(file_id, moment, sweep.nrays, sweep.nbins)?;
-    pixels.sample(
+    let Some(pixels) = pix.moment(file_id, moment, sweep.nrays, sweep.nbins) else {
+        return PixelClass::Masked;
+    };
+    pixels.sample_class(
         ray,
         bin as usize,
         moment.gain,
@@ -3218,16 +3258,28 @@ const DEFAULT_VOXEL_DIMS: [usize; 3] = [128, 360, 48];
 const MAX_VOXELS: usize = 32_000_000;
 /// Height ceiling (metres above antenna) for the voxel grid — above any echo.
 const VOXEL_HEIGHT_CEILING_M: f64 = 20_000.0;
+/// Physical value written for **clear-air** (`undetect`) voxel cells (#360): a
+/// finite floor well below any reflectivity threshold, so an isosurface seals
+/// against clear air (closed blobs) while genuinely-unmeasured cells stay `NaN`
+/// (and an isosurface leaves them open — no fabricated cap over the cone of
+/// silence). v1 uses the standard −32 dBZ radar floor regardless of quantity
+/// (consistent with the single reflectivity colormap); a per-quantity floor is
+/// a follow-up (tied to per-quantity colormaps, #350).
+const NO_ECHO_FLOOR: f32 = -32.0;
 
 /// Resample one polar volume into a regular cylindrical [`VoxelGrid`]: for each
 /// `(radius, azimuth, height)` cell centre, invert to `(slant_range, elevation)`
-/// via the 4/3-Earth beam model and sample the volume — reusing the same
-/// `sample_polar_slant` (with its sweep-envelope guard) the cross-section path
-/// uses, so cells outside the surveyed beam fan stay `NaN`. The angle axis is
-/// azimuth `0..2π` (the encoder maps to the cylinder convention); radius is
-/// ground range `0..max`, height `0..ceiling`.
-/// Returns the grid plus the count of sampled (finite) cells — counted during
-/// the fill so the caller needn't re-scan up to `MAX_VOXELS` cells.
+/// via the 4/3-Earth beam model and classify the volume sample
+/// (`sample_polar_slant_class`, with its sweep-envelope guard). Three outcomes
+/// (#360): an echo → its value; **clear air** (`undetect`) → the finite
+/// [`NO_ECHO_FLOOR`] (so an isosurface seals against it); **unmeasured**
+/// (outside the beam fan — cone of silence, beyond range, below the lowest
+/// beam) → `NaN` (so an isosurface leaves it open, not a fabricated cap). The
+/// angle axis is azimuth `0..2π` (the encoder maps to the cylinder convention);
+/// radius is ground range `0..max`, height `0..ceiling`.
+/// Returns the grid plus the count of **echo** cells (clear-air floor cells are
+/// not counted) — counted during the fill so the caller needn't re-scan up to
+/// `MAX_VOXELS` cells.
 fn voxel_grid_from_volume(
     volume: &PolarVolume,
     file_id: &str,
@@ -3282,7 +3334,7 @@ fn voxel_grid_from_volume(
             for i_h in 0..n_h {
                 let height = (i_h as f64 + 0.5) * ceiling / n_h as f64;
                 let (slant, el) = ground_height_to_slant(ground, height);
-                if let Some(v) = sample_polar_slant(
+                match sample_polar_slant_class(
                     volume,
                     file_id,
                     pix,
@@ -3292,16 +3344,29 @@ fn voxel_grid_from_volume(
                     azimuth_deg,
                     el,
                 ) {
-                    // Only finite samples count as data — a non-finite gain/
-                    // offset in a malformed file can yield `Some(NaN)`; writing
-                    // it would make `valid` (and the 404 guard) disagree with
-                    // the finite-only `valid_count()`.
-                    let fv = v as f32;
-                    if fv.is_finite() {
-                        // One source of truth for the axis order (in flux per #351).
-                        values[VoxelGrid::index_of(dims, i_r, i_a, i_h)] = fv;
-                        valid += 1;
+                    PixelClass::Value(v) => {
+                        // Only finite samples count as data — a non-finite gain/
+                        // offset in a malformed file can yield `Value(NaN)`;
+                        // writing it would make `valid` (and the 404 guard)
+                        // disagree with the finite-only `valid_count()`.
+                        let fv = v as f32;
+                        if fv.is_finite() {
+                            // One source of truth for the axis order (in flux #351).
+                            values[VoxelGrid::index_of(dims, i_r, i_a, i_h)] = fv;
+                            valid += 1;
+                        }
                     }
+                    // Clear air (radar looked, saw nothing): a finite "no echo"
+                    // floor so an isosurface seals against it into closed blobs.
+                    // NOT counted as `valid` — it is the absence of echo, so a
+                    // clear-air-only volume still yields an empty grid (→ 404).
+                    PixelClass::Undetect => {
+                        values[VoxelGrid::index_of(dims, i_r, i_a, i_h)] = NO_ECHO_FLOOR;
+                    }
+                    // Genuinely unmeasured (cone of silence / beyond range /
+                    // below the lowest beam) → leave `NaN`, so an isosurface
+                    // doesn't fabricate a cap there.
+                    PixelClass::Masked => {}
                 }
             }
         }
@@ -4330,6 +4395,48 @@ mod tests {
             object: "PVOL".to_string(),
             sweeps: vec![sweep],
         }
+    }
+
+    /// #360: the voxel grid fills clear air (`undetect`) with the finite
+    /// [`NO_ECHO_FLOOR`] (so an isosurface seals against it) while leaving
+    /// genuinely-unmeasured cells (outside the single sweep's envelope) as
+    /// `NaN`. An all-`undetect` volume therefore yields a grid that has both
+    /// finite floor cells and NaN cells, and ZERO echo cells (floor is not
+    /// counted as echo, so a clear-air-only volume still reads as empty → 404).
+    #[test]
+    fn voxel_grid_fills_clear_air_floor_and_leaves_unmeasured_nan() {
+        // The radar looked across its whole fan and saw nothing (all undetect).
+        let (nrays, nbins) = (360usize, 100usize);
+        let data = Array2::<u16>::from_elem((nrays, nbins), 65_534u16); // 65534 = undetect
+        let fid = unique_file_id();
+        pixel_cache().insert(
+            &fid,
+            SYNTHETIC_DS,
+            std::sync::Arc::new(RawPixels::U16(data)),
+        );
+        let vol = synthetic_volume(25.0, 60.0);
+
+        let (grid, echoes) =
+            voxel_grid_from_volume(&vol, &fid, test_pixels(), "DBZH", Some([64, 90, 48]))
+                .expect("voxel grid builds");
+
+        let floor = grid.values.iter().filter(|v| **v == NO_ECHO_FLOOR).count();
+        let nan = grid.values.iter().filter(|v| v.is_nan()).count();
+        // Clear air inside the surveyed fan → finite floor; outside it → NaN.
+        assert!(floor > 0, "clear air is filled with the no-echo floor");
+        assert!(
+            nan > 0,
+            "unmeasured cells (cone of silence / beyond fan) stay NaN"
+        );
+        // No reflectivity anywhere → no echo cells, and the floor cells are NOT
+        // counted as echo (the returned count and `valid_count` disagree: the
+        // former is echoes, the latter is all finite = the floor cells).
+        assert_eq!(echoes, 0, "floor cells are not counted as echo");
+        assert_eq!(
+            grid.valid_count(),
+            floor,
+            "valid_count (finite) == the clear-air floor cells"
+        );
     }
 
     /// Polar→Cartesian: a pixel at a known bearing/range must sample

--- a/crates/engine-odim/tests/integration.rs
+++ b/crates/engine-odim/tests/integration.rs
@@ -714,7 +714,9 @@ fn pvol_volume_engine_voxel_grid() {
 
     // Real echoes are present — cells *above* the clear-air floor (#360 fills
     // clear air with exactly `NO_ECHO_FLOOR_DBZ`, so `valid_count()` alone, which
-    // now also counts those floor cells, would no longer prove "has echo").
+    // now also counts those floor cells, would no longer prove "has echo"). Uses
+    // `>` (not `>=`): an echo measured at exactly the floor is indistinguishable
+    // from clear air at the grid level — fine here, precip is well above −32 dBZ.
     let echoes = grid
         .values
         .iter()

--- a/crates/engine-odim/tests/integration.rs
+++ b/crates/engine-odim/tests/integration.rs
@@ -712,12 +712,22 @@ fn pvol_volume_engine_voxel_grid() {
     );
     assert!(grid.height_range[1] > 0.0 && grid.height_range[0] == 0.0);
 
-    // Some cells sampled (echoes), but not all — the cone of silence + below
-    // the lowest sweep + out-of-range stay NaN (no fabricated data).
-    let valid = grid.valid_count();
-    assert!(valid > 0, "a real volume must yield sampled voxels");
+    // Real echoes are present — cells *above* the clear-air floor (#360 fills
+    // clear air with exactly `NO_ECHO_FLOOR_DBZ`, so `valid_count()` alone, which
+    // now also counts those floor cells, would no longer prove "has echo").
+    let echoes = grid
+        .values
+        .iter()
+        .filter(|v| **v > ds_core::volume::NO_ECHO_FLOOR_DBZ)
+        .count();
     assert!(
-        valid < grid.values.len(),
+        echoes > 0,
+        "a real volume must yield echo voxels above the floor"
+    );
+    // …but not every cell is finite — the cone of silence + below the lowest
+    // sweep + out-of-range stay NaN (no fabricated data).
+    assert!(
+        grid.valid_count() < grid.values.len(),
         "expect NaN gaps (cone of silence etc.)"
     );
     // Every sampled value is a finite dBZ in a sane band.

--- a/crates/render/src/colormap.rs
+++ b/crates/render/src/colormap.rs
@@ -9,14 +9,6 @@ pub trait ColorMap: Send + Sync {
     fn nodata_color(&self) -> [u8; 4] {
         [0, 0, 0, 0]
     }
-
-    /// The continuous `(min, max)` value domain this colormap ramps over, if it
-    /// has one. Used e.g. as the "no-echo" floor when sealing a 3D Tiles
-    /// isosurface (the bottom of the reflectivity ramp). Defaults to `None`
-    /// (a categorical / domainless map).
-    fn domain(&self) -> Option<(f64, f64)> {
-        None
-    }
 }
 
 /// A color stop for defining gradient colormaps.
@@ -103,10 +95,6 @@ impl LutColorMap {
 impl ColorMap for LutColorMap {
     fn nodata_color(&self) -> [u8; 4] {
         self.nodata_color
-    }
-
-    fn domain(&self) -> Option<(f64, f64)> {
-        Some((self.min, self.max))
     }
 
     fn color(&self, value: Option<f64>) -> [u8; 4] {


### PR DESCRIPTION
## What

Closes #360. Makes the cylindrical `VoxelGrid` distinguish **clear air** (`undetect`: the radar looked and saw nothing) from **genuinely unmeasured** space (`nodata` / cone of silence / below the lowest beam / beyond max range), so the distinction is available to the isosurface (#357) and to true voxels (#351).

Before, `RawPixels::sample` masked both as `None` → `NaN` in the grid, indistinguishable.

## The visual default: **sealed** (solid blobs)

I first switched the isosurface to `background=None` (leave unmeasured cells open). **Render-verify + maintainer feedback:** that reintroduced the open/"curtain" look at the unmeasured boundaries (cone of silence, below the lowest beam). So the **isosurface seals by default** (`background=Some(-32)`, clamped `< threshold`) for the solid-blob look — render-verified byte-identical (17.2 MB) to the merged #359 mesh, curtains gone. #360's engine distinction is kept as a **foundation** (invisible under the seal, but the substrate voxels need) and enables an **opt-in** "honest open boundary" mode (`background=None`).

## Changes

- **`reader.rs`** — `RawPixels::sample_class(...) → PixelClass { Value | Undetect | Masked }`. `sample()` is reimplemented on it, unchanged for raster/EDR (undetect + nodata still both → `None`).
- **`volume_engine.rs`** — `sample_polar_slant_class` (out-of-envelope / range / malformed → `Masked`). `voxel_grid_from_volume` fills `Undetect` with the finite **`NO_ECHO_FLOOR` (−32 dBZ)**, leaves `Masked` `NaN`. Echo count excludes floor cells (clear-air-only volume → empty → 404).
- **Isosurface API + demo** seal with `background=Some(-32)` (clamped `< threshold`); the engine floor + the seal give one uniform no-echo level. `None` remains available for the open-boundary mode.
- **`ds-render`** — removed the now-unused `ColorMap::domain()` (added in #359 only for the API-computed floor).

## Verification
- **Render-verified live (CesiumJS):** sealed default = solid closed blobs, curtains gone, identical to #359.
- **Tests:** `sample_class` distinguishes value/undetect/nodata/out-of-range/NaN; a synthetic all-`undetect` volume → finite floor cells + `NaN` cells + zero echo count; the mock engine fills the clear-air floor. 137 engine-odim + 75 ds-render + 17 api-3dtiles green; clippy clean.

## Follow-up
Per-quantity no-echo floor (today −32 dBZ regardless of quantity) — tied to per-quantity colormaps (#350).

🤖 Generated with [Claude Code](https://claude.com/claude-code)