### PR TITLE
fix(wms): serve fresh "latest" frames + 8× faster meta-tile assembly (hot-path audit HIGHs)

### DIFF
--- a/crates/api-wms/src/handlers.rs
+++ b/crates/api-wms/src/handlers.rs
@@ -202,6 +202,16 @@ pub async fn wms_handler(
                 .reference_time
                 .filter(|&rt| info.reference_times.last().copied() != Some(rt));
 
+            // Resolve a TIME-less request to the engine's *current* latest
+            // timestamp before any cache key is built. The rendered + meta-tile
+            // caches have no TTL, so keying "latest" as `None` would freeze the
+            // first rendered frame (and its ETag) forever while the engine's
+            // catalog moves on — a TIME-less layer must track new data. Mirrors
+            // Maps/Tiles, which resolve latest the same way before keying.
+            // `info.times` is ascending; when it's empty (e.g. STAC cold start)
+            // the request falls through as `None` = the engine's own latest.
+            let time = params.time.or_else(|| info.times.last().copied());
+
             // Build cache key
             let cache_key = CacheKey {
                 layer: params.layer.clone(),
@@ -223,7 +233,7 @@ pub async fn wms_handler(
                 },
                 width: params.width,
                 height: params.height,
-                time: params.time,
+                time,
                 // WMS picks the parameter via `LAYERS=collection/param`
                 // (parsed into layer_parameter) and then `style_info.parameter`.
                 // Both are already folded into `style_parameter` below; mirror
@@ -298,7 +308,8 @@ pub async fn wms_handler(
             let bbox = params.bbox;
             let width = params.width;
             let height = params.height;
-            let time = params.time;
+            // `time` (latest-resolved above) is `Copy`; it flows into both the
+            // direct and meta-tile render closures below.
             let output_crs = params.output_crs.clone();
             let format = params.format;
             let elevation = params.elevation;

--- a/crates/api-wms/tests/integration.rs
+++ b/crates/api-wms/tests/integration.rs
@@ -1570,3 +1570,197 @@ async fn getmap_reference_time_against_non_forecast_layer_returns_400() {
         "reference_time on a non-forecast layer must be InvalidDimensionValue; got:\n{xml}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// TIME-less GetMap must track the engine's latest timestamp
+// ---------------------------------------------------------------------------
+
+/// Mock engine whose advertised `times` can be advanced mid-test, recording
+/// the `time` each render was asked for. Regression fixture for the
+/// stale-latest bug: the rendered/meta-tile caches have no TTL, so a TIME-less
+/// request keyed as `time: None` would serve the first rendered frame forever.
+struct AdvancingMockMapEngine {
+    times: Arc<std::sync::Mutex<Vec<chrono::DateTime<chrono::Utc>>>>,
+    calls: Arc<std::sync::Mutex<Vec<Option<chrono::DateTime<chrono::Utc>>>>>,
+}
+
+impl MapEngine for AdvancingMockMapEngine {
+    fn get_raster_tile(
+        &self,
+        _bbox: [f64; 4],
+        width: u32,
+        height: u32,
+        time: Option<chrono::DateTime<chrono::Utc>>,
+        _output_crs: &OutputCrs,
+        _parameter: Option<&str>,
+        _z: Option<f64>,
+        _reference_time: Option<chrono::DateTime<chrono::Utc>>,
+    ) -> Result<RasterTile, DataServerError> {
+        self.calls.lock().unwrap().push(time);
+        let pixel_count = (width * height) as usize;
+        let values: Vec<Option<f64>> = (0..pixel_count)
+            .map(|i| Some(i as f64 / pixel_count as f64))
+            .collect();
+        Ok(RasterTile {
+            width,
+            height,
+            values,
+        })
+    }
+
+    fn raster_info(&self) -> RasterInfo {
+        RasterInfo {
+            native_crs: "EPSG:4326".into(),
+            spatial_extent: Some([10.0, 55.0, 30.0, 70.0]),
+            times: self.times.lock().unwrap().clone(),
+            parameter: "reflectivity".into(),
+            unit: "dBZ".into(),
+            parameters: vec![],
+            vertical: None,
+            grid_size: None,
+            layer_subtitle: None,
+            reference_times: Vec::new(),
+        }
+    }
+}
+
+type AdvancingFixture = (
+    axum::Router,
+    Arc<std::sync::Mutex<Vec<chrono::DateTime<chrono::Utc>>>>,
+    Arc<std::sync::Mutex<Vec<Option<chrono::DateTime<chrono::Utc>>>>>,
+);
+
+fn build_advancing_router() -> AdvancingFixture {
+    let t1 = chrono::DateTime::parse_from_rfc3339("2026-06-10T10:00:00Z")
+        .unwrap()
+        .with_timezone(&chrono::Utc);
+    let times = Arc::new(std::sync::Mutex::new(vec![t1]));
+    let calls = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let engine: Arc<dyn MapEngine> = Arc::new(AdvancingMockMapEngine {
+        times: times.clone(),
+        calls: calls.clone(),
+    });
+    let mut engines = HashMap::new();
+    let mut collections = HashMap::new();
+    let mut styles_map = HashMap::new();
+
+    engines.insert("radar-live".to_string(), engine);
+    collections.insert(
+        "radar-live".to_string(),
+        CollectionConfig {
+            id: "radar-live".to_string(),
+            title: "Live Radar".to_string(),
+            description: "Fixture for the TIME-less stale-latest regression".into(),
+            data_path: None,
+            apis: vec!["wms".to_string()],
+            engine_type: "geotiff".to_string(),
+            keywords: Vec::new(),
+            license: None,
+            geotiff: None,
+            querydata: None,
+            wms: None,
+            grib: None,
+            zarr: None,
+            odim: None,
+            postgis: None,
+            preview: None,
+        },
+    );
+
+    let cmap = Arc::new(LutColorMap::from_builtin(
+        BuiltinColormap::Viridis,
+        0.0,
+        1.0,
+    ));
+    let mut layer_styles = HashMap::new();
+    layer_styles.insert(
+        "default".to_string(),
+        StyleInfo {
+            name: "default".to_string(),
+            title: "Default".to_string(),
+            colormap: cmap,
+            min: 0.0,
+            max: 1.0,
+            parameter: None,
+        },
+    );
+    styles_map.insert("radar-live".to_string(), layer_styles);
+
+    let state = Arc::new(ArcSwap::from_pointee(WmsState {
+        engines,
+        collections,
+        styles: styles_map,
+        render_semaphore: Arc::new(tokio::sync::Semaphore::new(4)),
+        rendered_cache: Arc::new(RenderedCache::new(16)),
+        tile_cache: Arc::new(ds_render::TilePixelCache::new(16)),
+        base_url: String::new(),
+    }));
+    (api_wms::router(state), times, calls)
+}
+
+const LIVE_GETMAP_URI: &str = "/?SERVICE=WMS&REQUEST=GetMap&VERSION=1.3.0&LAYERS=radar-live\
+                               &STYLES=&CRS=CRS:84&BBOX=10,55,30,70&WIDTH=64&HEIGHT=64\
+                               &FORMAT=image/png";
+
+/// A TIME-less GetMap is keyed on the engine's *current latest* timestamp, not
+/// `time: None` — so when a newer volume arrives, the next TIME-less request
+/// re-renders instead of serving the previous frame from the TTL-less cache.
+#[tokio::test]
+async fn timeless_getmap_tracks_new_latest_data() {
+    let (app, times, calls) = build_advancing_router();
+
+    // First TIME-less request renders the current latest (t1).
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri(LIVE_GETMAP_URI)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(resp.headers()["x-cache"], "MISS");
+    let t1 = times.lock().unwrap()[0];
+    assert_eq!(calls.lock().unwrap().clone(), vec![Some(t1)]);
+
+    // Same request again: cache HIT, no new engine call.
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri(LIVE_GETMAP_URI)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(resp.headers()["x-cache"], "HIT");
+    assert_eq!(calls.lock().unwrap().len(), 1);
+
+    // A newer timestep arrives (poll cycle): the next TIME-less request must
+    // re-render at the new latest, not serve the stale cached frame.
+    let t2 = chrono::DateTime::parse_from_rfc3339("2026-06-10T10:05:00Z")
+        .unwrap()
+        .with_timezone(&chrono::Utc);
+    times.lock().unwrap().push(t2);
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri(LIVE_GETMAP_URI)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(
+        resp.headers()["x-cache"],
+        "MISS",
+        "a TIME-less request after new data must re-render, not serve the stale frame"
+    );
+    assert_eq!(calls.lock().unwrap().last().copied(), Some(Some(t2)));
+}

--- a/crates/render/src/metatile.rs
+++ b/crates/render/src/metatile.rs
@@ -30,7 +30,6 @@
 //! CRSs fall back to a direct single-shot render. Degenerate or pathologically
 //! large requests return [`MetaTile::Fallback`] so the caller renders directly.
 
-use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
@@ -317,8 +316,18 @@ where
     }
 
     // Render or fetch each covering tile's RGBA pixels. `None` = an all-nodata
-    // tile (cached as a marker, drawn transparent at assembly time).
-    let mut tiles: HashMap<(i64, i64), Option<Arc<[u8]>>> = HashMap::with_capacity(ncols * nrows);
+    // tile (cached as a marker, drawn transparent at assembly time). The cover
+    // is a dense rectangle, so the tiles live in a row-major `Vec` indexed by
+    // grid position — the assembly loop below samples it 4× per output pixel,
+    // and a hash lookup there was ~8× the cost of the whole resample at
+    // megapixel viewports.
+    let mut tiles = Mosaic {
+        col0,
+        row0,
+        ncols,
+        nrows,
+        tiles: Vec::with_capacity(ncols * nrows),
+    };
     let mut any_data = false;
     let mut misses: u32 = 0;
     let tiles_count = (ncols * nrows) as u32;
@@ -374,7 +383,7 @@ where
                 );
                 entry
             };
-            tiles.insert((col, row), rgba);
+            tiles.tiles.push(rgba);
         }
     }
     let tile_loop_ms = t_loop.elapsed().as_millis() as u64;
@@ -438,29 +447,55 @@ where
     })
 }
 
+/// The rendered covering tiles, stored row-major over the dense rectangular
+/// grid `[col0..col0+ncols) × [row0..row0+nrows)`. `None` = an all-nodata
+/// tile. Indexed (not hashed) because the assembly loop samples it 4× per
+/// output pixel.
+struct Mosaic {
+    col0: i64,
+    row0: i64,
+    ncols: usize,
+    nrows: usize,
+    tiles: Vec<Option<Arc<[u8]>>>,
+}
+
+impl Mosaic {
+    /// The tile at grid position `(col, row)`, or `None` for a nodata marker
+    /// or a position outside the cover (only reachable ≤1px past an edge).
+    #[inline]
+    fn tile(&self, col: i64, row: i64) -> Option<&Arc<[u8]>> {
+        let c = col.wrapping_sub(self.col0) as usize;
+        let r = row.wrapping_sub(self.row0) as usize;
+        if c >= self.ncols || r >= self.nrows {
+            return None;
+        }
+        self.tiles[r * self.ncols + c].as_ref()
+    }
+}
+
 /// Fetch one global tile-pixel (nearest) from the covering set; transparent if
 /// the pixel falls outside the rendered tiles (only possible ≤1px past an edge).
 #[inline]
-fn global_pixel(tiles: &HashMap<(i64, i64), Option<Arc<[u8]>>>, xi: i64, yi: i64) -> [u8; 4] {
+fn global_pixel(tiles: &Mosaic, xi: i64, yi: i64) -> [u8; 4] {
     let col = xi.div_euclid(TILE_PX as i64);
     let row = yi.div_euclid(TILE_PX as i64);
     let lx = xi.rem_euclid(TILE_PX as i64) as usize;
     let ly = yi.rem_euclid(TILE_PX as i64) as usize;
-    match tiles.get(&(col, row)) {
-        // Present with data; nodata markers (`Some(None)`) and absent tiles
-        // (≤1px past an edge) are transparent.
-        Some(Some(rgba)) => {
+    match tiles.tile(col, row) {
+        // Present with data; nodata markers and absent tiles (≤1px past an
+        // edge) are transparent.
+        Some(rgba) => {
             let o = (ly * TILE_PX as usize + lx) * 4;
             [rgba[o], rgba[o + 1], rgba[o + 2], rgba[o + 3]]
         }
-        _ => [0, 0, 0, 0],
+        None => [0, 0, 0, 0],
     }
 }
 
 /// Premultiplied-alpha bilinear sample of the mosaic at global tile-pixel
 /// coordinates `(gx, gy)` (pixel centres at integer + 0.5).
 #[inline]
-fn sample_bilinear(tiles: &HashMap<(i64, i64), Option<Arc<[u8]>>>, gx: f64, gy: f64) -> [u8; 4] {
+fn sample_bilinear(tiles: &Mosaic, gx: f64, gy: f64) -> [u8; 4] {
     let fx = gx - 0.5;
     let fy = gy - 0.5;
     let x0 = fx.floor();


### PR DESCRIPTION
## Summary

The two HIGH findings from a performance audit of the GeoTIFF-engine WMS hot path (local Finland COGs, EPSG:3067, served via WMS), both verified against source before fixing:

### 1. Stale "latest": TIME-less GetMap was cached forever (correctness, HIGH)

A GetMap without `TIME` built its rendered-cache and meta-tile keys with `time: None`. Both caches are deliberately TTL-less (per-timestamp pixels are immutable), so the **first** "latest" render was served indefinitely — a TIME-less radar layer froze at its first frame while new volumes arrived every 5 minutes, and the content-derived ETag confirmed the stale pixels via 304 revalidations. Maps and Tiles already resolve "latest" to a concrete timestamp before keying; WMS now does the same (`params.time.or_else(|| info.times.last().copied())`). Explicit `TIME` is unchanged; an empty `times` list (STAC cold start) falls through as before.

Regression test included (`timeless_getmap_tracks_new_latest_data`) — verified to **fail** against the previous handler.

### 2. Meta-tile assembly: 4 SipHash HashMap lookups per output pixel (perf, HIGH) — closes #240

`sample_bilinear` → 4× `global_pixel` → 4× `HashMap<(i64,i64), _>::get` per output pixel: ~4.2M hashed lookups per 1024×1024 GetMap, **~60-77 ms measured** on an equivalent extracted loop — paid on every Web Mercator GetMap *including the fully cache-warm path*, where it dominated response time. The cover is a dense rectangle, so the tiles now live in a row-major `Vec` indexed by grid position (~8 ms at 1 MP, ~8×). Out-of-cover corners bounds-check to transparent (same semantics); the geography-tracking fidelity tests pin the output.

#240's "parallelize" half is intentionally **not** done — per-request rayon on a concurrently-served render path convoys through the shared pool (the #242 regression).

## Other audit findings (filed, not fixed here)

- #375 — meta-tiling for projected output CRS (EPSG:3067/3035): the main Finnish-desktop-client path currently gets no tile reuse (~3% rendered-cache hit rate). Largest remaining strategic gap for this workload.
- #376 — PNG8 palette scan does a SipHash lookup per pixel (~10 ms/MP on every PNG response).
- #171 (existing) — all-nodata responses re-allocate + re-encode per request; audit measurement added as a comment.
- #163 (existing) — `TRANSPARENT`/`BGCOLOR` parsed but ignored; re-confirmed.
- #206 (existing) — `Vec<Option<f64>>` engine→render boundary; re-confirmed, mitigated on the colorize side by `IntegerLutColorMap`.

Considered and rejected as false positives (verified): tower-http compression on images (predicate excludes them), `raster_info()` per request (#211 snapshot is real), render-semaphore sizing/placement, geotiff #222 rayon/`block_in_place` hazard (handle is threaded through), per-tile key string clones, FNV ETag cost.

## Test plan

- New regression test fails on old code, passes with fix
- `cargo test --workspace` green; `cargo fmt` + `clippy --workspace --tests` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)