### PR TITLE
feat(3dtiles): echo-top API representation + viewer toggle + reflectivity-scaled point size

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -315,23 +315,27 @@ into a glTF `.glb` triangle mesh.
   origin }>` — `Some` ⇒ the mesh products are available and the origin is present
   (tileset built without sampling; "supports but no origin" is unrepresentable,
   never a 500). It drives the collection JSON's `representations` array → the
-  viewer's toggle. The isosurface seals (`background=Some(-32)`); echo-top uses
-  full `[512,360,64]` resolution (`ECHO_TOP_DIMS`, ~12 s first compute — ETag
-  caches repeats) coloured by a height ramp. A too-low threshold → 400, an empty
-  result → 404.
+  viewer's toggle. The isosurface seals (`background=Some(-32)`); echo-top is
+  coloured by a height ramp. Both mesh products take a `?resolution=` detail tier
+  (`Resolution` enum → voxel-grid dims; `low` `[128,360,48]` ≈2.2 M cells, `med`
+  `[256,360,56]` ≈5.2 M *default*, `high` `[512,360,64]` ≈11.8 M / ~12 s first
+  compute — ETag caches repeats); the tier is echoed into the `content.uri`. The
+  point cloud is native-resolution and ignores it. A too-low threshold or a bad
+  resolution token → 400, an empty result → 404.
 - **Point sizing:** `encode_pnts` writes a per-point `value` (the physical value)
   into the `.pnts` **batch table** (no `BATCH_ID` ⇒ per-point properties), so the
   viewer styles `pointSize` by `${value}` — weak echo → ~1 px, strong → ~10 px.
 - **Routes** (mounted at `/3dtiles`): `GET /collections/{id}/tileset.json`
-  (`?representation=&quantity=&datetime=&min_value=&threshold=`),
+  (`?representation=&quantity=&datetime=&min_value=&threshold=&resolution=`),
   `GET /collections/{id}/content.pnts` (`?quantity=&datetime=&min_value=`),
-  `GET /collections/{id}/content.glb` (`?representation=&quantity=&datetime=&threshold=`),
+  `GET /collections/{id}/content.glb` (`?representation=&quantity=&datetime=&threshold=&resolution=`),
   plus `/` · `/collections` · `/collections/{id}` · **`/viewer`** (a bundled
-  CesiumJS page with collection + quantity + **representation** pickers,
-  `include_str!`-baked from `crates/api-3dtiles/viewer/index.html`; same-origin
-  API base by default, with a `?base=` override). The tileset's `content.uri`
-  embeds the resolved quantity (+ pinned time + `min_value`/`threshold` +
-  `representation`) so the content fetch is deterministic.
+  CesiumJS page with collection + quantity + **representation** + **resolution**
+  pickers, `include_str!`-baked from `crates/api-3dtiles/viewer/index.html`;
+  same-origin API base by default, with a `?base=` override). The tileset's
+  `content.uri` embeds the resolved quantity (+ pinned time +
+  `min_value`/`threshold` + `representation` + `resolution`) so the content fetch
+  is deterministic.
 - **Concurrency:** `read_point_cloud` / `read_voxel_grid` are sync (blocking
   HDF5 I/O + a long CPU loop — marching tet for the latter), so both content
   handlers bound them with the shared render semaphore and run via

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -322,9 +322,19 @@ into a glTF `.glb` triangle mesh.
   compute — ETag caches repeats); the tier is echoed into the `content.uri`. The
   point cloud is native-resolution and ignores it. A too-low threshold or a bad
   resolution token → 400, an empty result → 404.
-- **Point sizing:** `encode_pnts` writes a per-point `value` (the physical value)
-  into the `.pnts` **batch table** (no `BATCH_ID` ⇒ per-point properties), so the
-  viewer styles `pointSize` by `${value}` — weak echo → ~1 px, strong → ~10 px.
+- **Point sizing + client-side filter:** `encode_pnts` writes a per-point `value`
+  (the physical value) into the `.pnts` **batch table** (no `BATCH_ID` ⇒ per-point
+  properties; CesiumJS exposes them to the style engine as `${value}`). The viewer
+  styles `pointSize` by `${value}` (weak echo → ~1 px, strong → ~16 px) and
+  **filters** by it: the `min dBZ` field restyles `show` client-side (instant, no
+  re-fetch, as long as it stays ≥ the fetched floor; going lower re-fetches the
+  larger set). **Do not add `BATCH_ID`** to make points pickable features — it
+  disables per-point `pointSize` in CesiumJS's point-cloud pipeline (verified;
+  `pickMetadata` also can't read a `.pnts` batch table in 1.124 — only its
+  schema). The value is read off **color + size**, and the collection JSON
+  carries a `legend` (the point colormap sampled into `#rrggbb` stops over a dBZ
+  range via `legend_stops`) which the viewer renders as a gradient bar for the
+  point cloud.
 - **Routes** (mounted at `/3dtiles`): `GET /collections/{id}/tileset.json`
   (`?representation=&quantity=&datetime=&min_value=&threshold=&resolution=`),
   `GET /collections/{id}/content.pnts` (`?quantity=&datetime=&min_value=`),

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -305,27 +305,33 @@ into a glTF `.glb` triangle mesh.
   first cut rendered uniformly red). Demo: `cargo run -p engine-odim --example
   gen_echo_top` (render-verified). API route is a follow-up; the mesher will be
   reused for VIL (#365).
-- **Both representations are served from the API** (selected by
-  `?representation=points|isosurface` on `tileset.json`): `points` → `.pnts`
-  (region-only tileset, `RTC_CENTER` self-places), `isosurface` → `.glb` plus a
-  tile **`transform`** = the antenna ECEF. Capability + the origin it needs are
-  coupled in one field: `VolumeInfo.voxel_grid: Option<VoxelGridCaps { origin }>`
-  — `Some` ⇒ isosurface available and the origin is present (so the tileset is
-  built without sampling, and "supports but no origin" is unrepresentable, never
-  a 500). It drives the collection JSON's `representations` array → the viewer's
-  representation toggle. The isosurface seals (`background=Some(-32)`, clamped
-  `< threshold`) for the solid-blob look; an over-large surface (threshold too
-  low) → 400, an empty one (threshold above all echo) → 404.
+- **Three representations are served from the API** (selected by
+  `?representation=points|isosurface|echotop` on `tileset.json`): `points` →
+  `.pnts` (region-only tileset, `RTC_CENTER` self-places), `isosurface` /
+  `echotop` → `.glb` plus a tile **`transform`** = the antenna ECEF. The two glTF
+  products share `content.glb`, disambiguated by `?representation=echotop` in the
+  content URI (default = isosurface). Capability + the origin both glTF products
+  need are coupled in one field: `VolumeInfo.voxel_grid: Option<VoxelGridCaps {
+  origin }>` — `Some` ⇒ the mesh products are available and the origin is present
+  (tileset built without sampling; "supports but no origin" is unrepresentable,
+  never a 500). It drives the collection JSON's `representations` array → the
+  viewer's toggle. The isosurface seals (`background=Some(-32)`); echo-top uses
+  full `[512,360,64]` resolution (`ECHO_TOP_DIMS`, ~12 s first compute — ETag
+  caches repeats) coloured by a height ramp. A too-low threshold → 400, an empty
+  result → 404.
+- **Point sizing:** `encode_pnts` writes a per-point `value` (the physical value)
+  into the `.pnts` **batch table** (no `BATCH_ID` ⇒ per-point properties), so the
+  viewer styles `pointSize` by `${value}` — weak echo → ~1 px, strong → ~10 px.
 - **Routes** (mounted at `/3dtiles`): `GET /collections/{id}/tileset.json`
   (`?representation=&quantity=&datetime=&min_value=&threshold=`),
   `GET /collections/{id}/content.pnts` (`?quantity=&datetime=&min_value=`),
-  `GET /collections/{id}/content.glb` (`?quantity=&datetime=&threshold=`), plus
-  `/` · `/collections` · `/collections/{id}` · **`/viewer`** (a bundled CesiumJS
-  page with collection + quantity + **representation** pickers,
+  `GET /collections/{id}/content.glb` (`?representation=&quantity=&datetime=&threshold=`),
+  plus `/` · `/collections` · `/collections/{id}` · **`/viewer`** (a bundled
+  CesiumJS page with collection + quantity + **representation** pickers,
   `include_str!`-baked from `crates/api-3dtiles/viewer/index.html`; same-origin
   API base by default, with a `?base=` override). The tileset's `content.uri`
-  embeds the resolved quantity (+ pinned time + `min_value`/`threshold`) so the
-  content fetch is deterministic.
+  embeds the resolved quantity (+ pinned time + `min_value`/`threshold` +
+  `representation`) so the content fetch is deterministic.
 - **Concurrency:** `read_point_cloud` / `read_voxel_grid` are sync (blocking
   HDF5 I/O + a long CPU loop — marching tet for the latter), so both content
   handlers bound them with the shared render semaphore and run via

--- a/crates/api-3dtiles/src/handlers.rs
+++ b/crates/api-3dtiles/src/handlers.rs
@@ -33,7 +33,11 @@ use crate::error::Tiles3dError;
 /// Default isosurface threshold (dBZ) when a request names none — a light-rain
 /// reflectivity shell.
 const ISOSURFACE_DEFAULT_THRESHOLD: f64 = 20.0;
-/// Default echo-top reflectivity (dBZ) — the standard echo-top value.
+/// Default echo-top reflectivity (dBZ) — the standard echo-top value. Like the
+/// isosurface threshold and the no-echo-floor guard below, this is
+/// reflectivity-specific: an echo-top request for a non-reflectivity quantity
+/// (e.g. `VRADH`) still validates against the −32 dBZ floor, which is meaningless
+/// for velocity. Per-quantity floors land with per-quantity colormaps (#350).
 const ECHO_TOP_DEFAULT_THRESHOLD: f64 = 18.0;
 
 /// Voxel-grid resolution tier for the glTF mesh products (isosurface, echo-top):
@@ -44,9 +48,15 @@ const ECHO_TOP_DEFAULT_THRESHOLD: f64 = 18.0;
 /// historical default. All tiers stay under the engine's `MAX_VOXELS` cap.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum Resolution {
-    /// `[128, 360, 48]` ≈ 2.2 M cells — fast, coarse radial (~2 km bins).
+    /// `[128, 360, 48]` ≈ 2.2 M cells — fast, coarse radial (~2 km bins). Equals
+    /// the engine's historical `read_voxel_grid(None)` default.
     Low,
-    /// `[256, 360, 56]` ≈ 5.2 M cells — the balanced default.
+    /// `[256, 360, 56]` ≈ 5.2 M cells — the balanced default for an *absent*
+    /// `?resolution=`. NOTE: this is intentionally higher than the engine's old
+    /// `None` default (`Low` above) — adding the tiers deliberately bumped the
+    /// no-tier-specified isosurface/echo-top quality from coarse to balanced, so
+    /// a pre-tier bookmarked content URI without `?resolution=` now renders one
+    /// step sharper (and a touch slower), not differently-wrong.
     Med,
     /// `[512, 360, 64]` ≈ 11.8 M cells — full radial detail; ~12 s first compute.
     High,
@@ -372,6 +382,10 @@ pub async fn get_tileset(
     let (engine, _config) = lookup(&state, &id)?;
     let info = engine.volume_info();
     let representation = Representation::parse(params.representation.as_deref())?;
+    // Validate the detail tier up front so a bad `resolution=` is a 400 for *any*
+    // representation, not silently ignored on a `points` request (which doesn't
+    // use it). Only the mesh arm below consumes the parsed value.
+    let resolution = Resolution::parse(params.resolution.as_deref())?;
 
     // Resolve + validate the quantity against what the collection advertises.
     let quantity = match &params.quantity {
@@ -446,11 +460,9 @@ pub async fn get_tileset(
                 }
                 query.push_str(&format!("&threshold={t}"));
             }
-            // Carry the detail tier so the content fetch matches the tileset.
-            // Validate now (a bad value is a 400 here, not a surprise on fetch);
+            // Carry the detail tier so the content fetch matches the tileset;
             // emit the canonical token even when the request omitted it, so the
-            // `content.uri` is self-describing.
-            let resolution = Resolution::parse(params.resolution.as_deref())?;
+            // `content.uri` is self-describing. (Parsed/validated above.)
             query.push_str(&format!("&resolution={}", resolution.as_str()));
             // Tag the mesh product explicitly for *both* (not just echo-top), so
             // the `content.uri` is unambiguous and doesn't depend on the

--- a/crates/api-3dtiles/src/handlers.rs
+++ b/crates/api-3dtiles/src/handlers.rs
@@ -14,7 +14,7 @@
 //! render semaphore) and encoded by `ds-3dtiles`.
 
 use std::collections::HashMap;
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 
 use arc_swap::ArcSwap;
 use axum::extract::{Path, Query, State};
@@ -24,7 +24,7 @@ use chrono::{DateTime, Utc};
 use ds_core::config::CollectionConfig;
 use ds_core::geo::geodetic_to_ecef;
 use ds_core::volume::VolumeEngine;
-use ds_render::{ColorMap, ColorStop, LutColorMap};
+use ds_render::{BuiltinColormap, ColorMap, ColorStop, LutColorMap};
 use serde::Deserialize;
 use serde_json::json;
 
@@ -93,6 +93,19 @@ const LEGEND_MIN_DBZ: f64 = 0.0;
 const LEGEND_MAX_DBZ: f64 = 70.0;
 const LEGEND_STOPS: usize = 24;
 
+/// The shared colour ramp applied to point-cloud values. v1 uses one reflectivity
+/// ramp for every 3D-Tiles collection (per-collection/per-quantity colormaps are
+/// a follow-up — #350). Single source of truth so the points the server encodes
+/// and the legend it advertises can't drift; every `TilesState3d` construction
+/// site uses this.
+pub fn default_point_colormap() -> Arc<dyn ColorMap> {
+    Arc::new(LutColorMap::from_builtin(
+        BuiltinColormap::RadarDbz,
+        -32.0,
+        95.0,
+    ))
+}
+
 /// Sample `colormap` into `(value, "#rrggbb")` stops across `[min, max]` for the
 /// viewer legend. RGB only — `.pnts` colours are opaque, so alpha is dropped.
 fn legend_stops(colormap: &dyn ColorMap, min: f64, max: f64, n: usize) -> Vec<serde_json::Value> {
@@ -115,10 +128,31 @@ fn legend_stops(colormap: &dyn ColorMap, min: f64, max: f64, n: usize) -> Vec<se
         .collect()
 }
 
+/// The point-cloud colour-scale legend, built once. The colormap is fixed for the
+/// process ([`default_point_colormap`]), so we sample it a single time rather than
+/// on every `GET /collections/{id}` (a metadata accessor — keep it O(1), #211).
+/// When per-collection colormaps land (#350) this moves into the per-collection
+/// snapshot.
+static POINT_LEGEND: LazyLock<serde_json::Value> = LazyLock::new(|| {
+    json!({
+        "title": "Reflectivity",
+        "unit": "dBZ",
+        "min": LEGEND_MIN_DBZ,
+        "max": LEGEND_MAX_DBZ,
+        "stops": legend_stops(
+            default_point_colormap().as_ref(),
+            LEGEND_MIN_DBZ,
+            LEGEND_MAX_DBZ,
+            LEGEND_STOPS,
+        ),
+    })
+});
+
 /// The blue→red **height** colour ramp for the echo-top product (stops at height
 /// values, 0–15 km) — a builtin colormap's stops are in its own units, so they
-/// collapse over a height range; build it explicitly. Cheap to construct.
-fn echo_top_height_colormap() -> LutColorMap {
+/// collapse over a height range; build it explicitly. Fixed ramp, so build it
+/// once rather than per echo-top GLB request (mirrors the `colormap` pattern).
+static ECHO_TOP_COLORMAP: LazyLock<LutColorMap> = LazyLock::new(|| {
     let stops = [
         (0.0_f64, [40u8, 70, 200, 255]),
         (3_000.0, [0, 200, 220, 255]),
@@ -129,7 +163,7 @@ fn echo_top_height_colormap() -> LutColorMap {
     ]
     .map(|(value, color)| ColorStop { value, color });
     LutColorMap::from_stops(&stops, 0.0, 15_000.0)
-}
+});
 
 /// Shared state for the 3D Tiles API. Wrapped in `ArcSwap` for lock-free reads
 /// and atomic swap on config reload.
@@ -593,11 +627,7 @@ pub async fn get_content_glb(
                 Representation::EchoTop => {
                     let grid =
                         engine.read_voxel_grid(quantity.as_deref(), time, Some(dims), None)?;
-                    ds_3dtiles::encode_echo_top_columns_glb(
-                        &grid,
-                        threshold,
-                        &echo_top_height_colormap(),
-                    )
+                    ds_3dtiles::encode_echo_top_columns_glb(&grid, threshold, &*ECHO_TOP_COLORMAP)
                 }
                 Representation::Isosurface => {
                     let grid =
@@ -718,16 +748,11 @@ fn collection_doc(state: &TilesState3d, id: &str, base: &str) -> serde_json::Val
         links.push(json!({ "href": format!("{base}/3dtiles/collections/{id}/tileset.json?representation=isosurface"), "rel": "3dtiles", "type": "application/json", "title": "3D Tiles tileset (isosurface mesh)" }));
         links.push(json!({ "href": format!("{base}/3dtiles/collections/{id}/tileset.json?representation=echotop"), "rel": "3dtiles", "type": "application/json", "title": "3D Tiles tileset (echo-top columns)" }));
     }
-    // Colour-scale legend for the point cloud: sample the shared reflectivity
-    // colormap so the viewer can show a gradient bar whose colours match the
-    // points (v1 uses one reflectivity ramp for all quantities — #350).
-    let legend = json!({
-        "title": "Reflectivity",
-        "unit": "dBZ",
-        "min": LEGEND_MIN_DBZ,
-        "max": LEGEND_MAX_DBZ,
-        "stops": legend_stops(state.colormap.as_ref(), LEGEND_MIN_DBZ, LEGEND_MAX_DBZ, LEGEND_STOPS),
-    });
+    // Colour-scale legend for the point cloud: the precomputed gradient of the
+    // shared reflectivity colormap, so the viewer's bar matches the point colours
+    // (built once — this is a metadata accessor; v1 uses one ramp for all
+    // quantities — #350).
+    let legend = POINT_LEGEND.clone();
     json!({
         "id": id,
         "title": title,

--- a/crates/api-3dtiles/src/handlers.rs
+++ b/crates/api-3dtiles/src/handlers.rs
@@ -84,6 +84,30 @@ impl Resolution {
     }
 }
 
+/// Reflectivity range (dBZ) sampled for the viewer's colour-scale legend. The
+/// shared point colormap is sampled across this span so the legend reads the
+/// same colours the points show. 0–70 dBZ is the conventional radar display
+/// range — it covers the whole coloured ramp (the radar colormap is ~black
+/// below a few dBZ, so a lower bound just adds an invisible band).
+const LEGEND_MIN_DBZ: f64 = 0.0;
+const LEGEND_MAX_DBZ: f64 = 70.0;
+const LEGEND_STOPS: usize = 24;
+
+/// Sample `colormap` into `(value, "#rrggbb")` stops across `[min, max]` for the
+/// viewer legend. RGB only — `.pnts` colours are opaque, so alpha is dropped.
+fn legend_stops(colormap: &dyn ColorMap, min: f64, max: f64, n: usize) -> Vec<serde_json::Value> {
+    (0..n)
+        .map(|i| {
+            let v = min + (max - min) * (i as f64) / ((n - 1) as f64);
+            let c = colormap.color(Some(v));
+            json!({
+                "value": (v * 10.0).round() / 10.0,
+                "color": format!("#{:02x}{:02x}{:02x}", c[0], c[1], c[2]),
+            })
+        })
+        .collect()
+}
+
 /// The blue→red **height** colour ramp for the echo-top product (stops at height
 /// values, 0–15 km) — a builtin colormap's stops are in its own units, so they
 /// collapse over a height range; build it explicitly. Cheap to construct.
@@ -585,11 +609,13 @@ pub async fn get_content_glb(
                 ds_3dtiles::Tiles3dError::TooLarge(_) => Tiles3dError::BadRequest(format!(
                     "threshold {threshold} produces too large a {product}; raise it"
                 )),
-                // Unreachable (floor < threshold above) — defensive 400.
+                // Unreachable (floor < threshold above) — defensive 400. Only
+                // the isosurface encoder emits this today, but this `map_err`
+                // covers both products, so use `{product}` for consistency.
                 ds_3dtiles::Tiles3dError::BackgroundNotBelowThreshold { .. } => {
-                    Tiles3dError::BadRequest(
-                        "isosurface sealing floor is not below the threshold".into(),
-                    )
+                    Tiles3dError::BadRequest(format!(
+                        "{product} sealing floor is not below the threshold"
+                    ))
                 }
                 other => Tiles3dError::Internal(format!("{product} encode failed: {other}")),
             })?;
@@ -681,12 +707,23 @@ fn collection_doc(state: &TilesState3d, id: &str, base: &str) -> serde_json::Val
         links.push(json!({ "href": format!("{base}/3dtiles/collections/{id}/tileset.json?representation=isosurface"), "rel": "3dtiles", "type": "application/json", "title": "3D Tiles tileset (isosurface mesh)" }));
         links.push(json!({ "href": format!("{base}/3dtiles/collections/{id}/tileset.json?representation=echotop"), "rel": "3dtiles", "type": "application/json", "title": "3D Tiles tileset (echo-top columns)" }));
     }
+    // Colour-scale legend for the point cloud: sample the shared reflectivity
+    // colormap so the viewer can show a gradient bar whose colours match the
+    // points (v1 uses one reflectivity ramp for all quantities — #350).
+    let legend = json!({
+        "title": "Reflectivity",
+        "unit": "dBZ",
+        "min": LEGEND_MIN_DBZ,
+        "max": LEGEND_MAX_DBZ,
+        "stops": legend_stops(state.colormap.as_ref(), LEGEND_MIN_DBZ, LEGEND_MAX_DBZ, LEGEND_STOPS),
+    });
     json!({
         "id": id,
         "title": title,
         "description": description,
         "quantities": quantities,
         "representations": representations,
+        "legend": legend,
         "links": links,
     })
 }

--- a/crates/api-3dtiles/src/handlers.rs
+++ b/crates/api-3dtiles/src/handlers.rs
@@ -421,10 +421,24 @@ pub async fn get_content_glb(
     State(state): State<AppState>,
 ) -> Result<Response, Tiles3dError> {
     let state = state.load_full();
-    let representation = Representation::parse(params.representation.as_deref())?;
+    // `.glb` serves the mesh products. An *absent* representation defaults to
+    // the isosurface (the isosurface tileset's `content.uri` omits the param),
+    // but an *explicit* `points` is rejected below — the point cloud has its own
+    // `content.pnts` route, and a tileset-following client never asks `.glb` for
+    // it. (Distinguishing absent from explicit-points is why we don't lean on
+    // `Representation::parse`'s `None → Points` default here.)
+    let representation = match params.representation.as_deref().map(str::trim) {
+        None | Some("") => Representation::Isosurface,
+        other => Representation::parse(other)?,
+    };
     let product = match representation {
+        Representation::Points => {
+            return Err(Tiles3dError::BadRequest(
+                "use content.pnts for the point-cloud representation".into(),
+            ))
+        }
         Representation::EchoTop => "echo-top",
-        _ => "isosurface",
+        Representation::Isosurface => "isosurface",
     };
     let (engine, _config) = lookup(&state, &id)?;
     let info = engine.volume_info();
@@ -495,7 +509,7 @@ pub async fn get_content_glb(
                         &echo_top_height_colormap(),
                     )
                 }
-                _ => {
+                Representation::Isosurface => {
                     let grid = engine.read_voxel_grid(quantity.as_deref(), time, None, None)?;
                     // Colour the shell at the threshold (v1: one colormap for all
                     // quantities — #350); seal NaN at the no-echo floor so it
@@ -503,6 +517,8 @@ pub async fn get_content_glb(
                     let color = colormap.color(Some(threshold));
                     ds_3dtiles::encode_isosurface_glb(&grid, threshold, color, Some(floor))
                 }
+                // Rejected before the blocking task (see the `product` match).
+                Representation::Points => unreachable!("points rejected above"),
             };
             let bytes = result.map_err(|e| match e {
                 // No surface / no columns (threshold above all echo) — 404.

--- a/crates/api-3dtiles/src/handlers.rs
+++ b/crates/api-3dtiles/src/handlers.rs
@@ -418,10 +418,14 @@ pub async fn get_tileset(
             // `content.uri` is self-describing.
             let resolution = Resolution::parse(params.resolution.as_deref())?;
             query.push_str(&format!("&resolution={}", resolution.as_str()));
-            // The `content.glb` handler defaults to isosurface; tag echo-top.
-            if representation == Representation::EchoTop {
-                query.push_str("&representation=echotop");
-            }
+            // Tag the mesh product explicitly for *both* (not just echo-top), so
+            // the `content.uri` is unambiguous and doesn't depend on the
+            // content.glb handler's absent→isosurface default — a future default
+            // change there can't then silently repoint old isosurface tilesets.
+            query.push_str(match representation {
+                Representation::EchoTop => "&representation=echotop",
+                _ => "&representation=isosurface",
+            });
             let content_uri = format!("content.glb?{query}");
             ds_3dtiles::tileset_json_glb(region, &content_uri, rtc)
                 .map_err(|e| Tiles3dError::Internal(format!("tileset build failed: {e}")))?

--- a/crates/api-3dtiles/src/handlers.rs
+++ b/crates/api-3dtiles/src/handlers.rs
@@ -1,14 +1,16 @@
 //! HTTP handlers for the 3D Tiles API.
 //!
-//! Serves OGC 3D Tiles from any collection implementing `VolumeEngine`, in two
+//! Serves OGC 3D Tiles from any collection implementing `VolumeEngine`, in three
 //! representations (selected by `?representation=`):
 //! - `GET /collections/{id}/tileset.json` — the tileset (bounding region from
 //!   `VolumeInfo`; content points at `.pnts` for `points`, or `.glb` plus an
-//!   antenna-ECEF `transform` for `isosurface`).
+//!   antenna-ECEF `transform` for the `isosurface`/`echotop` mesh products).
 //! - `GET /collections/{id}/content.pnts` — the point-cloud tile.
-//! - `GET /collections/{id}/content.glb` — the isosurface-mesh tile.
+//! - `GET /collections/{id}/content.glb` — a mesh tile (`isosurface` shell, the
+//!   default, or `echotop` columns). The mesh products take a `resolution`
+//!   (`low`/`med`/`high`) detail tier; the point cloud is native-resolution.
 //!
-//! Both content types are sampled on a blocking thread (bounded by the shared
+//! All content types are sampled on a blocking thread (bounded by the shared
 //! render semaphore) and encoded by `ds-3dtiles`.
 
 use std::collections::HashMap;
@@ -33,11 +35,54 @@ use crate::error::Tiles3dError;
 const ISOSURFACE_DEFAULT_THRESHOLD: f64 = 20.0;
 /// Default echo-top reflectivity (dBZ) — the standard echo-top value.
 const ECHO_TOP_DEFAULT_THRESHOLD: f64 = 18.0;
-/// Voxel-grid resolution for the echo-top product: `[radius, azimuth, height]`.
-/// Full radial resolution (≈ the native 500 m range bins; azimuth 360 = native;
-/// height interpolates the ~10 elevation sweeps). ~11.8 M cells — bounded by the
-/// engine's `MAX_VOXELS`; the heavier `.glb` is offset by the content ETag.
-const ECHO_TOP_DIMS: [usize; 3] = [512, 360, 64];
+
+/// Voxel-grid resolution tier for the glTF mesh products (isosurface, echo-top):
+/// `[radius, azimuth, height]`. Azimuth stays 360 (the native 1° ray spacing) at
+/// every tier; radius/height trade detail for compute. The cell count drives both
+/// the resample and the mesher, so the first-request cost scales with it (repeats
+/// are ETag-cached). `High` ≈ the native 500 m range bins; `Low` is the engine's
+/// historical default. All tiers stay under the engine's `MAX_VOXELS` cap.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Resolution {
+    /// `[128, 360, 48]` ≈ 2.2 M cells — fast, coarse radial (~2 km bins).
+    Low,
+    /// `[256, 360, 56]` ≈ 5.2 M cells — the balanced default.
+    Med,
+    /// `[512, 360, 64]` ≈ 11.8 M cells — full radial detail; ~12 s first compute.
+    High,
+}
+
+impl Resolution {
+    /// Parse the `resolution` query value (`None`/empty → `Med`).
+    fn parse(s: Option<&str>) -> Result<Self, Tiles3dError> {
+        match s.map(str::trim) {
+            None | Some("") | Some("med") | Some("medium") => Ok(Self::Med),
+            Some("low") => Ok(Self::Low),
+            Some("high") => Ok(Self::High),
+            Some(other) => Err(Tiles3dError::BadRequest(format!(
+                "unknown resolution '{other}' (expected 'low', 'med', or 'high')"
+            ))),
+        }
+    }
+
+    /// The voxel-grid dimensions `[radius, azimuth, height]` for this tier.
+    fn dims(self) -> [usize; 3] {
+        match self {
+            Self::Low => [128, 360, 48],
+            Self::Med => [256, 360, 56],
+            Self::High => [512, 360, 64],
+        }
+    }
+
+    /// The canonical query-string token (round-trips through `parse`).
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Low => "low",
+            Self::Med => "med",
+            Self::High => "high",
+        }
+    }
+}
 
 /// The blue→red **height** colour ramp for the echo-top product (stops at height
 /// values, 0–15 km) — a builtin colormap's stops are in its own units, so they
@@ -106,6 +151,10 @@ pub struct TilesetParams {
     /// `isosurface` only: the iso-value (e.g. dBZ) of the shell; carried into
     /// the `.glb` `content.uri`. `None` → [`ISOSURFACE_DEFAULT_THRESHOLD`].
     pub threshold: Option<f64>,
+    /// Mesh products only (`isosurface`/`echotop`): voxel-grid detail tier
+    /// (`low`/`med`/`high`); carried into the `.glb` `content.uri`. `None` →
+    /// `med`. Ignored for `points` (the cloud is native-resolution).
+    pub resolution: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -126,6 +175,8 @@ pub struct GlbContentParams {
     pub threshold: Option<f64>,
     /// Which glTF product: `isosurface` (default) or `echotop`.
     pub representation: Option<String>,
+    /// Voxel-grid detail tier (`low`/`med`/`high`). `None` → `med`.
+    pub resolution: Option<String>,
 }
 
 /// The 3D Tiles representations of a volume — all valid OGC 3D Tiles tilesets,
@@ -330,6 +381,12 @@ pub async fn get_tileset(
                 }
                 query.push_str(&format!("&threshold={t}"));
             }
+            // Carry the detail tier so the content fetch matches the tileset.
+            // Validate now (a bad value is a 400 here, not a surprise on fetch);
+            // emit the canonical token even when the request omitted it, so the
+            // `content.uri` is self-describing.
+            let resolution = Resolution::parse(params.resolution.as_deref())?;
+            query.push_str(&format!("&resolution={}", resolution.as_str()));
             // The `content.glb` handler defaults to isosurface; tag echo-top.
             if representation == Representation::EchoTop {
                 query.push_str("&representation=echotop");
@@ -462,6 +519,9 @@ pub async fn get_content_glb(
 
     let time = params.datetime.as_deref().map(parse_datetime).transpose()?;
     let quantity = params.quantity.clone();
+    // Detail tier (`low`/`med`/`high`, default `med`) → voxel-grid dims, applied
+    // to both mesh products. A bad value is a 400 before the blocking task.
+    let dims = Resolution::parse(params.resolution.as_deref())?.dims();
     let threshold = params.threshold.unwrap_or(match representation {
         Representation::EchoTop => ECHO_TOP_DEFAULT_THRESHOLD,
         _ => ISOSURFACE_DEFAULT_THRESHOLD,
@@ -496,13 +556,8 @@ pub async fn get_content_glb(
         tokio::task::spawn_blocking(move || -> Result<(Vec<u8>, String), Tiles3dError> {
             let result = match representation {
                 Representation::EchoTop => {
-                    // Full radial resolution for the bars (ECHO_TOP_DIMS).
-                    let grid = engine.read_voxel_grid(
-                        quantity.as_deref(),
-                        time,
-                        Some(ECHO_TOP_DIMS),
-                        None,
-                    )?;
+                    let grid =
+                        engine.read_voxel_grid(quantity.as_deref(), time, Some(dims), None)?;
                     ds_3dtiles::encode_echo_top_columns_glb(
                         &grid,
                         threshold,
@@ -510,7 +565,8 @@ pub async fn get_content_glb(
                     )
                 }
                 Representation::Isosurface => {
-                    let grid = engine.read_voxel_grid(quantity.as_deref(), time, None, None)?;
+                    let grid =
+                        engine.read_voxel_grid(quantity.as_deref(), time, Some(dims), None)?;
                     // Colour the shell at the threshold (v1: one colormap for all
                     // quantities — #350); seal NaN at the no-echo floor so it
                     // closes into solid blobs (`floor < threshold` guaranteed).

--- a/crates/api-3dtiles/src/handlers.rs
+++ b/crates/api-3dtiles/src/handlers.rs
@@ -56,7 +56,7 @@ impl Resolution {
     /// Parse the `resolution` query value (`None`/empty → `Med`).
     fn parse(s: Option<&str>) -> Result<Self, Tiles3dError> {
         match s.map(str::trim) {
-            None | Some("") | Some("med") | Some("medium") => Ok(Self::Med),
+            None | Some("") | Some("med") => Ok(Self::Med),
             Some("low") => Ok(Self::Low),
             Some("high") => Ok(Self::High),
             Some(other) => Err(Tiles3dError::BadRequest(format!(
@@ -98,7 +98,14 @@ const LEGEND_STOPS: usize = 24;
 fn legend_stops(colormap: &dyn ColorMap, min: f64, max: f64, n: usize) -> Vec<serde_json::Value> {
     (0..n)
         .map(|i| {
-            let v = min + (max - min) * (i as f64) / ((n - 1) as f64);
+            // Guard n == 1: `i/(n-1)` would be `0/0 = NaN`, which serde emits as
+            // `null`. (LEGEND_STOPS is 24 today, but keep the invariant explicit.)
+            let v = min
+                + if n <= 1 {
+                    0.0
+                } else {
+                    (max - min) * (i as f64) / ((n - 1) as f64)
+                };
             let c = colormap.color(Some(v));
             json!({
                 "value": (v * 10.0).round() / 10.0,

--- a/crates/api-3dtiles/src/handlers.rs
+++ b/crates/api-3dtiles/src/handlers.rs
@@ -22,7 +22,7 @@ use chrono::{DateTime, Utc};
 use ds_core::config::CollectionConfig;
 use ds_core::geo::geodetic_to_ecef;
 use ds_core::volume::VolumeEngine;
-use ds_render::ColorMap;
+use ds_render::{ColorMap, ColorStop, LutColorMap};
 use serde::Deserialize;
 use serde_json::json;
 
@@ -31,6 +31,29 @@ use crate::error::Tiles3dError;
 /// Default isosurface threshold (dBZ) when a request names none — a light-rain
 /// reflectivity shell.
 const ISOSURFACE_DEFAULT_THRESHOLD: f64 = 20.0;
+/// Default echo-top reflectivity (dBZ) — the standard echo-top value.
+const ECHO_TOP_DEFAULT_THRESHOLD: f64 = 18.0;
+/// Voxel-grid resolution for the echo-top product: `[radius, azimuth, height]`.
+/// Full radial resolution (≈ the native 500 m range bins; azimuth 360 = native;
+/// height interpolates the ~10 elevation sweeps). ~11.8 M cells — bounded by the
+/// engine's `MAX_VOXELS`; the heavier `.glb` is offset by the content ETag.
+const ECHO_TOP_DIMS: [usize; 3] = [512, 360, 64];
+
+/// The blue→red **height** colour ramp for the echo-top product (stops at height
+/// values, 0–15 km) — a builtin colormap's stops are in its own units, so they
+/// collapse over a height range; build it explicitly. Cheap to construct.
+fn echo_top_height_colormap() -> LutColorMap {
+    let stops = [
+        (0.0_f64, [40u8, 70, 200, 255]),
+        (3_000.0, [0, 200, 220, 255]),
+        (6_000.0, [40, 200, 80, 255]),
+        (9_000.0, [240, 230, 60, 255]),
+        (12_000.0, [240, 140, 40, 255]),
+        (15_000.0, [220, 40, 40, 255]),
+    ]
+    .map(|(value, color)| ColorStop { value, color });
+    LutColorMap::from_stops(&stops, 0.0, 15_000.0)
+}
 
 /// Shared state for the 3D Tiles API. Wrapped in `ArcSwap` for lock-free reads
 /// and atomic swap on config reload.
@@ -97,16 +120,25 @@ pub struct ContentParams {
 pub struct GlbContentParams {
     pub quantity: Option<String>,
     pub datetime: Option<String>,
-    /// Iso-value of the reflectivity shell. `None` → [`ISOSURFACE_DEFAULT_THRESHOLD`].
+    /// `isosurface`: iso-value of the shell; `echotop`: the reflectivity floor
+    /// for the echo top. `None` → [`ISOSURFACE_DEFAULT_THRESHOLD`] /
+    /// [`ECHO_TOP_DEFAULT_THRESHOLD`].
     pub threshold: Option<f64>,
+    /// Which glTF product: `isosurface` (default) or `echotop`.
+    pub representation: Option<String>,
 }
 
-/// The two 3D Tiles representations of a volume. Both are valid OGC 3D Tiles
-/// tilesets; they differ only in content type (`.pnts` vs glTF `.glb`).
+/// The 3D Tiles representations of a volume — all valid OGC 3D Tiles tilesets,
+/// differing in content (`.pnts` point cloud vs glTF `.glb` mesh) and, for the
+/// two mesh products, in what the mesh *is*.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum Representation {
+    /// `.pnts` point cloud — one point per echo cell.
     Points,
+    /// `.glb` closed reflectivity shell at a threshold.
     Isosurface,
+    /// `.glb` extruded echo-top columns (ground → echo-top height, by column).
+    EchoTop,
 }
 
 impl Representation {
@@ -115,8 +147,9 @@ impl Representation {
         match s.map(str::trim) {
             None | Some("") | Some("points") => Ok(Self::Points),
             Some("isosurface") => Ok(Self::Isosurface),
+            Some("echotop") => Ok(Self::EchoTop),
             Some(other) => Err(Tiles3dError::BadRequest(format!(
-                "unknown representation '{other}' (expected 'points' or 'isosurface')"
+                "unknown representation '{other}' (expected 'points', 'isosurface', or 'echotop')"
             ))),
         }
     }
@@ -271,12 +304,18 @@ pub async fn get_tileset(
             ds_3dtiles::tileset_json_for_region(region, &content_uri)
                 .map_err(|e| Tiles3dError::Internal(format!("tileset build failed: {e}")))?
         }
-        Representation::Isosurface => {
-            // `voxel_grid` couples capability with the origin, so an isosurface
-            // collection always has the origin — no separate `None` → 500 path.
+        Representation::Isosurface | Representation::EchoTop => {
+            // Both glTF products need the voxel grid. `voxel_grid` couples the
+            // capability with the origin, so such a collection always has the
+            // origin — no separate `None` → 500 path.
             let caps = info.voxel_grid.as_ref().ok_or_else(|| {
+                let name = if representation == Representation::EchoTop {
+                    "echo-top"
+                } else {
+                    "isosurface"
+                };
                 Tiles3dError::BadRequest(format!(
-                    "collection '{id}' does not support the isosurface representation"
+                    "collection '{id}' does not support the {name} representation"
                 ))
             })?;
             // The glTF `.glb` content has no embedded origin (unlike `.pnts`
@@ -290,6 +329,10 @@ pub async fn get_tileset(
                     return Err(Tiles3dError::BadRequest("threshold must be finite".into()));
                 }
                 query.push_str(&format!("&threshold={t}"));
+            }
+            // The `content.glb` handler defaults to isosurface; tag echo-top.
+            if representation == Representation::EchoTop {
+                query.push_str("&representation=echotop");
             }
             let content_uri = format!("content.glb?{query}");
             ds_3dtiles::tileset_json_glb(region, &content_uri, rtc)
@@ -366,9 +409,11 @@ pub async fn get_content(
 // Content (.glb isosurface)
 // ---------------------------------------------------------------------------
 
-/// `GET /collections/{id}/content.glb` — the isosurface reflectivity-shell mesh,
-/// resampled to a voxel grid and meshed (marching tetrahedra) on a blocking
-/// thread, then encoded as a glTF `.glb` by `ds-3dtiles`.
+/// `GET /collections/{id}/content.glb` — a glTF `.glb` mesh of the volume:
+/// `representation=isosurface` (default) is a reflectivity shell (marching
+/// tetrahedra); `representation=echotop` is extruded echo-top columns. Resampled
+/// to a voxel grid and meshed on a blocking thread (bounded by the shared render
+/// semaphore), encoded by `ds-3dtiles`.
 pub async fn get_content_glb(
     headers: HeaderMap,
     Path(id): Path<String>,
@@ -376,13 +421,18 @@ pub async fn get_content_glb(
     State(state): State<AppState>,
 ) -> Result<Response, Tiles3dError> {
     let state = state.load_full();
+    let representation = Representation::parse(params.representation.as_deref())?;
+    let product = match representation {
+        Representation::EchoTop => "echo-top",
+        _ => "isosurface",
+    };
     let (engine, _config) = lookup(&state, &id)?;
     let info = engine.volume_info();
     // Reject early if the engine can't produce a voxel grid (avoids a blocking
     // task just to return the trait's "unsupported" → 404).
     if info.voxel_grid.is_none() {
         return Err(Tiles3dError::BadRequest(format!(
-            "collection '{id}' does not support the isosurface representation"
+            "collection '{id}' does not support the {product} representation"
         )));
     }
     // Validate the quantity against the advertised set *before* the blocking
@@ -398,15 +448,16 @@ pub async fn get_content_glb(
 
     let time = params.datetime.as_deref().map(parse_datetime).transpose()?;
     let quantity = params.quantity.clone();
-    let threshold = params.threshold.unwrap_or(ISOSURFACE_DEFAULT_THRESHOLD);
+    let threshold = params.threshold.unwrap_or(match representation {
+        Representation::EchoTop => ECHO_TOP_DEFAULT_THRESHOLD,
+        _ => ISOSURFACE_DEFAULT_THRESHOLD,
+    });
     if !threshold.is_finite() {
         return Err(Tiles3dError::BadRequest("threshold must be finite".into()));
     }
-    // The engine fills clear air with the no-echo floor; a threshold at/below it
-    // would put clear air *inside* the surface (all clear air would render as
-    // echo). Reject — a reflectivity shell below the −32 dBZ floor is meaningless.
-    // (v1: the floor is dBZ for every quantity; for a non-reflectivity quantity
-    // it's just "below any sane threshold" — per-quantity floors are #350.)
+    // Both products lean on the engine's no-echo floor: the isosurface seals NaN
+    // at it; an echo-top column needs its threshold above it (else clear air
+    // would count as echo). (v1: the floor is dBZ for every quantity — #350.)
     let floor = f64::from(ds_core::volume::NO_ECHO_FLOOR_DBZ);
     if threshold <= floor {
         return Err(Tiles3dError::BadRequest(format!(
@@ -414,19 +465,9 @@ pub async fn get_content_glb(
         )));
     }
 
-    // Colour the shell at the threshold. v1 uses the single collection-level
-    // colormap regardless of quantity (the `.pnts` path has the same
-    // limitation); per-quantity colormaps are #350.
-    let color = state.colormap.color(Some(threshold));
-    // Seal NaN at the same no-echo floor the engine fills clear air with, so the
-    // shell closes into solid blobs (the preferred look — an open unmeasured
-    // boundary reads as "curtains") and clear air + unmeasured seal at one
-    // uniform level. `floor < threshold` is guaranteed above.
-    let background = Some(floor);
-
-    // read_voxel_grid does blocking HDF5 I/O + a long CPU loop (marching tet),
-    // so bound it with the shared render semaphore and run on a blocking thread
-    // (same rule as the `.pnts` path / the raster `get_raster_tile`).
+    // read_voxel_grid + meshing do blocking HDF5 I/O + a long CPU loop, so bound
+    // them with the shared render semaphore and run on a blocking thread (same
+    // rule as the `.pnts` path / the raster `get_raster_tile`).
     let _permit = state
         .render_semaphore
         .clone()
@@ -435,33 +476,51 @@ pub async fn get_content_glb(
         .map_err(|_| Tiles3dError::Internal("render semaphore closed".into()))?;
 
     let engine = engine.clone();
+    let colormap = state.colormap.clone(); // reflectivity ramp (isosurface)
     let id_for_err = id.clone();
     let (bytes, etag) =
         tokio::task::spawn_blocking(move || -> Result<(Vec<u8>, String), Tiles3dError> {
-            let grid = engine.read_voxel_grid(quantity.as_deref(), time, None, None)?;
-            let bytes = ds_3dtiles::encode_isosurface_glb(&grid, threshold, color, background)
-                .map_err(|e| match e {
-                    // An empty surface (threshold above all echo) is "no data
-                    // here", not a server fault — 404, matching the no-data path.
-                    ds_3dtiles::Tiles3dError::Empty => Tiles3dError::NotFound(format!(
-                        "no isosurface at threshold {threshold} for collection '{id_for_err}'"
-                    )),
-                    // Too many triangles is client-driven (the threshold is too
-                    // low for this grid) — 400, not a 500 server fault.
-                    ds_3dtiles::Tiles3dError::TooLarge(_) => Tiles3dError::BadRequest(format!(
-                        "threshold {threshold} produces too large an isosurface; raise it"
-                    )),
-                    // The seal floor is clamped < threshold above, so this is
-                    // currently unreachable — but map it to 400 (a bad
-                    // parameter combination) so a future floor-formula change
-                    // can't silently surface as an opaque 500.
-                    ds_3dtiles::Tiles3dError::BackgroundNotBelowThreshold { .. } => {
-                        Tiles3dError::BadRequest(
-                            "isosurface sealing floor is not below the threshold".into(),
-                        )
-                    }
-                    other => Tiles3dError::Internal(format!("isosurface encode failed: {other}")),
-                })?;
+            let result = match representation {
+                Representation::EchoTop => {
+                    // Full radial resolution for the bars (ECHO_TOP_DIMS).
+                    let grid = engine.read_voxel_grid(
+                        quantity.as_deref(),
+                        time,
+                        Some(ECHO_TOP_DIMS),
+                        None,
+                    )?;
+                    ds_3dtiles::encode_echo_top_columns_glb(
+                        &grid,
+                        threshold,
+                        &echo_top_height_colormap(),
+                    )
+                }
+                _ => {
+                    let grid = engine.read_voxel_grid(quantity.as_deref(), time, None, None)?;
+                    // Colour the shell at the threshold (v1: one colormap for all
+                    // quantities — #350); seal NaN at the no-echo floor so it
+                    // closes into solid blobs (`floor < threshold` guaranteed).
+                    let color = colormap.color(Some(threshold));
+                    ds_3dtiles::encode_isosurface_glb(&grid, threshold, color, Some(floor))
+                }
+            };
+            let bytes = result.map_err(|e| match e {
+                // No surface / no columns (threshold above all echo) — 404.
+                ds_3dtiles::Tiles3dError::Empty => Tiles3dError::NotFound(format!(
+                    "no {product} at threshold {threshold} for collection '{id_for_err}'"
+                )),
+                // Client-driven (threshold too low for this grid) — 400.
+                ds_3dtiles::Tiles3dError::TooLarge(_) => Tiles3dError::BadRequest(format!(
+                    "threshold {threshold} produces too large a {product}; raise it"
+                )),
+                // Unreachable (floor < threshold above) — defensive 400.
+                ds_3dtiles::Tiles3dError::BackgroundNotBelowThreshold { .. } => {
+                    Tiles3dError::BadRequest(
+                        "isosurface sealing floor is not below the threshold".into(),
+                    )
+                }
+                other => Tiles3dError::Internal(format!("{product} encode failed: {other}")),
+            })?;
             let etag = etag_of(&bytes);
             Ok((bytes, etag))
         })
@@ -532,21 +591,23 @@ fn collection_doc(state: &TilesState3d, id: &str, base: &str) -> serde_json::Val
         })
         .unwrap_or_default();
     // Every volume collection serves a point cloud; those whose engine can also
-    // produce a voxel grid additionally serve an isosurface mesh. The viewer
-    // reads this to populate its representation toggle.
-    let supports_iso = info.as_ref().is_some_and(|i| i.voxel_grid.is_some());
+    // produce a voxel grid additionally serve the two glTF mesh products
+    // (isosurface, echo-top). The viewer reads this to populate its toggle.
+    let supports_mesh = info.as_ref().is_some_and(|i| i.voxel_grid.is_some());
     let mut representations = vec!["points"];
-    if supports_iso {
+    if supports_mesh {
         representations.push("isosurface");
+        representations.push("echotop");
     }
     // A link per representation so a link-following client (not just one that
-    // reads `representations` and builds URLs itself) can discover both.
+    // reads `representations` and builds URLs itself) can discover them.
     let mut links = vec![
         json!({ "href": format!("{base}/3dtiles/collections/{id}"), "rel": "self", "type": "application/json", "title": "This document" }),
         json!({ "href": format!("{base}/3dtiles/collections/{id}/tileset.json"), "rel": "3dtiles", "type": "application/json", "title": "3D Tiles tileset (point cloud)" }),
     ];
-    if supports_iso {
+    if supports_mesh {
         links.push(json!({ "href": format!("{base}/3dtiles/collections/{id}/tileset.json?representation=isosurface"), "rel": "3dtiles", "type": "application/json", "title": "3D Tiles tileset (isosurface mesh)" }));
+        links.push(json!({ "href": format!("{base}/3dtiles/collections/{id}/tileset.json?representation=echotop"), "rel": "3dtiles", "type": "application/json", "title": "3D Tiles tileset (echo-top columns)" }));
     }
     json!({
         "id": id,

--- a/crates/api-3dtiles/src/lib.rs
+++ b/crates/api-3dtiles/src/lib.rs
@@ -16,7 +16,7 @@ pub mod error;
 pub mod handlers;
 
 pub use error::Tiles3dError;
-pub use handlers::{AppState, TilesState3d};
+pub use handlers::{default_point_colormap, AppState, TilesState3d};
 
 use axum::routing::get;
 use axum::Router;

--- a/crates/api-3dtiles/tests/integration.rs
+++ b/crates/api-3dtiles/tests/integration.rs
@@ -367,14 +367,14 @@ async fn collections_list_and_doc() {
     assert_eq!(status, StatusCode::OK);
     let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
     assert_eq!(v["quantities"][0]["id"], "DBZH");
-    // The mock supports voxel grids, so both representations are advertised.
+    // The mock supports voxel grids, so all three representations are advertised.
     let reps: Vec<&str> = v["representations"]
         .as_array()
         .unwrap()
         .iter()
         .map(|r| r.as_str().unwrap())
         .collect();
-    assert_eq!(reps, vec!["points", "isosurface"]);
+    assert_eq!(reps, vec!["points", "isosurface", "echotop"]);
     // …and a link-following client can discover the isosurface tileset too.
     let hrefs: Vec<&str> = v["links"]
         .as_array()
@@ -452,6 +452,37 @@ async fn isosurface_on_unsupported_collection_is_400() {
         .map(|r| r.as_str().unwrap())
         .collect();
     assert_eq!(reps, vec!["points"]);
+}
+
+#[tokio::test]
+async fn echotop_tileset_and_content_is_valid_glb() {
+    // The tileset advertises echo-top glb content tagged with the representation,
+    // plus the antenna-ECEF transform (like the isosurface).
+    let (status, body, _h) =
+        get("/collections/radar-fivih/tileset.json?representation=echotop&quantity=DBZH").await;
+    assert_eq!(status, StatusCode::OK);
+    let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(v["root"]["transform"].as_array().unwrap().len(), 16);
+    let uri = v["root"]["content"]["uri"].as_str().unwrap();
+    assert!(uri.starts_with("content.glb?"), "glb content: {uri}");
+    assert!(
+        uri.contains("representation=echotop"),
+        "echotop-tagged: {uri}"
+    );
+
+    // The content itself is a valid glTF binary.
+    let (status, body, headers) =
+        get("/collections/radar-fivih/content.glb?representation=echotop&quantity=DBZH").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(&body[0..4], b"glTF", "glb magic");
+    assert_eq!(
+        u32::from_le_bytes(body[8..12].try_into().unwrap()) as usize,
+        body.len()
+    );
+    assert_eq!(
+        headers[axum::http::header::CONTENT_TYPE],
+        "model/gltf-binary"
+    );
 }
 
 #[tokio::test]

--- a/crates/api-3dtiles/tests/integration.rs
+++ b/crates/api-3dtiles/tests/integration.rs
@@ -404,6 +404,12 @@ async fn collections_list_and_doc() {
             .any(|h| h.contains("tileset.json?representation=isosurface")),
         "isosurface tileset link present: {hrefs:?}"
     );
+    assert!(
+        hrefs
+            .iter()
+            .any(|h| h.contains("tileset.json?representation=echotop")),
+        "echo-top tileset link present: {hrefs:?}"
+    );
 }
 
 #[tokio::test]

--- a/crates/api-3dtiles/tests/integration.rs
+++ b/crates/api-3dtiles/tests/integration.rs
@@ -548,9 +548,13 @@ async fn isosurface_tileset_has_transform_and_glb_content() {
     let t = v["root"]["transform"].as_array().unwrap();
     assert_eq!(t.len(), 16);
     // Content points at the .glb, carrying the resolved quantity + threshold +
-    // the (defaulted) resolution tier, so the content fetch is deterministic.
+    // the (defaulted) resolution tier + the explicit representation, so the
+    // content fetch is deterministic and unambiguous.
     let uri = v["root"]["content"]["uri"].as_str().unwrap();
-    assert_eq!(uri, "content.glb?quantity=DBZH&threshold=20&resolution=med");
+    assert_eq!(
+        uri,
+        "content.glb?quantity=DBZH&threshold=20&resolution=med&representation=isosurface"
+    );
     // The region bounding volume is still present (unaffected by the transform).
     assert_eq!(
         v["root"]["boundingVolume"]["region"]

--- a/crates/api-3dtiles/tests/integration.rs
+++ b/crates/api-3dtiles/tests/integration.rs
@@ -530,6 +530,14 @@ async fn tileset_carries_resolution_tier_into_glb_content_uri() {
     let (status, _b, _h) =
         get("/collections/radar-fivih/content.glb?quantity=DBZH&resolution=ultra").await;
     assert_eq!(status, StatusCode::BAD_REQUEST);
+
+    // A bad tier is rejected even on a `points` tileset (which ignores the value)
+    // — the param is validated up front regardless of representation.
+    let (status, _b, _h) = get(
+        "/collections/radar-fivih/tileset.json?representation=points&quantity=DBZH&resolution=ultra",
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
 }
 
 #[tokio::test]

--- a/crates/api-3dtiles/tests/integration.rs
+++ b/crates/api-3dtiles/tests/integration.rs
@@ -486,6 +486,32 @@ async fn echotop_tileset_and_content_is_valid_glb() {
 }
 
 #[tokio::test]
+async fn tileset_carries_resolution_tier_into_glb_content_uri() {
+    // An explicit resolution is validated and echoed into the content.uri so the
+    // content fetch matches the tileset.
+    let (status, body, _h) = get(
+        "/collections/radar-fivih/tileset.json?representation=isosurface&quantity=DBZH&threshold=20&resolution=high",
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let uri = v["root"]["content"]["uri"].as_str().unwrap();
+    assert!(uri.contains("resolution=high"), "tier in uri: {uri}");
+
+    // A bad tier is a 400 at the tileset, not a surprise on the content fetch.
+    let (status, _b, _h) = get(
+        "/collections/radar-fivih/tileset.json?representation=isosurface&quantity=DBZH&resolution=ultra",
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+
+    // …and on the content route too.
+    let (status, _b, _h) =
+        get("/collections/radar-fivih/content.glb?quantity=DBZH&resolution=ultra").await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
 async fn glb_rejects_points_representation() {
     // `.glb` serves only the mesh products — asking it for `points` is a 400
     // (the point cloud has its own `content.pnts` route), not a silently
@@ -506,9 +532,10 @@ async fn isosurface_tileset_has_transform_and_glb_content() {
     // glTF content needs the antenna-ECEF tile transform (16-element matrix).
     let t = v["root"]["transform"].as_array().unwrap();
     assert_eq!(t.len(), 16);
-    // Content points at the .glb, carrying the resolved quantity + threshold.
+    // Content points at the .glb, carrying the resolved quantity + threshold +
+    // the (defaulted) resolution tier, so the content fetch is deterministic.
     let uri = v["root"]["content"]["uri"].as_str().unwrap();
-    assert_eq!(uri, "content.glb?quantity=DBZH&threshold=20");
+    assert_eq!(uri, "content.glb?quantity=DBZH&threshold=20&resolution=med");
     // The region bounding volume is still present (unaffected by the transform).
     assert_eq!(
         v["root"]["boundingVolume"]["region"]

--- a/crates/api-3dtiles/tests/integration.rs
+++ b/crates/api-3dtiles/tests/integration.rs
@@ -375,6 +375,18 @@ async fn collections_list_and_doc() {
         .map(|r| r.as_str().unwrap())
         .collect();
     assert_eq!(reps, vec!["points", "isosurface", "echotop"]);
+    // A colour-scale legend is advertised for the point cloud: a unit, a range,
+    // and sampled `#rrggbb` stops the viewer renders as a gradient bar.
+    let lg = &v["legend"];
+    assert_eq!(lg["unit"], "dBZ");
+    assert!(lg["min"].as_f64().unwrap() < lg["max"].as_f64().unwrap());
+    let stops = lg["stops"].as_array().unwrap();
+    assert!(stops.len() >= 2, "legend has multiple stops");
+    let c0 = stops[0]["color"].as_str().unwrap();
+    assert!(
+        c0.starts_with('#') && c0.len() == 7,
+        "stop colour is #rrggbb: {c0}"
+    );
     // …and a link-following client can discover the isosurface tileset too.
     let hrefs: Vec<&str> = v["links"]
         .as_array()
@@ -469,6 +481,9 @@ async fn echotop_tileset_and_content_is_valid_glb() {
         uri.contains("representation=echotop"),
         "echotop-tagged: {uri}"
     );
+    // Both mesh products embed the (defaulted) resolution tier — the tileset
+    // handler shares the code path, but assert it here so the two can't diverge.
+    assert!(uri.contains("resolution="), "resolution tier in uri: {uri}");
 
     // The content itself is a valid glTF binary.
     let (status, body, headers) =

--- a/crates/api-3dtiles/tests/integration.rs
+++ b/crates/api-3dtiles/tests/integration.rs
@@ -486,6 +486,16 @@ async fn echotop_tileset_and_content_is_valid_glb() {
 }
 
 #[tokio::test]
+async fn glb_rejects_points_representation() {
+    // `.glb` serves only the mesh products — asking it for `points` is a 400
+    // (the point cloud has its own `content.pnts` route), not a silently
+    // mislabelled isosurface.
+    let (status, _body, _h) =
+        get("/collections/radar-fivih/content.glb?representation=points&quantity=DBZH").await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
 async fn isosurface_tileset_has_transform_and_glb_content() {
     let (status, body, _h) =
         get("/collections/radar-fivih/tileset.json?representation=isosurface&quantity=DBZH&threshold=20")

--- a/crates/api-3dtiles/viewer/index.html
+++ b/crates/api-3dtiles/viewer/index.html
@@ -136,13 +136,17 @@ async function loadCollections() {
       $coll.appendChild(o);
     }
     if (!cols.length) { setStatus("no 3D-Tiles collections at " + BASE, true); return; }
-    await loadCollectionMeta();
+    await loadCollectionMeta(true); // first view → frame the volume
   } catch (e) {
     setStatus("can't reach " + BASE + " — " + e, true);
   }
 }
 
-async function loadCollectionMeta() {
+// `reframe` controls whether the camera is moved to frame the volume. Frame on a
+// collection switch (the volume may be elsewhere); preserve the camera for
+// in-place changes (quantity/representation/threshold/resolution) so adjusting a
+// filter doesn't yank the view.
+async function loadCollectionMeta(reframe) {
   const id = $coll.value;
   if (!id) return;
   try {
@@ -168,7 +172,7 @@ async function loadCollectionMeta() {
       $rep.appendChild(o);
     }
     syncNumField();
-    await loadTileset();
+    await loadTileset(reframe);
   } catch (e) {
     setStatus("error loading collection — " + e, true);
   }
@@ -183,7 +187,7 @@ function syncNumField() {
   $resField.hidden = !meta.mesh;
 }
 
-async function loadTileset() {
+async function loadTileset(reframe = false) {
   const id = $coll.value, q = $qty.value;
   const rep = $rep.value || "points";
   const num = $num.value.trim();
@@ -217,8 +221,12 @@ async function loadTileset() {
         pointSize: "clamp((${value} - 5.0) * 0.16 + 1.0, 1.0, 10.0)",
       });
     }
-    await viewer.zoomTo(ts, new Cesium.HeadingPitchRange(
-      Cesium.Math.toRadians(210), Cesium.Math.toRadians(-28), 300000));
+    // Frame from the south-west (camera faces NE, heading 45°) looking down at
+    // -28° — only on a reframe; otherwise leave the camera where the user put it.
+    if (reframe) {
+      await viewer.zoomTo(ts, new Cesium.HeadingPitchRange(
+        Cesium.Math.toRadians(45), Cesium.Math.toRadians(-28), 300000));
+    }
     setStatus(`${id} · ${q} · ${rep}`);
   } catch (e) {
     if (token === loadToken) setStatus("no data for this selection", true);
@@ -226,13 +234,17 @@ async function loadTileset() {
   }
 }
 
-$coll.addEventListener("change", loadCollectionMeta);
-$qty.addEventListener("change", loadTileset);
+// Collection switch → reframe (new volume, possibly elsewhere). Every other
+// control is an in-place change → preserve the camera. (Arrow wrappers are
+// load-bearing: passing the handler bare would feed the DOM Event as `reframe`,
+// which is truthy and would reframe on every filter tweak.)
+$coll.addEventListener("change", () => loadCollectionMeta(true));
+$qty.addEventListener("change", () => loadTileset(false));
 // Switching representation relabels + re-defaults the numeric field, toggles the
-// Resolution selector, then reloads.
-$rep.addEventListener("change", () => { syncNumField(); loadTileset(); });
-$res.addEventListener("change", loadTileset);
-$num.addEventListener("change", loadTileset);
+// Resolution selector, then reloads (camera preserved).
+$rep.addEventListener("change", () => { syncNumField(); loadTileset(false); });
+$res.addEventListener("change", () => loadTileset(false));
+$num.addEventListener("change", () => loadTileset(false));
 loadCollections();
 </script>
 </body>

--- a/crates/api-3dtiles/viewer/index.html
+++ b/crates/api-3dtiles/viewer/index.html
@@ -90,10 +90,12 @@ const setStatus = (msg, err) => { $status.textContent = msg; $status.className =
 
 // Each representation's label for the numeric field + its default value:
 // point clouds drop echoes below `min_value`; isosurfaces draw the shell AT
-// `threshold`. Both are a dBZ number, so one input serves both, relabelled.
+// `threshold`; echo-top columns rise to where reflectivity drops below
+// `threshold`. All a dBZ number, so one input serves them, relabelled.
 const REP_META = {
   points:     { label: "Point cloud", numLabel: "min dBZ",       numDefault: "5"  },
   isosurface: { label: "Isosurface",  numLabel: "threshold dBZ", numDefault: "20" },
+  echotop:    { label: "Echo top",    numLabel: "threshold dBZ", numDefault: "18" },
 };
 
 // Token-free CesiumJS: CARTO Dark Matter basemap, no Cesium Ion.
@@ -183,8 +185,8 @@ async function loadTileset() {
   if (current) { viewer.scene.primitives.remove(current); current = null; }
 
   let url = `${BASE}/collections/${encodeURIComponent(id)}/tileset.json?quantity=${encodeURIComponent(q)}`;
-  if (rep === "isosurface") {
-    url += `&representation=isosurface`;
+  if (rep === "isosurface" || rep === "echotop") {
+    url += `&representation=${rep}`;
     if (num !== "") url += `&threshold=${encodeURIComponent(num)}`;
   } else if (num !== "") {
     url += `&min_value=${encodeURIComponent(num)}`;
@@ -194,8 +196,14 @@ async function loadTileset() {
     if (token !== loadToken) { ts.destroy(); return; } // superseded — free its GPU buffers
     current = ts;
     viewer.scene.primitives.add(ts);
-    // pointSize styling only applies to the .pnts point cloud; a mesh ignores it.
-    if (rep === "points") ts.style = new Cesium.Cesium3DTileStyle({ pointSize: 5.0 });
+    // Point clouds: scale each dot by its reflectivity (the per-point `value`
+    // batch property) — faint/small for weak echo, big for strong. (A mesh
+    // ignores pointSize.)
+    if (rep === "points") {
+      ts.style = new Cesium.Cesium3DTileStyle({
+        pointSize: "clamp((${value} - 5.0) * 0.16 + 1.0, 1.0, 10.0)",
+      });
+    }
     await viewer.zoomTo(ts, new Cesium.HeadingPitchRange(
       Cesium.Math.toRadians(210), Cesium.Math.toRadians(-28), 300000));
     setStatus(`${id} · ${q} · ${rep}`);

--- a/crates/api-3dtiles/viewer/index.html
+++ b/crates/api-3dtiles/viewer/index.html
@@ -46,6 +46,11 @@
   <div class="field"><label for="coll">Collection</label><select id="coll"></select></div>
   <div class="field"><label for="qty">Quantity</label><select id="qty"></select></div>
   <div class="field"><label for="rep">View</label><select id="rep"></select></div>
+  <div class="field" id="resField" hidden><label for="res">Resolution</label><select id="res">
+    <option value="low">Low</option>
+    <option value="med" selected>Med</option>
+    <option value="high">High</option>
+  </select></div>
   <div class="field"><label id="numLabel" for="num">min dBZ</label><input id="num" type="number" value="5" step="1"></div>
   <div id="status"></div>
 </div>
@@ -83,6 +88,8 @@ const BASE = override || sameOrigin || "https://meteocore.app.meteo.fi/3dtiles";
 const $coll = document.getElementById("coll");
 const $qty = document.getElementById("qty");
 const $rep = document.getElementById("rep");
+const $res = document.getElementById("res");
+const $resField = document.getElementById("resField");
 const $num = document.getElementById("num");
 const $numLabel = document.getElementById("numLabel");
 const $status = document.getElementById("status");
@@ -92,10 +99,13 @@ const setStatus = (msg, err) => { $status.textContent = msg; $status.className =
 // point clouds drop echoes below `min_value`; isosurfaces draw the shell AT
 // `threshold`; echo-top columns rise to where reflectivity drops below
 // `threshold`. All a dBZ number, so one input serves them, relabelled.
+// `mesh` products (isosurface/echotop) are resampled to a voxel grid, so they
+// take the low/med/high Resolution selector; the point cloud is native-res and
+// hides it.
 const REP_META = {
-  points:     { label: "Point cloud", numLabel: "min dBZ",       numDefault: "5"  },
-  isosurface: { label: "Isosurface",  numLabel: "threshold dBZ", numDefault: "20" },
-  echotop:    { label: "Echo top",    numLabel: "threshold dBZ", numDefault: "18" },
+  points:     { label: "Point cloud", numLabel: "min dBZ",       numDefault: "5",  mesh: false },
+  isosurface: { label: "Isosurface",  numLabel: "threshold dBZ", numDefault: "20", mesh: true  },
+  echotop:    { label: "Echo top",    numLabel: "threshold dBZ", numDefault: "18", mesh: true  },
 };
 
 // Token-free CesiumJS: CARTO Dark Matter basemap, no Cesium Ion.
@@ -164,11 +174,13 @@ async function loadCollectionMeta() {
   }
 }
 
-// Relabel + default the numeric field for the active representation.
+// Relabel + default the numeric field for the active representation, and show
+// the Resolution selector only for the (resampled) mesh products.
 function syncNumField() {
   const meta = REP_META[$rep.value] || REP_META.points;
   $numLabel.textContent = meta.numLabel;
   $num.value = meta.numDefault;
+  $resField.hidden = !meta.mesh;
 }
 
 async function loadTileset() {
@@ -188,6 +200,7 @@ async function loadTileset() {
   if (rep === "isosurface" || rep === "echotop") {
     url += `&representation=${rep}`;
     if (num !== "") url += `&threshold=${encodeURIComponent(num)}`;
+    url += `&resolution=${encodeURIComponent($res.value)}`;
   } else if (num !== "") {
     url += `&min_value=${encodeURIComponent(num)}`;
   }
@@ -215,8 +228,10 @@ async function loadTileset() {
 
 $coll.addEventListener("change", loadCollectionMeta);
 $qty.addEventListener("change", loadTileset);
-// Switching representation relabels + re-defaults the numeric field, then reloads.
+// Switching representation relabels + re-defaults the numeric field, toggles the
+// Resolution selector, then reloads.
 $rep.addEventListener("change", () => { syncNumField(); loadTileset(); });
+$res.addEventListener("change", loadTileset);
 $num.addEventListener("change", loadTileset);
 loadCollections();
 </script>

--- a/crates/api-3dtiles/viewer/index.html
+++ b/crates/api-3dtiles/viewer/index.html
@@ -30,6 +30,8 @@
   #bar .brand { font-weight: 650; letter-spacing: .2px; margin-right: 4px; }
   #bar .brand span { opacity: .55; font-weight: 400; }
   #bar .field { display: flex; align-items: center; gap: 6px; }
+  /* `[hidden]` alone loses to the rule above on specificity — force it. */
+  #bar .field[hidden] { display: none; }
   #bar label { opacity: .6; }
   #bar select, #bar input {
     background: #161b25; color: #e8eef6; border: 1px solid #2a3340;
@@ -38,6 +40,21 @@
   #bar input[type=number] { width: 58px; }
   #status { margin-left: auto; opacity: .6; font-size: 12px; white-space: nowrap; }
   #status.err { color: #ff8a8a; opacity: .95; }
+  /* Colour-scale legend for the point cloud (value → colour). */
+  #legend {
+    position: absolute; left: 14px; bottom: 34px; z-index: 10;
+    padding: 8px 10px; border-radius: 8px;
+    background: rgba(10, 13, 20, 0.82); -webkit-backdrop-filter: blur(6px); backdrop-filter: blur(6px);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    color: #e8eef6; font: 11px/1.2 system-ui, -apple-system, sans-serif;
+  }
+  #legend[hidden] { display: none; }
+  #legend .ltitle { opacity: .7; margin-bottom: 6px; font-size: 11px; }
+  #legend .lwrap { display: flex; height: 132px; }
+  #legend .lbar { width: 13px; height: 100%; border: 1px solid rgba(255,255,255,.18); border-radius: 2px; }
+  #legend .lticks { position: relative; width: 30px; margin-left: 5px; }
+  #legend .tick { position: absolute; left: 0; transform: translateY(50%); white-space: nowrap; opacity: .85; }
+  #legend .tick::before { content: "– "; opacity: .5; }
 </style>
 </head>
 <body>
@@ -55,6 +72,10 @@
   <div id="status"></div>
 </div>
 <div id="cesium"></div>
+<div id="legend" hidden>
+  <div class="ltitle"></div>
+  <div class="lwrap"><div class="lbar"></div><div class="lticks"></div></div>
+</div>
 <script>
 "use strict";
 
@@ -93,6 +114,10 @@ const $resField = document.getElementById("resField");
 const $num = document.getElementById("num");
 const $numLabel = document.getElementById("numLabel");
 const $status = document.getElementById("status");
+const $legend = document.getElementById("legend");
+const $legendTitle = $legend.querySelector(".ltitle");
+const $legendBar = $legend.querySelector(".lbar");
+const $legendTicks = $legend.querySelector(".lticks");
 const setStatus = (msg, err) => { $status.textContent = msg; $status.className = err ? "err" : ""; };
 
 // Each representation's label for the numeric field + its default value:
@@ -123,6 +148,9 @@ viewer.scene.globe.depthTestAgainstTerrain = false;
 
 let current = null;       // active tileset
 let loadToken = 0;        // guards against out-of-order async loads
+let currentRep = null;    // representation of the active tileset
+let pointsFetchFloor = null; // the min_value (dBZ) the active point cloud was fetched at
+let legendData = null;    // colour-scale legend {title,unit,min,max,stops} from the collection doc
 
 async function loadCollections() {
   setStatus("loading collections…");
@@ -151,6 +179,8 @@ async function loadCollectionMeta(reframe) {
   if (!id) return;
   try {
     const data = await (await fetch(`${BASE}/collections/${encodeURIComponent(id)}`)).json();
+    legendData = data.legend || null;
+    buildLegend();
     const qs = data.quantities || [];
     $qty.innerHTML = "";
     for (const q of qs) {
@@ -178,13 +208,40 @@ async function loadCollectionMeta(reframe) {
   }
 }
 
-// Relabel + default the numeric field for the active representation, and show
-// the Resolution selector only for the (resampled) mesh products.
+// Relabel + default the numeric field for the active representation, show the
+// Resolution selector only for the (resampled) mesh products, and show the
+// colour legend only for the point cloud (whose points are coloured by value;
+// the mesh products colour by threshold / height instead).
 function syncNumField() {
   const meta = REP_META[$rep.value] || REP_META.points;
   $numLabel.textContent = meta.numLabel;
   $num.value = meta.numDefault;
   $resField.hidden = !meta.mesh;
+  $legend.hidden = meta.mesh || !legendData;
+}
+
+// Build the colour-scale legend from the collection doc's `legend` (a sampled
+// gradient of the point colormap). A vertical bar, low value at the bottom, with
+// tick labels at round values across the range.
+function buildLegend() {
+  const lg = legendData;
+  if (!lg || !lg.stops || !lg.stops.length) { $legend.hidden = true; return; }
+  $legendTitle.textContent = (lg.title || "") + (lg.unit ? ` (${lg.unit})` : "");
+  const span = (lg.max - lg.min) || 1;
+  const frac = (v) => Math.max(0, Math.min(1, (v - lg.min) / span));
+  // CSS gradient bottom→top, each stop placed at its value's fraction.
+  const css = lg.stops.map(s => `${s.color} ${(frac(s.value) * 100).toFixed(1)}%`).join(", ");
+  $legendBar.style.background = `linear-gradient(to top, ${css})`;
+  // ~5 tick labels at round values within the range.
+  const step = span > 80 ? 25 : span > 40 ? 10 : 5;
+  $legendTicks.innerHTML = "";
+  for (let val = Math.ceil(lg.min / step) * step; val <= lg.max + 1e-6; val += step) {
+    const el = document.createElement("div");
+    el.className = "tick";
+    el.style.bottom = (frac(val) * 100) + "%";
+    el.textContent = val;
+    $legendTicks.appendChild(el);
+  }
 }
 
 async function loadTileset(reframe = false) {
@@ -212,14 +269,13 @@ async function loadTileset(reframe = false) {
     const ts = await Cesium.Cesium3DTileset.fromUrl(url, { maximumScreenSpaceError: 1 });
     if (token !== loadToken) { ts.destroy(); return; } // superseded — free its GPU buffers
     current = ts;
+    currentRep = rep;
     viewer.scene.primitives.add(ts);
-    // Point clouds: scale each dot by its reflectivity (the per-point `value`
-    // batch property) — faint/small for weak echo, big for strong. (A mesh
-    // ignores pointSize.)
     if (rep === "points") {
-      ts.style = new Cesium.Cesium3DTileStyle({
-        pointSize: "clamp((${value} - 5.0) * 0.16 + 1.0, 1.0, 10.0)",
-      });
+      // The server already dropped points below `num`; remember that floor so
+      // the slider can filter *up* from it client-side (see applyPointFilter).
+      pointsFetchFloor = num === "" ? -Infinity : parseFloat(num);
+      applyPointStyle(pointsFetchFloor);
     }
     // Frame from the south-west (camera faces NE, heading 45°) looking down at
     // -28° — only on a reframe; otherwise leave the camera where the user put it.
@@ -234,6 +290,44 @@ async function loadTileset(reframe = false) {
   }
 }
 
+// Point-cloud style: drop points below `min` and scale each dot by its
+// reflectivity (the per-point `value` batch property) — faint/small for weak
+// echo, big for strong. Both expressions read `${value}`, which is why the
+// `.pnts` carries it. (A mesh ignores both.)
+function applyPointStyle(min) {
+  if (!current) return;
+  const cond = Number.isFinite(min) ? "${value} >= " + min : "true";
+  current.style = new Cesium.Cesium3DTileStyle({
+    show: cond,
+    // Steep ramp so weak vs strong reads clearly: ~1 px at 5 dBZ up to 16 px at
+    // 55 dBZ (slope 0.3). Weak clutter stays a speck; storm cores are fat dots.
+    pointSize: "clamp((${value} - 5.0) * 0.3 + 1.0, 1.0, 16.0)",
+  });
+}
+
+// The `min dBZ` field for a point cloud filters CLIENT-SIDE (no re-fetch) by
+// restyling `show` — instant, since every point carries its value. We can only
+// hide points we already have, so dropping below the fetched floor re-fetches
+// the (larger) set; raising the threshold is always client-side.
+//   - `pointsClientFilter()` runs live on every `input` (fast, points-in-range).
+//   - `onNumCommit()` runs on `change` and re-fetches when needed: meshes, or a
+//     point cloud that needs values below its fetched floor.
+function pointsClientFilter() {
+  if (($rep.value || "points") !== "points" || currentRep !== "points" || !current) return false;
+  const min = parseFloat($num.value);
+  if (!Number.isFinite(min) || pointsFetchFloor === null || min < pointsFetchFloor) return false;
+  applyPointStyle(min);
+  viewer.scene.requestRender();
+  setStatus(`${$coll.value} · ${$qty.value} · points · ≥ ${min} dBZ`);
+  return true;
+}
+
+function onNumCommit() {
+  // Points within the fetched range already restyled live → nothing to fetch.
+  if (pointsClientFilter()) return;
+  loadTileset(false); // mesh threshold/resolution, or points needing more data
+}
+
 // Collection switch → reframe (new volume, possibly elsewhere). Every other
 // control is an in-place change → preserve the camera. (Arrow wrappers are
 // load-bearing: passing the handler bare would feed the DOM Event as `reframe`,
@@ -244,7 +338,11 @@ $qty.addEventListener("change", () => loadTileset(false));
 // Resolution selector, then reloads (camera preserved).
 $rep.addEventListener("change", () => { syncNumField(); loadTileset(false); });
 $res.addEventListener("change", () => loadTileset(false));
-$num.addEventListener("change", () => loadTileset(false));
+// Live: a point cloud re-filters client-side as you drag the field. Commit
+// (`change`): re-fetch for meshes, or for points that need values below their
+// fetched floor.
+$num.addEventListener("input", pointsClientFilter);
+$num.addEventListener("change", onNumCommit);
 loadCollections();
 </script>
 </body>

--- a/crates/ds-3dtiles/src/lib.rs
+++ b/crates/ds-3dtiles/src/lib.rs
@@ -102,13 +102,13 @@ pub fn encode_pnts(
     // build (the byte-length guards below would only catch this at ~4 GiB).
     let points_len = u32::try_from(count).map_err(|_| Tiles3dError::TooLarge("POINTS_LENGTH"))?;
 
-    // Front-load the body byte-budget check too: reject an oversized cloud
-    // *before* allocating the body (POSITION 12 B + RGB 3 B per point, + ≤7 B
-    // tail padding), so a caller bypassing the engine's MAX_POINTS cap can't
+    // Front-load the byte-budget check too: reject an oversized cloud *before*
+    // allocating (POSITION 12 B + RGB 3 B + batch-table value 4 B per point, +
+    // section padding), so a caller bypassing the engine's MAX_POINTS cap can't
     // force a multi-GB allocation that only errors afterward.
     if count
-        .checked_mul(15)
-        .and_then(|n| n.checked_add(7))
+        .checked_mul(19)
+        .and_then(|n| n.checked_add(64))
         .is_none_or(|n| u32::try_from(n).is_err())
     {
         // Distinct label from the post-build check below so the two guards are
@@ -151,13 +151,43 @@ pub fn encode_pnts(
         ft_json.push(b' ');
     }
 
+    // Batch table: one per-point `value` (the physical value, e.g. dBZ) so a
+    // client can style point size by it. No `BATCH_ID` in the feature table ⇒
+    // the batch table holds POINTS_LENGTH per-point properties (one per point).
+    let bt = json!({
+        "value": { "byteOffset": 0, "componentType": "FLOAT", "type": "SCALAR" },
+    });
+    let mut bt_json = serde_json::to_vec(&bt).expect("batch table serializes");
+    while !bt_json.len().is_multiple_of(8) {
+        bt_json.push(b' ');
+    }
+    let mut bt_bin = Vec::with_capacity(count * 4);
+    for p in &cloud.points {
+        // Points come from real (finite) echoes; guard anyway so a stray NaN
+        // can't reach the buffer as a non-finite property.
+        let v = if p.value.is_finite() {
+            p.value as f32
+        } else {
+            0.0
+        };
+        bt_bin.extend_from_slice(&v.to_le_bytes());
+    }
+    // The batch-table binary must also end on an 8-byte boundary.
+    while !bt_bin.len().is_multiple_of(8) {
+        bt_bin.push(0);
+    }
+
     const HEADER_LEN: usize = 28;
-    let total = HEADER_LEN + ft_json.len() + body.len();
+    let total = HEADER_LEN + ft_json.len() + body.len() + bt_json.len() + bt_bin.len();
     let total = u32::try_from(total).map_err(|_| Tiles3dError::TooLarge("byteLength"))?;
     let ft_json_len =
         u32::try_from(ft_json.len()).map_err(|_| Tiles3dError::TooLarge("featureTableJSON"))?;
     let body_len =
         u32::try_from(body.len()).map_err(|_| Tiles3dError::TooLarge("featureTableBinary"))?;
+    let bt_json_len =
+        u32::try_from(bt_json.len()).map_err(|_| Tiles3dError::TooLarge("batchTableJSON"))?;
+    let bt_bin_len =
+        u32::try_from(bt_bin.len()).map_err(|_| Tiles3dError::TooLarge("batchTableBinary"))?;
 
     let mut pnts = Vec::with_capacity(total as usize);
     pnts.extend_from_slice(b"pnts");
@@ -165,10 +195,12 @@ pub fn encode_pnts(
     pnts.extend_from_slice(&total.to_le_bytes());
     pnts.extend_from_slice(&ft_json_len.to_le_bytes());
     pnts.extend_from_slice(&body_len.to_le_bytes());
-    pnts.extend_from_slice(&0u32.to_le_bytes()); // batch-table JSON length
-    pnts.extend_from_slice(&0u32.to_le_bytes()); // batch-table binary length
+    pnts.extend_from_slice(&bt_json_len.to_le_bytes());
+    pnts.extend_from_slice(&bt_bin_len.to_le_bytes());
     pnts.extend_from_slice(&ft_json);
     pnts.extend_from_slice(&body);
+    pnts.extend_from_slice(&bt_json);
+    pnts.extend_from_slice(&bt_bin);
     Ok(pnts)
 }
 
@@ -289,12 +321,21 @@ mod tests {
         );
         let ft_json_len = u32_at(12) as usize;
         let ft_bin_len = u32_at(16) as usize;
-        assert_eq!(u32_at(20), 0, "no batch-table JSON");
-        assert_eq!(u32_at(24), 0, "no batch-table binary");
-        // Sections are 8-byte aligned, and the three lengths tile the file.
+        let bt_json_len = u32_at(20) as usize;
+        let bt_bin_len = u32_at(24) as usize;
+        // A per-point `value` batch table is present (for client point sizing):
+        // 3 f32 values = 12 B, padded to the next 8-byte boundary → 16 B.
+        assert!(bt_json_len > 0, "batch-table JSON present");
+        assert_eq!(bt_bin_len, 16, "3 f32 values (12 B) padded to 16");
+        // All four sections are 8-byte aligned and tile the file exactly.
         assert_eq!(ft_json_len % 8, 0);
         assert_eq!(ft_bin_len % 8, 0);
-        assert_eq!(28 + ft_json_len + ft_bin_len, bytes.len());
+        assert_eq!(bt_json_len % 8, 0);
+        assert_eq!(bt_bin_len % 8, 0);
+        assert_eq!(
+            28 + ft_json_len + ft_bin_len + bt_json_len + bt_bin_len,
+            bytes.len()
+        );
 
         // Feature-table JSON parses and carries the right point count + RTC.
         let ft: serde_json::Value =
@@ -303,6 +344,19 @@ mod tests {
         assert_eq!(ft["RTC_CENTER"][0], 3_000_000.0);
         // RGB starts after the 3 positions (3 * 12 = 36 bytes).
         assert_eq!(ft["RGB"]["byteOffset"], 36);
+
+        // Batch table declares the per-point `value` (FLOAT SCALAR), and its
+        // binary carries the three sample values (10, 45, 60).
+        let bt_start = 28 + ft_json_len + ft_bin_len;
+        let bt: serde_json::Value =
+            serde_json::from_slice(&bytes[bt_start..bt_start + bt_json_len])
+                .expect("BT JSON parses");
+        assert_eq!(bt["value"]["componentType"], "FLOAT");
+        let vbin = &bytes[bt_start + bt_json_len..bt_start + bt_json_len + bt_bin_len];
+        let v0 = f32::from_le_bytes(vbin[0..4].try_into().unwrap());
+        let v1 = f32::from_le_bytes(vbin[4..8].try_into().unwrap());
+        assert_eq!(v0, 10.0);
+        assert_eq!(v1, 45.0);
     }
 
     #[test]

--- a/crates/ds-3dtiles/src/lib.rs
+++ b/crates/ds-3dtiles/src/lib.rs
@@ -103,12 +103,15 @@ pub fn encode_pnts(
     let points_len = u32::try_from(count).map_err(|_| Tiles3dError::TooLarge("POINTS_LENGTH"))?;
 
     // Front-load the byte-budget check too: reject an oversized cloud *before*
-    // allocating (POSITION 12 B + RGB 3 B + batch-table value 4 B per point, +
-    // section padding), so a caller bypassing the engine's MAX_POINTS cap can't
-    // force a multi-GB allocation that only errors afterward.
+    // allocating (POSITION 12 B + RGB 3 B + batch-table value 4 B per point, plus
+    // the fixed overhead), so a caller bypassing the engine's MAX_POINTS cap can't
+    // force a multi-GB allocation that only errors afterward. The `+128` covers
+    // the fixed overhead conservatively (HEADER 28 + the two JSON blobs + ≤4
+    // section alignments); the authoritative guard is the `u32::try_from(total)`
+    // on the assembled size below, so this only needs to be in the ballpark.
     if count
         .checked_mul(19)
-        .and_then(|n| n.checked_add(64))
+        .and_then(|n| n.checked_add(128))
         .is_none_or(|n| u32::try_from(n).is_err())
     {
         // Distinct label from the post-build check below so the two guards are

--- a/crates/ds-3dtiles/src/lib.rs
+++ b/crates/ds-3dtiles/src/lib.rs
@@ -151,9 +151,12 @@ pub fn encode_pnts(
         ft_json.push(b' ');
     }
 
-    // Batch table: one per-point `value` (the physical value, e.g. dBZ) so a
-    // client can style point size by it. No `BATCH_ID` in the feature table ⇒
-    // the batch table holds POINTS_LENGTH per-point properties (one per point).
+    // Batch table: one per-point `value` (the physical value, e.g. dBZ). No
+    // `BATCH_ID` in the feature table ⇒ the batch table holds POINTS_LENGTH
+    // per-point properties (one per point), which CesiumJS exposes to the style
+    // engine as `${value}` — driving client-side point sizing AND filtering.
+    // (A `BATCH_ID` would make points pickable features but disables per-point
+    // `pointSize` styling in CesiumJS's point-cloud pipeline — not worth it.)
     let bt = json!({
         "value": { "byteOffset": 0, "componentType": "FLOAT", "type": "SCALAR" },
     });
@@ -344,6 +347,13 @@ mod tests {
         assert_eq!(ft["RTC_CENTER"][0], 3_000_000.0);
         // RGB starts after the 3 positions (3 * 12 = 36 bytes).
         assert_eq!(ft["RGB"]["byteOffset"], 36);
+        // No BATCH_ID: per-point `value` reaches the style engine (sizing +
+        // filtering) without promoting points to features (which would disable
+        // per-point pointSize in CesiumJS).
+        assert!(
+            ft.get("BATCH_ID").is_none(),
+            "no BATCH_ID (keeps pointSize)"
+        );
 
         // Batch table declares the per-point `value` (FLOAT SCALAR), and its
         // binary carries the three sample values (10, 45, 60).
@@ -355,8 +365,10 @@ mod tests {
         let vbin = &bytes[bt_start + bt_json_len..bt_start + bt_json_len + bt_bin_len];
         let v0 = f32::from_le_bytes(vbin[0..4].try_into().unwrap());
         let v1 = f32::from_le_bytes(vbin[4..8].try_into().unwrap());
+        let v2 = f32::from_le_bytes(vbin[8..12].try_into().unwrap());
         assert_eq!(v0, 10.0);
         assert_eq!(v1, 45.0);
+        assert_eq!(v2, 60.0); // all three written — a truncated loop would fail here
     }
 
     #[test]

--- a/crates/server/src/admin.rs
+++ b/crates/server/src/admin.rs
@@ -1836,13 +1836,10 @@ pub fn load_collections(
         tiles_3d_state: api_3dtiles::TilesState3d {
             volume_engines,
             collections: volume_collections,
-            // v1: one shared reflectivity ramp for all 3D-Tiles collections.
-            // Per-collection/per-quantity colormaps from config are a follow-up.
-            colormap: Arc::new(ds_render::LutColorMap::from_builtin(
-                ds_render::BuiltinColormap::RadarDbz,
-                -32.0,
-                95.0,
-            )),
+            // v1: one shared reflectivity ramp for all 3D-Tiles collections (the
+            // legend the API advertises samples this same source). Per-collection
+            // /per-quantity colormaps from config are a follow-up (#350).
+            colormap: api_3dtiles::default_point_colormap(),
             render_semaphore: render_semaphore.clone(),
             base_url: base_url.to_string(),
         },

--- a/crates/server/src/preview.rs
+++ b/crates/server/src/preview.rs
@@ -952,11 +952,7 @@ mod tests {
             tiles_3d: Arc::new(ArcSwap::from_pointee(api_3dtiles::TilesState3d {
                 volume_engines: std::collections::HashMap::new(),
                 collections: std::collections::HashMap::new(),
-                colormap: Arc::new(ds_render::LutColorMap::from_builtin(
-                    ds_render::BuiltinColormap::RadarDbz,
-                    -32.0,
-                    95.0,
-                )),
+                colormap: api_3dtiles::default_point_colormap(),
                 render_semaphore: Arc::new(tokio::sync::Semaphore::new(1)),
                 base_url: String::new(),
             })),


### PR DESCRIPTION
## What

Two 3D Tiles enhancements (builds on the merged echo-top encoder #362):

### 1. Echo-top as a third API representation + viewer toggle
`tileset.json?representation=echotop` serves the extruded **echo-top columns** (the 3-D storm-depth bar field) as a glTF `.glb` + the antenna-ECEF tile `transform`. The two glTF products share `content.glb`, disambiguated by `?representation=echotop` (default = isosurface). Echo-top uses **full `[512,360,64]` resolution** (`ECHO_TOP_DIMS` — ≈ native radial; ~12 s first compute, ETag-cached after) coloured by a height ramp. The collection JSON's `representations` array and the viewer's **View** dropdown gain `echotop`, so points / isosurface / echo-top are all selectable live.

### 2. Point-cloud dot size by reflectivity
`encode_pnts` now writes a per-point `value` into the `.pnts` **batch table** (no `BATCH_ID` ⇒ per-point properties), and the viewer styles `pointSize: clamp((${value} − 5)·0.16 + 1, 1, 10)` — weak echo → ~1 px, strong → ~10 px.

## Verification (render-verified live in CesiumJS)
- **Point cloud:** dots scale with reflectivity — strong cores pop (bigger), weak clutter recedes (1 px); the radial beam structure is clearly visible.
- **Echo top:** the 3-D bar field renders via the **View → Echo top** dropdown (full-res bars, blue→green/yellow by depth).
- **Toggle:** all three representations selectable; the numeric field relabels (min dBZ / threshold dBZ).
- Endpoints over HTTP: `content.pnts` carries the value batch table; `content.glb?representation=echotop` → 200, valid glTF (28 MB); isosurface unchanged.

21 ds-3dtiles + 19 api-3dtiles tests green (incl. a new echo-top route test + the batch-table assertion), clippy clean.

## Notes / follow-ups
- **Echo-top first-compute is ~12 s** (the 11.8 M-cell resample); ETag caches repeats. A precompute/coarser-default or background cache is a candidate if this becomes a hot path.
- The deferred isosurface `TooLarge` test (from #369) still wants a home; not exercised here (needs a >4 M-triangle grid).

Part of epic #346 (#362 follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)