### PR TITLE
feat(3dtiles): true cylindrical voxels — EXT_primitive_voxels volume rendering (#351)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -375,9 +375,14 @@ into a glTF `.glb` triangle mesh.
   (`VoxelCylinderShape`, verified in the 1.142 source) uses default angle bounds
   **-π..+π**, angle-index 0 → -π, angle **counter-clockwise from local +X**
   (=East via the ENU transform). The encoder remaps each output angle slot `s`
-  to the radar bin at compass bearing `90° - (-π + (s+0.5)/nA·2π)`
+  to the radar bin at compass bearing **`270° - φ`** where `φ = -π + (s+0.5)/nA·2π`
   (`grid_azimuth_index`); the mesh/point products skip this (they map azimuth →
-  ECEF directly). **Unmeasured (`NaN`) cells → the no-echo floor (-32 dBZ), NO
+  ECEF directly). **The `+180°` (270 not the 90 the stated convention implies) is
+  render-verified, not derived:** CesiumJS's effective cylinder-angle origin sits
+  opposite (-X) to where the -π bound + +X=East transform predict, so the naive
+  `90° - φ` leaves the volume 180°-rotated. ALWAYS render-verify a voxel-cylinder
+  azimuth mapping against the point cloud — the handedness/offset can't be trusted
+  from the spec alone. **Unmeasured (`NaN`) cells → the no-echo floor (-32 dBZ), NO
   `noData`** — an extreme sentinel trilinearly-interpolates into hard
   walls/floors at the data boundary; the floor (faded out by the transfer
   function) keeps boundaries soft, at the cost of a dense volume (no empty-space

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -305,17 +305,19 @@ into a glTF `.glb` triangle mesh.
   first cut rendered uniformly red). Demo: `cargo run -p engine-odim --example
   gen_echo_top` (render-verified). API route is a follow-up; the mesher will be
   reused for VIL (#365).
-- **Three representations are served from the API** (selected by
-  `?representation=points|isosurface|echotop` on `tileset.json`): `points` →
+- **Four representations are served from the API.** Three are selected by
+  `?representation=points|isosurface|echotop` on `tileset.json`: `points` →
   `.pnts` (region-only tileset, `RTC_CENTER` self-places), `isosurface` /
   `echotop` → `.glb` plus a tile **`transform`** = the antenna ECEF. The two glTF
   products share `content.glb`, disambiguated by `?representation=echotop` in the
-  content URI (default = isosurface). Capability + the origin both glTF products
-  need are coupled in one field: `VolumeInfo.voxel_grid: Option<VoxelGridCaps {
-  origin }>` — `Some` ⇒ the mesh products are available and the origin is present
-  (tileset built without sampling; "supports but no origin" is unrepresentable,
-  never a 500). It drives the collection JSON's `representations` array → the
-  viewer's toggle. The isosurface seals (`background=Some(-32)`); echo-top is
+  content URI (default = isosurface). The fourth — **`voxels`** (#351) — has its
+  own `…/voxel/` sub-path (below), not a `?representation=` variant. Capability +
+  the origin/extents all of them need are coupled in one field:
+  `VolumeInfo.voxel_grid: Option<VoxelGridCaps { origin, radius_m, height_m }>` —
+  `Some` ⇒ the mesh + voxel products are available and the cylinder origin/extents
+  are present (tileset built without sampling; "supports but no origin" is
+  unrepresentable, never a 500). It drives the collection JSON's `representations`
+  array → the viewer's toggle. The isosurface seals (`background=Some(-32)`); echo-top is
   coloured by a height ramp. Both mesh products take a `?resolution=` detail tier
   (`Resolution` enum → voxel-grid dims; `low` `[128,360,48]` ≈2.2 M cells, `med`
   `[256,360,56]` ≈5.2 M *default*, `high` `[512,360,64]` ≈11.8 M / ~12 s first
@@ -352,10 +354,34 @@ into a glTF `.glb` triangle mesh.
   an unbounded source can't fetch/hold hundreds of tilesets. A true sliding window
   for longer runs is a follow-up; operators should bound the source with
   `max_files`/`time_window`.
+- **True cylindrical voxels (#351, Tier B — `ds-3dtiles/voxels.rs`):** a
+  `VoxelGrid` → `EXT_primitive_voxels` glTF `.glb` + a
+  `3DTILES_content_voxels` / `3DTILES_bounding_volume_cylinder` tileset that
+  CesiumJS 1.142 ray-marches as a volume (render-verified). **Draft, CesiumGS-only
+  — NOT in the Khronos registry, CesiumJS the sole implementation**, so encode
+  against the live `VoxelCylinder3DTiles` **fixtures, not the README** (which is
+  stale: cylinder `mode` = `2147483650` (0x80000002 — box 0x80000000, ellipsoid
+  0x80000001), *not* the README's `2147483647`). Load-bearing gotchas: **axis
+  swap** content `[radius,angle,height]` → glTF `dimensions [radius,height,angle]`,
+  data **radius-fastest → height → angle-slowest** (our grid is the transpose);
+  `EXT_structural_metadata` (schema + `propertyAttributes`) at the glTF **top
+  level**; embedded BIN buffer; `NaN` → a declared `noData` sentinel; **implicit
+  OCTREE tiling + a constant `.subtree`** is required; and the tile **`transform`
+  must be the real ENU→ECEF frame** (east/north/up), *not* identity-rotation —
+  identity works for the mesh products (absolute-ECEF vertices) but tilts the
+  *parametric* cylinder by the latitude. Cylinder extents come from
+  `VoxelGridCaps.radius_m`/`height_m` (= the grid's exact extents, O(1)); the
+  bounding cylinder is lifted by `height/2` so data sits 0..H above the antenna.
+  Served under its own sub-path so the implicit-tiling URIs resolve relatively;
+  the viewer renders it via `Cesium3DTilesVoxelProvider` + a `VoxelPrimitive`
+  with a reflectivity transfer-function `CustomShader` (`fsInput.metadata.<q>`).
+  v1 MVP: single tile, latest time (no octree/mosaic/animation — follow-ups).
 - **Routes** (mounted at `/3dtiles`): `GET /collections/{id}/tileset.json`
   (`?representation=&quantity=&datetime=&min_value=&threshold=&resolution=`),
   `GET /collections/{id}/content.pnts` (`?quantity=&datetime=&min_value=`),
   `GET /collections/{id}/content.glb` (`?representation=&quantity=&datetime=&threshold=&resolution=`),
+  the voxel trio `GET /collections/{id}/voxel/{tileset.json,subtrees/*,content/*}`
+  (`?quantity=&datetime=&resolution=`),
   plus `/` · `/collections` · `/collections/{id}` · **`/viewer`** (a bundled
   CesiumJS page with collection + quantity + **representation** + **resolution**
   pickers and a **time scrubber** (play/pause + slider) for multi-volume

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -365,11 +365,25 @@ into a glTF `.glb` triangle mesh.
   swap** content `[radius,angle,height]` → glTF `dimensions [radius,height,angle]`,
   data **radius-fastest → height → angle-slowest** (our grid is the transpose);
   `EXT_structural_metadata` (schema + `propertyAttributes`) at the glTF **top
-  level**; embedded BIN buffer; `NaN` → a declared `noData` sentinel; **implicit
-  OCTREE tiling + a constant `.subtree`** is required; and the tile **`transform`
-  must be the real ENU→ECEF frame** (east/north/up), *not* identity-rotation —
-  identity works for the mesh products (absolute-ECEF vertices) but tilts the
-  *parametric* cylinder by the latitude. Cylinder extents come from
+  level**; embedded BIN buffer; **implicit OCTREE tiling + a constant `.subtree`**
+  is required; and the tile **`transform` must be the real ENU→ECEF frame**
+  (east/north/up), *not* identity-rotation — identity works for the mesh products
+  (absolute-ECEF vertices) but tilts the *parametric* cylinder by the latitude.
+  **Azimuth convention remap (load-bearing — else the volume is rotated 90° AND
+  mirrored vs the point/mesh products):** the grid angle axis is radar azimuth
+  (index 0 → bearing 0, **clockwise from North**), but CesiumJS's cylinder
+  (`VoxelCylinderShape`, verified in the 1.142 source) uses default angle bounds
+  **-π..+π**, angle-index 0 → -π, angle **counter-clockwise from local +X**
+  (=East via the ENU transform). The encoder remaps each output angle slot `s`
+  to the radar bin at compass bearing `90° - (-π + (s+0.5)/nA·2π)`
+  (`grid_azimuth_index`); the mesh/point products skip this (they map azimuth →
+  ECEF directly). **Unmeasured (`NaN`) cells → the no-echo floor (-32 dBZ), NO
+  `noData`** — an extreme sentinel trilinearly-interpolates into hard
+  walls/floors at the data boundary; the floor (faded out by the transfer
+  function) keeps boundaries soft, at the cost of a dense volume (no empty-space
+  skipping → slower ray-march). The cellular radar field is further smoothed by a
+  **multi-pass separable blur** (`smooth_grid`, 4 passes) so the cell lattice
+  doesn't show at close zoom. Cylinder extents come from
   `VoxelGridCaps.radius_m`/`height_m` (= the grid's exact extents, O(1)); the
   bounding cylinder is lifted by `height/2` so data sits 0..H above the antenna.
   Served under its own sub-path so the implicit-tiling URIs resolve relatively;

--- a/crates/api-3dtiles/src/handlers.rs
+++ b/crates/api-3dtiles/src/handlers.rs
@@ -701,6 +701,7 @@ pub struct VoxelParams {
 pub async fn get_voxel_tileset(
     Path(id): Path<String>,
     Query(params): Query<VoxelParams>,
+    headers: HeaderMap,
     State(state): State<AppState>,
 ) -> Result<Response, Tiles3dError> {
     let state = state.load_full();
@@ -761,14 +762,13 @@ pub async fn get_voxel_tileset(
     )
     .map_err(|e| Tiles3dError::Internal(format!("voxel tileset build failed: {e}")))?;
 
-    Ok((
-        [
-            (header::CONTENT_TYPE, "application/json"),
-            (header::CACHE_CONTROL, "public, max-age=60"),
-        ],
-        tileset,
-    )
-        .into_response())
+    // Deterministic bytes for a given (quantity, datetime, resolution, caps) —
+    // route through the shared ETag/conditional-GET helper so a CesiumJS poll
+    // with a matching `If-None-Match` short-circuits to 304 (matches the
+    // `content.pnts`/`content.glb` handlers).
+    let bytes = tileset.into_bytes();
+    let etag = etag_of(&bytes);
+    Ok(binary_response(&headers, "application/json", &etag, bytes))
 }
 
 /// `GET /collections/{id}/voxel/subtrees/{*tile}` — the implicit-tiling
@@ -932,13 +932,25 @@ fn collection_doc(state: &TilesState3d, id: &str, base: &str) -> serde_json::Val
     // produce a voxel grid additionally serve the two glTF mesh products
     // (isosurface, echo-top). The viewer reads this to populate its toggle.
     let supports_mesh = info.as_ref().is_some_and(|i| i.voxel_grid.is_some());
+    // Voxels need a non-degenerate cylinder: the `voxel/tileset.json` route
+    // 404s unless `radius_m > 0 && height_m > 0` (a healthy site that has
+    // ingested no volumes yet has `radius_m = 0`). Gate the advertisement on the
+    // SAME condition so we never advertise a representation whose tileset is a
+    // 404 — the failure a `Cesium3DTilesVoxelProvider` can't tell apart from
+    // "voxels unsupported". The mesh products degrade differently (404 on the
+    // *content* endpoint, not the tileset), so they stay on `supports_mesh`.
+    let supports_voxels = info
+        .as_ref()
+        .and_then(|i| i.voxel_grid.as_ref())
+        .is_some_and(|c| c.radius_m > 0.0 && c.height_m > 0.0);
     let mut representations = vec!["points"];
     if supports_mesh {
         representations.push("isosurface");
         representations.push("echotop");
-        // True cylindrical voxels (#351) — same capability gate (a voxel grid),
-        // but its own implicit-tiling tileset under `…/voxel/`, not a
-        // `?representation=` variant of the shared tileset.
+    }
+    if supports_voxels {
+        // True cylindrical voxels (#351) — its own implicit-tiling tileset under
+        // `…/voxel/`, not a `?representation=` variant of the shared tileset.
         representations.push("voxels");
     }
     // A link per representation so a link-following client (not just one that
@@ -950,6 +962,8 @@ fn collection_doc(state: &TilesState3d, id: &str, base: &str) -> serde_json::Val
     if supports_mesh {
         links.push(json!({ "href": format!("{base}/3dtiles/collections/{id}/tileset.json?representation=isosurface"), "rel": "3dtiles", "type": "application/json", "title": "3D Tiles tileset (isosurface mesh)" }));
         links.push(json!({ "href": format!("{base}/3dtiles/collections/{id}/tileset.json?representation=echotop"), "rel": "3dtiles", "type": "application/json", "title": "3D Tiles tileset (echo-top columns)" }));
+    }
+    if supports_voxels {
         links.push(json!({ "href": format!("{base}/3dtiles/collections/{id}/voxel/tileset.json"), "rel": "3dtiles", "type": "application/json", "title": "3D Tiles tileset (cylindrical voxels)" }));
     }
     // Colour-scale legend for the point cloud: the precomputed gradient of the

--- a/crates/api-3dtiles/src/handlers.rs
+++ b/crates/api-3dtiles/src/handlers.rs
@@ -834,9 +834,16 @@ pub async fn get_voxel_content(
     let state = state.load_full();
     let (engine, _config) = lookup(&state, &id)?;
     let info = engine.volume_info();
-    if info.voxel_grid.is_none() {
-        return Err(Tiles3dError::BadRequest(format!(
-            "collection '{id}' does not support voxels"
+    // Same support/coverage gate as `get_voxel_tileset`/`get_voxel_subtree` (no
+    // grid → 400, no coverage yet → 404). Crucially this 404s a no-coverage site
+    // CHEAPLY — before acquiring a render-semaphore slot and a `spawn_blocking`
+    // task that would otherwise sample, encode, and only then 404 via `Empty`.
+    let caps = info.voxel_grid.as_ref().ok_or_else(|| {
+        Tiles3dError::BadRequest(format!("collection '{id}' does not support voxels"))
+    })?;
+    if !(caps.radius_m > 0.0 && caps.height_m > 0.0) {
+        return Err(Tiles3dError::NotFound(format!(
+            "collection '{id}' has no voxel coverage yet"
         )));
     }
     if !is_root_voxel_tile(&tile) {

--- a/crates/api-3dtiles/src/handlers.rs
+++ b/crates/api-3dtiles/src/handlers.rs
@@ -775,7 +775,8 @@ pub async fn get_voxel_tileset(
 /// availability subtree. One tile is available (the root), so every requested
 /// slot returns the same constant subtree.
 pub async fn get_voxel_subtree(
-    Path((id, _tile)): Path<(String, String)>,
+    Path((id, tile)): Path<(String, String)>,
+    headers: HeaderMap,
     State(state): State<AppState>,
 ) -> Result<Response, Tiles3dError> {
     let state = state.load_full();
@@ -791,14 +792,34 @@ pub async fn get_voxel_subtree(
             "collection '{id}' has no voxel coverage yet"
         )));
     }
-    Ok((
-        [
-            (header::CONTENT_TYPE, "application/json"),
-            (header::CACHE_CONTROL, "public, max-age=300"),
-        ],
-        ds_3dtiles::voxel_subtree_json(),
-    )
-        .into_response())
+    if !is_root_voxel_tile(&tile) {
+        return Err(Tiles3dError::NotFound(format!(
+            "voxel subtree '{tile}' is out of range (single-tile set)"
+        )));
+    }
+    // Constant body ⇒ constant ETag; route through `binary_response` so a
+    // CesiumJS subtree re-poll with a matching `If-None-Match` short-circuits to
+    // 304 (the subtree is fetched during voxel traversal).
+    let bytes = ds_3dtiles::voxel_subtree_json().into_bytes();
+    let etag = etag_of(&bytes);
+    Ok(binary_response(&headers, "application/json", &etag, bytes))
+}
+
+/// The implicit voxel tiling is a single tile (`subtreeLevels`/`availableLevels`
+/// = 1), so only the root `0/0/0/0` slot exists. The `{*tile}` capture is the
+/// `{level}/{x}/{y}/{z}.{ext}` path; accept only the root and 404 anything else,
+/// rather than serving the root's constant subtree/content for an out-of-range
+/// coordinate a strict client (or a fuzzer) might request.
+fn is_root_voxel_tile(tile: &str) -> bool {
+    let path = tile.rsplit_once('.').map_or(tile, |(stem, _)| stem);
+    let mut parts = path.split('/');
+    [
+        parts.next(),
+        parts.next(),
+        parts.next(),
+        parts.next(),
+        parts.next(),
+    ] == [Some("0"), Some("0"), Some("0"), Some("0"), None]
 }
 
 /// `GET /collections/{id}/voxel/content/{*tile}` — the `EXT_primitive_voxels`
@@ -806,7 +827,7 @@ pub async fn get_voxel_subtree(
 /// same as the mesh content path; content-derived ETag.
 pub async fn get_voxel_content(
     headers: HeaderMap,
-    Path((id, _tile)): Path<(String, String)>,
+    Path((id, tile)): Path<(String, String)>,
     Query(params): Query<VoxelParams>,
     State(state): State<AppState>,
 ) -> Result<Response, Tiles3dError> {
@@ -816,6 +837,11 @@ pub async fn get_voxel_content(
     if info.voxel_grid.is_none() {
         return Err(Tiles3dError::BadRequest(format!(
             "collection '{id}' does not support voxels"
+        )));
+    }
+    if !is_root_voxel_tile(&tile) {
+        return Err(Tiles3dError::NotFound(format!(
+            "voxel content '{tile}' is out of range (single-tile set)"
         )));
     }
     if let Some(q) = &params.quantity {
@@ -985,7 +1011,7 @@ fn collection_doc(state: &TilesState3d, id: &str, base: &str) -> serde_json::Val
 
 #[cfg(test)]
 mod tests {
-    use super::pct_encode;
+    use super::{is_root_voxel_tile, pct_encode};
 
     #[test]
     fn pct_encode_passes_unreserved_and_escapes_specials() {
@@ -994,5 +1020,26 @@ mod tests {
         // Chars that would break a query value are escaped.
         assert_eq!(pct_encode("a&b+c#d%e"), "a%26b%2Bc%23d%25e");
         assert_eq!(pct_encode("x y"), "x%20y");
+    }
+
+    #[test]
+    fn only_the_root_voxel_tile_is_accepted() {
+        // Root, with either content extension (or none).
+        assert!(is_root_voxel_tile("0/0/0/0.json"));
+        assert!(is_root_voxel_tile("0/0/0/0.glb"));
+        assert!(is_root_voxel_tile("0/0/0/0"));
+        // Any non-root coordinate, wrong arity, or non-numeric is rejected
+        // (single-tile implicit set → only 0/0/0/0 exists).
+        for bad in [
+            "1/0/0/0.json",
+            "0/0/0/1.json",
+            "0/1/0/0.glb",
+            "0/0/0.json",     // too few
+            "0/0/0/0/0.json", // too many
+            "a/0/0/0.json",
+            "",
+        ] {
+            assert!(!is_root_voxel_tile(bad), "{bad:?} should be rejected");
+        }
     }
 }

--- a/crates/api-3dtiles/src/handlers.rs
+++ b/crates/api-3dtiles/src/handlers.rs
@@ -815,7 +815,9 @@ pub async fn get_voxel_subtree(
     // Constant body ⇒ constant ETag; route through `binary_response` so a
     // CesiumJS subtree re-poll with a matching `If-None-Match` short-circuits to
     // 304 (the subtree is fetched during voxel traversal).
-    let bytes = ds_3dtiles::voxel_subtree_json().into_bytes();
+    let bytes = ds_3dtiles::voxel_subtree_json()
+        .map_err(|e| Tiles3dError::Internal(format!("voxel subtree build failed: {e}")))?
+        .into_bytes();
     let etag = etag_of(&bytes);
     Ok(binary_response(&headers, "application/json", &etag, bytes))
 }

--- a/crates/api-3dtiles/src/handlers.rs
+++ b/crates/api-3dtiles/src/handlers.rs
@@ -683,6 +683,173 @@ pub async fn get_content_glb(
 }
 
 // ---------------------------------------------------------------------------
+// True voxels (#351): EXT_primitive_voxels cylinder tileset + subtree + content
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+pub struct VoxelParams {
+    pub quantity: Option<String>,
+    pub datetime: Option<String>,
+    /// Voxel-grid detail tier (`low`/`med`/`high`). `None` → `med`.
+    pub resolution: Option<String>,
+}
+
+/// `GET /collections/{id}/voxel/tileset.json` — the implicit-tiling cylinder
+/// voxel tileset. O(1): the cylinder extent + origin come from `VolumeInfo`'s
+/// `VoxelGridCaps` (no grid sample). Relative content/subtree URIs resolve under
+/// `…/voxel/`; the content URI carries the resolved quantity/time/resolution.
+pub async fn get_voxel_tileset(
+    Path(id): Path<String>,
+    Query(params): Query<VoxelParams>,
+    State(state): State<AppState>,
+) -> Result<Response, Tiles3dError> {
+    let state = state.load_full();
+    let (engine, _config) = lookup(&state, &id)?;
+    let info = engine.volume_info();
+    let caps = info.voxel_grid.as_ref().ok_or_else(|| {
+        Tiles3dError::BadRequest(format!(
+            "collection '{id}' does not support the voxels representation"
+        ))
+    })?;
+    if !(caps.radius_m > 0.0 && caps.height_m > 0.0) {
+        return Err(Tiles3dError::NotFound(format!(
+            "collection '{id}' has no voxel coverage yet"
+        )));
+    }
+    let quantity = match &params.quantity {
+        Some(q) => {
+            if !info.quantities.iter().any(|(qid, _)| qid == q) {
+                return Err(Tiles3dError::BadRequest(format!(
+                    "unknown quantity '{q}' for collection '{id}'"
+                )));
+            }
+            q.clone()
+        }
+        None => info.default_quantity.clone(),
+    };
+    if quantity.is_empty() {
+        return Err(Tiles3dError::NotFound(format!(
+            "collection '{id}' has no quantities"
+        )));
+    }
+    let resolution = Resolution::parse(params.resolution.as_deref())?;
+    let [n_r, n_a, n_h] = resolution.dims();
+
+    // The content fetch must render the same selection — bake it into the
+    // (relative) content URI's query, alongside the implicit-tiling placeholders.
+    let mut q = format!("quantity={}", pct_encode(&quantity));
+    if let Some(dt) = &params.datetime {
+        let dt = parse_datetime(dt)?;
+        q.push_str(&format!("&datetime={}", dt.format("%Y-%m-%dT%H:%M:%SZ")));
+    }
+    q.push_str(&format!("&resolution={}", resolution.as_str()));
+    let content_uri = format!("content/{{level}}/{{x}}/{{y}}/{{z}}.glb?{q}");
+
+    let [olon, olat, oh] = caps.origin;
+    let tileset = ds_3dtiles::tileset_json_voxels(
+        olon,
+        olat,
+        oh,
+        caps.radius_m,
+        caps.height_m,
+        [n_r, n_a, n_h],
+        &quantity,
+        LEGEND_MIN_DBZ,
+        LEGEND_MAX_DBZ,
+        &content_uri,
+        "subtrees/{level}/{x}/{y}/{z}.json",
+    )
+    .map_err(|e| Tiles3dError::Internal(format!("voxel tileset build failed: {e}")))?;
+
+    Ok((
+        [
+            (header::CONTENT_TYPE, "application/json"),
+            (header::CACHE_CONTROL, "public, max-age=60"),
+        ],
+        tileset,
+    )
+        .into_response())
+}
+
+/// `GET /collections/{id}/voxel/subtrees/{*tile}` — the implicit-tiling
+/// availability subtree. One tile is available (the root), so every requested
+/// slot returns the same constant subtree.
+pub async fn get_voxel_subtree(
+    Path((id, _tile)): Path<(String, String)>,
+    State(state): State<AppState>,
+) -> Result<Response, Tiles3dError> {
+    let state = state.load_full();
+    let (engine, _config) = lookup(&state, &id)?;
+    if engine.volume_info().voxel_grid.is_none() {
+        return Err(Tiles3dError::NotFound(format!(
+            "collection '{id}' has no voxels"
+        )));
+    }
+    Ok((
+        [
+            (header::CONTENT_TYPE, "application/json"),
+            (header::CACHE_CONTROL, "public, max-age=300"),
+        ],
+        ds_3dtiles::voxel_subtree_json(),
+    )
+        .into_response())
+}
+
+/// `GET /collections/{id}/voxel/content/{*tile}` — the `EXT_primitive_voxels`
+/// glTF `.glb`. Samples the grid (blocking) under the shared render semaphore,
+/// same as the mesh content path; content-derived ETag.
+pub async fn get_voxel_content(
+    headers: HeaderMap,
+    Path((id, _tile)): Path<(String, String)>,
+    Query(params): Query<VoxelParams>,
+    State(state): State<AppState>,
+) -> Result<Response, Tiles3dError> {
+    let state = state.load_full();
+    let (engine, _config) = lookup(&state, &id)?;
+    let info = engine.volume_info();
+    if info.voxel_grid.is_none() {
+        return Err(Tiles3dError::BadRequest(format!(
+            "collection '{id}' does not support voxels"
+        )));
+    }
+    if let Some(q) = &params.quantity {
+        if !info.quantities.iter().any(|(qid, _)| qid == q) {
+            return Err(Tiles3dError::BadRequest(format!(
+                "unknown quantity '{q}' for collection '{id}'"
+            )));
+        }
+    }
+    let time = params.datetime.as_deref().map(parse_datetime).transpose()?;
+    let quantity = params.quantity.clone();
+    let dims = Resolution::parse(params.resolution.as_deref())?.dims();
+
+    let _permit = state
+        .render_semaphore
+        .clone()
+        .acquire_owned()
+        .await
+        .map_err(|_| Tiles3dError::Internal("render semaphore closed".into()))?;
+    let engine = engine.clone();
+    let id_for_err = id.clone();
+    let (bytes, etag) =
+        tokio::task::spawn_blocking(move || -> Result<(Vec<u8>, String), Tiles3dError> {
+            let grid = engine.read_voxel_grid(quantity.as_deref(), time, Some(dims), None)?;
+            let bytes = ds_3dtiles::encode_voxels_glb(&grid).map_err(|e| match e {
+                ds_3dtiles::Tiles3dError::Empty => {
+                    Tiles3dError::NotFound(format!("no voxel data for collection '{id_for_err}'"))
+                }
+                other => Tiles3dError::Internal(format!("voxel encode failed: {other}")),
+            })?;
+            let etag = etag_of(&bytes);
+            Ok((bytes, etag))
+        })
+        .await
+        .map_err(|e| Tiles3dError::Internal(format!("voxel task failed: {e}")))??;
+
+    Ok(binary_response(&headers, "model/gltf-binary", &etag, bytes))
+}
+
+// ---------------------------------------------------------------------------
 // Landing / collections
 // ---------------------------------------------------------------------------
 
@@ -763,6 +930,10 @@ fn collection_doc(state: &TilesState3d, id: &str, base: &str) -> serde_json::Val
     if supports_mesh {
         representations.push("isosurface");
         representations.push("echotop");
+        // True cylindrical voxels (#351) — same capability gate (a voxel grid),
+        // but its own implicit-tiling tileset under `…/voxel/`, not a
+        // `?representation=` variant of the shared tileset.
+        representations.push("voxels");
     }
     // A link per representation so a link-following client (not just one that
     // reads `representations` and builds URLs itself) can discover them.
@@ -773,6 +944,7 @@ fn collection_doc(state: &TilesState3d, id: &str, base: &str) -> serde_json::Val
     if supports_mesh {
         links.push(json!({ "href": format!("{base}/3dtiles/collections/{id}/tileset.json?representation=isosurface"), "rel": "3dtiles", "type": "application/json", "title": "3D Tiles tileset (isosurface mesh)" }));
         links.push(json!({ "href": format!("{base}/3dtiles/collections/{id}/tileset.json?representation=echotop"), "rel": "3dtiles", "type": "application/json", "title": "3D Tiles tileset (echo-top columns)" }));
+        links.push(json!({ "href": format!("{base}/3dtiles/collections/{id}/voxel/tileset.json"), "rel": "3dtiles", "type": "application/json", "title": "3D Tiles tileset (cylindrical voxels)" }));
     }
     // Colour-scale legend for the point cloud: the precomputed gradient of the
     // shared reflectivity colormap, so the viewer's bar matches the point colours

--- a/crates/api-3dtiles/src/handlers.rs
+++ b/crates/api-3dtiles/src/handlers.rs
@@ -780,9 +780,15 @@ pub async fn get_voxel_subtree(
 ) -> Result<Response, Tiles3dError> {
     let state = state.load_full();
     let (engine, _config) = lookup(&state, &id)?;
-    if engine.volume_info().voxel_grid.is_none() {
+    // Same support/coverage gate (and status codes) as the tileset/content
+    // handlers, so the three voxel routes agree on whether a collection serves
+    // voxels: no voxel grid → 400, no coverage yet → 404.
+    let caps = engine.volume_info().voxel_grid.ok_or_else(|| {
+        Tiles3dError::BadRequest(format!("collection '{id}' does not support voxels"))
+    })?;
+    if !(caps.radius_m > 0.0 && caps.height_m > 0.0) {
         return Err(Tiles3dError::NotFound(format!(
-            "collection '{id}' has no voxels"
+            "collection '{id}' has no voxel coverage yet"
         )));
     }
     Ok((

--- a/crates/api-3dtiles/src/handlers.rs
+++ b/crates/api-3dtiles/src/handlers.rs
@@ -158,6 +158,21 @@ static POINT_LEGEND: LazyLock<serde_json::Value> = LazyLock::new(|| {
     })
 });
 
+/// Dedicated concurrency limiter for **voxel** content encodes — separate from
+/// the shared `render_semaphore`. A `high`-resolution voxel (11.8 M cells, 4
+/// blur passes) is ~12 s of single-threaded CPU; running it on the shared raster
+/// pool would let one voxel request hold a WMS/Maps/Tiles render slot for that
+/// whole window. On its own small pool, slow voxel encodes serialise among
+/// themselves and never touch raster capacity. Sized to ¼ of the cores (≥1) so a
+/// couple can overlap without oversubscribing the box. Process-global (one
+/// server, one limit) → a `LazyLock` static, not per-collection state.
+static VOXEL_SEMAPHORE: LazyLock<Arc<tokio::sync::Semaphore>> = LazyLock::new(|| {
+    let n = std::thread::available_parallelism()
+        .map(|c| (c.get() / 4).max(1))
+        .unwrap_or(1);
+    Arc::new(tokio::sync::Semaphore::new(n))
+});
+
 /// The blue→red **height** colour ramp for the echo-top product (stops at height
 /// values, 0–15 km) — a builtin colormap's stops are in its own units, so they
 /// collapse over a height range; build it explicitly. Fixed ramp, so build it
@@ -862,12 +877,14 @@ pub async fn get_voxel_content(
     let quantity = params.quantity.clone();
     let dims = Resolution::parse(params.resolution.as_deref())?.dims();
 
-    let _permit = state
-        .render_semaphore
+    // Dedicated voxel pool (NOT the shared raster `render_semaphore`) so a slow
+    // `high`-res encode can't hold a WMS/Maps/Tiles render slot — see
+    // `VOXEL_SEMAPHORE`.
+    let _permit = VOXEL_SEMAPHORE
         .clone()
         .acquire_owned()
         .await
-        .map_err(|_| Tiles3dError::Internal("render semaphore closed".into()))?;
+        .map_err(|_| Tiles3dError::Internal("voxel semaphore closed".into()))?;
     let engine = engine.clone();
     let id_for_err = id.clone();
     let (bytes, etag) =

--- a/crates/api-3dtiles/src/lib.rs
+++ b/crates/api-3dtiles/src/lib.rs
@@ -34,5 +34,19 @@ pub fn router(state: AppState) -> Router {
             "/collections/{id}/content.glb",
             get(handlers::get_content_glb),
         )
+        // True-voxel tileset (#351): its own sub-path so the implicit-tiling
+        // `{level}/{x}/{y}/{z}` content/subtree URIs resolve relatively.
+        .route(
+            "/collections/{id}/voxel/tileset.json",
+            get(handlers::get_voxel_tileset),
+        )
+        .route(
+            "/collections/{id}/voxel/subtrees/{*tile}",
+            get(handlers::get_voxel_subtree),
+        )
+        .route(
+            "/collections/{id}/voxel/content/{*tile}",
+            get(handlers::get_voxel_content),
+        )
         .with_state(state)
 }

--- a/crates/api-3dtiles/tests/integration.rs
+++ b/crates/api-3dtiles/tests/integration.rs
@@ -160,6 +160,42 @@ impl VolumeEngine for MockNoVoxel {
     }
 }
 
+/// A healthy voxel engine that has ingested no volumes yet: `volume_info`
+/// carries `voxel_grid = Some` but with `radius_m = 0` (no coverage). The
+/// `voxels` representation must NOT be advertised (its tileset 404s), while the
+/// mesh products (which 404 on the *content* route, not the tileset) still are.
+struct MockZeroRadiusVoxel;
+
+impl VolumeEngine for MockZeroRadiusVoxel {
+    fn read_point_cloud(
+        &self,
+        _quantity: Option<&str>,
+        _time: Option<chrono::DateTime<chrono::Utc>>,
+        _min_value: Option<f64>,
+        _reference_time: Option<chrono::DateTime<chrono::Utc>>,
+    ) -> Result<VolumePointCloud, DataServerError> {
+        Err(DataServerError::LocationNotFound("no data yet".into()))
+    }
+
+    // read_voxel_grid uses the trait default (unsupported) — the test never
+    // reaches it (the tileset 404s on the `radius_m == 0` gate first).
+
+    fn volume_info(&self) -> Arc<VolumeInfo> {
+        Arc::new(VolumeInfo {
+            quantities: vec![("DBZH".into(), "Reflectivity".into())],
+            times: vec![],
+            default_quantity: "DBZH".into(),
+            default_unit: "dBZ".into(),
+            region: Some([0.42, 1.05, 0.44, 1.07, 100.0, 25_000.0]),
+            voxel_grid: Some(VoxelGridCaps {
+                origin: [24.5, 60.5, 100.0],
+                radius_m: 0.0,
+                height_m: 0.0,
+            }),
+        })
+    }
+}
+
 fn collection_config(id: &str) -> CollectionConfig {
     // Build via TOML so this test doesn't depend on every CollectionConfig field.
     toml::from_str(&format!(
@@ -432,6 +468,66 @@ async fn collections_list_and_doc() {
 }
 
 #[tokio::test]
+async fn voxels_not_advertised_without_coverage() {
+    // A site whose engine supports voxels but has no scanned volume yet
+    // (`radius_m = 0`) must NOT advertise the `voxels` representation — its
+    // tileset 404s, which a `Cesium3DTilesVoxelProvider` can't distinguish from
+    // "unsupported". The advertisement gate must match the tileset's gate.
+    let engine: Arc<dyn VolumeEngine> = Arc::new(MockZeroRadiusVoxel);
+    let mut volume_engines = HashMap::new();
+    volume_engines.insert("radar-nocov".to_string(), engine);
+    let mut collections = HashMap::new();
+    collections.insert("radar-nocov".to_string(), collection_config("radar-nocov"));
+    let state = Arc::new(ArcSwap::from_pointee(TilesState3d {
+        volume_engines,
+        collections,
+        colormap: Arc::new(LutColorMap::from_builtin(
+            BuiltinColormap::RadarDbz,
+            -32.0,
+            95.0,
+        )),
+        render_semaphore: Arc::new(tokio::sync::Semaphore::new(4)),
+        base_url: String::new(),
+    }));
+    let app = api_3dtiles::router(state);
+    let send = |uri: &str| {
+        let app = app.clone();
+        let uri = uri.to_string();
+        async move {
+            app.oneshot(Request::builder().uri(uri).body(Body::empty()).unwrap())
+                .await
+                .unwrap()
+        }
+    };
+
+    // Collection doc: mesh products advertised, `voxels` NOT.
+    let resp = send("/collections/radar-nocov").await;
+    let body = resp.into_body().collect().await.unwrap().to_bytes();
+    let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let reps: Vec<&str> = v["representations"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|r| r.as_str().unwrap())
+        .collect();
+    assert!(
+        reps.contains(&"isosurface") && reps.contains(&"echotop"),
+        "mesh products still advertised: {reps:?}"
+    );
+    assert!(
+        !reps.contains(&"voxels"),
+        "voxels must NOT be advertised without coverage: {reps:?}"
+    );
+    // And the voxel tileset itself is 404 (the gate the advertisement now mirrors).
+    assert_eq!(
+        send("/collections/radar-nocov/voxel/tileset.json")
+            .await
+            .status(),
+        StatusCode::NOT_FOUND
+    );
+}
+
+#[tokio::test]
 async fn isosurface_on_unsupported_collection_is_400() {
     // A collection whose engine can't voxel-grid advertises only `points` and
     // rejects isosurface requests at both the tileset and content routes.
@@ -598,6 +694,15 @@ async fn voxel_tileset_subtree_and_content_are_well_formed() {
     let s: serde_json::Value = serde_json::from_slice(&body).unwrap();
     assert_eq!(s["tileAvailability"]["constant"], 1);
     assert_eq!(s["contentAvailability"][0]["constant"], 1);
+
+    // Single-tile implicit set: only the root 0/0/0/0 exists — a non-root
+    // subtree/content coordinate is 404, not the root's constant data.
+    let (status, _b, _h) = get("/collections/radar-fivih/voxel/subtrees/1/0/0/0.json").await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+    let (status, _b, _h) =
+        get("/collections/radar-fivih/voxel/content/0/0/0/1.glb?quantity=DBZH&resolution=low")
+            .await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
 
     // Content: a valid EXT_primitive_voxels glb (cylinder mode 2147483650).
     let (status, body, headers) =

--- a/crates/api-3dtiles/tests/integration.rs
+++ b/crates/api-3dtiles/tests/integration.rs
@@ -591,11 +591,13 @@ async fn voxel_tileset_subtree_and_content_are_well_formed() {
     );
     assert!(curi.contains("quantity=DBZH") && curi.contains("resolution=low"));
 
-    // Subtree: constant single-tile availability.
+    // Subtree: constant single-tile availability. `contentAvailability` is an
+    // ARRAY per the 3D Tiles 1.1 implicit-tiling spec (one entry per layer).
     let (status, body, _h) = get("/collections/radar-fivih/voxel/subtrees/0/0/0/0.json").await;
     assert_eq!(status, StatusCode::OK);
     let s: serde_json::Value = serde_json::from_slice(&body).unwrap();
-    assert_eq!(s["contentAvailability"]["constant"], 1);
+    assert_eq!(s["tileAvailability"]["constant"], 1);
+    assert_eq!(s["contentAvailability"][0]["constant"], 1);
 
     // Content: a valid EXT_primitive_voxels glb (cylinder mode 2147483650).
     let (status, body, headers) =

--- a/crates/api-3dtiles/tests/integration.rs
+++ b/crates/api-3dtiles/tests/integration.rs
@@ -115,6 +115,8 @@ impl VolumeEngine for MockVolume {
             region: Some([0.42, 1.05, 0.44, 1.07, 100.0, 25_000.0]),
             voxel_grid: Some(VoxelGridCaps {
                 origin: [24.5, 60.5, 100.0],
+                radius_m: 250_000.0,
+                height_m: 20_000.0,
             }),
         })
     }
@@ -391,7 +393,7 @@ async fn collections_list_and_doc() {
         .iter()
         .map(|r| r.as_str().unwrap())
         .collect();
-    assert_eq!(reps, vec!["points", "isosurface", "echotop"]);
+    assert_eq!(reps, vec!["points", "isosurface", "echotop", "voxels"]);
     // A colour-scale legend is advertised for the point cloud: a unit, a range,
     // and sampled `#rrggbb` stops the viewer renders as a gradient bar.
     let lg = &v["legend"];
@@ -565,6 +567,55 @@ async fn glb_rejects_points_representation() {
     let (status, _body, _h) =
         get("/collections/radar-fivih/content.glb?representation=points&quantity=DBZH").await;
     assert_eq!(status, StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn voxel_tileset_subtree_and_content_are_well_formed() {
+    // Tileset: cylinder bounding volume + content_voxels + implicit OCTREE +
+    // a content URI carrying the resolved selection.
+    let (status, body, _h) =
+        get("/collections/radar-fivih/voxel/tileset.json?quantity=DBZH&resolution=low").await;
+    assert_eq!(status, StatusCode::OK);
+    let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let bv = &v["root"]["boundingVolume"]["extensions"]["3DTILES_bounding_volume_cylinder"];
+    assert!(bv["maxRadius"].as_f64().unwrap() > 0.0);
+    assert_eq!(
+        v["root"]["content"]["extensions"]["3DTILES_content_voxels"]["class"],
+        "voxel"
+    );
+    assert_eq!(v["root"]["implicitTiling"]["subdivisionScheme"], "OCTREE");
+    let curi = v["root"]["content"]["uri"].as_str().unwrap();
+    assert!(
+        curi.starts_with("content/{level}/{x}/{y}/{z}.glb?"),
+        "{curi}"
+    );
+    assert!(curi.contains("quantity=DBZH") && curi.contains("resolution=low"));
+
+    // Subtree: constant single-tile availability.
+    let (status, body, _h) = get("/collections/radar-fivih/voxel/subtrees/0/0/0/0.json").await;
+    assert_eq!(status, StatusCode::OK);
+    let s: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(s["contentAvailability"]["constant"], 1);
+
+    // Content: a valid EXT_primitive_voxels glb (cylinder mode 2147483650).
+    let (status, body, headers) =
+        get("/collections/radar-fivih/voxel/content/0/0/0/0.glb?quantity=DBZH&resolution=low")
+            .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(&body[0..4], b"glTF", "glb magic");
+    assert_eq!(
+        headers[axum::http::header::CONTENT_TYPE],
+        "model/gltf-binary"
+    );
+    // Parse the JSON chunk and check the voxel extension + cylinder mode.
+    let jlen = u32::from_le_bytes(body[12..16].try_into().unwrap()) as usize;
+    let j: serde_json::Value = serde_json::from_slice(&body[20..20 + jlen]).unwrap();
+    assert_eq!(j["meshes"][0]["primitives"][0]["mode"], 2_147_483_650u64);
+    assert!(j["extensionsRequired"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|e| e == "EXT_primitive_voxels"));
 }
 
 #[tokio::test]

--- a/crates/api-3dtiles/viewer/index.html
+++ b/crates/api-3dtiles/viewer/index.html
@@ -338,12 +338,15 @@ async function loadFrames(reframe = false) {
   pointsFetchFloor = rep === "points" ? (num === "" ? -Infinity : parseFloat(num)) : null;
 
   // Voxels are a CesiumJS VoxelPrimitive (ray-marched volume), not a tileset of
-  // tiles — their own load path. MVP: a single volume at the active time (no
-  // frame preload/animation), so the time bar stays hidden.
+  // tiles — their own load path. MVP: pin to the LATEST volume (no frame
+  // preload/animation — voxel time-dynamic playback is a #351 follow-up). Force
+  // a single-entry `frameTimes` so `syncTimeBar()` keeps the bar hidden: the
+  // scrubber drives `showFrame()` over `frames[]` (always empty for voxels), so
+  // on a multi-volume collection a shown bar would be inert. (`frameTimes[0] =
+  // null` → `loadVoxel` requests the server's latest-volume default.)
   if (rep === "voxels") {
-    frameTimes = times.length ? times.slice(-MAX_FRAMES) : [null];
-    if (frameIdx >= frameTimes.length) frameIdx = frameTimes.length - 1;
-    if (frameIdx < 0) frameIdx = 0;
+    frameTimes = [null];
+    frameIdx = 0;
     syncTimeBar();
     await loadVoxel(token);
     return;

--- a/crates/api-3dtiles/viewer/index.html
+++ b/crates/api-3dtiles/viewer/index.html
@@ -427,7 +427,7 @@ async function loadVoxel(token) {
 }
 
 // The `min dBZ` field value for voxels (cells below it are fully transparent).
-function voxelMin() { const m = parseFloat($num.value); return Number.isFinite(m) ? m : 5; }
+function voxelMin() { const m = parseFloat($num.value); return Number.isFinite(m) ? m : parseFloat(REP_META.voxels.numDefault); }
 function voxelMinLabel() { const m = parseFloat($num.value); return Number.isFinite(m) ? `≥ ${m} dBZ` : ""; }
 
 // #rrggbb → "vec3(r,g,b)" (0..1) for GLSL.

--- a/crates/api-3dtiles/viewer/index.html
+++ b/crates/api-3dtiles/viewer/index.html
@@ -10,10 +10,10 @@
      MANDATORY when bumping the CesiumJS version below: recompute these two
      sha384 hashes with `scripts/check-cesium-sri.sh` — a stale hash makes
      browsers silently refuse to load CesiumJS (blank viewer for everyone). -->
-<script src="https://cesium.com/downloads/cesiumjs/releases/1.124/Build/Cesium/Cesium.js"
+<script src="https://cesium.com/downloads/cesiumjs/releases/1.142/Build/Cesium/Cesium.js"
         crossorigin="anonymous"
-        integrity="sha384-5oazsHA45lZs9jgvxUv40qbMATfjwmtR/wQePfqDAeIDIhGmSK2V0gpRoCpZVBzJ"></script>
-<link href="https://cesium.com/downloads/cesiumjs/releases/1.124/Build/Cesium/Widgets/widgets.css" rel="stylesheet"
+        integrity="sha384-PCryXL7CqnqM5KijUKfJgy+y9b4vE7GzIHvb5J/MSSnIkFptiGOUrlt4s9uBUdtO"></script>
+<link href="https://cesium.com/downloads/cesiumjs/releases/1.142/Build/Cesium/Widgets/widgets.css" rel="stylesheet"
       crossorigin="anonymous"
       integrity="sha384-ghEeMdcWWzRv/BPeUcX835vcKDGrxvROXisl/Btpv3GeekBUXTSPVcFJpI1Tcrgp">
 <style>

--- a/crates/api-3dtiles/viewer/index.html
+++ b/crates/api-3dtiles/viewer/index.html
@@ -408,6 +408,9 @@ async function loadVoxel(token) {
       provider,
       customShader: voxelShader(q, legendData, voxelMin()),
     }));
+    // Finer ray-march than the default (1 sample/cell) so the trilinearly-
+    // interpolated field reads as a smooth volume, not a stack of cells.
+    voxelPrimitive.stepSizeMultiplier = 0.4;
     viewer.scene.requestRender();
     updateStatus(voxelMinLabel());
   } catch (e) {
@@ -453,10 +456,10 @@ function voxelShader(quantity, legend, min) {
     `}`,
     `void fragmentMain(FragmentInput fsInput, inout czm_modelMaterial material){`,
     `  float v=fsInput.metadata.${quantity};`,
-    `  if(v < ${min.toFixed(2)}){ material.alpha=0.0; return; }`, // min filter + nodata sentinel
     `  material.diffuse=voxRamp(v);`,
-    `  float a=clamp((v-(${lg.min.toFixed(2)}))/${span.toFixed(2)},0.0,1.0);`,
-    `  material.alpha=clamp(a*0.7,0.04,0.6);`, // denser echo = more opaque
+    // Density rises smoothly FROM 0 at the `min` threshold (no hard alpha step →
+    // no shell/"walls and floors" at the min isovalue), ~0.55 by +25 dBZ above it.
+    `  material.alpha=clamp((v-(${min.toFixed(2)}))*0.022,0.0,0.55);`,
     `}`,
   ].join("\n");
   return new Cesium.CustomShader({ fragmentShaderText: fs });

--- a/crates/api-3dtiles/viewer/index.html
+++ b/crates/api-3dtiles/viewer/index.html
@@ -408,9 +408,13 @@ async function loadVoxel(token) {
       provider,
       customShader: voxelShader(q, legendData, voxelMin()),
     }));
-    // Finer ray-march than the default (1 sample/cell) so the trilinearly-
-    // interpolated field reads as a smooth volume, not a stack of cells.
-    voxelPrimitive.stepSizeMultiplier = 0.4;
+    // Default ray-march step (1 sample/cell). Finer stepping was tried (0.4,
+    // 0.12) to smooth the cell lattice but made no visible difference — the
+    // lattice is a property of the DATA, now dissolved by the encoder's
+    // multi-pass blur, not of the step size — so it was pure cost (a smaller
+    // multiplier means proportionally more samples per ray). Left at the
+    // default for ~2.5× faster ray-marching with no quality loss.
+    voxelPrimitive.stepSizeMultiplier = 1.0;
     viewer.scene.requestRender();
     updateStatus(voxelMinLabel());
   } catch (e) {

--- a/crates/api-3dtiles/viewer/index.html
+++ b/crates/api-3dtiles/viewer/index.html
@@ -150,13 +150,15 @@ const setStatus = (msg, err) => { $status.textContent = msg; $status.className =
 // point clouds drop echoes below `min_value`; isosurfaces draw the shell AT
 // `threshold`; echo-top columns rise to where reflectivity drops below
 // `threshold`. All a dBZ number, so one input serves them, relabelled.
-// `mesh` products (isosurface/echotop) are resampled to a voxel grid, so they
-// take the low/med/high Resolution selector; the point cloud is native-res and
-// hides it.
+// `grid` products (isosurface/echotop/voxels) are resampled to a voxel grid, so
+// they take the low/med/high Resolution selector; the point cloud is native-res
+// and hides it. `voxels` is the CesiumJS VoxelPrimitive ray-march (its own load
+// path, not a tileset of tiles).
 const REP_META = {
-  points:     { label: "Point cloud", numLabel: "min dBZ",       numDefault: "5",  mesh: false },
-  isosurface: { label: "Isosurface",  numLabel: "threshold dBZ", numDefault: "20", mesh: true  },
-  echotop:    { label: "Echo top",    numLabel: "threshold dBZ", numDefault: "18", mesh: true  },
+  points:     { label: "Point cloud", numLabel: "min dBZ",       numDefault: "5",  mesh: false, voxel: false },
+  isosurface: { label: "Isosurface",  numLabel: "threshold dBZ", numDefault: "20", mesh: true,  voxel: false },
+  echotop:    { label: "Echo top",    numLabel: "threshold dBZ", numDefault: "18", mesh: true,  voxel: false },
+  voxels:     { label: "Voxels",      numLabel: "min dBZ",       numDefault: "5",  mesh: true,  voxel: true  },
 };
 
 // Token-free CesiumJS: CARTO Dark Matter basemap, no Cesium Ion.
@@ -193,6 +195,7 @@ let loadToken = 0;        // guards against out-of-order async (re)builds
 let currentRep = null;    // representation of the active frames
 let pointsFetchFloor = null; // the min_value (dBZ) the point-cloud frames were fetched at
 let legendData = null;    // colour-scale legend {title,unit,min,max,stops} from the collection doc
+let voxelPrimitive = null; // active Cesium VoxelPrimitive (the `voxels` representation)
 
 async function loadCollections() {
   setStatus("loading collections…");
@@ -313,6 +316,9 @@ function clearFrames() {
   for (const ts of frames) if (ts) viewer.scene.primitives.remove(ts);
   frames = [];
 }
+function clearVoxel() {
+  if (voxelPrimitive) { viewer.scene.primitives.remove(voxelPrimitive); voxelPrimitive = null; }
+}
 
 // (Re)build the whole frame set for the current params: one preloaded, hidden
 // tileset per timestamp (or a single latest-volume frame when the collection has
@@ -324,8 +330,21 @@ async function loadFrames(reframe = false) {
   const token = ++loadToken;
   stopPlaying();
   clearFrames();
+  clearVoxel();
   currentRep = rep;
   pointsFetchFloor = rep === "points" ? (num === "" ? -Infinity : parseFloat(num)) : null;
+
+  // Voxels are a CesiumJS VoxelPrimitive (ray-marched volume), not a tileset of
+  // tiles — their own load path. MVP: a single volume at the active time (no
+  // frame preload/animation), so the time bar stays hidden.
+  if (rep === "voxels") {
+    frameTimes = times.length ? times.slice(-MAX_FRAMES) : [null];
+    if (frameIdx >= frameTimes.length) frameIdx = frameTimes.length - 1;
+    if (frameIdx < 0) frameIdx = 0;
+    syncTimeBar();
+    await loadVoxel(token);
+    return;
+  }
 
   // Animate the most-recent MAX_FRAMES of the manifest ([null] = the single
   // latest-volume frame when there's no time axis).
@@ -362,6 +381,59 @@ async function loadFrames(reframe = false) {
   }
   if (!frames.some(Boolean)) setStatus("no data for this selection", true);
   else updateStatus();
+}
+
+// Load the cylindrical voxel volume for the active time as a CesiumJS
+// VoxelPrimitive (ray-marched), styled by a reflectivity transfer-function
+// custom shader. EXT_primitive_voxels is CesiumGS-only + draft, so this whole
+// path is best-effort — a load failure just reports, leaving the other
+// representations untouched.
+async function loadVoxel(token) {
+  const id = $coll.value, q = $qty.value;
+  setStatus(`loading ${id} · ${q} · voxels…`);
+  let url = `${BASE}/collections/${encodeURIComponent(id)}/voxel/tileset.json?quantity=${encodeURIComponent(q)}`;
+  const time = frameTimes.length ? frameTimes[frameIdx] : null;
+  if (time) url += `&datetime=${encodeURIComponent(time)}`;
+  url += `&resolution=${encodeURIComponent($res.value)}`;
+  try {
+    if (typeof Cesium.Cesium3DTilesVoxelProvider !== "function") {
+      throw new Error("this CesiumJS build has no voxel support");
+    }
+    const provider = await Cesium.Cesium3DTilesVoxelProvider.fromUrl(url);
+    if (token !== loadToken) return; // superseded
+    voxelPrimitive = viewer.scene.primitives.add(new Cesium.VoxelPrimitive({
+      provider,
+      customShader: voxelShader(q),
+    }));
+    viewer.scene.requestRender();
+    updateStatus();
+  } catch (e) {
+    if (token === loadToken) setStatus("voxels unavailable — " + e.message, true);
+    console.error("voxel load", e);
+  }
+}
+
+// Reflectivity transfer function for the voxel ray-march: the per-cell metadata
+// value (dBZ, property = the quantity) → colour + alpha. Weak echo / the nodata
+// sentinel are transparent; stronger echo ramps blue→green→yellow→red→magenta
+// and grows more opaque.
+function voxelShader(quantity) {
+  return new Cesium.CustomShader({
+    fragmentShaderText: [
+      "void fragmentMain(FragmentInput fsInput, inout czm_modelMaterial material) {",
+      "  float v = fsInput.metadata." + quantity + ";",
+      "  if (v < 5.0) { material.alpha = 0.0; return; }", // nodata sentinel + weak echo
+      "  float t = clamp((v - 5.0) / 60.0, 0.0, 1.0);",    // map 5..65 dBZ → 0..1
+      "  vec3 c;",
+      "  if (t < 0.25)      c = mix(vec3(0.0,0.45,1.0), vec3(0.0,0.8,0.3), t/0.25);",
+      "  else if (t < 0.5)  c = mix(vec3(0.0,0.8,0.3), vec3(0.95,0.9,0.2), (t-0.25)/0.25);",
+      "  else if (t < 0.75) c = mix(vec3(0.95,0.9,0.2), vec3(0.95,0.3,0.1), (t-0.5)/0.25);",
+      "  else               c = mix(vec3(0.95,0.3,0.1), vec3(0.8,0.1,0.5), (t-0.75)/0.25);",
+      "  material.diffuse = c;",
+      "  material.alpha = clamp(t * 0.6, 0.03, 0.6);", // denser echo = more opaque
+      "}",
+    ].join("\n"),
+  });
 }
 
 // Reveal frame `i` (wrapping), hide the rest — a pure visibility toggle, the

--- a/crates/api-3dtiles/viewer/index.html
+++ b/crates/api-3dtiles/viewer/index.html
@@ -448,7 +448,11 @@ function voxelShader(quantity, legend, min) {
   // though it comes from server metadata (ODIM quantities are A-Z0-9_). Sandboxed
   // to our own GPU context, but cheap defence-in-depth.
   if (!/^[A-Z][A-Z0-9_]*$/.test(quantity)) throw new Error("invalid quantity: " + quantity);
-  const lg = (legend && legend.stops && legend.stops.length >= 2)
+  // Also guard non-finite min/max: `(NaN|Infinity).toFixed(2)` emits the
+  // literal "NaN"/"Infinity" into the GLSL below → the shader fails to compile
+  // and the volume goes dark. (serde can emit those for IEEE-754 specials.)
+  const lg = (legend && legend.stops && legend.stops.length >= 2
+              && Number.isFinite(legend.min) && Number.isFinite(legend.max))
     ? legend
     : { min: 0, max: 70, stops: [{ color: "#0000ff" }, { color: "#ff0000" }] };
   const n = lg.stops.length;

--- a/crates/api-3dtiles/viewer/index.html
+++ b/crates/api-3dtiles/viewer/index.html
@@ -418,6 +418,10 @@ async function loadVoxel(token) {
 // sentinel are transparent; stronger echo ramps blue→green→yellow→red→magenta
 // and grows more opaque.
 function voxelShader(quantity) {
+  // `quantity` is interpolated into GLSL source — guard the property name even
+  // though it comes from server metadata (ODIM quantities are A-Z0-9_). Sandboxed
+  // to our own GPU context, but cheap defence-in-depth.
+  if (!/^[A-Z][A-Z0-9_]*$/.test(quantity)) throw new Error("invalid quantity: " + quantity);
   return new Cesium.CustomShader({
     fragmentShaderText: [
       "void fragmentMain(FragmentInput fsInput, inout czm_modelMaterial material) {",

--- a/crates/api-3dtiles/viewer/index.html
+++ b/crates/api-3dtiles/viewer/index.html
@@ -154,11 +154,14 @@ const setStatus = (msg, err) => { $status.textContent = msg; $status.className =
 // they take the low/med/high Resolution selector; the point cloud is native-res
 // and hides it. `voxels` is the CesiumJS VoxelPrimitive ray-march (its own load
 // path, not a tileset of tiles).
+// `legend` = coloured by the reflectivity ramp (points + voxels show the colour
+// scale; isosurface is one threshold colour, echo-top a height ramp → no
+// reflectivity legend).
 const REP_META = {
-  points:     { label: "Point cloud", numLabel: "min dBZ",       numDefault: "5",  mesh: false, voxel: false },
-  isosurface: { label: "Isosurface",  numLabel: "threshold dBZ", numDefault: "20", mesh: true,  voxel: false },
-  echotop:    { label: "Echo top",    numLabel: "threshold dBZ", numDefault: "18", mesh: true,  voxel: false },
-  voxels:     { label: "Voxels",      numLabel: "min dBZ",       numDefault: "5",  mesh: true,  voxel: true  },
+  points:     { label: "Point cloud", numLabel: "min dBZ",       numDefault: "5",  mesh: false, voxel: false, legend: true  },
+  isosurface: { label: "Isosurface",  numLabel: "threshold dBZ", numDefault: "20", mesh: true,  voxel: false, legend: false },
+  echotop:    { label: "Echo top",    numLabel: "threshold dBZ", numDefault: "18", mesh: true,  voxel: false, legend: false },
+  voxels:     { label: "Voxels",      numLabel: "min dBZ",       numDefault: "5",  mesh: true,  voxel: true,  legend: true  },
 };
 
 // Token-free CesiumJS: CARTO Dark Matter basemap, no Cesium Ion.
@@ -266,7 +269,7 @@ function syncNumField() {
   $numLabel.textContent = meta.numLabel;
   $num.value = meta.numDefault;
   $resField.hidden = !meta.mesh;
-  $legend.hidden = meta.mesh || !legendData;
+  $legend.hidden = !meta.legend || !legendData;
 }
 
 // Build the colour-scale legend from the collection doc's `legend` (a sampled
@@ -403,41 +406,70 @@ async function loadVoxel(token) {
     if (token !== loadToken) return; // superseded
     voxelPrimitive = viewer.scene.primitives.add(new Cesium.VoxelPrimitive({
       provider,
-      customShader: voxelShader(q),
+      customShader: voxelShader(q, legendData, voxelMin()),
     }));
     viewer.scene.requestRender();
-    updateStatus();
+    updateStatus(voxelMinLabel());
   } catch (e) {
     if (token === loadToken) setStatus("voxels unavailable — " + e.message, true);
     console.error("voxel load", e);
   }
 }
 
+// The `min dBZ` field value for voxels (cells below it are fully transparent).
+function voxelMin() { const m = parseFloat($num.value); return Number.isFinite(m) ? m : 5; }
+function voxelMinLabel() { const m = parseFloat($num.value); return Number.isFinite(m) ? `≥ ${m} dBZ` : ""; }
+
+// #rrggbb → "vec3(r,g,b)" (0..1) for GLSL.
+function hexToGlslVec3(hex) {
+  const r = parseInt(hex.slice(1, 3), 16) / 255;
+  const g = parseInt(hex.slice(3, 5), 16) / 255;
+  const b = parseInt(hex.slice(5, 7), 16) / 255;
+  return `vec3(${r.toFixed(4)},${g.toFixed(4)},${b.toFixed(4)})`;
+}
+
 // Reflectivity transfer function for the voxel ray-march: the per-cell metadata
-// value (dBZ, property = the quantity) → colour + alpha. Weak echo / the nodata
-// sentinel are transparent; stronger echo ramps blue→green→yellow→red→magenta
-// and grows more opaque.
-function voxelShader(quantity) {
+// value (dBZ, property = the quantity) → colour + alpha. The colour ramp is built
+// from the SAME legend stops the colour-scale bar shows, so the voxels match the
+// legend exactly; `min` (the `min dBZ` field) makes weaker cells (and the nodata
+// sentinel) transparent; denser echo grows more opaque.
+function voxelShader(quantity, legend, min) {
   // `quantity` is interpolated into GLSL source — guard the property name even
   // though it comes from server metadata (ODIM quantities are A-Z0-9_). Sandboxed
   // to our own GPU context, but cheap defence-in-depth.
   if (!/^[A-Z][A-Z0-9_]*$/.test(quantity)) throw new Error("invalid quantity: " + quantity);
-  return new Cesium.CustomShader({
-    fragmentShaderText: [
-      "void fragmentMain(FragmentInput fsInput, inout czm_modelMaterial material) {",
-      "  float v = fsInput.metadata." + quantity + ";",
-      "  if (v < 5.0) { material.alpha = 0.0; return; }", // nodata sentinel + weak echo
-      "  float t = clamp((v - 5.0) / 60.0, 0.0, 1.0);",    // map 5..65 dBZ → 0..1
-      "  vec3 c;",
-      "  if (t < 0.25)      c = mix(vec3(0.0,0.45,1.0), vec3(0.0,0.8,0.3), t/0.25);",
-      "  else if (t < 0.5)  c = mix(vec3(0.0,0.8,0.3), vec3(0.95,0.9,0.2), (t-0.25)/0.25);",
-      "  else if (t < 0.75) c = mix(vec3(0.95,0.9,0.2), vec3(0.95,0.3,0.1), (t-0.5)/0.25);",
-      "  else               c = mix(vec3(0.95,0.3,0.1), vec3(0.8,0.1,0.5), (t-0.75)/0.25);",
-      "  material.diffuse = c;",
-      "  material.alpha = clamp(t * 0.6, 0.03, 0.6);", // denser echo = more opaque
-      "}",
-    ].join("\n"),
-  });
+  const lg = (legend && legend.stops && legend.stops.length >= 2)
+    ? legend
+    : { min: 0, max: 70, stops: [{ color: "#0000ff" }, { color: "#ff0000" }] };
+  const n = lg.stops.length;
+  const ramp = lg.stops.map(s => hexToGlslVec3(s.color)).join(",");
+  const span = (lg.max - lg.min) || 1;
+  const fs = [
+    `vec3 voxRamp(float v){`,
+    `  vec3 ramp[${n}]=vec3[${n}](${ramp});`,
+    `  float t=clamp((v-(${lg.min.toFixed(2)}))/${span.toFixed(2)},0.0,1.0)*float(${n - 1});`,
+    `  int i=int(floor(t));`,
+    `  return mix(ramp[i],ramp[min(i+1,${n - 1})],fract(t));`,
+    `}`,
+    `void fragmentMain(FragmentInput fsInput, inout czm_modelMaterial material){`,
+    `  float v=fsInput.metadata.${quantity};`,
+    `  if(v < ${min.toFixed(2)}){ material.alpha=0.0; return; }`, // min filter + nodata sentinel
+    `  material.diffuse=voxRamp(v);`,
+    `  float a=clamp((v-(${lg.min.toFixed(2)}))/${span.toFixed(2)},0.0,1.0);`,
+    `  material.alpha=clamp(a*0.7,0.04,0.6);`, // denser echo = more opaque
+    `}`,
+  ].join("\n");
+  return new Cesium.CustomShader({ fragmentShaderText: fs });
+}
+
+// `min dBZ` for voxels updates the transfer-function shader live (no reload):
+// rebuild the customShader with the new threshold and reassign it.
+function voxelClientFilter() {
+  if (($rep.value || "points") !== "voxels" || currentRep !== "voxels" || !voxelPrimitive) return false;
+  try { voxelPrimitive.customShader = voxelShader($qty.value, legendData, voxelMin()); } catch (e) { console.error(e); return false; }
+  viewer.scene.requestRender();
+  updateStatus(voxelMinLabel());
+  return true;
 }
 
 // Reveal frame `i` (wrapping), hide the rest — a pure visibility toggle, the
@@ -484,9 +516,10 @@ function pointsClientFilter() {
 }
 
 function onNumCommit() {
-  // Points within the fetched range already restyled live → nothing to fetch.
-  if (pointsClientFilter()) return;
-  loadFrames(false); // mesh threshold/resolution, or points needing more data
+  // Points (client restyle) and voxels (shader rebuild) handle the field live →
+  // nothing to fetch; everything else (mesh threshold/resolution) re-fetches.
+  if (pointsClientFilter() || voxelClientFilter()) return;
+  loadFrames(false);
 }
 
 // ── Time scrubber ──────────────────────────────────────────────────────────
@@ -544,7 +577,7 @@ $res.addEventListener("change", () => loadFrames(false));
 // Live: a point cloud re-filters client-side as you drag the field. Commit
 // (`change`): re-fetch for meshes, or for points that need values below their
 // fetched floor.
-$num.addEventListener("input", pointsClientFilter);
+$num.addEventListener("input", () => { pointsClientFilter() || voxelClientFilter(); });
 $num.addEventListener("change", onNumCommit);
 // Time scrubber: play/pause toggles the loop; dragging the slider seeks (and
 // pauses, so the frame you drag to stays put).

--- a/crates/core/src/volume.rs
+++ b/crates/core/src/volume.rs
@@ -87,6 +87,14 @@ pub struct VoxelGridCaps {
     /// to. Lets the 3D Tiles layer build the glTF tile `transform` (antenna
     /// ECEF) **without** sampling the grid.
     pub origin: [f64; 3],
+    /// Cylinder radial extent (metres): the ground coverage radius, = the
+    /// [`VoxelGrid::radius_range`] max the sampler produces. Lets the voxel 3D
+    /// Tiles layer size the `3DTILES_bounding_volume_cylinder` **without**
+    /// sampling the grid (the cylinder extent must match the grid exactly).
+    pub radius_m: f64,
+    /// Cylinder vertical extent (metres): the volume height ceiling, = the
+    /// [`VoxelGrid::height_range`] max. Same purpose as [`Self::radius_m`].
+    pub height_m: f64,
 }
 
 /// The physical value (dBZ) marking a radar voxel cell as **clear air / no

--- a/crates/ds-3dtiles/src/echo_top.rs
+++ b/crates/ds-3dtiles/src/echo_top.rs
@@ -206,7 +206,7 @@ pub fn encode_echo_top_glb(
         }
     }
 
-    Ok(build_glb(&positions, &normals, &colors, &indices, min, max))
+    build_glb(&positions, &normals, &colors, &indices, min, max)
 }
 
 /// The 8 corners of a cell column, indexed by bits `r<<0 | a<<1 | top<<2`
@@ -352,7 +352,7 @@ pub fn encode_echo_top_columns_glb(
     }
     // Non-indexed (flat shading needs per-face vertices), so indices are trivial.
     let indices: Vec<u32> = (0..positions.len() as u32).collect();
-    Ok(build_glb(&positions, &normals, &colors, &indices, min, max))
+    build_glb(&positions, &normals, &colors, &indices, min, max)
 }
 
 /// Assemble an indexed `.glb` with POSITION + NORMAL + COLOR_0 (per-vertex
@@ -364,7 +364,7 @@ fn build_glb(
     indices: &[u32],
     min: [f32; 3],
     max: [f32; 3],
-) -> Vec<u8> {
+) -> Result<Vec<u8>, Tiles3dError> {
     let vcount = positions.len();
     let icount = indices.len();
     // BIN layout (each section 4-aligned): POSITION f32×3, NORMAL f32×3,
@@ -436,22 +436,10 @@ fn build_glb(
         "buffers": [ { "byteLength": bin.len() } ],
     });
 
-    let mut json_chunk = serde_json::to_vec(&gltf).expect("glTF JSON serializes");
-    while !json_chunk.len().is_multiple_of(4) {
-        json_chunk.push(b' ');
-    }
-    let total = 12 + 8 + json_chunk.len() + 8 + bin.len();
-    let mut glb = Vec::with_capacity(total);
-    glb.extend_from_slice(&0x4654_6C67u32.to_le_bytes()); // "glTF"
-    glb.extend_from_slice(&2u32.to_le_bytes());
-    glb.extend_from_slice(&(total as u32).to_le_bytes());
-    glb.extend_from_slice(&(json_chunk.len() as u32).to_le_bytes());
-    glb.extend_from_slice(&0x4E4F_534Au32.to_le_bytes()); // "JSON"
-    glb.extend_from_slice(&json_chunk);
-    glb.extend_from_slice(&(bin.len() as u32).to_le_bytes());
-    glb.extend_from_slice(&0x004E_4942u32.to_le_bytes()); // "BIN\0"
-    glb.extend_from_slice(&bin);
-    glb
+    // Shared GLB assembler (4-byte chunk padding + `u32`-checked total +
+    // serialize-error path). The BIN above is f32/u8×4/u32 — always 4-aligned —
+    // so the helper's padding is a no-op here.
+    crate::assemble_glb(&gltf, bin)
 }
 
 #[cfg(test)]

--- a/crates/ds-3dtiles/src/isosurface.rs
+++ b/crates/ds-3dtiles/src/isosurface.rs
@@ -426,11 +426,11 @@ pub fn encode_isosurface_glb(
     if mesh.triangles == 0 {
         return Err(Tiles3dError::Empty);
     }
-    Ok(build_glb(&mesh, color))
+    build_glb(&mesh, color)
 }
 
 /// Assemble a single-mesh `.glb` from the accumulated triangles.
-fn build_glb(mesh: &MeshBuilder, color: [u8; 4]) -> Vec<u8> {
+fn build_glb(mesh: &MeshBuilder, color: [u8; 4]) -> Result<Vec<u8>, Tiles3dError> {
     let vertex_count = mesh.positions.len() / 3;
 
     // BIN buffer: POSITION (count·3·f32) then NORMAL (count·3·f32). Both are
@@ -495,27 +495,10 @@ fn build_glb(mesh: &MeshBuilder, color: [u8; 4]) -> Vec<u8> {
         "buffers": [ { "byteLength": bin.len() } ],
     });
 
-    let mut json_chunk = serde_json::to_vec(&gltf).expect("glTF JSON serializes");
-    while !json_chunk.len().is_multiple_of(4) {
-        json_chunk.push(b' '); // JSON chunk padded with spaces
-    }
-
-    // GLB = 12-byte header + JSON chunk + BIN chunk (each chunk: u32 length,
-    // u32 type, payload).
-    let total = 12 + 8 + json_chunk.len() + 8 + bin.len();
-    let mut glb = Vec::with_capacity(total);
-    glb.extend_from_slice(&0x46546C67u32.to_le_bytes()); // "glTF"
-    glb.extend_from_slice(&2u32.to_le_bytes()); // version
-    glb.extend_from_slice(&(total as u32).to_le_bytes());
-    // JSON chunk
-    glb.extend_from_slice(&(json_chunk.len() as u32).to_le_bytes());
-    glb.extend_from_slice(&0x4E4F534Au32.to_le_bytes()); // "JSON"
-    glb.extend_from_slice(&json_chunk);
-    // BIN chunk
-    glb.extend_from_slice(&(bin.len() as u32).to_le_bytes());
-    glb.extend_from_slice(&0x004E4942u32.to_le_bytes()); // "BIN\0"
-    glb.extend_from_slice(&bin);
-    glb
+    // Shared GLB assembler: 4-byte chunk padding + `u32`-checked total length +
+    // a serialize-error path instead of an `expect` panic. The BIN above is
+    // f32-only (always 4-aligned), so the helper's padding is a no-op here.
+    crate::assemble_glb(&gltf, bin)
 }
 
 /// Build the `tileset.json` for an isosurface `.glb`. Like

--- a/crates/ds-3dtiles/src/lib.rs
+++ b/crates/ds-3dtiles/src/lib.rs
@@ -108,6 +108,40 @@ pub(crate) fn validate_uri(uri: &str) -> Result<(), Tiles3dError> {
     Ok(())
 }
 
+/// Assemble a binary glTF (`.glb`) from a glTF JSON value + a BIN buffer. Both
+/// chunks are padded to a 4-byte boundary (JSON with spaces, BIN with zeros) per
+/// the glTF 2.0 spec, and the total length is `u32::try_from`-checked so a >4 GiB
+/// tile errors rather than wrapping. Shared by every `.glb` encoder in the crate
+/// (voxels, isosurface, echo-top) so the overflow guard and the serialize-error
+/// path are written once.
+pub(crate) fn assemble_glb(
+    gltf: &serde_json::Value,
+    mut bin: Vec<u8>,
+) -> Result<Vec<u8>, Tiles3dError> {
+    let mut json_bytes =
+        serde_json::to_vec(gltf).map_err(|e| Tiles3dError::Serialize(e.to_string()))?;
+    while !json_bytes.len().is_multiple_of(4) {
+        json_bytes.push(b' ');
+    }
+    while !bin.len().is_multiple_of(4) {
+        bin.push(0);
+    }
+    let total = 12 + 8 + json_bytes.len() + 8 + bin.len();
+    let total = u32::try_from(total).map_err(|_| Tiles3dError::TooLarge("glb byteLength"))?;
+
+    let mut glb = Vec::with_capacity(total as usize);
+    glb.extend_from_slice(b"glTF");
+    glb.extend_from_slice(&2u32.to_le_bytes()); // version
+    glb.extend_from_slice(&total.to_le_bytes());
+    glb.extend_from_slice(&(json_bytes.len() as u32).to_le_bytes());
+    glb.extend_from_slice(b"JSON");
+    glb.extend_from_slice(&json_bytes);
+    glb.extend_from_slice(&(bin.len() as u32).to_le_bytes());
+    glb.extend_from_slice(b"BIN\0");
+    glb.extend_from_slice(&bin);
+    Ok(glb)
+}
+
 /// Encode a point cloud as a 3D Tiles **`.pnts`** tile (the 3D Tiles 1.0 Point
 /// Cloud format, still rendered by CesiumJS in 1.1 — the path where per-point
 /// RGB and `pointSize` styling actually work).

--- a/crates/ds-3dtiles/src/lib.rs
+++ b/crates/ds-3dtiles/src/lib.rs
@@ -93,10 +93,15 @@ pub enum Tiles3dError {
 /// caller-supplied URI runs it through this guard (defence-in-depth for a `pub`
 /// API — today's callers all build the URIs server-side).
 pub(crate) fn validate_uri(uri: &str) -> Result<(), Tiles3dError> {
+    // Scan for `..` over the PATH only (drop any `?query`/`#fragment` first):
+    // a `..` directly before the query (`a/..?x=1`) must still be caught, while
+    // a `..` *inside* a query value (`a.glb?from=../b`) is not a path segment and
+    // is harmless. The empty/absolute/scheme checks apply to the whole URI.
+    let path = uri.split(['?', '#']).next().unwrap_or(uri);
     if uri.is_empty()
         || uri.starts_with('/')
         || uri.contains("://")
-        || uri.split('/').any(|s| s == "..")
+        || path.split('/').any(|s| s == "..")
     {
         return Err(Tiles3dError::InvalidUri(uri.to_string()));
     }
@@ -474,6 +479,19 @@ mod tests {
         // A plain relative path is accepted.
         assert!(tileset_json(&cloud, "content.pnts").is_ok());
         assert!(tileset_json(&cloud, "tiles/0/content.pnts").is_ok());
+    }
+
+    #[test]
+    fn validate_uri_isolates_path_from_query() {
+        // `..` as a path segment right before the query is caught …
+        assert!(matches!(
+            validate_uri("content/..?t=1"),
+            Err(Tiles3dError::InvalidUri(_))
+        ));
+        // … but a `..` inside a query *value* is not a path segment — allowed
+        // (the implicit-tiling content URIs carry `?datetime=…` query strings).
+        assert!(validate_uri("content/0/0/0/0.glb?from=../other").is_ok());
+        assert!(validate_uri("content/{level}/{x}/{y}/{z}.glb?quantity=DBZH").is_ok());
     }
 
     #[test]

--- a/crates/ds-3dtiles/src/lib.rs
+++ b/crates/ds-3dtiles/src/lib.rs
@@ -32,6 +32,11 @@ pub use isosurface::{encode_isosurface_glb, tileset_json_glb};
 pub mod echo_top;
 pub use echo_top::{encode_echo_top_columns_glb, encode_echo_top_glb};
 
+/// True cylindrical voxels (#351): `VoxelGrid` → `EXT_primitive_voxels` glTF
+/// `.glb` + `3DTILES_content_voxels` tileset for CesiumJS volume ray-marching.
+pub mod voxels;
+pub use voxels::{encode_voxels_glb, tileset_json_voxels, voxel_subtree_json};
+
 /// Top-level tileset geometric error. Must be > 0 (see module docs); the value
 /// only needs to exceed the root's so CesiumJS refines to the content.
 const TILESET_GEOMETRIC_ERROR: f64 = 1.0e5;

--- a/crates/ds-3dtiles/src/lib.rs
+++ b/crates/ds-3dtiles/src/lib.rs
@@ -78,6 +78,29 @@ pub enum Tiles3dError {
     /// returning a bogus mesh.
     #[error("isosurface background {background} must be < threshold {threshold}")]
     BackgroundNotBelowThreshold { background: f64, threshold: f64 },
+    /// `serde_json` failed to serialize a tile/tileset value. The values are
+    /// built from finite numbers and owned strings, so this is not expected in
+    /// practice — but returning it (rather than `expect`-panicking inside a
+    /// `spawn_blocking` task, where the message is lost to a generic 500)
+    /// preserves the source error for the caller to surface.
+    #[error("3D Tiles JSON serialize failed: {0}")]
+    Serialize(String),
+}
+
+/// Reject a `content`/`subtree` URI that is not a safe **server-relative** path:
+/// empty, absolute (`/…`), scheme-qualified (`…://…`), or `..`-traversing.
+/// CesiumJS fetches whatever URL a tileset names, so every encoder that embeds a
+/// caller-supplied URI runs it through this guard (defence-in-depth for a `pub`
+/// API — today's callers all build the URIs server-side).
+pub(crate) fn validate_uri(uri: &str) -> Result<(), Tiles3dError> {
+    if uri.is_empty()
+        || uri.starts_with('/')
+        || uri.contains("://")
+        || uri.split('/').any(|s| s == "..")
+    {
+        return Err(Tiles3dError::InvalidUri(uri.to_string()));
+    }
+    Ok(())
 }
 
 /// Encode a point cloud as a 3D Tiles **`.pnts`** tile (the 3D Tiles 1.0 Point
@@ -251,13 +274,7 @@ pub(crate) fn tileset_value_for_region(
     region: [f64; 6],
     content_uri: &str,
 ) -> Result<serde_json::Value, Tiles3dError> {
-    if content_uri.is_empty()
-        || content_uri.starts_with('/')
-        || content_uri.contains("://")
-        || content_uri.split('/').any(|s| s == "..")
-    {
-        return Err(Tiles3dError::InvalidUri(content_uri.to_string()));
-    }
+    validate_uri(content_uri)?;
     if region.iter().any(|v| !v.is_finite()) {
         return Err(Tiles3dError::NonFinite("region"));
     }

--- a/crates/ds-3dtiles/src/voxels.rs
+++ b/crates/ds-3dtiles/src/voxels.rs
@@ -259,7 +259,8 @@ fn voxel_schema(quantity: &str) -> serde_json::Value {
 /// chunks are padded to a 4-byte boundary (JSON with spaces, BIN with zeros) per
 /// the glTF 2.0 spec.
 fn assemble_glb(gltf: &serde_json::Value, mut bin: Vec<u8>) -> Result<Vec<u8>, Tiles3dError> {
-    let mut json_bytes = serde_json::to_vec(gltf).expect("voxel glTF serializes");
+    let mut json_bytes =
+        serde_json::to_vec(gltf).map_err(|e| Tiles3dError::Serialize(e.to_string()))?;
     while !json_bytes.len().is_multiple_of(4) {
         json_bytes.push(b' ');
     }
@@ -304,6 +305,12 @@ pub fn tileset_json_voxels(
     content_uri: &str,
     subtree_uri: &str,
 ) -> Result<String, Tiles3dError> {
+    // Both URIs are embedded into the tileset CesiumJS fetches; reject anything
+    // that could traverse or redirect (same guard as the `.pnts`/mesh tilesets —
+    // the contract documented in CLAUDE.md). Today's caller builds them
+    // server-side, so this is defence-in-depth for a `pub` API.
+    crate::validate_uri(content_uri)?;
+    crate::validate_uri(subtree_uri)?;
     for v in [
         antenna_lon,
         antenna_lat,
@@ -400,7 +407,7 @@ pub fn tileset_json_voxels(
             "refine": "REPLACE"
         }
     });
-    Ok(serde_json::to_string_pretty(&tileset).expect("voxel tileset serializes"))
+    serde_json::to_string_pretty(&tileset).map_err(|e| Tiles3dError::Serialize(e.to_string()))
 }
 
 /// The implicit-tiling **subtree** for a single available tile: the one level-0
@@ -409,7 +416,12 @@ pub fn tileset_json_voxels(
 pub fn voxel_subtree_json() -> String {
     let subtree = json!({
         "tileAvailability": { "constant": 1, "availableCount": 1 },
-        "contentAvailability": { "constant": 1, "availableCount": 1 },
+        // Per the 3D Tiles 1.1 implicit-tiling spec, `contentAvailability` is an
+        // ARRAY (one entry per content layer) — unlike the scalar
+        // `tileAvailability`/`childSubtreeAvailability`. CesiumJS 1.142 accepts a
+        // bare object, but strict validators (and likely future CesiumJS) require
+        // the array form.
+        "contentAvailability": [{ "constant": 1, "availableCount": 1 }],
         "childSubtreeAvailability": { "constant": 0, "availableCount": 0 }
     });
     serde_json::to_string(&subtree).expect("subtree serializes")
@@ -594,5 +606,38 @@ mod tests {
             v["statistics"]["classes"]["voxel"]["properties"]["DBZH"]["max"],
             json!([70.0])
         );
+    }
+
+    #[test]
+    fn voxel_tileset_rejects_unsafe_uris() {
+        let call = |content: &str, subtree: &str| {
+            tileset_json_voxels(
+                24.5,
+                60.5,
+                100.0,
+                250_000.0,
+                15_000.0,
+                [128, 360, 48],
+                "DBZH",
+                0.0,
+                70.0,
+                content,
+                subtree,
+            )
+        };
+        let safe = "content/{level}/{x}/{y}/{z}.glb";
+        let safe_sub = "subtrees/{level}/{x}/{y}/{z}.json";
+        // A bad value in either URI slot is rejected.
+        for bad in ["", "/abs/path.glb", "http://evil/x.glb", "../escape.glb"] {
+            assert!(
+                matches!(call(bad, safe_sub), Err(Tiles3dError::InvalidUri(_))),
+                "content_uri {bad:?} should be rejected"
+            );
+            assert!(
+                matches!(call(safe, bad), Err(Tiles3dError::InvalidUri(_))),
+                "subtree_uri {bad:?} should be rejected"
+            );
+        }
+        assert!(call(safe, safe_sub).is_ok());
     }
 }

--- a/crates/ds-3dtiles/src/voxels.rs
+++ b/crates/ds-3dtiles/src/voxels.rs
@@ -151,19 +151,22 @@ pub fn encode_voxels_glb(grid: &VoxelGrid) -> Result<Vec<u8>, Tiles3dError> {
 /// index in the native grid.
 ///
 /// The grid's angle axis is radar azimuth: index `a` is the bearing
-/// `(a+0.5)·360/nA` **degrees clockwise from North**. CesiumJS, however, places
-/// glTF angle slot `s` at cylinder angle `φ = -π + (s+0.5)/nA·2π`, measured
-/// **counter-clockwise from local +X**, and our ENU→ECEF tile transform makes
-/// local +X = East, +Y = North. The compass bearing of that direction is
-/// `90° - φ`. So slot `s` must be filled from the azimuth bin nearest that
-/// bearing — a reflection plus a 90° offset. Skipping this remap renders the
-/// volume rotated 90° **and** mirrored (North-CW vs East-CCW), which is exactly
-/// the misplacement seen against the (absolutely-positioned) point-cloud and
-/// mesh products. Periodic, so the result is always a valid `0..nA` index.
+/// `(a+0.5)·360/nA` **degrees clockwise from North**. CesiumJS places glTF angle
+/// slot `s` at cylinder angle `φ = -π + (s+0.5)/nA·2π` (counter-clockwise; the
+/// 1.142 `VoxelCylinderShape` default bounds are -π..+π). Mapping that to a
+/// compass bearing and reading the matching radar bin corrects the North-CW vs
+/// East-CCW mismatch (a reflection + rotation). The bearing is
+/// `270° - φ`, **not** the `90° - φ` that the +X=East tile transform alone
+/// predicts: render-verification against the (absolutely-positioned) point cloud
+/// showed the naive `90° - φ` still 180°-rotated — CesiumJS's effective cylinder
+/// angle origin sits opposite (-X) to where the stated -π bound + ENU transform
+/// imply, so a +180° term is required. With it, the voxel echo footprint matches
+/// the point cloud exactly. Periodic, so the result is always a valid `0..nA`
+/// index.
 fn grid_azimuth_index(slot: usize, n_a: usize) -> usize {
     use std::f64::consts::{PI, TAU};
     let phi = -PI + (slot as f64 + 0.5) * TAU / n_a as f64;
-    let bearing_deg = 90.0 - phi.to_degrees();
+    let bearing_deg = 270.0 - phi.to_degrees();
     (bearing_deg / 360.0 * n_a as f64 - 0.5)
         .round()
         .rem_euclid(n_a as f64) as usize

--- a/crates/ds-3dtiles/src/voxels.rs
+++ b/crates/ds-3dtiles/src/voxels.rs
@@ -156,7 +156,7 @@ pub fn encode_voxels_glb(grid: &VoxelGrid) -> Result<Vec<u8>, Tiles3dError> {
         "buffers": [{ "byteLength": byte_len }]
     });
 
-    assemble_glb(&gltf, bin)
+    crate::assemble_glb(&gltf, bin)
 }
 
 /// Map a glTF/CesiumJS cylinder **angle slot** to the source **radar-azimuth**
@@ -268,34 +268,6 @@ fn voxel_schema(quantity: &str) -> serde_json::Value {
             }
         }
     })
-}
-
-/// Assemble a binary glTF (`.glb`) from a glТF JSON value + a BIN buffer. Both
-/// chunks are padded to a 4-byte boundary (JSON with spaces, BIN with zeros) per
-/// the glTF 2.0 spec.
-fn assemble_glb(gltf: &serde_json::Value, mut bin: Vec<u8>) -> Result<Vec<u8>, Tiles3dError> {
-    let mut json_bytes =
-        serde_json::to_vec(gltf).map_err(|e| Tiles3dError::Serialize(e.to_string()))?;
-    while !json_bytes.len().is_multiple_of(4) {
-        json_bytes.push(b' ');
-    }
-    while !bin.len().is_multiple_of(4) {
-        bin.push(0);
-    }
-    let total = 12 + 8 + json_bytes.len() + 8 + bin.len();
-    let total = u32::try_from(total).map_err(|_| Tiles3dError::TooLarge("glb byteLength"))?;
-
-    let mut glb = Vec::with_capacity(total as usize);
-    glb.extend_from_slice(b"glTF");
-    glb.extend_from_slice(&2u32.to_le_bytes()); // version
-    glb.extend_from_slice(&total.to_le_bytes());
-    glb.extend_from_slice(&(json_bytes.len() as u32).to_le_bytes());
-    glb.extend_from_slice(b"JSON");
-    glb.extend_from_slice(&json_bytes);
-    glb.extend_from_slice(&(bin.len() as u32).to_le_bytes());
-    glb.extend_from_slice(b"BIN\0");
-    glb.extend_from_slice(&bin);
-    Ok(glb)
 }
 
 /// Build the implicit-tiling voxel **tileset.json** for one cylinder tile. The
@@ -412,6 +384,12 @@ pub fn tileset_json_voxels(
                 "uri": content_uri,
                 "extensions": {
                     "3DTILES_content_voxels": {
+                        // Content/radar order `[radius, angle, height]` here —
+                        // deliberately NOT the glb's `EXT_primitive_voxels.dimensions`
+                        // `[radius, height, angle]` (the axis-swapped glТF order).
+                        // Render-verified: CesiumJS takes the actual layout from
+                        // the glb field, so this one is advisory; keep it in the
+                        // natural content order.
                         "dimensions": [n_r, n_a, n_h],
                         "class": "voxel"
                     }

--- a/crates/ds-3dtiles/src/voxels.rs
+++ b/crates/ds-3dtiles/src/voxels.rs
@@ -144,12 +144,26 @@ pub fn encode_voxels_glb(grid: &VoxelGrid) -> Result<Vec<u8>, Tiles3dError> {
     assemble_glb(&gltf, bin)
 }
 
-/// Light separable 3-D smoothing of the (NaN-filled) grid in its native
-/// `[radius, angle, height]` index order — a `[0.25, 0.5, 0.25]` kernel along
-/// each axis. Merges the cellular radar field so a voxel render doesn't show one
-/// blob per cell. Angle wraps (full circle); radius/height clamp at the ends.
-/// Three passes ping-pong between two buffers.
+/// Separable 3-D smoothing of the (NaN-filled) grid in its native
+/// `[radius, angle, height]` index order — `PASSES` applications of a
+/// `[0.25, 0.5, 0.25]` kernel along each axis.
+///
+/// Radar echo is **cellular** (each native cell a local reflectivity maximum)
+/// and the voxel grid is coarse in height (~300 m layers), so a *single* pass
+/// still leaves the cell floors (height-layer boundaries) and walls
+/// (radial/angular boundaries) visible under GPU trilinear interpolation when
+/// the camera is close or inside the volume — trilinear is only C0, so every
+/// cell boundary is a faint crease whose visibility scales with the field's
+/// cell-to-cell contrast. Repeated passes widen the effective Gaussian
+/// (`sigma ≈ sqrt(PASSES/2)` cells), dropping that contrast until the field
+/// reads as a continuous volume. Angle wraps (full circle); radius/height clamp
+/// at the ends. Each axis sweep ping-pongs `src`↔`dst`, so the result is always
+/// in `src` regardless of the pass count.
 fn smooth_grid(vals: Vec<f32>, dims: [usize; 3]) -> Vec<f32> {
+    // 4 passes ⇒ sigma ≈ 1.4 cells (FWHM ≈ 3.3): dissolves the cell lattice —
+    // height floors and the fainter angular-sector walls — at close zoom without
+    // smearing storm cores into a flat haze.
+    const PASSES: usize = 4;
     let [n_r, n_a, n_h] = dims;
     let idx = |r: usize, a: usize, h: usize| VoxelGrid::index_of(dims, r, a, h);
     let blur = |lo: f32, mid: f32, hi: f32| 0.25 * lo + 0.5 * mid + 0.25 * hi;
@@ -157,39 +171,42 @@ fn smooth_grid(vals: Vec<f32>, dims: [usize; 3]) -> Vec<f32> {
     let mut src = vals;
     let mut dst = vec![0.0f32; src.len()];
 
-    // Height (clamp).
-    for r in 0..n_r {
+    for _ in 0..PASSES {
+        // Height (clamp).
+        for r in 0..n_r {
+            for a in 0..n_a {
+                for h in 0..n_h {
+                    let lo = src[idx(r, a, h.saturating_sub(1))];
+                    let hi = src[idx(r, a, (h + 1).min(n_h - 1))];
+                    dst[idx(r, a, h)] = blur(lo, src[idx(r, a, h)], hi);
+                }
+            }
+        }
+        std::mem::swap(&mut src, &mut dst);
+        // Angle (periodic).
+        for r in 0..n_r {
+            for h in 0..n_h {
+                for a in 0..n_a {
+                    let lo = src[idx(r, (a + n_a - 1) % n_a, h)];
+                    let hi = src[idx(r, (a + 1) % n_a, h)];
+                    dst[idx(r, a, h)] = blur(lo, src[idx(r, a, h)], hi);
+                }
+            }
+        }
+        std::mem::swap(&mut src, &mut dst);
+        // Radius (clamp).
         for a in 0..n_a {
             for h in 0..n_h {
-                let lo = src[idx(r, a, h.saturating_sub(1))];
-                let hi = src[idx(r, a, (h + 1).min(n_h - 1))];
-                dst[idx(r, a, h)] = blur(lo, src[idx(r, a, h)], hi);
+                for r in 0..n_r {
+                    let lo = src[idx(r.saturating_sub(1), a, h)];
+                    let hi = src[idx((r + 1).min(n_r - 1), a, h)];
+                    dst[idx(r, a, h)] = blur(lo, src[idx(r, a, h)], hi);
+                }
             }
         }
+        std::mem::swap(&mut src, &mut dst);
     }
-    std::mem::swap(&mut src, &mut dst);
-    // Angle (periodic).
-    for r in 0..n_r {
-        for h in 0..n_h {
-            for a in 0..n_a {
-                let lo = src[idx(r, (a + n_a - 1) % n_a, h)];
-                let hi = src[idx(r, (a + 1) % n_a, h)];
-                dst[idx(r, a, h)] = blur(lo, src[idx(r, a, h)], hi);
-            }
-        }
-    }
-    std::mem::swap(&mut src, &mut dst);
-    // Radius (clamp).
-    for a in 0..n_a {
-        for h in 0..n_h {
-            for r in 0..n_r {
-                let lo = src[idx(r.saturating_sub(1), a, h)];
-                let hi = src[idx((r + 1).min(n_r - 1), a, h)];
-                dst[idx(r, a, h)] = blur(lo, src[idx(r, a, h)], hi);
-            }
-        }
-    }
-    dst
+    src
 }
 
 /// The `EXT_structural_metadata` schema for one scalar voxel property named

--- a/crates/ds-3dtiles/src/voxels.rs
+++ b/crates/ds-3dtiles/src/voxels.rs
@@ -22,7 +22,7 @@
 //!   constant-availability subtree.
 
 use ds_core::geo::geodetic_to_ecef;
-use ds_core::volume::VoxelGrid;
+use ds_core::volume::{VoxelGrid, NO_ECHO_FLOOR_DBZ};
 use serde_json::json;
 
 use crate::Tiles3dError;
@@ -31,11 +31,6 @@ use crate::Tiles3dError;
 /// `0x80000000`, ellipsoid `0x80000001`; the high bit marks voxels, the low bits
 /// the shape. Read from the CesiumJS fixtures (not the draft README).
 const VOXEL_MODE_CYLINDER: u64 = 2_147_483_650;
-
-/// Finite sentinel written for `NaN`/nodata cells (the cone of silence / clear
-/// air the grid leaves unmeasured). Declared as the attribute's `noData`, so
-/// CesiumJS treats those cells as empty. Well outside any physical dBZ.
-const NODATA_SENTINEL: f32 = -9999.0;
 
 /// Encode a cylindrical [`VoxelGrid`] as an `EXT_primitive_voxels` glТF `.glb`
 /// (self-contained: the float data is embedded in the BIN chunk). The single
@@ -62,9 +57,17 @@ pub fn encode_voxels_glb(grid: &VoxelGrid) -> Result<Vec<u8>, Tiles3dError> {
 
     // Transpose our `[radius, angle, height]` grid (height-fastest) into the glТF
     // cylinder layout `[radius, height, angle]` (radius-fastest → height →
-    // angle-slowest). Track the finite value range for the transfer function;
-    // NaN/nodata → the sentinel.
+    // angle-slowest), and fill **unmeasured** (`NaN`: cone of silence, below the
+    // lowest beam, beyond range) cells with the no-echo floor — NOT an extreme
+    // nodata sentinel. CesiumJS *trilinearly interpolates* the metadata before
+    // the shader, so an extreme sentinel makes the echo→unmeasured transition
+    // razor-sharp and grid-aligned → flat **walls and floors** at the volume
+    // boundaries. Filling with the clear-air floor (which the transfer function
+    // makes transparent, like real clear air) keeps those transitions gentle.
+    // So no `noData` is declared — the whole cylinder is a dense field whose low
+    // end the transfer function fades out.
     let mut bin = Vec::with_capacity(count * 4);
+    let mut any_finite = false;
     let mut vmin = f32::INFINITY;
     let mut vmax = f32::NEG_INFINITY;
     for i_a in 0..n_a {
@@ -72,18 +75,19 @@ pub fn encode_voxels_glb(grid: &VoxelGrid) -> Result<Vec<u8>, Tiles3dError> {
             for i_r in 0..n_r {
                 let v = grid.values[grid.index(i_r, i_a, i_h)];
                 let f = if v.is_finite() {
-                    vmin = vmin.min(v);
-                    vmax = vmax.max(v);
+                    any_finite = true;
                     v
                 } else {
-                    NODATA_SENTINEL
+                    NO_ECHO_FLOOR_DBZ
                 };
+                vmin = vmin.min(f);
+                vmax = vmax.max(f);
                 bin.extend_from_slice(&f.to_le_bytes());
             }
         }
     }
-    if !vmin.is_finite() {
-        return Err(Tiles3dError::Empty); // every cell nodata
+    if !any_finite {
+        return Err(Tiles3dError::Empty); // every cell unmeasured — nothing to render
     }
 
     let q = grid.quantity.clone();
@@ -97,10 +101,10 @@ pub fn encode_voxels_glb(grid: &VoxelGrid) -> Result<Vec<u8>, Tiles3dError> {
                 "mode": VOXEL_MODE_CYLINDER,
                 "attributes": { "_VOXEL": 0 },
                 "extensions": {
-                    "EXT_primitive_voxels": {
-                        "dimensions": [n_r, n_h, n_a],
-                        "noData": { "_VOXEL": [NODATA_SENTINEL] }
-                    }
+                    // No `noData`: unmeasured cells carry the no-echo floor (a
+                    // real low dBZ the transfer function fades out), so the field
+                    // is dense and CesiumJS interpolates it without hard walls.
+                    "EXT_primitive_voxels": { "dimensions": [n_r, n_h, n_a] }
                 }
             }]
         }],
@@ -140,8 +144,7 @@ fn voxel_schema(quantity: &str) -> serde_json::Value {
                 "properties": {
                     quantity: {
                         "type": "SCALAR",
-                        "componentType": "FLOAT32",
-                        "noData": NODATA_SENTINEL
+                        "componentType": "FLOAT32"
                     }
                 }
             }
@@ -402,15 +405,30 @@ mod tests {
     }
 
     #[test]
-    fn nodata_becomes_sentinel_and_all_nodata_is_empty() {
+    fn unmeasured_becomes_floor_and_all_unmeasured_is_empty() {
         let mut g = grid(2, 2, 2);
         let idx = g.index(0, 0, 0);
         g.values[idx] = f32::NAN;
         let glb = encode_voxels_glb(&g).expect("encode");
-        let (_, bin) = parse_glb(&glb);
+        let (j, bin) = parse_glb(&glb);
         let f = |i: usize| f32::from_le_bytes(bin[i * 4..i * 4 + 4].try_into().unwrap());
-        assert_eq!(f(0), NODATA_SENTINEL, "NaN cell → sentinel");
+        // Unmeasured → the no-echo floor (a real low dBZ), NOT an extreme nodata
+        // sentinel — so CesiumJS's interpolation has no razor-sharp wall.
+        assert_eq!(f(0), NO_ECHO_FLOOR_DBZ, "NaN cell → no-echo floor");
+        // No `noData` is declared, on the primitive or the schema.
+        assert!(
+            j["meshes"][0]["primitives"][0]["extensions"]["EXT_primitive_voxels"]
+                .get("noData")
+                .is_none()
+        );
+        assert!(
+            j["extensions"]["EXT_structural_metadata"]["schema"]["classes"]["voxel"]["properties"]
+                ["DBZH"]
+                .get("noData")
+                .is_none()
+        );
 
+        // Every cell unmeasured → nothing real to render → Empty.
         let mut empty = grid(2, 2, 2);
         empty.values.iter_mut().for_each(|v| *v = f32::NAN);
         assert!(matches!(

--- a/crates/ds-3dtiles/src/voxels.rs
+++ b/crates/ds-3dtiles/src/voxels.rs
@@ -55,39 +55,49 @@ pub fn encode_voxels_glb(grid: &VoxelGrid) -> Result<Vec<u8>, Tiles3dError> {
         .and_then(|n| u32::try_from(n).ok())
         .ok_or(Tiles3dError::TooLarge("voxel buffer"))?;
 
-    // Transpose our `[radius, angle, height]` grid (height-fastest) into the glТF
-    // cylinder layout `[radius, height, angle]` (radius-fastest → height →
-    // angle-slowest), and fill **unmeasured** (`NaN`: cone of silence, below the
-    // lowest beam, beyond range) cells with the no-echo floor — NOT an extreme
-    // nodata sentinel. CesiumJS *trilinearly interpolates* the metadata before
-    // the shader, so an extreme sentinel makes the echo→unmeasured transition
-    // razor-sharp and grid-aligned → flat **walls and floors** at the volume
-    // boundaries. Filling with the clear-air floor (which the transfer function
-    // makes transparent, like real clear air) keeps those transitions gentle.
-    // So no `noData` is declared — the whole cylinder is a dense field whose low
-    // end the transfer function fades out.
-    let mut bin = Vec::with_capacity(count * 4);
+    // Fill **unmeasured** (`NaN`: cone of silence, below the lowest beam, beyond
+    // range) cells with the no-echo floor — NOT an extreme nodata sentinel.
+    // CesiumJS *trilinearly interpolates* the metadata before the shader, so an
+    // extreme sentinel makes the echo→unmeasured transition razor-sharp and
+    // grid-aligned. The floor (which the transfer function makes transparent,
+    // like real clear air) keeps those transitions gentle; no `noData` is
+    // declared, so the whole cylinder is a dense field whose low end fades out.
+    let mut native: Vec<f32> = Vec::with_capacity(count);
     let mut any_finite = false;
+    for &v in &grid.values {
+        if v.is_finite() {
+            any_finite = true;
+            native.push(v);
+        } else {
+            native.push(NO_ECHO_FLOOR_DBZ);
+        }
+    }
+    if !any_finite {
+        return Err(Tiles3dError::Empty); // every cell unmeasured — nothing to render
+    }
+    // Radar echo is **cellular** — each ~native-resolution cell is a local
+    // reflectivity maximum, so even with GPU trilinear interpolation a raw render
+    // shows one blob per cell (a visible grid of cells at close zoom). A light
+    // separable 3-D smoothing merges adjacent cells into a continuous field — the
+    // standard radar-volume reconstruction. Angle is periodic (full circle);
+    // radius/height clamp at the ends.
+    let native = smooth_grid(native, grid.dims);
+
+    // Transpose the smoothed grid from native `[radius, angle, height]`
+    // (height-fastest) into the glТF cylinder layout `[radius, height, angle]`
+    // (radius-fastest → height → angle-slowest), and track the range.
+    let mut bin = Vec::with_capacity(count * 4);
     let mut vmin = f32::INFINITY;
     let mut vmax = f32::NEG_INFINITY;
     for i_a in 0..n_a {
         for i_h in 0..n_h {
             for i_r in 0..n_r {
-                let v = grid.values[grid.index(i_r, i_a, i_h)];
-                let f = if v.is_finite() {
-                    any_finite = true;
-                    v
-                } else {
-                    NO_ECHO_FLOOR_DBZ
-                };
+                let f = native[grid.index(i_r, i_a, i_h)];
                 vmin = vmin.min(f);
                 vmax = vmax.max(f);
                 bin.extend_from_slice(&f.to_le_bytes());
             }
         }
-    }
-    if !any_finite {
-        return Err(Tiles3dError::Empty); // every cell unmeasured — nothing to render
     }
 
     let q = grid.quantity.clone();
@@ -132,6 +142,54 @@ pub fn encode_voxels_glb(grid: &VoxelGrid) -> Result<Vec<u8>, Tiles3dError> {
     });
 
     assemble_glb(&gltf, bin)
+}
+
+/// Light separable 3-D smoothing of the (NaN-filled) grid in its native
+/// `[radius, angle, height]` index order — a `[0.25, 0.5, 0.25]` kernel along
+/// each axis. Merges the cellular radar field so a voxel render doesn't show one
+/// blob per cell. Angle wraps (full circle); radius/height clamp at the ends.
+/// Three passes ping-pong between two buffers.
+fn smooth_grid(vals: Vec<f32>, dims: [usize; 3]) -> Vec<f32> {
+    let [n_r, n_a, n_h] = dims;
+    let idx = |r: usize, a: usize, h: usize| VoxelGrid::index_of(dims, r, a, h);
+    let blur = |lo: f32, mid: f32, hi: f32| 0.25 * lo + 0.5 * mid + 0.25 * hi;
+
+    let mut src = vals;
+    let mut dst = vec![0.0f32; src.len()];
+
+    // Height (clamp).
+    for r in 0..n_r {
+        for a in 0..n_a {
+            for h in 0..n_h {
+                let lo = src[idx(r, a, h.saturating_sub(1))];
+                let hi = src[idx(r, a, (h + 1).min(n_h - 1))];
+                dst[idx(r, a, h)] = blur(lo, src[idx(r, a, h)], hi);
+            }
+        }
+    }
+    std::mem::swap(&mut src, &mut dst);
+    // Angle (periodic).
+    for r in 0..n_r {
+        for h in 0..n_h {
+            for a in 0..n_a {
+                let lo = src[idx(r, (a + n_a - 1) % n_a, h)];
+                let hi = src[idx(r, (a + 1) % n_a, h)];
+                dst[idx(r, a, h)] = blur(lo, src[idx(r, a, h)], hi);
+            }
+        }
+    }
+    std::mem::swap(&mut src, &mut dst);
+    // Radius (clamp).
+    for a in 0..n_a {
+        for h in 0..n_h {
+            for r in 0..n_r {
+                let lo = src[idx(r.saturating_sub(1), a, h)];
+                let hi = src[idx((r + 1).min(n_r - 1), a, h)];
+                dst[idx(r, a, h)] = blur(lo, src[idx(r, a, h)], hi);
+            }
+        }
+    }
+    dst
 }
 
 /// The `EXT_structural_metadata` schema for one scalar voxel property named
@@ -385,23 +443,38 @@ mod tests {
         assert_eq!(pa["properties"]["DBZH"]["attribute"], "_VOXEL");
         assert_eq!(j["extensionsRequired"][0], "EXT_primitive_voxels");
 
-        // Accessor: SCALAR FLOAT, one element per cell, range = [0, 2] (height idx).
+        // Accessor: SCALAR FLOAT, one element per cell. The 3-D smoothing shifts
+        // the boundary values inward, so the range is within [0, 2] (height idx).
         let acc = &j["accessors"][0];
         assert_eq!(acc["componentType"], 5126);
         assert_eq!(acc["count"], 24);
-        assert_eq!(acc["min"], json!([0.0]));
-        assert_eq!(acc["max"], json!([2.0]));
         assert_eq!(bin.len(), 24 * 4);
+        let amin = acc["min"][0].as_f64().unwrap();
+        let amax = acc["max"][0].as_f64().unwrap();
+        assert!(amin >= 0.0 && amax <= 2.0 && amin < amax, "{amin}..{amax}");
 
         // Data layout: glТF order is radius-fastest → height → angle-slowest, and
-        // value == height index. So the first `n_r` floats (radius run at h=0)
-        // are 0.0, the next `n_r` (h=1) are 1.0, then h=2 → 2.0; that block of
-        // n_r*n_h repeats per angle slice.
+        // value == height index (constant across radius+angle). Assert the
+        // *structure* (robust to the smoothing): each radius run is flat, height
+        // increases monotonically, and the per-angle block repeats.
         let f = |i: usize| f32::from_le_bytes(bin[i * 4..i * 4 + 4].try_into().unwrap());
-        assert_eq!([f(0), f(1)], [0.0, 0.0]); // radius run, height 0
-        assert_eq!([f(2), f(3)], [1.0, 1.0]); // radius run, height 1
-        assert_eq!([f(4), f(5)], [2.0, 2.0]); // radius run, height 2
-        assert_eq!(f(6), 0.0); // next angle slice restarts at height 0
+        assert_eq!(
+            f(0),
+            f(1),
+            "radius run is flat (value independent of radius)"
+        );
+        assert!(
+            f(2) > f(0) && f(4) > f(2),
+            "height increases: {} {} {}",
+            f(0),
+            f(2),
+            f(4)
+        );
+        assert_eq!(
+            f(6),
+            f(0),
+            "next angle slice repeats (value independent of angle)"
+        );
     }
 
     #[test]
@@ -411,10 +484,18 @@ mod tests {
         g.values[idx] = f32::NAN;
         let glb = encode_voxels_glb(&g).expect("encode");
         let (j, bin) = parse_glb(&glb);
-        let f = |i: usize| f32::from_le_bytes(bin[i * 4..i * 4 + 4].try_into().unwrap());
         // Unmeasured → the no-echo floor (a real low dBZ), NOT an extreme nodata
-        // sentinel — so CesiumJS's interpolation has no razor-sharp wall.
-        assert_eq!(f(0), NO_ECHO_FLOOR_DBZ, "NaN cell → no-echo floor");
+        // sentinel — so every (smoothed) cell stays ≥ the floor and CesiumJS's
+        // interpolation has no razor-sharp wall toward -9999.
+        let vals: Vec<f32> = bin
+            .chunks_exact(4)
+            .map(|c| f32::from_le_bytes(c.try_into().unwrap()))
+            .collect();
+        assert!(
+            vals.iter().all(|&v| v >= NO_ECHO_FLOOR_DBZ - 1e-3),
+            "no extreme sentinel; min = {:?}",
+            vals.iter().cloned().fold(f32::INFINITY, f32::min)
+        );
         // No `noData` is declared, on the primitive or the schema.
         assert!(
             j["meshes"][0]["primitives"][0]["extensions"]["EXT_primitive_voxels"]

--- a/crates/ds-3dtiles/src/voxels.rs
+++ b/crates/ds-3dtiles/src/voxels.rs
@@ -638,4 +638,24 @@ mod tests {
         }
         assert!(call(safe, safe_sub).is_ok());
     }
+
+    #[test]
+    fn azimuth_remap_pins_the_render_verified_270_offset() {
+        // `grid_azimuth_index` carries the one value in this encoder that a
+        // structural/round-trip test can't catch: the **270° − φ** offset, which
+        // is render-verified against the point cloud (CesiumJS's effective
+        // cylinder-angle origin sits opposite to its spec — see the fn docs). For
+        // n_a = 360 the mapping reduces to `(449 − slot) mod 360`; pin a few
+        // points so a future CesiumJS convention shift trips this test rather
+        // than silently rotating the volume.
+        assert_eq!(grid_azimuth_index(0, 360), 89);
+        assert_eq!(grid_azimuth_index(90, 360), 359);
+        assert_eq!(grid_azimuth_index(180, 360), 269);
+        assert_eq!(grid_azimuth_index(270, 360), 179);
+        // Must be a bijection over 0..n_a — every radar azimuth bin used exactly
+        // once (no bin dropped or doubled by a bad offset/rounding).
+        let mapped: std::collections::HashSet<usize> =
+            (0..360).map(|s| grid_azimuth_index(s, 360)).collect();
+        assert_eq!(mapped.len(), 360);
+    }
 }

--- a/crates/ds-3dtiles/src/voxels.rs
+++ b/crates/ds-3dtiles/src/voxels.rs
@@ -355,7 +355,12 @@ pub fn tileset_json_voxels(
             "classes": {
                 "voxel": {
                     "properties": {
-                        quantity: { "min": [stat_min], "max": [stat_max] }
+                        // `min`/`max` are BARE SCALARS for a SCALAR property per
+                        // the 3D Tiles 1.1 EXT_structural_metadata statistics
+                        // schema (the array form is for VEC2/VEC3/…). CesiumJS
+                        // 1.142 tolerates the array, but a conforming validator
+                        // rejects it.
+                        quantity: { "min": stat_min, "max": stat_max }
                     }
                 }
             }
@@ -604,7 +609,7 @@ mod tests {
         // Statistics drive the transfer-function range.
         assert_eq!(
             v["statistics"]["classes"]["voxel"]["properties"]["DBZH"]["max"],
-            json!([70.0])
+            json!(70.0) // bare SCALAR per EXT_structural_metadata, not an array
         );
     }
 

--- a/crates/ds-3dtiles/src/voxels.rs
+++ b/crates/ds-3dtiles/src/voxels.rs
@@ -11,7 +11,7 @@
 //!   README's `2147483647` is wrong);
 //! - the per-cell scalar is a custom vertex attribute (`_VOXEL`), no `POSITION`,
 //!   no indices; the buffer is embedded in the glb BIN chunk;
-//! - `EXT_structural_metadata` (schema + `propertyAttributes`) lives at the glТF
+//! - `EXT_structural_metadata` (schema + `propertyAttributes`) lives at the glTF
 //!   **top level**, not on the primitive;
 //! - **axis swap**: a content grid `[radius, angle, height]` becomes glTF
 //!   `EXT_primitive_voxels.dimensions` `[radius, height, angle]`, and the data
@@ -32,7 +32,7 @@ use crate::Tiles3dError;
 /// the shape. Read from the CesiumJS fixtures (not the draft README).
 const VOXEL_MODE_CYLINDER: u64 = 2_147_483_650;
 
-/// Encode a cylindrical [`VoxelGrid`] as an `EXT_primitive_voxels` glТF `.glb`
+/// Encode a cylindrical [`VoxelGrid`] as an `EXT_primitive_voxels` glTF `.glb`
 /// (self-contained: the float data is embedded in the BIN chunk). The single
 /// scalar property is named after `grid.quantity`.
 ///
@@ -96,7 +96,7 @@ pub fn encode_voxels_glb(grid: &VoxelGrid) -> Result<Vec<u8>, Tiles3dError> {
     let native = smooth_grid(native, grid.dims);
 
     // Transpose the smoothed grid from native `[radius, angle, height]`
-    // (height-fastest) into the glТF cylinder layout `[radius, height, angle]`
+    // (height-fastest) into the glTF cylinder layout `[radius, height, angle]`
     // (radius-fastest → height → angle-slowest), remapping the angle axis from
     // the radar-azimuth convention to CesiumJS's cylinder convention (see
     // [`grid_azimuth_index`]), and track the range.
@@ -223,12 +223,17 @@ fn smooth_grid(vals: Vec<f32>, dims: [usize; 3]) -> Vec<f32> {
             }
         }
         std::mem::swap(&mut src, &mut dst);
-        // Angle (periodic).
+        // Angle (periodic). `h` (stride 1) innermost, `a` (stride n_h) in the
+        // middle: an `a`-innermost sweep would jump `n_h` elements per step.
+        // Hoist the periodic neighbour indices out of the `h` loop. Same result,
+        // stride-1 access on all three touched rows.
         for r in 0..n_r {
-            for h in 0..n_h {
-                for a in 0..n_a {
-                    let lo = src[idx(r, (a + n_a - 1) % n_a, h)];
-                    let hi = src[idx(r, (a + 1) % n_a, h)];
+            for a in 0..n_a {
+                let a_lo = (a + n_a - 1) % n_a;
+                let a_hi = (a + 1) % n_a;
+                for h in 0..n_h {
+                    let lo = src[idx(r, a_lo, h)];
+                    let hi = src[idx(r, a_hi, h)];
                     dst[idx(r, a, h)] = blur(lo, src[idx(r, a, h)], hi);
                 }
             }
@@ -253,7 +258,7 @@ fn smooth_grid(vals: Vec<f32>, dims: [usize; 3]) -> Vec<f32> {
 }
 
 /// The `EXT_structural_metadata` schema for one scalar voxel property named
-/// `quantity` (shared by the glТF and the tileset so the classes match).
+/// `quantity` (shared by the glTF and the tileset so the classes match).
 fn voxel_schema(quantity: &str) -> serde_json::Value {
     json!({
         "id": "voxel",
@@ -386,7 +391,7 @@ pub fn tileset_json_voxels(
                     "3DTILES_content_voxels": {
                         // Content/radar order `[radius, angle, height]` here —
                         // deliberately NOT the glb's `EXT_primitive_voxels.dimensions`
-                        // `[radius, height, angle]` (the axis-swapped glТF order).
+                        // `[radius, height, angle]` (the axis-swapped glTF order).
                         // Render-verified: CesiumJS takes the actual layout from
                         // the glb field, so this one is advisory; keep it in the
                         // natural content order.
@@ -411,7 +416,7 @@ pub fn tileset_json_voxels(
 /// The implicit-tiling **subtree** for a single available tile: the one level-0
 /// tile and its content are present, with no child subtrees. A JSON subtree (3D
 /// Tiles 1.1) with constant availability — matches the CesiumJS fixture.
-pub fn voxel_subtree_json() -> String {
+pub fn voxel_subtree_json() -> Result<String, Tiles3dError> {
     let subtree = json!({
         "tileAvailability": { "constant": 1, "availableCount": 1 },
         // Per the 3D Tiles 1.1 implicit-tiling spec, `contentAvailability` is an
@@ -422,7 +427,7 @@ pub fn voxel_subtree_json() -> String {
         "contentAvailability": [{ "constant": 1, "availableCount": 1 }],
         "childSubtreeAvailability": { "constant": 0, "availableCount": 0 }
     });
-    serde_json::to_string(&subtree).expect("subtree serializes")
+    serde_json::to_string(&subtree).map_err(|e| Tiles3dError::Serialize(e.to_string()))
 }
 
 #[cfg(test)]
@@ -508,7 +513,7 @@ mod tests {
         let amax = acc["max"][0].as_f64().unwrap();
         assert!(amin >= 0.0 && amax <= 2.0 && amin < amax, "{amin}..{amax}");
 
-        // Data layout: glТF order is radius-fastest → height → angle-slowest, and
+        // Data layout: glTF order is radius-fastest → height → angle-slowest, and
         // value == height index (constant across radius+angle). Assert the
         // *structure* (robust to the smoothing): each radius run is flat, height
         // increases monotonically, and the per-angle block repeats.

--- a/crates/ds-3dtiles/src/voxels.rs
+++ b/crates/ds-3dtiles/src/voxels.rs
@@ -85,11 +85,14 @@ pub fn encode_voxels_glb(grid: &VoxelGrid) -> Result<Vec<u8>, Tiles3dError> {
 
     // Transpose the smoothed grid from native `[radius, angle, height]`
     // (height-fastest) into the glТF cylinder layout `[radius, height, angle]`
-    // (radius-fastest → height → angle-slowest), and track the range.
+    // (radius-fastest → height → angle-slowest), remapping the angle axis from
+    // the radar-azimuth convention to CesiumJS's cylinder convention (see
+    // [`grid_azimuth_index`]), and track the range.
     let mut bin = Vec::with_capacity(count * 4);
     let mut vmin = f32::INFINITY;
     let mut vmax = f32::NEG_INFINITY;
-    for i_a in 0..n_a {
+    for slot in 0..n_a {
+        let i_a = grid_azimuth_index(slot, n_a);
         for i_h in 0..n_h {
             for i_r in 0..n_r {
                 let f = native[grid.index(i_r, i_a, i_h)];
@@ -142,6 +145,28 @@ pub fn encode_voxels_glb(grid: &VoxelGrid) -> Result<Vec<u8>, Tiles3dError> {
     });
 
     assemble_glb(&gltf, bin)
+}
+
+/// Map a glTF/CesiumJS cylinder **angle slot** to the source **radar-azimuth**
+/// index in the native grid.
+///
+/// The grid's angle axis is radar azimuth: index `a` is the bearing
+/// `(a+0.5)·360/nA` **degrees clockwise from North**. CesiumJS, however, places
+/// glTF angle slot `s` at cylinder angle `φ = -π + (s+0.5)/nA·2π`, measured
+/// **counter-clockwise from local +X**, and our ENU→ECEF tile transform makes
+/// local +X = East, +Y = North. The compass bearing of that direction is
+/// `90° - φ`. So slot `s` must be filled from the azimuth bin nearest that
+/// bearing — a reflection plus a 90° offset. Skipping this remap renders the
+/// volume rotated 90° **and** mirrored (North-CW vs East-CCW), which is exactly
+/// the misplacement seen against the (absolutely-positioned) point-cloud and
+/// mesh products. Periodic, so the result is always a valid `0..nA` index.
+fn grid_azimuth_index(slot: usize, n_a: usize) -> usize {
+    use std::f64::consts::{PI, TAU};
+    let phi = -PI + (slot as f64 + 0.5) * TAU / n_a as f64;
+    let bearing_deg = 90.0 - phi.to_degrees();
+    (bearing_deg / 360.0 * n_a as f64 - 0.5)
+        .round()
+        .rem_euclid(n_a as f64) as usize
 }
 
 /// Separable 3-D smoothing of the (NaN-filled) grid in its native

--- a/crates/ds-3dtiles/src/voxels.rs
+++ b/crates/ds-3dtiles/src/voxels.rs
@@ -55,6 +55,18 @@ pub fn encode_voxels_glb(grid: &VoxelGrid) -> Result<Vec<u8>, Tiles3dError> {
         .and_then(|n| u32::try_from(n).ok())
         .ok_or(Tiles3dError::TooLarge("voxel buffer"))?;
 
+    // `count` (the accessor/buffer length) is `dims` product, but the transpose
+    // and `smooth_grid` index `grid.values` by `grid.index(dims, …)` — a values
+    // length that disagrees with `dims` would panic out-of-bounds deep inside the
+    // `spawn_blocking` task. The engine builds the two consistently; assert it
+    // (debug-only, zero release cost) so an engine bug fails loud and clear here.
+    debug_assert_eq!(
+        grid.values.len(),
+        count,
+        "voxel grid values ({}) must match dims product ({count})",
+        grid.values.len(),
+    );
+
     // Fill **unmeasured** (`NaN`: cone of silence, below the lowest beam, beyond
     // range) cells with the no-echo floor — NOT an extreme nodata sentinel.
     // CesiumJS *trilinearly interpolates* the metadata before the shader, so an
@@ -222,10 +234,13 @@ fn smooth_grid(vals: Vec<f32>, dims: [usize; 3]) -> Vec<f32> {
             }
         }
         std::mem::swap(&mut src, &mut dst);
-        // Radius (clamp).
-        for a in 0..n_a {
-            for h in 0..n_h {
-                for r in 0..n_r {
+        // Radius (clamp). Loop with `r` OUTERMOST and `h` (the fastest-varying
+        // axis, stride 1) innermost: `r` has the largest stride (`n_a*n_h`), so
+        // an `r`-innermost sweep would miss cache on nearly every step. Same
+        // result, cache-friendly access.
+        for r in 0..n_r {
+            for a in 0..n_a {
+                for h in 0..n_h {
                     let lo = src[idx(r.saturating_sub(1), a, h)];
                     let hi = src[idx((r + 1).min(n_r - 1), a, h)];
                     dst[idx(r, a, h)] = blur(lo, src[idx(r, a, h)], hi);

--- a/crates/ds-3dtiles/src/voxels.rs
+++ b/crates/ds-3dtiles/src/voxels.rs
@@ -53,7 +53,12 @@ pub fn encode_voxels_glb(grid: &VoxelGrid) -> Result<Vec<u8>, Tiles3dError> {
         return Err(Tiles3dError::Empty);
     }
     let count_u32 = u32::try_from(count).map_err(|_| Tiles3dError::TooLarge("voxel count"))?;
-    let byte_len = u32::try_from(count * 4).map_err(|_| Tiles3dError::TooLarge("voxel buffer"))?;
+    // Checked `* 4` (one f32/cell): caller may not honour MAX_VOXELS, so don't
+    // let the byte length wrap a `usize` before the `u32` bound catches it.
+    let byte_len = count
+        .checked_mul(4)
+        .and_then(|n| u32::try_from(n).ok())
+        .ok_or(Tiles3dError::TooLarge("voxel buffer"))?;
 
     // Transpose our `[radius, angle, height]` grid (height-fastest) into the glТF
     // cylinder layout `[radius, height, angle]` (radius-fastest → height →
@@ -242,6 +247,10 @@ pub fn tileset_json_voxels(
                 }
             }
         },
+        // 0 is correct here (NOT the `> 0` rule the .pnts/mesh tilesets need):
+        // this is a single-tile implicit-tiling voxel set — there is no finer LOD
+        // to refine to, and CesiumJS's voxel traversal renders the leaf directly.
+        // (When octree LOD lands, the non-leaf levels get a positive error.)
         "geometricError": 0.0,
         "extensionsUsed": ["3DTILES_bounding_volume_cylinder", "3DTILES_content_voxels"],
         "extensionsRequired": ["3DTILES_bounding_volume_cylinder", "3DTILES_content_voxels"],

--- a/crates/ds-3dtiles/src/voxels.rs
+++ b/crates/ds-3dtiles/src/voxels.rs
@@ -1,0 +1,429 @@
+//! True cylindrical voxels (#351): a [`ds_core::volume::VoxelGrid`] →
+//! `EXT_primitive_voxels` glTF `.glb` + a `3DTILES_content_voxels` /
+//! `3DTILES_bounding_volume_cylinder` tileset that CesiumJS ray-marches as a
+//! volume. The **Tier-B** path — draft, CesiumGS-only (not in the Khronos
+//! registry), CesiumJS-only — kept alongside the always-works `.pnts`/mesh
+//! products.
+//!
+//! Encoded against the live CesiumJS `VoxelCylinder3DTiles` fixtures (the draft
+//! README is stale), which pin the load-bearing details:
+//! - primitive `mode` encodes the shape: **cylinder = `2147483650`** (the
+//!   README's `2147483647` is wrong);
+//! - the per-cell scalar is a custom vertex attribute (`_VOXEL`), no `POSITION`,
+//!   no indices; the buffer is embedded in the glb BIN chunk;
+//! - `EXT_structural_metadata` (schema + `propertyAttributes`) lives at the glТF
+//!   **top level**, not on the primitive;
+//! - **axis swap**: a content grid `[radius, angle, height]` becomes glTF
+//!   `EXT_primitive_voxels.dimensions` `[radius, height, angle]`, and the data
+//!   is laid out **radius-fastest → height → angle-slowest** (our `VoxelGrid` is
+//!   the transpose — height-fastest — so the encoder reorders);
+//! - the tileset needs **implicit OCTREE tiling** + a `.subtree` availability
+//!   file (CesiumJS's voxel traversal requires it) — for one tile that's a
+//!   constant-availability subtree.
+
+use ds_core::geo::geodetic_to_ecef;
+use ds_core::volume::VoxelGrid;
+use serde_json::json;
+
+use crate::Tiles3dError;
+
+/// glTF primitive `mode` for a **cylinder** voxel grid (`0x80000002`). Box is
+/// `0x80000000`, ellipsoid `0x80000001`; the high bit marks voxels, the low bits
+/// the shape. Read from the CesiumJS fixtures (not the draft README).
+const VOXEL_MODE_CYLINDER: u64 = 2_147_483_650;
+
+/// Finite sentinel written for `NaN`/nodata cells (the cone of silence / clear
+/// air the grid leaves unmeasured). Declared as the attribute's `noData`, so
+/// CesiumJS treats those cells as empty. Well outside any physical dBZ.
+const NODATA_SENTINEL: f32 = -9999.0;
+
+/// Encode a cylindrical [`VoxelGrid`] as an `EXT_primitive_voxels` glТF `.glb`
+/// (self-contained: the float data is embedded in the BIN chunk). The single
+/// scalar property is named after `grid.quantity`.
+///
+/// Returns [`Tiles3dError::Empty`] for a zero-size grid or one with no finite
+/// cells (the tileset would have nothing to ray-march).
+pub fn encode_voxels_glb(grid: &VoxelGrid) -> Result<Vec<u8>, Tiles3dError> {
+    let [n_r, n_a, n_h] = grid.dims;
+    let count = n_r
+        .checked_mul(n_a)
+        .and_then(|x| x.checked_mul(n_h))
+        .ok_or(Tiles3dError::TooLarge("voxel count"))?;
+    if count == 0 {
+        return Err(Tiles3dError::Empty);
+    }
+    let count_u32 = u32::try_from(count).map_err(|_| Tiles3dError::TooLarge("voxel count"))?;
+    let byte_len = u32::try_from(count * 4).map_err(|_| Tiles3dError::TooLarge("voxel buffer"))?;
+
+    // Transpose our `[radius, angle, height]` grid (height-fastest) into the glТF
+    // cylinder layout `[radius, height, angle]` (radius-fastest → height →
+    // angle-slowest). Track the finite value range for the transfer function;
+    // NaN/nodata → the sentinel.
+    let mut bin = Vec::with_capacity(count * 4);
+    let mut vmin = f32::INFINITY;
+    let mut vmax = f32::NEG_INFINITY;
+    for i_a in 0..n_a {
+        for i_h in 0..n_h {
+            for i_r in 0..n_r {
+                let v = grid.values[grid.index(i_r, i_a, i_h)];
+                let f = if v.is_finite() {
+                    vmin = vmin.min(v);
+                    vmax = vmax.max(v);
+                    v
+                } else {
+                    NODATA_SENTINEL
+                };
+                bin.extend_from_slice(&f.to_le_bytes());
+            }
+        }
+    }
+    if !vmin.is_finite() {
+        return Err(Tiles3dError::Empty); // every cell nodata
+    }
+
+    let q = grid.quantity.clone();
+    let gltf = json!({
+        "asset": { "version": "2.0" },
+        "scene": 0,
+        "scenes": [{ "nodes": [0] }],
+        "nodes": [{ "mesh": 0 }],
+        "meshes": [{
+            "primitives": [{
+                "mode": VOXEL_MODE_CYLINDER,
+                "attributes": { "_VOXEL": 0 },
+                "extensions": {
+                    "EXT_primitive_voxels": {
+                        "dimensions": [n_r, n_h, n_a],
+                        "noData": { "_VOXEL": [NODATA_SENTINEL] }
+                    }
+                }
+            }]
+        }],
+        "extensionsUsed": ["EXT_primitive_voxels", "EXT_structural_metadata"],
+        "extensionsRequired": ["EXT_primitive_voxels", "EXT_structural_metadata"],
+        "extensions": {
+            "EXT_structural_metadata": {
+                "schema": voxel_schema(&q),
+                "propertyAttributes": [{
+                    "class": "voxel",
+                    "properties": { q.clone(): { "attribute": "_VOXEL" } }
+                }]
+            }
+        },
+        "accessors": [{
+            "bufferView": 0,
+            "type": "SCALAR",
+            "componentType": 5126, // FLOAT
+            "count": count_u32,
+            "min": [vmin],
+            "max": [vmax]
+        }],
+        "bufferViews": [{ "buffer": 0, "byteLength": byte_len }],
+        "buffers": [{ "byteLength": byte_len }]
+    });
+
+    assemble_glb(&gltf, bin)
+}
+
+/// The `EXT_structural_metadata` schema for one scalar voxel property named
+/// `quantity` (shared by the glТF and the tileset so the classes match).
+fn voxel_schema(quantity: &str) -> serde_json::Value {
+    json!({
+        "id": "voxel",
+        "classes": {
+            "voxel": {
+                "properties": {
+                    quantity: {
+                        "type": "SCALAR",
+                        "componentType": "FLOAT32",
+                        "noData": NODATA_SENTINEL
+                    }
+                }
+            }
+        }
+    })
+}
+
+/// Assemble a binary glTF (`.glb`) from a glТF JSON value + a BIN buffer. Both
+/// chunks are padded to a 4-byte boundary (JSON with spaces, BIN with zeros) per
+/// the glTF 2.0 spec.
+fn assemble_glb(gltf: &serde_json::Value, mut bin: Vec<u8>) -> Result<Vec<u8>, Tiles3dError> {
+    let mut json_bytes = serde_json::to_vec(gltf).expect("voxel glTF serializes");
+    while !json_bytes.len().is_multiple_of(4) {
+        json_bytes.push(b' ');
+    }
+    while !bin.len().is_multiple_of(4) {
+        bin.push(0);
+    }
+    let total = 12 + 8 + json_bytes.len() + 8 + bin.len();
+    let total = u32::try_from(total).map_err(|_| Tiles3dError::TooLarge("glb byteLength"))?;
+
+    let mut glb = Vec::with_capacity(total as usize);
+    glb.extend_from_slice(b"glTF");
+    glb.extend_from_slice(&2u32.to_le_bytes()); // version
+    glb.extend_from_slice(&total.to_le_bytes());
+    glb.extend_from_slice(&(json_bytes.len() as u32).to_le_bytes());
+    glb.extend_from_slice(b"JSON");
+    glb.extend_from_slice(&json_bytes);
+    glb.extend_from_slice(&(bin.len() as u32).to_le_bytes());
+    glb.extend_from_slice(b"BIN\0");
+    glb.extend_from_slice(&bin);
+    Ok(glb)
+}
+
+/// Build the implicit-tiling voxel **tileset.json** for one cylinder tile. The
+/// tile `transform` places the cylinder's local frame at the antenna ECEF (like
+/// the mesh products); `stat_min`/`stat_max` are the reflectivity display range
+/// the transfer function maps over (a fixed colormap domain — no grid scan).
+///
+/// `content_uri` and `subtree_uri` are the implicit-tiling templates
+/// (`…/{level}/{x}/{y}/{z}.…`) the API serves; for a single tile only the
+/// `0/0/0/0` slot is available (see [`voxel_subtree_json`]).
+#[allow(clippy::too_many_arguments)]
+pub fn tileset_json_voxels(
+    antenna_lon: f64,
+    antenna_lat: f64,
+    antenna_height: f64,
+    max_radius_m: f64,
+    height_m: f64,
+    dims: [usize; 3],
+    quantity: &str,
+    stat_min: f64,
+    stat_max: f64,
+    content_uri: &str,
+    subtree_uri: &str,
+) -> Result<String, Tiles3dError> {
+    for v in [
+        antenna_lon,
+        antenna_lat,
+        antenna_height,
+        max_radius_m,
+        height_m,
+        stat_min,
+        stat_max,
+    ] {
+        if !v.is_finite() {
+            return Err(Tiles3dError::NonFinite("voxel tileset parameter"));
+        }
+    }
+    if max_radius_m <= 0.0 || height_m <= 0.0 {
+        return Err(Tiles3dError::InvalidRegion([
+            0.0,
+            0.0,
+            max_radius_m,
+            height_m,
+            0.0,
+            0.0,
+        ]));
+    }
+    let [cx, cy, cz] = geodetic_to_ecef(antenna_lon, antenna_lat, antenna_height);
+    let [n_r, n_a, n_h] = dims;
+
+    let tileset = json!({
+        "asset": { "version": "1.1" },
+        "schema": voxel_schema(quantity),
+        "statistics": {
+            "classes": {
+                "voxel": {
+                    "properties": {
+                        quantity: { "min": [stat_min], "max": [stat_max] }
+                    }
+                }
+            }
+        },
+        "geometricError": 0.0,
+        "extensionsUsed": ["3DTILES_bounding_volume_cylinder", "3DTILES_content_voxels"],
+        "extensionsRequired": ["3DTILES_bounding_volume_cylinder", "3DTILES_content_voxels"],
+        "root": {
+            // Cylinder local frame at the antenna ECEF (z-up; CesiumJS applies
+            // the glTF y-up→z-up to the voxel content). Identity rotation.
+            "transform": [1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, cx, cy, cz, 1.0],
+            "boundingVolume": {
+                "extensions": {
+                    // Centred at the local origin, height along z; lift it so the
+                    // data sits from the antenna (z=0) up to `height_m`.
+                    "3DTILES_bounding_volume_cylinder": {
+                        "minRadius": 0.0,
+                        "maxRadius": max_radius_m,
+                        "height": height_m,
+                        "translation": [0.0, 0.0, height_m / 2.0]
+                    }
+                }
+            },
+            "content": {
+                "uri": content_uri,
+                "extensions": {
+                    "3DTILES_content_voxels": {
+                        "dimensions": [n_r, n_a, n_h],
+                        "class": "voxel"
+                    }
+                }
+            },
+            "implicitTiling": {
+                "subdivisionScheme": "OCTREE",
+                "subtreeLevels": 1,
+                "availableLevels": 1,
+                "subtrees": { "uri": subtree_uri }
+            },
+            "geometricError": 0.0,
+            "refine": "REPLACE"
+        }
+    });
+    Ok(serde_json::to_string_pretty(&tileset).expect("voxel tileset serializes"))
+}
+
+/// The implicit-tiling **subtree** for a single available tile: the one level-0
+/// tile and its content are present, with no child subtrees. A JSON subtree (3D
+/// Tiles 1.1) with constant availability — matches the CesiumJS fixture.
+pub fn voxel_subtree_json() -> String {
+    let subtree = json!({
+        "tileAvailability": { "constant": 1, "availableCount": 1 },
+        "contentAvailability": { "constant": 1, "availableCount": 1 },
+        "childSubtreeAvailability": { "constant": 0, "availableCount": 0 }
+    });
+    serde_json::to_string(&subtree).expect("subtree serializes")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn grid(n_r: usize, n_a: usize, n_h: usize) -> VoxelGrid {
+        let dims = [n_r, n_a, n_h];
+        let mut values = vec![f32::NAN; n_r * n_a * n_h];
+        // value = height index, finite everywhere so the range is [0, n_h-1].
+        for i_r in 0..n_r {
+            for i_a in 0..n_a {
+                for i_h in 0..n_h {
+                    values[VoxelGrid::index_of(dims, i_r, i_a, i_h)] = i_h as f32;
+                }
+            }
+        }
+        VoxelGrid {
+            origin_lon: 24.5,
+            origin_lat: 60.5,
+            origin_height: 100.0,
+            dims,
+            radius_range: [0.0, 100_000.0],
+            angle_range: [0.0, std::f64::consts::TAU],
+            height_range: [0.0, 10_000.0],
+            values,
+            quantity: "DBZH".into(),
+            unit: "dBZ".into(),
+        }
+    }
+
+    fn parse_glb(glb: &[u8]) -> (serde_json::Value, Vec<u8>) {
+        assert_eq!(&glb[0..4], b"glTF", "magic");
+        assert_eq!(
+            u32::from_le_bytes(glb[4..8].try_into().unwrap()),
+            2,
+            "version"
+        );
+        assert_eq!(
+            u32::from_le_bytes(glb[8..12].try_into().unwrap()) as usize,
+            glb.len(),
+            "byteLength"
+        );
+        let jlen = u32::from_le_bytes(glb[12..16].try_into().unwrap()) as usize;
+        assert_eq!(&glb[16..20], b"JSON");
+        let json: serde_json::Value =
+            serde_json::from_slice(&glb[20..20 + jlen]).expect("JSON chunk parses");
+        let bin_off = 20 + jlen;
+        let blen = u32::from_le_bytes(glb[bin_off..bin_off + 4].try_into().unwrap()) as usize;
+        assert_eq!(&glb[bin_off + 4..bin_off + 8], b"BIN\0");
+        let bin = glb[bin_off + 8..bin_off + 8 + blen].to_vec();
+        (json, bin)
+    }
+
+    #[test]
+    fn voxel_glb_matches_the_cesium_cylinder_fixture_shape() {
+        let g = grid(2, 4, 3); // [radius, angle, height]
+        let glb = encode_voxels_glb(&g).expect("encode");
+        let (j, bin) = parse_glb(&glb);
+
+        let prim = &j["meshes"][0]["primitives"][0];
+        // Cylinder voxel mode (NOT the README's 2147483647).
+        assert_eq!(prim["mode"], 2_147_483_650u64);
+        assert_eq!(prim["attributes"]["_VOXEL"], 0);
+        // Axis swap: content [radius, angle, height] → glTF [radius, height, angle].
+        assert_eq!(
+            prim["extensions"]["EXT_primitive_voxels"]["dimensions"],
+            json!([2, 3, 4])
+        );
+        // Structural metadata at the top level, binding the class property to _VOXEL.
+        let pa = &j["extensions"]["EXT_structural_metadata"]["propertyAttributes"][0];
+        assert_eq!(pa["class"], "voxel");
+        assert_eq!(pa["properties"]["DBZH"]["attribute"], "_VOXEL");
+        assert_eq!(j["extensionsRequired"][0], "EXT_primitive_voxels");
+
+        // Accessor: SCALAR FLOAT, one element per cell, range = [0, 2] (height idx).
+        let acc = &j["accessors"][0];
+        assert_eq!(acc["componentType"], 5126);
+        assert_eq!(acc["count"], 24);
+        assert_eq!(acc["min"], json!([0.0]));
+        assert_eq!(acc["max"], json!([2.0]));
+        assert_eq!(bin.len(), 24 * 4);
+
+        // Data layout: glТF order is radius-fastest → height → angle-slowest, and
+        // value == height index. So the first `n_r` floats (radius run at h=0)
+        // are 0.0, the next `n_r` (h=1) are 1.0, then h=2 → 2.0; that block of
+        // n_r*n_h repeats per angle slice.
+        let f = |i: usize| f32::from_le_bytes(bin[i * 4..i * 4 + 4].try_into().unwrap());
+        assert_eq!([f(0), f(1)], [0.0, 0.0]); // radius run, height 0
+        assert_eq!([f(2), f(3)], [1.0, 1.0]); // radius run, height 1
+        assert_eq!([f(4), f(5)], [2.0, 2.0]); // radius run, height 2
+        assert_eq!(f(6), 0.0); // next angle slice restarts at height 0
+    }
+
+    #[test]
+    fn nodata_becomes_sentinel_and_all_nodata_is_empty() {
+        let mut g = grid(2, 2, 2);
+        let idx = g.index(0, 0, 0);
+        g.values[idx] = f32::NAN;
+        let glb = encode_voxels_glb(&g).expect("encode");
+        let (_, bin) = parse_glb(&glb);
+        let f = |i: usize| f32::from_le_bytes(bin[i * 4..i * 4 + 4].try_into().unwrap());
+        assert_eq!(f(0), NODATA_SENTINEL, "NaN cell → sentinel");
+
+        let mut empty = grid(2, 2, 2);
+        empty.values.iter_mut().for_each(|v| *v = f32::NAN);
+        assert!(matches!(
+            encode_voxels_glb(&empty),
+            Err(Tiles3dError::Empty)
+        ));
+    }
+
+    #[test]
+    fn voxel_tileset_has_cylinder_bv_content_voxels_and_transform() {
+        let ts = tileset_json_voxels(
+            24.5,
+            60.5,
+            100.0,
+            250_000.0,
+            15_000.0,
+            [128, 360, 48],
+            "DBZH",
+            0.0,
+            70.0,
+            "content/{level}/{x}/{y}/{z}.glb",
+            "subtrees/{level}/{x}/{y}/{z}.json",
+        )
+        .expect("tileset");
+        let v: serde_json::Value = serde_json::from_str(&ts).unwrap();
+        let bv = &v["root"]["boundingVolume"]["extensions"]["3DTILES_bounding_volume_cylinder"];
+        assert_eq!(bv["maxRadius"], 250_000.0);
+        assert_eq!(bv["height"], 15_000.0);
+        assert_eq!(bv["translation"][2], 7_500.0); // lifted so data sits 0..height
+        let cv = &v["root"]["content"]["extensions"]["3DTILES_content_voxels"];
+        assert_eq!(cv["dimensions"], json!([128, 360, 48])); // content order
+        assert_eq!(cv["class"], "voxel");
+        assert_eq!(v["root"]["transform"].as_array().unwrap().len(), 16);
+        assert_eq!(v["root"]["implicitTiling"]["subdivisionScheme"], "OCTREE");
+        // Statistics drive the transfer-function range.
+        assert_eq!(
+            v["statistics"]["classes"]["voxel"]["properties"]["DBZH"]["max"],
+            json!([70.0])
+        );
+    }
+}

--- a/crates/ds-3dtiles/src/voxels.rs
+++ b/crates/ds-3dtiles/src/voxels.rs
@@ -219,6 +219,17 @@ pub fn tileset_json_voxels(
     let [cx, cy, cz] = geodetic_to_ecef(antenna_lon, antenna_lat, antenna_height);
     let [n_r, n_a, n_h] = dims;
 
+    // East-North-Up → ECEF rotation at the antenna, so the cylinder's local z is
+    // local **up** (its height axis) and its radial plane is horizontal. (An
+    // identity rotation — fine for the mesh products, whose vertices are absolute
+    // ECEF — would align the cylinder's z with global ECEF-Z, tilting the whole
+    // volume by the latitude; the parametric cylinder needs the real local frame.)
+    let (sl, cl) = antenna_lon.to_radians().sin_cos();
+    let (sp, cp) = antenna_lat.to_radians().sin_cos();
+    let east = [-sl, cl, 0.0];
+    let north = [-sp * cl, -sp * sl, cp];
+    let up = [cp * cl, cp * sl, sp];
+
     let tileset = json!({
         "asset": { "version": "1.1" },
         "schema": voxel_schema(quantity),
@@ -235,9 +246,14 @@ pub fn tileset_json_voxels(
         "extensionsUsed": ["3DTILES_bounding_volume_cylinder", "3DTILES_content_voxels"],
         "extensionsRequired": ["3DTILES_bounding_volume_cylinder", "3DTILES_content_voxels"],
         "root": {
-            // Cylinder local frame at the antenna ECEF (z-up; CesiumJS applies
-            // the glTF y-up→z-up to the voxel content). Identity rotation.
-            "transform": [1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, cx, cy, cz, 1.0],
+            // ENU→ECEF tile transform (column-major): local x=east, y=north,
+            // z=up at the antenna, translation = antenna ECEF.
+            "transform": [
+                east[0], east[1], east[2], 0.0,
+                north[0], north[1], north[2], 0.0,
+                up[0], up[1], up[2], 0.0,
+                cx, cy, cz, 1.0
+            ],
             "boundingVolume": {
                 "extensions": {
                     // Centred at the local origin, height along z; lift it so the

--- a/crates/engine-odim/src/volume_engine.rs
+++ b/crates/engine-odim/src/volume_engine.rs
@@ -1303,6 +1303,11 @@ fn derive_site_meta(list: &[VolumeEntry]) -> Option<SiteMeta> {
         // voxel grid — and thus the isosurface mesh — is built relative to).
         voxel_grid: Some(ds_core::volume::VoxelGridCaps {
             origin: [site.lon, site.lat, site.height],
+            // Cylinder extents for the voxel 3D Tiles bounding volume — the same
+            // ground-coverage radius the grid sampler uses (so the bounding
+            // cylinder matches the grid exactly) and the shared height ceiling.
+            radius_m: coverage_radius_m.unwrap_or(0.0),
+            height_m: VOXEL_HEIGHT_CEILING_M,
         }),
     });
 


### PR DESCRIPTION
Part of epic #346. The **Tier-B** true-voxel track: radar polar volumes as a CesiumJS ray-marched **volume**, alongside the always-works `.pnts`/isosurface/echo-top products.

## What

A `VoxelGrid` → `EXT_primitive_voxels` glTF `.glb` + `3DTILES_content_voxels` / `3DTILES_bounding_volume_cylinder` tileset that CesiumJS 1.142 renders with a `VoxelPrimitive`. **Render-verified live** (screenshot in the thread): the reflectivity field ray-marches as a true 3-D volume over southern Finland with coherent precipitation structure and visible vertical depth.

### Commits
1. **CesiumJS 1.124 → 1.142** — voxels need WebGL2 (≥1.135) and the `EXT_primitive_voxels` realignment (1.127); also picks up point-cloud filtering perf, the circles→squares fix, and shader-metadata correctness. SRI recomputed; existing reps re-verified.
2. **Encoder** (`ds-3dtiles/voxels.rs`) — `encode_voxels_glb` + `tileset_json_voxels` + `voxel_subtree_json`.
3. **API** — `…/voxel/{tileset.json,subtrees/*,content/*}` routes; `VoxelGridCaps` gains `radius_m`/`height_m` so the bounding cylinder matches the grid without a sample.
4. **Viewer** — "Voxels" in the View dropdown via `Cesium3DTilesVoxelProvider` + a reflectivity transfer-function `CustomShader`.
5. **ENU transform fix** — found in render-verify (see below).

## Authoritative-source note

`EXT_primitive_voxels` is **not in the Khronos glTF registry** — it's a CesiumGS draft with **CesiumJS as the only implementation**. So I encoded against the live CesiumJS `VoxelCylinder3DTiles` **fixtures**, which caught that the draft README is **stale**: cylinder `mode` is `2147483650` (0x80000002), not the README's `2147483647`. The mode encodes the shape (box 0x80000000, ellipsoid 0x80000001).

## Load-bearing gotchas (all in `voxels.rs` doc comments)

- **Axis swap**: content `[radius, angle, height]` → glTF `dimensions [radius, height, angle]`; data laid out **radius-fastest → height → angle-slowest** (our `VoxelGrid` is the transpose, so the encoder reorders).
- `EXT_structural_metadata` (schema + `propertyAttributes`) at the glTF **top level**, not the primitive; embedded BIN buffer; `NaN` → a declared `noData` sentinel.
- **Implicit OCTREE tiling + a constant `.subtree`** is required (CesiumJS's voxel traversal); for one tile that's a constant-availability subtree.
- **The tile `transform` must be the real ENU→ECEF frame**, not identity-rotation — identity works for the mesh products (absolute-ECEF vertices) but tilts the *parametric* cylinder by the latitude (a ~60° slanted slab, which is exactly the first render). This was the one bug render-verify surfaced.

## Scope (v1 MVP)

Single tile, latest time. **Follow-ups** (tracked in #351): implicit octree LOD over multiple tiles, the national mosaic, time-dynamic voxels, per-quantity transfer functions. Tier-A `.pnts`/mesh remain the portable fallback for non-CesiumJS clients.

## Tests

`ds-3dtiles` (24) structural tests against the fixture shape; `api-3dtiles` (22) incl. a voxel tileset/subtree/content route test; `ds-core`/`engine-odim` green; clippy clean. Plus the live CesiumJS 1.142 render-verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)