### PR TITLE
perf(3dtiles): content + voxel-grid caches — cached repeats 165× faster

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -428,10 +428,11 @@ into a glTF `.glb` triangle mesh.
   changes share one polar resample (`MC_PVOL_VOXEL_GRID_CACHE_MB`, default 512);
   the resample itself resolves each `(radius, height)` column once
   (`ColumnTarget`) instead of per-cell sweep/moment/pixel-cache lookups.
-  **`Cache-Control`:** content/tilesets pinned to an explicit `?datetime=` get
-  `max-age=86400, immutable` (the viewer pins every animation frame, so reloads
-  re-use the browser cache); "latest" keeps `max-age=60`. A 304 revalidation
-  costs two cache lookups, not a recompute. Cache metrics are in `/metrics`
+  **`Cache-Control`:** content/tilesets whose `?datetime=` **exactly matches an
+  advertised volume time** get `max-age=86400, immutable` (the viewer pins every
+  animation frame from the `times` manifest, so reloads re-use the browser
+  cache); a between-volumes datetime (nearest-selection can change) and "latest"
+  keep `max-age=60`. A 304 revalidation costs two cache lookups, not a recompute. Cache metrics are in `/metrics`
   (`tiles3d_content_cache_*`, `pvol_voxel_grid_cache_*`). `content_uri` is
   validated (no `..`/absolute/scheme) in `ds-3dtiles`.
 - **Config:** add `"3dtiles"` to a collection's `apis` (only `odim-volume`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -414,8 +414,25 @@ into a glTF `.glb` triangle mesh.
   handlers bound them with the shared render semaphore and run via
   `spawn_blocking` — never inline on a request worker (the same pattern the
   raster APIs use for `get_raster_tile`).
-- **Caching:** content-derived ETag on both `.pnts` and `.glb` (deterministic
-  bytes ⇒ cheap 304s, shared `binary_response` helper); `content_uri` is
+- **Caching (two layers, hot-path audit 2026-06):** (1) `api-3dtiles/src/cache.rs`
+  — a process-global byte-bounded LRU of the **encoded content bytes + ETag**
+  (`.pnts`/`.glb`/voxel `.glb`), keyed by (collection, product, quantity,
+  datetime, params, dims) **plus a data-version hashed from `VolumeInfo.times`**
+  (new volume ⇒ new version, so "latest" and nearest-time selection invalidate
+  without duplicating engine selection logic), with per-key **single-flight**
+  coalescing (concurrent identical requests share one compute; the semaphore is
+  only acquired by the computing request). `MC_3DTILES_CONTENT_CACHE_MB`
+  (default 512, 0 disables). (2) engine-side `VOXEL_GRID_CACHE` in
+  `engine-odim` — `read_voxel_grid` returns `Arc<VoxelGrid>` from a global LRU
+  keyed (file, quantity, dims), so isosurface/echo-top/voxels and threshold
+  changes share one polar resample (`MC_PVOL_VOXEL_GRID_CACHE_MB`, default 512);
+  the resample itself resolves each `(radius, height)` column once
+  (`ColumnTarget`) instead of per-cell sweep/moment/pixel-cache lookups.
+  **`Cache-Control`:** content/tilesets pinned to an explicit `?datetime=` get
+  `max-age=86400, immutable` (the viewer pins every animation frame, so reloads
+  re-use the browser cache); "latest" keeps `max-age=60`. A 304 revalidation
+  costs two cache lookups, not a recompute. Cache metrics are in `/metrics`
+  (`tiles3d_content_cache_*`, `pvol_voxel_grid_cache_*`). `content_uri` is
   validated (no `..`/absolute/scheme) in `ds-3dtiles`.
 - **Config:** add `"3dtiles"` to a collection's `apis` (only `odim-volume`
   supports it today). v1 uses one shared reflectivity colormap; per-collection /

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,6 +76,7 @@ dependencies = [
  "ds-core",
  "ds-render",
  "http-body-util",
+ "quick_cache",
  "serde",
  "serde_json",
  "tokio",

--- a/collections.d/radar-fi-volume-s3-h5.toml
+++ b/collections.d/radar-fi-volume-s3-h5.toml
@@ -27,7 +27,7 @@ id = "radar-fi-volume-s3-h5"
 title = "FMI — radar polar volumes (S3, ODIM_H5)"
 description = "Finnish radar polar volumes (ODIM_H5 PVOL) streamed from FMI's open-data S3 bucket — every FMI radar site, all elevation sweeps and dual-polarisation moments. One collection per radar site."
 engine_type = "odim-volume"
-apis = ["edr", "wms", "maps", "tiles"]
+apis = ["edr", "wms", "maps", "tiles", "3dtiles"]
 
 [odim]
 endpoint = "https://s3-eu-west-1.amazonaws.com"

--- a/crates/api-3dtiles/Cargo.toml
+++ b/crates/api-3dtiles/Cargo.toml
@@ -12,6 +12,7 @@ arc-swap = "1"
 axum = "0.8"
 bytes = "1"
 chrono = { version = "0.4", features = ["serde"] }
+quick_cache = "0.6"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["sync", "rt"] }
@@ -20,4 +21,5 @@ tracing = "0.1"
 [dev-dependencies]
 tower = "0.5"
 http-body-util = "0.1"
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }
 toml = "0.8"

--- a/crates/api-3dtiles/src/cache.rs
+++ b/crates/api-3dtiles/src/cache.rs
@@ -38,8 +38,11 @@ use crate::error::Tiles3dError;
 /// Default encoded-content cache size (MB) when `MC_3DTILES_CONTENT_CACHE_MB`
 /// is unset. Encoded tiles are a few hundred KB (echo-top) to tens of MB
 /// (dense point clouds); 512 MB comfortably holds an animation window of one
-/// busy collection. `0` disables caching (every request recomputes —
-/// diagnostic only; single-flight still coalesces concurrent duplicates).
+/// busy collection. `0` disables caching entirely (diagnostic only): every
+/// request recomputes — concurrent duplicates are merely **serialized** by the
+/// per-key gate (each waiter re-checks the cache, misses because nothing is
+/// admitted at capacity 0, and recomputes in turn), so the gate bounds the
+/// stampede to one compute at a time but does not share results.
 const DEFAULT_CONTENT_CACHE_MB: u64 = 512;
 
 /// Which encoded product the bytes are — part of the key so two products with

--- a/crates/api-3dtiles/src/cache.rs
+++ b/crates/api-3dtiles/src/cache.rs
@@ -1,0 +1,331 @@
+//! Process-global cache of **encoded 3D Tiles content bytes**, with
+//! single-flight coalescing.
+//!
+//! Why this exists (hot-path audit, 2026-06): every `content.pnts` /
+//! `content.glb` / voxel-content request used to pay the full engine read +
+//! resample + encode pipeline — *including* `If-None-Match` revalidations,
+//! whose ETag was only known after a complete recompute. The bundled viewer
+//! preloads up to 48 animation frames concurrently, multiplying that cost by
+//! the frame count on every load, reload, and control change.
+//!
+//! The cache stores the final encoded bytes + their strong ETag, keyed by
+//! everything that determines them (collection, product, quantity, time,
+//! product parameters, resolution) **plus a data-version** derived from the
+//! collection's `VolumeInfo` time axis — when the engine ingests or drops a
+//! volume the version changes, so "latest" requests and nearest-time
+//! selection changes invalidate naturally without duplicating the engine's
+//! selection logic here.
+//!
+//! Single-flight: concurrent requests for the same key share one compute
+//! (a per-key async mutex). Without it, the viewer's frame preload could run
+//! the identical multi-second resample N times in parallel.
+//!
+//! Process-global (`LazyLock`, like the engine-side pixel cache) rather than
+//! per-`TilesState3d`: the key carries the collection id + data version, so
+//! entries stay correct across config reloads, and one byte budget bounds the
+//! whole server.
+
+use std::collections::HashMap;
+use std::future::Future;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, LazyLock, Mutex};
+
+use bytes::Bytes;
+use chrono::{DateTime, Utc};
+
+use crate::error::Tiles3dError;
+
+/// Default encoded-content cache size (MB) when `MC_3DTILES_CONTENT_CACHE_MB`
+/// is unset. Encoded tiles are a few hundred KB (echo-top) to tens of MB
+/// (dense point clouds); 512 MB comfortably holds an animation window of one
+/// busy collection. `0` disables caching (every request recomputes —
+/// diagnostic only; single-flight still coalesces concurrent duplicates).
+const DEFAULT_CONTENT_CACHE_MB: u64 = 512;
+
+/// Which encoded product the bytes are — part of the key so two products with
+/// otherwise-identical parameters can't collide.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ContentKind {
+    /// `.pnts` point cloud.
+    Pnts,
+    /// Isosurface mesh `.glb`.
+    Isosurface,
+    /// Echo-top columns `.glb`.
+    EchoTop,
+    /// `EXT_primitive_voxels` `.glb`.
+    Voxels,
+}
+
+/// Everything that determines the encoded bytes.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ContentKey {
+    pub collection: String,
+    pub kind: ContentKind,
+    /// Resolved quantity — callers resolve an absent `?quantity=` to the
+    /// collection default so both forms share one entry.
+    pub quantity: String,
+    /// Requested valid time (`None` = latest). The engine's nearest-volume
+    /// selection for a *pinned* time can change when data arrives; that (and
+    /// "latest" advancing) is covered by `version`, not by this field.
+    pub datetime: Option<DateTime<Utc>>,
+    /// Product parameter bits: `min_value` (points) or `threshold` (meshes),
+    /// `f64::to_bits` for `Eq`/`Hash`. `None` when the request had none (the
+    /// callers pass the applied default explicitly, so a defaulted and an
+    /// explicit-default request share an entry).
+    pub param_bits: Option<u64>,
+    /// Voxel-grid dims for the mesh/voxel products; `[0; 3]` for points
+    /// (native resolution, no grid).
+    pub dims: [usize; 3],
+    /// Data version of the collection — see [`module docs`](self). Computed
+    /// by the handler from `VolumeInfo`.
+    pub version: u64,
+}
+
+/// A cached response body: cheap-clone bytes + the strong ETag computed over
+/// them. Returned by value (both fields are refcounted).
+#[derive(Clone)]
+pub struct CachedContent {
+    pub bytes: Bytes,
+    pub etag: Arc<str>,
+}
+
+/// Byte-weights an entry by its encoded payload.
+#[derive(Clone)]
+struct ContentWeighter;
+
+impl quick_cache::Weighter<ContentKey, CachedContent> for ContentWeighter {
+    fn weight(&self, key: &ContentKey, val: &CachedContent) -> u64 {
+        (val.bytes.len() + val.etag.len() + key.collection.len() + key.quantity.len() + 128) as u64
+    }
+}
+
+/// Byte-bounded LRU of encoded content + per-key single-flight gates.
+pub struct ContentCache {
+    cache: quick_cache::sync::Cache<ContentKey, CachedContent, ContentWeighter>,
+    /// One async mutex per in-flight key. The first requester computes while
+    /// holding the gate; coalesced requesters block on it, then find the
+    /// cache populated. Entries are removed when their compute finishes, so
+    /// the map only ever holds currently-computing keys.
+    inflight: Mutex<HashMap<ContentKey, Arc<tokio::sync::Mutex<()>>>>,
+    hits: AtomicU64,
+    misses: AtomicU64,
+}
+
+impl ContentCache {
+    fn new(capacity_mb: u64) -> Self {
+        let capacity_bytes = capacity_mb.saturating_mul(1024 * 1024);
+        // Estimate item slots at ~2 MB each; `.max(1)` keeps capacity 0 valid
+        // (entries heavier than capacity are simply never admitted — the same
+        // "disabled" idiom as the engine's pixel cache).
+        let estimated_items = ((capacity_bytes / (2 * 1024 * 1024)).max(16)) as usize;
+        ContentCache {
+            cache: quick_cache::sync::Cache::with_weighter(
+                estimated_items,
+                capacity_bytes.max(1),
+                ContentWeighter,
+            ),
+            inflight: Mutex::new(HashMap::new()),
+            hits: AtomicU64::new(0),
+            misses: AtomicU64::new(0),
+        }
+    }
+
+    /// Cached bytes for `key`, or run `compute` (which returns the encoded
+    /// bytes + their ETag) and cache its result. Concurrent callers with the
+    /// same key share one compute; errors are not cached (coalesced waiters
+    /// then retry serially, which bounds an error stampede without pinning a
+    /// transient failure).
+    pub async fn get_or_compute<F, Fut>(
+        &self,
+        key: ContentKey,
+        compute: F,
+    ) -> Result<CachedContent, Tiles3dError>
+    where
+        F: FnOnce() -> Fut,
+        Fut: Future<Output = Result<(Vec<u8>, String), Tiles3dError>>,
+    {
+        if let Some(hit) = self.cache.get(&key) {
+            self.hits.fetch_add(1, Ordering::Relaxed);
+            return Ok(hit);
+        }
+        let gate = {
+            let mut map = self.inflight.lock().unwrap_or_else(|e| e.into_inner());
+            map.entry(key.clone())
+                .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
+                .clone()
+        };
+        let _held = gate.lock().await;
+        // Re-check under the gate: if a coalesced compute just finished, the
+        // bytes are in the cache and this request cost two lookups.
+        if let Some(hit) = self.cache.get(&key) {
+            self.hits.fetch_add(1, Ordering::Relaxed);
+            self.release(&key, &gate);
+            return Ok(hit);
+        }
+        self.misses.fetch_add(1, Ordering::Relaxed);
+        let result = compute().await;
+        let out = match result {
+            Ok((bytes, etag)) => {
+                let content = CachedContent {
+                    bytes: Bytes::from(bytes),
+                    etag: Arc::from(etag.as_str()),
+                };
+                self.cache.insert(key.clone(), content.clone());
+                Ok(content)
+            }
+            Err(e) => Err(e),
+        };
+        self.release(&key, &gate);
+        out
+    }
+
+    /// Drop this key's in-flight gate — but only if it is still *our* gate
+    /// (`ptr_eq`): after an error, a later request may have installed a fresh
+    /// gate for the same key, which must not be removed from under it.
+    fn release(&self, key: &ContentKey, gate: &Arc<tokio::sync::Mutex<()>>) {
+        let mut map = self.inflight.lock().unwrap_or_else(|e| e.into_inner());
+        if map.get(key).is_some_and(|g| Arc::ptr_eq(g, gate)) {
+            map.remove(key);
+        }
+    }
+
+    /// Snapshot for `/metrics`: `(hits, misses, resident_bytes, capacity_bytes)`.
+    pub fn metrics(&self) -> (u64, u64, u64, u64) {
+        (
+            self.hits.load(Ordering::Relaxed),
+            self.misses.load(Ordering::Relaxed),
+            self.cache.weight(),
+            self.cache.capacity(),
+        )
+    }
+}
+
+/// The process-global content cache, sized once from the environment.
+pub static CONTENT_CACHE: LazyLock<ContentCache> = LazyLock::new(|| {
+    let mb = std::env::var("MC_3DTILES_CONTENT_CACHE_MB")
+        .ok()
+        .and_then(|s| s.trim().parse::<u64>().ok())
+        .unwrap_or(DEFAULT_CONTENT_CACHE_MB);
+    ContentCache::new(mb)
+});
+
+/// Snapshot of the global cache for `/metrics`.
+pub fn content_cache_metrics() -> (u64, u64, u64, u64) {
+    CONTENT_CACHE.metrics()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn key(n: u64) -> ContentKey {
+        ContentKey {
+            collection: "c".into(),
+            kind: ContentKind::Pnts,
+            quantity: "DBZH".into(),
+            datetime: None,
+            param_bits: None,
+            dims: [0; 3],
+            version: n,
+        }
+    }
+
+    #[tokio::test]
+    async fn caches_and_serves_without_recompute() {
+        let cache = ContentCache::new(64);
+        let computes = Arc::new(AtomicU64::new(0));
+        for _ in 0..3 {
+            let c = computes.clone();
+            let got = cache
+                .get_or_compute(key(1), || async move {
+                    c.fetch_add(1, Ordering::Relaxed);
+                    Ok((vec![1, 2, 3], "\"abc\"".to_string()))
+                })
+                .await
+                .unwrap();
+            assert_eq!(&got.bytes[..], &[1, 2, 3]);
+            assert_eq!(&*got.etag, "\"abc\"");
+        }
+        assert_eq!(computes.load(Ordering::Relaxed), 1, "one compute, two hits");
+        let (hits, misses, bytes, _cap) = cache.metrics();
+        assert_eq!((hits, misses), (2, 1));
+        assert!(bytes > 0);
+    }
+
+    #[tokio::test]
+    async fn version_change_is_a_new_entry() {
+        let cache = ContentCache::new(64);
+        for v in [1u64, 2] {
+            let got = cache
+                .get_or_compute(
+                    key(v),
+                    || async move { Ok((vec![v as u8], format!("\"{v}\""))) },
+                )
+                .await
+                .unwrap();
+            assert_eq!(&got.bytes[..], &[v as u8]);
+        }
+        let (hits, misses, _, _) = cache.metrics();
+        assert_eq!((hits, misses), (0, 2));
+    }
+
+    #[tokio::test]
+    async fn concurrent_same_key_coalesces_to_one_compute() {
+        let cache = Arc::new(ContentCache::new(64));
+        let computes = Arc::new(AtomicU64::new(0));
+        let mut handles = Vec::new();
+        for _ in 0..8 {
+            let cache = cache.clone();
+            let computes = computes.clone();
+            handles.push(tokio::spawn(async move {
+                cache
+                    .get_or_compute(key(7), || async move {
+                        computes.fetch_add(1, Ordering::Relaxed);
+                        // Linger so the other tasks pile onto the gate.
+                        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+                        Ok((vec![9], "\"x\"".to_string()))
+                    })
+                    .await
+            }));
+        }
+        for h in handles {
+            let got = h.await.unwrap().unwrap();
+            assert_eq!(&got.bytes[..], &[9]);
+        }
+        assert_eq!(computes.load(Ordering::Relaxed), 1, "coalesced");
+        // The gate map must not leak finished keys.
+        assert!(cache.inflight.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn error_is_not_cached_and_gate_is_released() {
+        let cache = ContentCache::new(64);
+        let err = cache
+            .get_or_compute(key(3), || async {
+                Err(Tiles3dError::Internal("boom".into()))
+            })
+            .await;
+        assert!(err.is_err());
+        assert!(cache.inflight.lock().unwrap().is_empty());
+        // A later request recomputes and succeeds.
+        let got = cache
+            .get_or_compute(key(3), || async { Ok((vec![4], "\"y\"".to_string())) })
+            .await
+            .unwrap();
+        assert_eq!(&got.bytes[..], &[4]);
+    }
+
+    #[tokio::test]
+    async fn capacity_zero_disables_storage_but_still_serves() {
+        let cache = ContentCache::new(0);
+        for _ in 0..2 {
+            let got = cache
+                .get_or_compute(key(5), || async { Ok((vec![1], "\"z\"".to_string())) })
+                .await
+                .unwrap();
+            assert_eq!(&got.bytes[..], &[1]);
+        }
+        let (hits, misses, _, _) = cache.metrics();
+        assert_eq!((hits, misses), (0, 2), "nothing admitted at capacity 0");
+    }
+}

--- a/crates/api-3dtiles/src/handlers.rs
+++ b/crates/api-3dtiles/src/handlers.rs
@@ -335,27 +335,32 @@ fn etag_of(bytes: &[u8]) -> String {
     format!("\"{h:016x}\"")
 }
 
-/// The `Cache-Control` for a response: content pinned to an explicit
-/// `?datetime=` is an archived volume that effectively never changes, so let
+/// The `Cache-Control` for a response: content pinned to an **exactly
+/// advertised** volume time is an archived volume that never changes, so let
 /// browsers hold it for a day without revalidating (`immutable`) — exactly the
-/// WMS explicit-`TIME` policy. The bundled viewer pins every animation frame,
-/// so a reload re-uses all of them from the browser cache instead of issuing
-/// one revalidation per frame.
+/// WMS explicit-`TIME` policy. The bundled viewer pins every animation frame
+/// from the `times` manifest, so a reload re-uses all of them from the browser
+/// cache instead of issuing one revalidation per frame.
 ///
-/// Caveat (accepted): for a pinned time the engine selects the *nearest*
-/// retained volume, so if a closer volume arrives later the same URL would
-/// serve different bytes; clients that pin times from the advertised `times`
-/// manifest (the viewer does) always name an exact volume, where the response
-/// truly is immutable.
-///
-/// "Latest" (no `?datetime=`) keeps the short window: a new volume must show
-/// up within a minute.
+/// `pinned` must be computed via [`exact_volume_time`], NOT from the mere
+/// presence of `?datetime=`: the engine selects the *nearest* retained volume,
+/// so a datetime **between** volumes can start resolving to different bytes
+/// when a closer volume arrives — `immutable` would let browsers and shared
+/// caches (CDN/reverse proxy) serve that stale for a day (PR #378 review).
+/// Non-exact pinned times and "latest" both keep the short window.
 fn cache_control(pinned: bool) -> &'static str {
     if pinned {
         "public, max-age=86400, immutable"
     } else {
         "public, max-age=60"
     }
+}
+
+/// Whether `time` names an **exactly advertised** volume time — the only case
+/// where a response is truly immutable (see [`cache_control`]). `VolumeInfo.
+/// times` is sorted ascending per the engine contract, so binary search.
+fn exact_volume_time(info: &ds_core::volume::VolumeInfo, time: Option<DateTime<Utc>>) -> bool {
+    time.is_some_and(|t| info.times.binary_search(&t).is_ok())
 }
 
 /// Build a binary content response with strong-ETag conditional handling: a
@@ -467,9 +472,9 @@ pub async fn get_tileset(
     // URI so the content fetch is deterministic. Re-format the parsed time as
     // UTC `…Z` — a raw `+hh:mm` offset would be decoded as a space by the
     // client's URL parser and 400 on the fetch.
+    let time = params.datetime.as_deref().map(parse_datetime).transpose()?;
     let mut query = format!("quantity={}", pct_encode(&quantity));
-    if let Some(dt_str) = &params.datetime {
-        let dt = parse_datetime(dt_str)?;
+    if let Some(dt) = time {
         query.push_str(&format!("&datetime={}", dt.format("%Y-%m-%dT%H:%M:%SZ")));
     }
 
@@ -536,12 +541,13 @@ pub async fn get_tileset(
     Ok((
         [
             (header::CONTENT_TYPE, "application/json"),
-            // Pinned-time tilesets are stable like their content (the region
-            // is the site's static coverage), so let browsers keep them too —
-            // the viewer fetches one tileset per preloaded animation frame.
+            // Tilesets pinned to an exact advertised volume time are stable
+            // like their content (the region is the site's static coverage),
+            // so let browsers keep them too — the viewer fetches one tileset
+            // per preloaded animation frame.
             (
                 header::CACHE_CONTROL,
-                cache_control(params.datetime.is_some()),
+                cache_control(exact_volume_time(&info, time)),
             ),
         ],
         tileset,
@@ -585,7 +591,7 @@ pub async fn get_content(
         dims: [0; 3],
         version: data_version(&info),
     };
-    let pinned = time.is_some();
+    let pinned = exact_volume_time(&info, time);
 
     let engine = engine.clone();
     let semaphore = state.render_semaphore.clone();
@@ -720,7 +726,7 @@ pub async fn get_content_glb(
         dims,
         version: data_version(&info),
     };
-    let pinned = time.is_some();
+    let pinned = exact_volume_time(&info, time);
 
     let engine = engine.clone();
     let semaphore = state.render_semaphore.clone();
@@ -853,9 +859,9 @@ pub async fn get_voxel_tileset(
 
     // The content fetch must render the same selection — bake it into the
     // (relative) content URI's query, alongside the implicit-tiling placeholders.
+    let time = params.datetime.as_deref().map(parse_datetime).transpose()?;
     let mut q = format!("quantity={}", pct_encode(&quantity));
-    if let Some(dt) = &params.datetime {
-        let dt = parse_datetime(dt)?;
+    if let Some(dt) = time {
         q.push_str(&format!("&datetime={}", dt.format("%Y-%m-%dT%H:%M:%SZ")));
     }
     q.push_str(&format!("&resolution={}", resolution.as_str()));
@@ -881,7 +887,7 @@ pub async fn get_voxel_tileset(
     // route through the shared ETag/conditional-GET helper so a CesiumJS poll
     // with a matching `If-None-Match` short-circuits to 304 (matches the
     // `content.pnts`/`content.glb` handlers).
-    let pinned = params.datetime.is_some();
+    let pinned = exact_volume_time(&info, time);
     let bytes = Bytes::from(tileset.into_bytes());
     let etag = etag_of(&bytes);
     Ok(binary_response(
@@ -1006,7 +1012,7 @@ pub async fn get_voxel_content(
         dims,
         version: data_version(&info),
     };
-    let pinned = time.is_some();
+    let pinned = exact_volume_time(&info, time);
 
     let engine = engine.clone();
     let id_for_err = key.collection.clone();

--- a/crates/api-3dtiles/src/handlers.rs
+++ b/crates/api-3dtiles/src/handlers.rs
@@ -418,6 +418,23 @@ fn data_version(info: &ds_core::volume::VolumeInfo) -> u64 {
     h
 }
 
+/// [`ContentKey::version`] for a request: an **exact advertised volume time**
+/// pins an immutable volume (nearest-selection of a zero-distance match is
+/// that volume; the file never changes once scanned), so its key gets a
+/// constant version — new volume arrivals must NOT evict the whole preloaded
+/// animation window every poll cycle (PR #378 review r2). Everything else
+/// ("latest", between-volume datetimes) takes the full [`data_version`].
+/// Retirement is covered: once the volume drops from `VolumeInfo.times` the
+/// exactness check flips false and the same request maps to a fresh
+/// `data_version`-keyed entry, so a retired time can't serve stale bytes.
+fn content_version(info: &ds_core::volume::VolumeInfo, exact: bool) -> u64 {
+    if exact {
+        0
+    } else {
+        data_version(info)
+    }
+}
+
 /// The bundled CesiumJS viewer page (collection + quantity + representation
 /// picker), baked into the binary and served at `GET /3dtiles/viewer`.
 const VIEWER_HTML: &str = include_str!("../viewer/index.html");
@@ -578,6 +595,7 @@ pub async fn get_content(
     }
 
     let info = engine.volume_info();
+    let exact = exact_volume_time(&info, time);
     let key = ContentKey {
         collection: id,
         kind: ContentKind::Pnts,
@@ -589,9 +607,9 @@ pub async fn get_content(
         datetime: time,
         param_bits: min_value.map(f64::to_bits),
         dims: [0; 3],
-        version: data_version(&info),
+        version: content_version(&info, exact),
     };
-    let pinned = exact_volume_time(&info, time);
+    let pinned = exact;
 
     let engine = engine.clone();
     let semaphore = state.render_semaphore.clone();
@@ -710,6 +728,7 @@ pub async fn get_content_glb(
         )));
     }
 
+    let exact = exact_volume_time(&info, time);
     let key = ContentKey {
         collection: id,
         kind: match representation {
@@ -724,9 +743,9 @@ pub async fn get_content_glb(
         // defaulted and an explicit-default request share one entry.
         param_bits: Some(threshold.to_bits()),
         dims,
-        version: data_version(&info),
+        version: content_version(&info, exact),
     };
-    let pinned = exact_volume_time(&info, time);
+    let pinned = exact;
 
     let engine = engine.clone();
     let semaphore = state.render_semaphore.clone();
@@ -1001,6 +1020,7 @@ pub async fn get_voxel_content(
     let quantity = params.quantity.clone();
     let dims = Resolution::parse(params.resolution.as_deref())?.dims();
 
+    let exact = exact_volume_time(&info, time);
     let key = ContentKey {
         collection: id,
         kind: ContentKind::Voxels,
@@ -1010,9 +1030,9 @@ pub async fn get_voxel_content(
         datetime: time,
         param_bits: None,
         dims,
-        version: data_version(&info),
+        version: content_version(&info, exact),
     };
-    let pinned = exact_volume_time(&info, time);
+    let pinned = exact;
 
     let engine = engine.clone();
     let id_for_err = key.collection.clone();

--- a/crates/api-3dtiles/src/handlers.rs
+++ b/crates/api-3dtiles/src/handlers.rs
@@ -20,6 +20,7 @@ use arc_swap::ArcSwap;
 use axum::extract::{Path, Query, State};
 use axum::http::{header, HeaderMap, StatusCode};
 use axum::response::{IntoResponse, Json, Response};
+use bytes::Bytes;
 use chrono::{DateTime, SecondsFormat, Utc};
 use ds_core::config::CollectionConfig;
 use ds_core::geo::geodetic_to_ecef;
@@ -28,6 +29,7 @@ use ds_render::{BuiltinColormap, ColorMap, ColorStop, LutColorMap};
 use serde::Deserialize;
 use serde_json::json;
 
+use crate::cache::{ContentKey, ContentKind, CONTENT_CACHE};
 use crate::error::Tiles3dError;
 
 /// Default isosurface threshold (dBZ) when a request names none — a light-rain
@@ -333,20 +335,42 @@ fn etag_of(bytes: &[u8]) -> String {
     format!("\"{h:016x}\"")
 }
 
+/// The `Cache-Control` for a response: content pinned to an explicit
+/// `?datetime=` is an archived volume that effectively never changes, so let
+/// browsers hold it for a day without revalidating (`immutable`) — exactly the
+/// WMS explicit-`TIME` policy. The bundled viewer pins every animation frame,
+/// so a reload re-uses all of them from the browser cache instead of issuing
+/// one revalidation per frame.
+///
+/// Caveat (accepted): for a pinned time the engine selects the *nearest*
+/// retained volume, so if a closer volume arrives later the same URL would
+/// serve different bytes; clients that pin times from the advertised `times`
+/// manifest (the viewer does) always name an exact volume, where the response
+/// truly is immutable.
+///
+/// "Latest" (no `?datetime=`) keeps the short window: a new volume must show
+/// up within a minute.
+fn cache_control(pinned: bool) -> &'static str {
+    if pinned {
+        "public, max-age=86400, immutable"
+    } else {
+        "public, max-age=60"
+    }
+}
+
 /// Build a binary content response with strong-ETag conditional handling: a
 /// matching `If-None-Match` (or `*`) yields 304, otherwise 200 with the bytes.
 ///
-/// Note the 304 saves the *network transfer* but not the recompute — the
-/// caller already sampled + encoded + hashed to obtain `etag` (the
-/// `If-None-Match` value can't be trusted to match without recomputing the
-/// content). A CPU-cheap 304 needs an ETag cache keyed by the request params +
-/// a data-version — a follow-up. RFC 7232 §3.2: `If-None-Match` may be `*` or a
-/// comma-separated list.
+/// The bytes/ETag normally come from [`crate::cache::CONTENT_CACHE`], so a
+/// revalidation that hits the cache is two lookups — not a recompute. `pinned`
+/// selects the [`cache_control`] policy. RFC 7232 §3.2: `If-None-Match` may be
+/// `*` or a comma-separated list.
 fn binary_response(
     headers: &HeaderMap,
     content_type: &'static str,
     etag: &str,
-    bytes: Vec<u8>,
+    bytes: Bytes,
+    pinned: bool,
 ) -> Response {
     let not_modified = headers
         .get(header::IF_NONE_MATCH)
@@ -357,7 +381,7 @@ fn binary_response(
             StatusCode::NOT_MODIFIED,
             [
                 (header::ETAG, etag),
-                (header::CACHE_CONTROL, "public, max-age=60"),
+                (header::CACHE_CONTROL, cache_control(pinned)),
             ],
         )
             .into_response();
@@ -366,11 +390,27 @@ fn binary_response(
         [
             (header::CONTENT_TYPE, content_type),
             (header::ETAG, etag),
-            (header::CACHE_CONTROL, "public, max-age=60"),
+            (header::CACHE_CONTROL, cache_control(pinned)),
         ],
         bytes,
     )
         .into_response()
+}
+
+/// Data version of a collection for [`ContentKey`]: an FNV-1a hash of the
+/// volume time axis. Ingesting or dropping a volume changes it, which
+/// invalidates every cached "latest" entry *and* any pinned-time entry whose
+/// nearest-volume selection could have changed — without re-implementing the
+/// engine's selection rule at the API layer.
+fn data_version(info: &ds_core::volume::VolumeInfo) -> u64 {
+    let mut h: u64 = 0xcbf2_9ce4_8422_2325;
+    for t in &info.times {
+        for b in t.timestamp_millis().to_le_bytes() {
+            h ^= b as u64;
+            h = h.wrapping_mul(0x0000_0100_0000_01b3);
+        }
+    }
+    h
 }
 
 /// The bundled CesiumJS viewer page (collection + quantity + representation
@@ -496,7 +536,13 @@ pub async fn get_tileset(
     Ok((
         [
             (header::CONTENT_TYPE, "application/json"),
-            (header::CACHE_CONTROL, "public, max-age=60"),
+            // Pinned-time tilesets are stable like their content (the region
+            // is the site's static coverage), so let browsers keep them too —
+            // the viewer fetches one tileset per preloaded animation frame.
+            (
+                header::CACHE_CONTROL,
+                cache_control(params.datetime.is_some()),
+            ),
         ],
         tileset,
     )
@@ -525,36 +571,59 @@ pub async fn get_content(
         return Err(Tiles3dError::BadRequest("min_value must be finite".into()));
     }
 
-    // Sample + encode off the request worker: `read_point_cloud` does blocking
-    // HDF5 I/O and a long CPU loop (CLAUDE.md concurrency rules), so bound it
-    // with the shared render semaphore and run it on a blocking thread.
-    let _permit = state
-        .render_semaphore
-        .clone()
-        .acquire_owned()
-        .await
-        .map_err(|_| Tiles3dError::Internal("render semaphore closed".into()))?;
+    let info = engine.volume_info();
+    let key = ContentKey {
+        collection: id,
+        kind: ContentKind::Pnts,
+        // Resolve an absent quantity to the default so both forms share one
+        // entry (the engine resolves `None` to the same default).
+        quantity: quantity
+            .clone()
+            .unwrap_or_else(|| info.default_quantity.clone()),
+        datetime: time,
+        param_bits: min_value.map(f64::to_bits),
+        dims: [0; 3],
+        version: data_version(&info),
+    };
+    let pinned = time.is_some();
 
     let engine = engine.clone();
+    let semaphore = state.render_semaphore.clone();
     let colormap = state.colormap.clone();
-    // Sample, encode, and hash all on the blocking thread (the ETag hash over a
-    // multi-MB tile is real CPU — keep it off the async worker too).
-    let (bytes, etag) =
-        tokio::task::spawn_blocking(move || -> Result<(Vec<u8>, String), Tiles3dError> {
-            let cloud = engine.read_point_cloud(quantity.as_deref(), time, min_value, None)?;
-            let bytes = ds_3dtiles::encode_pnts(&cloud, colormap.as_ref())
-                .map_err(|e| Tiles3dError::Internal(format!("pnts encode failed: {e}")))?;
-            let etag = etag_of(&bytes);
-            Ok((bytes, etag))
+    let content = CONTENT_CACHE
+        .get_or_compute(key, || async move {
+            // Sample + encode off the request worker: `read_point_cloud` does
+            // blocking HDF5 I/O and a long CPU loop (CLAUDE.md concurrency
+            // rules), so bound it with the shared render semaphore and run it
+            // on a blocking thread. Only the computing (cache-missing)
+            // request pays this — hits and coalesced waiters never queue on
+            // the semaphore.
+            let _permit = semaphore
+                .acquire_owned()
+                .await
+                .map_err(|_| Tiles3dError::Internal("render semaphore closed".into()))?;
+
+            // Sample, encode, and hash all on the blocking thread (the ETag
+            // hash over a multi-MB tile is real CPU — keep it off the async
+            // worker too).
+            tokio::task::spawn_blocking(move || -> Result<(Vec<u8>, String), Tiles3dError> {
+                let cloud = engine.read_point_cloud(quantity.as_deref(), time, min_value, None)?;
+                let bytes = ds_3dtiles::encode_pnts(&cloud, colormap.as_ref())
+                    .map_err(|e| Tiles3dError::Internal(format!("pnts encode failed: {e}")))?;
+                let etag = etag_of(&bytes);
+                Ok((bytes, etag))
+            })
+            .await
+            .map_err(|e| Tiles3dError::Internal(format!("sample task failed: {e}")))?
         })
-        .await
-        .map_err(|e| Tiles3dError::Internal(format!("sample task failed: {e}")))??;
+        .await?;
 
     Ok(binary_response(
         &headers,
         "application/octet-stream",
-        &etag,
-        bytes,
+        &content.etag,
+        content.bytes,
+        pinned,
     ))
 }
 
@@ -635,66 +704,97 @@ pub async fn get_content_glb(
         )));
     }
 
-    // read_voxel_grid + meshing do blocking HDF5 I/O + a long CPU loop, so bound
-    // them with the shared render semaphore and run on a blocking thread (same
-    // rule as the `.pnts` path / the raster `get_raster_tile`).
-    let _permit = state
-        .render_semaphore
-        .clone()
-        .acquire_owned()
-        .await
-        .map_err(|_| Tiles3dError::Internal("render semaphore closed".into()))?;
+    let key = ContentKey {
+        collection: id,
+        kind: match representation {
+            Representation::EchoTop => ContentKind::EchoTop,
+            _ => ContentKind::Isosurface,
+        },
+        quantity: quantity
+            .clone()
+            .unwrap_or_else(|| info.default_quantity.clone()),
+        datetime: time,
+        // The *applied* threshold (default already folded in above), so a
+        // defaulted and an explicit-default request share one entry.
+        param_bits: Some(threshold.to_bits()),
+        dims,
+        version: data_version(&info),
+    };
+    let pinned = time.is_some();
 
     let engine = engine.clone();
+    let semaphore = state.render_semaphore.clone();
     let colormap = state.colormap.clone(); // reflectivity ramp (isosurface)
-    let id_for_err = id.clone();
-    let (bytes, etag) =
-        tokio::task::spawn_blocking(move || -> Result<(Vec<u8>, String), Tiles3dError> {
-            let result = match representation {
-                Representation::EchoTop => {
-                    let grid =
-                        engine.read_voxel_grid(quantity.as_deref(), time, Some(dims), None)?;
-                    ds_3dtiles::encode_echo_top_columns_glb(&grid, threshold, &*ECHO_TOP_COLORMAP)
-                }
-                Representation::Isosurface => {
-                    let grid =
-                        engine.read_voxel_grid(quantity.as_deref(), time, Some(dims), None)?;
-                    // Colour the shell at the threshold (v1: one colormap for all
-                    // quantities — #350); seal NaN at the no-echo floor so it
-                    // closes into solid blobs (`floor < threshold` guaranteed).
-                    let color = colormap.color(Some(threshold));
-                    ds_3dtiles::encode_isosurface_glb(&grid, threshold, color, Some(floor))
-                }
-                // Rejected before the blocking task (see the `product` match).
-                Representation::Points => unreachable!("points rejected above"),
-            };
-            let bytes = result.map_err(|e| match e {
-                // No surface / no columns (threshold above all echo) — 404.
-                ds_3dtiles::Tiles3dError::Empty => Tiles3dError::NotFound(format!(
-                    "no {product} at threshold {threshold} for collection '{id_for_err}'"
-                )),
-                // Client-driven (threshold too low for this grid) — 400.
-                ds_3dtiles::Tiles3dError::TooLarge(_) => Tiles3dError::BadRequest(format!(
-                    "threshold {threshold} produces too large a {product}; raise it"
-                )),
-                // Unreachable (floor < threshold above) — defensive 400. Only
-                // the isosurface encoder emits this today, but this `map_err`
-                // covers both products, so use `{product}` for consistency.
-                ds_3dtiles::Tiles3dError::BackgroundNotBelowThreshold { .. } => {
-                    Tiles3dError::BadRequest(format!(
-                        "{product} sealing floor is not below the threshold"
-                    ))
-                }
-                other => Tiles3dError::Internal(format!("{product} encode failed: {other}")),
-            })?;
-            let etag = etag_of(&bytes);
-            Ok((bytes, etag))
+    let id_for_err = key.collection.clone();
+    let content = CONTENT_CACHE
+        .get_or_compute(key, || async move {
+            // read_voxel_grid + meshing do blocking HDF5 I/O + a long CPU
+            // loop, so bound them with the shared render semaphore and run on
+            // a blocking thread (same rule as the `.pnts` path / the raster
+            // `get_raster_tile`). Only the computing request pays this.
+            let _permit = semaphore
+                .acquire_owned()
+                .await
+                .map_err(|_| Tiles3dError::Internal("render semaphore closed".into()))?;
+
+            tokio::task::spawn_blocking(move || -> Result<(Vec<u8>, String), Tiles3dError> {
+                let result = match representation {
+                    Representation::EchoTop => {
+                        let grid =
+                            engine.read_voxel_grid(quantity.as_deref(), time, Some(dims), None)?;
+                        ds_3dtiles::encode_echo_top_columns_glb(
+                            &grid,
+                            threshold,
+                            &*ECHO_TOP_COLORMAP,
+                        )
+                    }
+                    Representation::Isosurface => {
+                        let grid =
+                            engine.read_voxel_grid(quantity.as_deref(), time, Some(dims), None)?;
+                        // Colour the shell at the threshold (v1: one colormap for all
+                        // quantities — #350); seal NaN at the no-echo floor so it
+                        // closes into solid blobs (`floor < threshold` guaranteed).
+                        let color = colormap.color(Some(threshold));
+                        ds_3dtiles::encode_isosurface_glb(&grid, threshold, color, Some(floor))
+                    }
+                    // Rejected before the blocking task (see the `product` match).
+                    Representation::Points => unreachable!("points rejected above"),
+                };
+                let bytes = result.map_err(|e| match e {
+                    // No surface / no columns (threshold above all echo) — 404.
+                    ds_3dtiles::Tiles3dError::Empty => Tiles3dError::NotFound(format!(
+                        "no {product} at threshold {threshold} for collection '{id_for_err}'"
+                    )),
+                    // Client-driven (threshold too low for this grid) — 400.
+                    ds_3dtiles::Tiles3dError::TooLarge(_) => Tiles3dError::BadRequest(format!(
+                        "threshold {threshold} produces too large a {product}; raise it"
+                    )),
+                    // Unreachable (floor < threshold above) — defensive 400. Only
+                    // the isosurface encoder emits this today, but this `map_err`
+                    // covers both products, so use `{product}` for consistency.
+                    ds_3dtiles::Tiles3dError::BackgroundNotBelowThreshold { .. } => {
+                        Tiles3dError::BadRequest(format!(
+                            "{product} sealing floor is not below the threshold"
+                        ))
+                    }
+                    other => Tiles3dError::Internal(format!("{product} encode failed: {other}")),
+                })?;
+                let etag = etag_of(&bytes);
+                Ok((bytes, etag))
+            })
+            .await
+            .map_err(|e| Tiles3dError::Internal(format!("sample task failed: {e}")))?
         })
-        .await
-        .map_err(|e| Tiles3dError::Internal(format!("sample task failed: {e}")))??;
+        .await?;
 
     // glTF binary media type (CesiumJS also keys off the `.glb` magic).
-    Ok(binary_response(&headers, "model/gltf-binary", &etag, bytes))
+    Ok(binary_response(
+        &headers,
+        "model/gltf-binary",
+        &content.etag,
+        content.bytes,
+        pinned,
+    ))
 }
 
 // ---------------------------------------------------------------------------
@@ -781,9 +881,16 @@ pub async fn get_voxel_tileset(
     // route through the shared ETag/conditional-GET helper so a CesiumJS poll
     // with a matching `If-None-Match` short-circuits to 304 (matches the
     // `content.pnts`/`content.glb` handlers).
-    let bytes = tileset.into_bytes();
+    let pinned = params.datetime.is_some();
+    let bytes = Bytes::from(tileset.into_bytes());
     let etag = etag_of(&bytes);
-    Ok(binary_response(&headers, "application/json", &etag, bytes))
+    Ok(binary_response(
+        &headers,
+        "application/json",
+        &etag,
+        bytes,
+        pinned,
+    ))
 }
 
 /// `GET /collections/{id}/voxel/subtrees/{*tile}` — the implicit-tiling
@@ -814,12 +921,21 @@ pub async fn get_voxel_subtree(
     }
     // Constant body ⇒ constant ETag; route through `binary_response` so a
     // CesiumJS subtree re-poll with a matching `If-None-Match` short-circuits to
-    // 304 (the subtree is fetched during voxel traversal).
-    let bytes = ds_3dtiles::voxel_subtree_json()
-        .map_err(|e| Tiles3dError::Internal(format!("voxel subtree build failed: {e}")))?
-        .into_bytes();
+    // 304 (the subtree is fetched during voxel traversal). The body never
+    // changes (single-tile set), so it gets the long-lived policy.
+    let bytes = Bytes::from(
+        ds_3dtiles::voxel_subtree_json()
+            .map_err(|e| Tiles3dError::Internal(format!("voxel subtree build failed: {e}")))?
+            .into_bytes(),
+    );
     let etag = etag_of(&bytes);
-    Ok(binary_response(&headers, "application/json", &etag, bytes))
+    Ok(binary_response(
+        &headers,
+        "application/json",
+        &etag,
+        bytes,
+        true,
+    ))
 }
 
 /// The implicit voxel tiling is a single tile (`subtreeLevels`/`availableLevels`
@@ -879,32 +995,54 @@ pub async fn get_voxel_content(
     let quantity = params.quantity.clone();
     let dims = Resolution::parse(params.resolution.as_deref())?.dims();
 
-    // Dedicated voxel pool (NOT the shared raster `render_semaphore`) so a slow
-    // `high`-res encode can't hold a WMS/Maps/Tiles render slot — see
-    // `VOXEL_SEMAPHORE`.
-    let _permit = VOXEL_SEMAPHORE
-        .clone()
-        .acquire_owned()
-        .await
-        .map_err(|_| Tiles3dError::Internal("voxel semaphore closed".into()))?;
-    let engine = engine.clone();
-    let id_for_err = id.clone();
-    let (bytes, etag) =
-        tokio::task::spawn_blocking(move || -> Result<(Vec<u8>, String), Tiles3dError> {
-            let grid = engine.read_voxel_grid(quantity.as_deref(), time, Some(dims), None)?;
-            let bytes = ds_3dtiles::encode_voxels_glb(&grid).map_err(|e| match e {
-                ds_3dtiles::Tiles3dError::Empty => {
-                    Tiles3dError::NotFound(format!("no voxel data for collection '{id_for_err}'"))
-                }
-                other => Tiles3dError::Internal(format!("voxel encode failed: {other}")),
-            })?;
-            let etag = etag_of(&bytes);
-            Ok((bytes, etag))
-        })
-        .await
-        .map_err(|e| Tiles3dError::Internal(format!("voxel task failed: {e}")))??;
+    let key = ContentKey {
+        collection: id,
+        kind: ContentKind::Voxels,
+        quantity: quantity
+            .clone()
+            .unwrap_or_else(|| info.default_quantity.clone()),
+        datetime: time,
+        param_bits: None,
+        dims,
+        version: data_version(&info),
+    };
+    let pinned = time.is_some();
 
-    Ok(binary_response(&headers, "model/gltf-binary", &etag, bytes))
+    let engine = engine.clone();
+    let id_for_err = key.collection.clone();
+    let content = CONTENT_CACHE
+        .get_or_compute(key, || async move {
+            // Dedicated voxel pool (NOT the shared raster `render_semaphore`)
+            // so a slow `high`-res encode can't hold a WMS/Maps/Tiles render
+            // slot — see `VOXEL_SEMAPHORE`. Only the computing request pays.
+            let _permit = VOXEL_SEMAPHORE
+                .clone()
+                .acquire_owned()
+                .await
+                .map_err(|_| Tiles3dError::Internal("voxel semaphore closed".into()))?;
+            tokio::task::spawn_blocking(move || -> Result<(Vec<u8>, String), Tiles3dError> {
+                let grid = engine.read_voxel_grid(quantity.as_deref(), time, Some(dims), None)?;
+                let bytes = ds_3dtiles::encode_voxels_glb(&grid).map_err(|e| match e {
+                    ds_3dtiles::Tiles3dError::Empty => Tiles3dError::NotFound(format!(
+                        "no voxel data for collection '{id_for_err}'"
+                    )),
+                    other => Tiles3dError::Internal(format!("voxel encode failed: {other}")),
+                })?;
+                let etag = etag_of(&bytes);
+                Ok((bytes, etag))
+            })
+            .await
+            .map_err(|e| Tiles3dError::Internal(format!("voxel task failed: {e}")))?
+        })
+        .await?;
+
+    Ok(binary_response(
+        &headers,
+        "model/gltf-binary",
+        &content.etag,
+        content.bytes,
+        pinned,
+    ))
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/api-3dtiles/src/lib.rs
+++ b/crates/api-3dtiles/src/lib.rs
@@ -12,9 +12,11 @@
 //! - `GET /collections/{id}/content.glb` — isosurface-mesh content
 //! - `GET /` · `/collections` · `/collections/{id}` · `/viewer`
 
+pub mod cache;
 pub mod error;
 pub mod handlers;
 
+pub use cache::content_cache_metrics;
 pub use error::Tiles3dError;
 pub use handlers::{default_point_colormap, AppState, TilesState3d};
 

--- a/crates/api-3dtiles/tests/integration.rs
+++ b/crates/api-3dtiles/tests/integration.rs
@@ -1001,3 +1001,79 @@ async fn non_manifest_datetime_is_not_immutable() {
     assert_eq!(s, StatusCode::OK);
     assert_eq!(h[axum::http::header::CACHE_CONTROL], "public, max-age=60");
 }
+
+/// Engine whose time manifest can grow mid-test — simulates a live collection
+/// ingesting a new volume between requests.
+struct GrowingVolume {
+    reads: Arc<std::sync::atomic::AtomicU64>,
+    times: std::sync::Mutex<Vec<chrono::DateTime<Utc>>>,
+}
+
+impl VolumeEngine for GrowingVolume {
+    fn read_point_cloud(
+        &self,
+        quantity: Option<&str>,
+        time: Option<chrono::DateTime<chrono::Utc>>,
+        min_value: Option<f64>,
+        reference_time: Option<chrono::DateTime<chrono::Utc>>,
+    ) -> Result<VolumePointCloud, DataServerError> {
+        self.reads
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        MockVolume.read_point_cloud(quantity, time, min_value, reference_time)
+    }
+
+    fn volume_info(&self) -> Arc<VolumeInfo> {
+        let base = MockVolume.volume_info();
+        Arc::new(VolumeInfo {
+            times: self.times.lock().unwrap().clone(),
+            ..(*base).clone()
+        })
+    }
+}
+
+#[tokio::test]
+async fn exact_time_entry_survives_new_volume_arrival() {
+    // A new volume arriving must NOT evict pinned exact-time entries (they
+    // are immutable) — only "latest"/non-exact entries re-key (PR #378 r2).
+    let reads = Arc::new(std::sync::atomic::AtomicU64::new(0));
+    let t0 = Utc.with_ymd_and_hms(2026, 5, 15, 0, 0, 0).unwrap();
+    let t1 = Utc.with_ymd_and_hms(2026, 5, 15, 0, 5, 0).unwrap();
+    let engine = Arc::new(GrowingVolume {
+        reads: reads.clone(),
+        times: std::sync::Mutex::new(vec![t0, t1]),
+    });
+    let app = router_with("radar-grow", engine.clone());
+
+    let pinned_uri =
+        "/collections/radar-grow/content.pnts?quantity=DBZH&datetime=2026-05-15T00:00:00Z";
+    let latest_uri = "/collections/radar-grow/content.pnts?quantity=DBZH";
+    let (s, _b, _h) = get_on(&app, pinned_uri).await;
+    assert_eq!(s, StatusCode::OK);
+    let (s, _b, _h) = get_on(&app, latest_uri).await;
+    assert_eq!(s, StatusCode::OK);
+    assert_eq!(reads.load(std::sync::atomic::Ordering::Relaxed), 2);
+
+    // A new volume arrives.
+    engine
+        .times
+        .lock()
+        .unwrap()
+        .push(Utc.with_ymd_and_hms(2026, 5, 15, 0, 10, 0).unwrap());
+
+    // The pinned exact-time frame is still served from the cache…
+    let (s, _b, _h) = get_on(&app, pinned_uri).await;
+    assert_eq!(s, StatusCode::OK);
+    assert_eq!(
+        reads.load(std::sync::atomic::Ordering::Relaxed),
+        2,
+        "exact-time entry must survive the manifest change"
+    );
+    // …while "latest" re-keys (data_version changed) and recomputes.
+    let (s, _b, _h) = get_on(&app, latest_uri).await;
+    assert_eq!(s, StatusCode::OK);
+    assert_eq!(
+        reads.load(std::sync::atomic::Ordering::Relaxed),
+        3,
+        "latest entry must re-key on a new volume"
+    );
+}

--- a/crates/api-3dtiles/tests/integration.rs
+++ b/crates/api-3dtiles/tests/integration.rs
@@ -989,3 +989,15 @@ async fn pinned_datetime_gets_immutable_cache_control() {
         "public, max-age=86400, immutable"
     );
 }
+
+#[tokio::test]
+async fn non_manifest_datetime_is_not_immutable() {
+    // A datetime BETWEEN advertised volume times resolves by nearest-volume
+    // selection, which can change when a closer volume arrives — it must NOT
+    // get the immutable policy (PR #378 review).
+    let (s, _b, h) =
+        get("/collections/radar-fivih/content.pnts?quantity=DBZH&datetime=2026-05-15T00:02:30Z")
+            .await;
+    assert_eq!(s, StatusCode::OK);
+    assert_eq!(h[axum::http::header::CACHE_CONTROL], "public, max-age=60");
+}

--- a/crates/api-3dtiles/tests/integration.rs
+++ b/crates/api-3dtiles/tests/integration.rs
@@ -66,7 +66,7 @@ impl VolumeEngine for MockVolume {
         _time: Option<chrono::DateTime<chrono::Utc>>,
         dims: Option<[usize; 3]>,
         _reference_time: Option<chrono::DateTime<chrono::Utc>>,
-    ) -> Result<VoxelGrid, DataServerError> {
+    ) -> Result<Arc<VoxelGrid>, DataServerError> {
         if let Some(q) = quantity {
             if q != "DBZH" {
                 return Err(DataServerError::InvalidParameter(format!("unknown {q}")));
@@ -86,7 +86,7 @@ impl VolumeEngine for MockVolume {
                 }
             }
         }
-        Ok(VoxelGrid {
+        Ok(Arc::new(VoxelGrid {
             origin_lon: 24.5,
             origin_lat: 60.5,
             origin_height: 100.0,
@@ -97,7 +97,7 @@ impl VolumeEngine for MockVolume {
             values,
             quantity: "DBZH".into(),
             unit: "dBZ".into(),
-        })
+        }))
     }
 
     fn volume_info(&self) -> Arc<VolumeInfo> {
@@ -824,4 +824,168 @@ async fn non_finite_threshold_is_400() {
         .await;
         assert_eq!(cs, StatusCode::BAD_REQUEST, "content rejects threshold={v}");
     }
+}
+
+// ---------------------------------------------------------------------------
+// Content cache + cache-control policy (hot-path audit, 2026-06)
+// ---------------------------------------------------------------------------
+
+/// `MockVolume` that counts engine reads, to prove the content cache short-
+/// circuits the recompute (not just the transfer).
+struct CountingVolume {
+    reads: Arc<std::sync::atomic::AtomicU64>,
+}
+
+impl VolumeEngine for CountingVolume {
+    fn read_point_cloud(
+        &self,
+        quantity: Option<&str>,
+        time: Option<chrono::DateTime<chrono::Utc>>,
+        min_value: Option<f64>,
+        reference_time: Option<chrono::DateTime<chrono::Utc>>,
+    ) -> Result<VolumePointCloud, DataServerError> {
+        self.reads
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        MockVolume.read_point_cloud(quantity, time, min_value, reference_time)
+    }
+
+    fn read_voxel_grid(
+        &self,
+        quantity: Option<&str>,
+        time: Option<chrono::DateTime<chrono::Utc>>,
+        dims: Option<[usize; 3]>,
+        reference_time: Option<chrono::DateTime<chrono::Utc>>,
+    ) -> Result<Arc<VoxelGrid>, DataServerError> {
+        self.reads
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        MockVolume.read_voxel_grid(quantity, time, dims, reference_time)
+    }
+
+    fn volume_info(&self) -> Arc<VolumeInfo> {
+        MockVolume.volume_info()
+    }
+}
+
+/// A router over one named collection + engine (the shared `router()` is
+/// fixed to `radar-fivih`/`MockVolume`). Cache-sensitive tests use unique
+/// collection ids so the process-global content cache can't leak state
+/// between tests.
+fn router_with(id: &str, engine: Arc<dyn VolumeEngine>) -> axum::Router {
+    let mut volume_engines = HashMap::new();
+    volume_engines.insert(id.to_string(), engine);
+    let mut collections = HashMap::new();
+    collections.insert(id.to_string(), collection_config(id));
+    let state = Arc::new(ArcSwap::from_pointee(TilesState3d {
+        volume_engines,
+        collections,
+        colormap: Arc::new(LutColorMap::from_builtin(
+            BuiltinColormap::RadarDbz,
+            -32.0,
+            95.0,
+        )),
+        render_semaphore: Arc::new(tokio::sync::Semaphore::new(4)),
+        base_url: String::new(),
+    }));
+    api_3dtiles::router(state)
+}
+
+async fn get_on(router: &axum::Router, uri: &str) -> (StatusCode, Vec<u8>, axum::http::HeaderMap) {
+    let resp = router
+        .clone()
+        .oneshot(Request::builder().uri(uri).body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    let status = resp.status();
+    let headers = resp.headers().clone();
+    let body = resp
+        .into_body()
+        .collect()
+        .await
+        .unwrap()
+        .to_bytes()
+        .to_vec();
+    (status, body, headers)
+}
+
+#[tokio::test]
+async fn repeated_pnts_request_is_served_from_cache_without_recompute() {
+    let reads = Arc::new(std::sync::atomic::AtomicU64::new(0));
+    let app = router_with(
+        "radar-cache-pnts",
+        Arc::new(CountingVolume {
+            reads: reads.clone(),
+        }),
+    );
+    let uri = "/collections/radar-cache-pnts/content.pnts?quantity=DBZH";
+    let (s1, b1, h1) = get_on(&app, uri).await;
+    let (s2, b2, h2) = get_on(&app, uri).await;
+    assert_eq!((s1, s2), (StatusCode::OK, StatusCode::OK));
+    assert_eq!(b1, b2, "identical bytes");
+    assert_eq!(
+        h1[axum::http::header::ETAG],
+        h2[axum::http::header::ETAG],
+        "identical ETag"
+    );
+    assert_eq!(
+        reads.load(std::sync::atomic::Ordering::Relaxed),
+        1,
+        "second request must hit the content cache, not the engine"
+    );
+}
+
+#[tokio::test]
+async fn glb_revalidation_304_does_not_recompute() {
+    let reads = Arc::new(std::sync::atomic::AtomicU64::new(0));
+    let app = router_with(
+        "radar-cache-glb",
+        Arc::new(CountingVolume {
+            reads: reads.clone(),
+        }),
+    );
+    let uri = "/collections/radar-cache-glb/content.glb?quantity=DBZH&resolution=low";
+    let (s1, _b, h1) = get_on(&app, uri).await;
+    assert_eq!(s1, StatusCode::OK);
+    let etag = h1[axum::http::header::ETAG].to_str().unwrap().to_string();
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri(uri)
+                .header(axum::http::header::IF_NONE_MATCH, &etag)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_MODIFIED);
+    assert_eq!(
+        reads.load(std::sync::atomic::Ordering::Relaxed),
+        1,
+        "the 304 must be served from the content cache"
+    );
+}
+
+#[tokio::test]
+async fn pinned_datetime_gets_immutable_cache_control() {
+    // Pinned to an advertised volume time → long-lived immutable.
+    let (s, _b, h) =
+        get("/collections/radar-fivih/content.pnts?quantity=DBZH&datetime=2026-05-15T00:05:00Z")
+            .await;
+    assert_eq!(s, StatusCode::OK);
+    assert_eq!(
+        h[axum::http::header::CACHE_CONTROL],
+        "public, max-age=86400, immutable"
+    );
+    // Latest (no datetime) → short revalidation window.
+    let (s, _b, h) = get("/collections/radar-fivih/content.pnts?quantity=DBZH").await;
+    assert_eq!(s, StatusCode::OK);
+    assert_eq!(h[axum::http::header::CACHE_CONTROL], "public, max-age=60");
+    // The tileset follows the same policy.
+    let (s, _b, h) =
+        get("/collections/radar-fivih/tileset.json?datetime=2026-05-15T00:05:00Z").await;
+    assert_eq!(s, StatusCode::OK);
+    assert_eq!(
+        h[axum::http::header::CACHE_CONTROL],
+        "public, max-age=86400, immutable"
+    );
 }

--- a/crates/core/src/volume.rs
+++ b/crates/core/src/volume.rs
@@ -221,13 +221,19 @@ pub trait VolumeEngine: Send + Sync {
     /// (→ 404) — a capability gap is "this resource doesn't exist for this
     /// collection", not a server fault (matching the no-data-in-window
     /// convention), so the future voxel route won't surface a misleading 500.
+    ///
+    /// Returns `Arc<VoxelGrid>` (not an owned grid): one resampled grid feeds
+    /// several consumers — the isosurface, echo-top, and voxel encoders all
+    /// mesh the same `(quantity, time, dims)` grid — so engines cache and
+    /// share the (multi-MB) result instead of recomputing the multi-million-
+    /// cell resample per representation.
     fn read_voxel_grid(
         &self,
         _quantity: Option<&str>,
         _time: Option<DateTime<Utc>>,
         _dims: Option<[usize; 3]>,
         _reference_time: Option<DateTime<Utc>>,
-    ) -> Result<VoxelGrid, DataServerError> {
+    ) -> Result<Arc<VoxelGrid>, DataServerError> {
         Err(DataServerError::LocationNotFound(
             "voxel grid not supported by this engine".into(),
         ))

--- a/crates/engine-odim/src/lib.rs
+++ b/crates/engine-odim/src/lib.rs
@@ -31,4 +31,6 @@ pub mod volume_engine;
 
 pub use engine::{EngineError, OdimEngine};
 pub use pixel_cache::PixelCache;
-pub use volume_engine::{pixel_cache_metrics, PolarVolumeEngine, PolarVolumeSiteView};
+pub use volume_engine::{
+    pixel_cache_metrics, voxel_grid_cache_metrics, PolarVolumeEngine, PolarVolumeSiteView,
+};

--- a/crates/engine-odim/src/volume_engine.rs
+++ b/crates/engine-odim/src/volume_engine.rs
@@ -136,6 +136,12 @@ pub fn pixel_cache_metrics() -> (u64, u64, u64, u64, u64) {
 /// `(volume, quantity, dims)` — without this cache every representation,
 /// threshold change, and animation frame repeats the multi-million-cell polar
 /// resample. 512 MB holds ~24 `med` grids — roughly one animation window.
+///
+/// Memory-hygiene note: entries for volumes retired by `max_files` /
+/// `time_window` are only reclaimed by LRU pressure (the key has no
+/// data-version, because a volume file is immutable). On a long-running
+/// deployment, bound the source's retention (`max_files` / `time_window`) so
+/// retired-volume grids cycle out instead of crowding the budget.
 const DEFAULT_VOXEL_GRID_CACHE_MB: u64 = 512;
 
 /// Cache key: source-qualified volume file id (see [`pixel_cache_id`]) +
@@ -3665,11 +3671,16 @@ impl VolumeEngine for PolarVolumeSiteView {
             Arc::from(quantity.as_str()),
             dims,
         );
-        let (grid, valid) = if let Some(hit) = VOXEL_GRID_CACHE.get(&key) {
-            VOXEL_GRID_HITS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-            hit
-        } else {
-            VOXEL_GRID_MISSES.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        // `get_or_insert_with` is the single-flight: quick_cache's placeholder
+        // guard runs the closure for exactly one caller per key and blocks
+        // concurrent callers until it finishes — so simultaneous first-time
+        // requests for *different representations* of the same grid (whose
+        // content-cache keys differ, hence separate gates there) still share
+        // one polar resample (PR #378 review). Blocking the calling thread is
+        // fine: every caller is on a `spawn_blocking` pool by contract.
+        let mut computed = false;
+        let (grid, valid) = VOXEL_GRID_CACHE.get_or_insert_with(&key, || {
+            computed = true;
             let handle = blocking_pixel_handle();
             let pix = Pixels {
                 source: &self.source,
@@ -3677,10 +3688,13 @@ impl VolumeEngine for PolarVolumeSiteView {
             };
             let (grid, valid) =
                 voxel_grid_from_volume(&entry.volume, &entry.id, pix, &quantity, Some(dims))?;
-            let cached = (Arc::new(grid), valid);
-            VOXEL_GRID_CACHE.insert(key, cached.clone());
-            cached
-        };
+            Ok::<_, DataServerError>((Arc::new(grid), valid))
+        })?;
+        if computed {
+            VOXEL_GRID_MISSES.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        } else {
+            VOXEL_GRID_HITS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        }
 
         // No sampled cell (every cell outside the beam fan / nodata) ⇒ 404,
         // matching the other engines' "no data in window" convention.

--- a/crates/engine-odim/src/volume_engine.rs
+++ b/crates/engine-odim/src/volume_engine.rs
@@ -129,6 +129,70 @@ pub fn pixel_cache_metrics() -> (u64, u64, u64, u64, u64) {
     )
 }
 
+/// Default resampled voxel-grid cache size (MB) when
+/// `MC_PVOL_VOXEL_GRID_CACHE_MB` is unset. A grid is `4 B × cells` (≈ 8.5 MB
+/// `low`, 21 MB `med`, 47 MB `high`), and the 3D Tiles mesh products
+/// (isosurface, echo-top, voxels) all re-mesh the *same* grid per
+/// `(volume, quantity, dims)` — without this cache every representation,
+/// threshold change, and animation frame repeats the multi-million-cell polar
+/// resample. 512 MB holds ~24 `med` grids — roughly one animation window.
+const DEFAULT_VOXEL_GRID_CACHE_MB: u64 = 512;
+
+/// Cache key: source-qualified volume file id (see [`pixel_cache_id`]) +
+/// quantity + resolved grid dims. Volumes are immutable once scanned, so the
+/// key needs no data-version.
+type VoxelGridKey = (Arc<str>, Arc<str>, [usize; 3]);
+
+/// Cached resample result: the shared grid plus its echo-cell count (the
+/// caller's empty ⇒ 404 decision), so a no-echo volume's 404 is cheap too.
+type VoxelGridEntry = (Arc<VoxelGrid>, usize);
+
+/// Byte-weights each entry by its `f32` cell payload (plus key overhead).
+#[derive(Clone)]
+struct VoxelGridWeighter;
+
+impl quick_cache::Weighter<VoxelGridKey, VoxelGridEntry> for VoxelGridWeighter {
+    fn weight(&self, key: &VoxelGridKey, val: &VoxelGridEntry) -> u64 {
+        (val.0.values.len() * 4) as u64 + key.0.len() as u64 + key.1.len() as u64 + 256
+    }
+}
+
+/// Process-global LRU of resampled cylindrical voxel grids, shared across
+/// every PVOL collection (keys are source-qualified). Sized once from the
+/// environment on first use; `0` disables (every read resamples).
+static VOXEL_GRID_CACHE: std::sync::LazyLock<
+    quick_cache::sync::Cache<VoxelGridKey, VoxelGridEntry, VoxelGridWeighter>,
+> = std::sync::LazyLock::new(|| {
+    let capacity_bytes = std::env::var("MC_PVOL_VOXEL_GRID_CACHE_MB")
+        .ok()
+        .and_then(|s| s.trim().parse::<u64>().ok())
+        .unwrap_or(DEFAULT_VOXEL_GRID_CACHE_MB)
+        .saturating_mul(1024 * 1024);
+    // Estimate item slots at one `med` grid each; `max(1)` keeps a zero
+    // capacity valid (an effectively-disabled cache that can hold nothing).
+    let estimated_items = ((capacity_bytes / (21 * 1024 * 1024)).max(4)) as usize;
+    quick_cache::sync::Cache::with_weighter(
+        estimated_items,
+        capacity_bytes.max(1),
+        VoxelGridWeighter,
+    )
+});
+
+/// Cumulative `(hits, misses)` of [`VOXEL_GRID_CACHE`], for `/metrics`.
+static VOXEL_GRID_HITS: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+static VOXEL_GRID_MISSES: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+/// Snapshot of the process-global voxel-grid cache for `/metrics`:
+/// `(hits, misses, resident_bytes, capacity_bytes)`.
+pub fn voxel_grid_cache_metrics() -> (u64, u64, u64, u64) {
+    (
+        VOXEL_GRID_HITS.load(std::sync::atomic::Ordering::Relaxed),
+        VOXEL_GRID_MISSES.load(std::sync::atomic::Ordering::Relaxed),
+        VOXEL_GRID_CACHE.weight(),
+        VOXEL_GRID_CACHE.capacity(),
+    )
+}
+
 /// Days of date-partitioned prefixes to scan when an S3 source has no
 /// `time_window`. Two days covers the just-after-midnight case where
 /// the recent tail still straddles yesterday's partition. Mirrors
@@ -3281,6 +3345,78 @@ const NO_ECHO_FLOOR: f32 = ds_core::volume::NO_ECHO_FLOOR_DBZ;
 /// Returns the grid plus the count of **echo** cells (clear-air floor cells are
 /// not counted) — counted during the fill so the caller needn't re-scan up to
 /// `MAX_VOXELS` cells.
+/// One `(radius, height)` column of the voxel grid, resolved once and reused
+/// across all azimuths. Everything `sample_polar_slant_class` derives from the
+/// cell target *except* the ray index — the nearest sweep, the envelope/range
+/// guards, the moment, the range bin, and the decoded pixels — depends only on
+/// `(ground, height)`, never azimuth. Resolving per column turns the per-cell
+/// work from "sweep scan + moment scan + pixel-cache lookup (two `Arc<str>`
+/// allocations + hashes)" into a table index + one `sample_class`, a large
+/// constant-factor win over `n_r × n_a × n_h` cells.
+enum ColumnTarget {
+    /// Outside the beam fan / unresolvable — `Masked` at every azimuth.
+    Masked,
+    /// Resolved to one sweep's range gate: sample `(ray(azimuth), bin)`.
+    Gate {
+        pixels: Arc<RawPixels>,
+        nrays: usize,
+        bin: usize,
+        gain: f64,
+        offset: f64,
+        nodata: f64,
+        undetect: f64,
+    },
+}
+
+/// Resolve one `(slant_range, elevation)` target to its [`ColumnTarget`] —
+/// the azimuth-independent prefix of [`sample_polar_slant_class`], guard for
+/// guard, so the two stay behaviourally identical.
+fn resolve_column(
+    volume: &PolarVolume,
+    file_id: &str,
+    pix: Pixels,
+    envelope: (f64, f64),
+    quantity: &str,
+    slant_range_m: f64,
+    elangle_deg: f64,
+) -> ColumnTarget {
+    let Some(sweep) = nearest_sweep(volume, elangle_deg) else {
+        return ColumnTarget::Masked;
+    };
+    if sweep.nrays == 0 || sweep.nbins == 0 {
+        return ColumnTarget::Masked;
+    }
+    let (min_el, max_el) = envelope;
+    if !elangle_deg.is_finite()
+        || elangle_deg < min_el - SWEEP_ENVELOPE_TOL_DEG
+        || elangle_deg > max_el + SWEEP_ENVELOPE_TOL_DEG
+    {
+        return ColumnTarget::Masked;
+    }
+    if !sweep.rscale.is_finite() || sweep.rscale <= 0.0 {
+        return ColumnTarget::Masked;
+    }
+    let Some(moment) = sweep.moments.iter().find(|m| m.quantity == *quantity) else {
+        return ColumnTarget::Masked;
+    };
+    let bin = ((slant_range_m - sweep.rstart) / sweep.rscale).floor() as i64;
+    if bin < 0 || bin >= sweep.nbins as i64 {
+        return ColumnTarget::Masked;
+    }
+    let Some(pixels) = pix.moment(file_id, moment, sweep.nrays, sweep.nbins) else {
+        return ColumnTarget::Masked;
+    };
+    ColumnTarget::Gate {
+        pixels,
+        nrays: sweep.nrays,
+        bin: bin as usize,
+        gain: moment.gain,
+        offset: moment.offset,
+        nodata: moment.nodata,
+        undetect: moment.undetect,
+    }
+}
+
 fn voxel_grid_from_volume(
     volume: &PolarVolume,
     file_id: &str,
@@ -3326,25 +3462,45 @@ fn voxel_grid_from_volume(
     let ceiling = VOXEL_HEIGHT_CEILING_M;
     let site = &volume.site;
 
+    // Resolve each `(radius, height)` column once — `n_r × n_h` resolutions
+    // instead of `n_r × n_a × n_h` (the geometry, sweep choice, moment, bin,
+    // and pixel-cache lookup are all azimuth-independent; see [`ColumnTarget`]).
+    // At `med` (256×360×56) this is 14 k resolutions vs 5.2 M.
+    let columns: Vec<ColumnTarget> = (0..n_r)
+        .flat_map(|i_r| {
+            let ground = (i_r as f64 + 0.5) * radius_max / n_r as f64;
+            (0..n_h).map(move |i_h| (ground, i_h))
+        })
+        .map(|(ground, i_h)| {
+            let height = (i_h as f64 + 0.5) * ceiling / n_h as f64;
+            let (slant, el) = ground_height_to_slant(ground, height);
+            resolve_column(volume, file_id, pix, envelope, quantity, slant, el)
+        })
+        .collect();
+
     let mut values = vec![f32::NAN; total];
     let mut valid = 0usize; // counted here to avoid a second O(N) pass
     for i_r in 0..n_r {
-        let ground = (i_r as f64 + 0.5) * radius_max / n_r as f64;
         for i_a in 0..n_a {
             let azimuth_deg = (i_a as f64 + 0.5) * 360.0 / n_a as f64;
             for i_h in 0..n_h {
-                let height = (i_h as f64 + 0.5) * ceiling / n_h as f64;
-                let (slant, el) = ground_height_to_slant(ground, height);
-                match sample_polar_slant_class(
-                    volume,
-                    file_id,
-                    pix,
-                    envelope,
-                    quantity,
-                    slant,
-                    azimuth_deg,
-                    el,
-                ) {
+                let ColumnTarget::Gate {
+                    ref pixels,
+                    nrays,
+                    bin,
+                    gain,
+                    offset,
+                    nodata,
+                    undetect,
+                } = columns[i_r * n_h + i_h]
+                else {
+                    // Genuinely unmeasured (cone of silence / beyond range /
+                    // below the lowest beam) → leave `NaN`, so an isosurface
+                    // doesn't fabricate a cap there.
+                    continue;
+                };
+                let ray = (azimuth_deg / (360.0 / nrays as f64)).floor() as usize % nrays;
+                match pixels.sample_class(ray, bin, gain, offset, nodata, Some(undetect)) {
                     PixelClass::Value(v) => {
                         // Only a finite echo is written + counted — a non-finite
                         // gain/offset in a malformed file can yield `Value(NaN)`;
@@ -3364,9 +3520,6 @@ fn voxel_grid_from_volume(
                     PixelClass::Undetect => {
                         values[VoxelGrid::index_of(dims, i_r, i_a, i_h)] = NO_ECHO_FLOOR;
                     }
-                    // Genuinely unmeasured (cone of silence / beyond range /
-                    // below the lowest beam) → leave `NaN`, so an isosurface
-                    // doesn't fabricate a cap there.
                     PixelClass::Masked => {}
                 }
             }
@@ -3495,16 +3648,39 @@ impl VolumeEngine for PolarVolumeSiteView {
         time: Option<DateTime<Utc>>,
         dims: Option<[usize; 3]>,
         _reference_time: Option<DateTime<Utc>>,
-    ) -> Result<VoxelGrid, DataServerError> {
+    ) -> Result<Arc<VoxelGrid>, DataServerError> {
         let catalog = self.catalog.load();
         let (entry, quantity) = self.select_entry_and_quantity(&catalog, quantity, time)?;
+        // Resolve the default *before* the cache key so `None` and an explicit
+        // default-dims request share one entry.
+        let dims = dims.unwrap_or(DEFAULT_VOXEL_DIMS);
 
-        let handle = blocking_pixel_handle();
-        let pix = Pixels {
-            source: &self.source,
-            handle: handle.as_ref(),
+        // A volume file is immutable once scanned, so `(file, quantity, dims)`
+        // fully determines the resample — no data-version in the key. The three
+        // 3D Tiles mesh products (isosurface, echo-top, voxels) and repeated
+        // threshold/animation requests all share one cached grid. The empty
+        // (`valid == 0`) result is cached too, so the no-echo 404 is cheap.
+        let key: VoxelGridKey = (
+            Arc::from(pixel_cache_id(&self.source, &entry.id).as_ref()),
+            Arc::from(quantity.as_str()),
+            dims,
+        );
+        let (grid, valid) = if let Some(hit) = VOXEL_GRID_CACHE.get(&key) {
+            VOXEL_GRID_HITS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            hit
+        } else {
+            VOXEL_GRID_MISSES.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            let handle = blocking_pixel_handle();
+            let pix = Pixels {
+                source: &self.source,
+                handle: handle.as_ref(),
+            };
+            let (grid, valid) =
+                voxel_grid_from_volume(&entry.volume, &entry.id, pix, &quantity, Some(dims))?;
+            let cached = (Arc::new(grid), valid);
+            VOXEL_GRID_CACHE.insert(key, cached.clone());
+            cached
         };
-        let (grid, valid) = voxel_grid_from_volume(&entry.volume, &entry.id, pix, &quantity, dims)?;
 
         // No sampled cell (every cell outside the beam fan / nodata) ⇒ 404,
         // matching the other engines' "no data in window" convention.

--- a/crates/server/src/admin.rs
+++ b/crates/server/src/admin.rs
@@ -249,6 +249,92 @@ static PVOL_PIXEL_READ_FAILURES: LazyLock<IntCounter> = LazyLock::new(|| {
     counter
 });
 
+// 3D Tiles encoded-content cache — global, the final `.pnts`/`.glb` bytes per
+// (collection, product, quantity, time, params, data-version), so repeats and
+// `If-None-Match` revalidations skip the engine read + encode entirely.
+static TILES3D_CONTENT_CACHE_HITS: LazyLock<IntCounter> = LazyLock::new(|| {
+    let counter = IntCounter::new(
+        "tiles3d_content_cache_hits_total",
+        "3D Tiles encoded-content cache hits",
+    )
+    .unwrap();
+    REGISTRY.register(Box::new(counter.clone())).unwrap();
+    counter
+});
+
+static TILES3D_CONTENT_CACHE_MISSES: LazyLock<IntCounter> = LazyLock::new(|| {
+    let counter = IntCounter::new(
+        "tiles3d_content_cache_misses_total",
+        "3D Tiles encoded-content cache misses (full engine read + encode)",
+    )
+    .unwrap();
+    REGISTRY.register(Box::new(counter.clone())).unwrap();
+    counter
+});
+
+static TILES3D_CONTENT_CACHE_BYTES: LazyLock<IntGauge> = LazyLock::new(|| {
+    let gauge = IntGauge::new(
+        "tiles3d_content_cache_bytes",
+        "Bytes currently held in the 3D Tiles encoded-content cache",
+    )
+    .unwrap();
+    REGISTRY.register(Box::new(gauge.clone())).unwrap();
+    gauge
+});
+
+static TILES3D_CONTENT_CACHE_CAPACITY_BYTES: LazyLock<IntGauge> = LazyLock::new(|| {
+    let gauge = IntGauge::new(
+        "tiles3d_content_cache_capacity_bytes",
+        "Configured 3D Tiles encoded-content cache capacity in bytes",
+    )
+    .unwrap();
+    REGISTRY.register(Box::new(gauge.clone())).unwrap();
+    gauge
+});
+
+// PVOL resampled voxel-grid cache — global, the cylindrical grids the 3D Tiles
+// mesh products (isosurface / echo-top / voxels) share per (volume, quantity,
+// dims) instead of repeating the multi-million-cell polar resample.
+static PVOL_VOXEL_GRID_CACHE_HITS: LazyLock<IntCounter> = LazyLock::new(|| {
+    let counter = IntCounter::new(
+        "pvol_voxel_grid_cache_hits_total",
+        "PVOL voxel-grid cache hits",
+    )
+    .unwrap();
+    REGISTRY.register(Box::new(counter.clone())).unwrap();
+    counter
+});
+
+static PVOL_VOXEL_GRID_CACHE_MISSES: LazyLock<IntCounter> = LazyLock::new(|| {
+    let counter = IntCounter::new(
+        "pvol_voxel_grid_cache_misses_total",
+        "PVOL voxel-grid cache misses (full polar resamples)",
+    )
+    .unwrap();
+    REGISTRY.register(Box::new(counter.clone())).unwrap();
+    counter
+});
+
+static PVOL_VOXEL_GRID_CACHE_BYTES: LazyLock<IntGauge> = LazyLock::new(|| {
+    let gauge = IntGauge::new(
+        "pvol_voxel_grid_cache_bytes",
+        "Bytes currently held in the PVOL voxel-grid cache",
+    )
+    .unwrap();
+    REGISTRY.register(Box::new(gauge.clone())).unwrap();
+    gauge
+});
+
+static PVOL_VOXEL_GRID_CACHE_CAPACITY_BYTES: LazyLock<IntGauge> = LazyLock::new(|| {
+    let gauge = IntGauge::new(
+        "pvol_voxel_grid_cache_capacity_bytes",
+        "Configured PVOL voxel-grid cache capacity in bytes",
+    )
+    .unwrap();
+    REGISTRY.register(Box::new(gauge.clone())).unwrap();
+    gauge
+});
+
 // Meta-tile pixel cache (#202) — global, decoded-RGBA tiles for the Web
 // Mercator WMS meta-tiling path. Distinct from the per-collection GeoTIFF
 // compressed-byte tile cache (`tile_cache_*`).
@@ -378,6 +464,10 @@ struct CacheCounterState {
     /// PVOL pixel cache `(hits, misses, read_failures)` — global cache, never
     /// replaced on reload, so always monotonic.
     pvol_pixel: (u64, u64, u64),
+    /// PVOL voxel-grid cache `(hits, misses)` — global cache, monotonic.
+    pvol_voxel_grid: (u64, u64),
+    /// 3D Tiles encoded-content cache `(hits, misses)` — global, monotonic.
+    tiles3d_content: (u64, u64),
 }
 
 static RENDER_SEMAPHORE_AVAILABLE: LazyLock<IntGauge> = LazyLock::new(|| {
@@ -2771,6 +2861,28 @@ pub async fn metrics_handler(State(state): State<AdminState>) -> impl IntoRespon
         counter_state.pvol_pixel = (p_hits, p_misses, p_fail);
         PVOL_PIXEL_CACHE_BYTES.set(p_bytes as i64);
         PVOL_PIXEL_CACHE_CAPACITY_BYTES.set(p_cap as i64);
+
+        // Voxel-grid cache: same process-global monotonic-counter shape.
+        let (v_hits, v_misses, v_bytes, v_cap) = engine_odim::voxel_grid_cache_metrics();
+        let (last_vh, last_vm) = counter_state.pvol_voxel_grid;
+        PVOL_VOXEL_GRID_CACHE_HITS.inc_by(v_hits.saturating_sub(last_vh));
+        PVOL_VOXEL_GRID_CACHE_MISSES.inc_by(v_misses.saturating_sub(last_vm));
+        counter_state.pvol_voxel_grid = (v_hits, v_misses);
+        PVOL_VOXEL_GRID_CACHE_BYTES.set(v_bytes as i64);
+        PVOL_VOXEL_GRID_CACHE_CAPACITY_BYTES.set(v_cap as i64);
+    }
+
+    // 3D Tiles encoded-content cache: process-global + monotonic, like the
+    // PVOL caches. Only emit when 3D Tiles collections are loaded, so other
+    // deployments don't carry empty `tiles3d_*` series.
+    if !state.tiles_3d.load().volume_engines.is_empty() {
+        let (c_hits, c_misses, c_bytes, c_cap) = api_3dtiles::content_cache_metrics();
+        let (last_ch, last_cm) = counter_state.tiles3d_content;
+        TILES3D_CONTENT_CACHE_HITS.inc_by(c_hits.saturating_sub(last_ch));
+        TILES3D_CONTENT_CACHE_MISSES.inc_by(c_misses.saturating_sub(last_cm));
+        counter_state.tiles3d_content = (c_hits, c_misses);
+        TILES3D_CONTENT_CACHE_BYTES.set(c_bytes as i64);
+        TILES3D_CONTENT_CACHE_CAPACITY_BYTES.set(c_cap as i64);
     }
 
     // Tile cache: per-collection


### PR DESCRIPTION
## Summary

A hot-path audit of the 3D Tiles APIs found that **every** content request — including `If-None-Match` revalidations that end in a 304 — paid the full engine read → polar resample → encode pipeline, and the bundled viewer multiplies that by up to 48 preloaded animation frames on every load, reload, and control change. This PR adds the two cache layers the audit ranked highest (P1 + P2):

### 1. Encoded-content cache + single-flight (`api-3dtiles/src/cache.rs`)
- Process-global byte-bounded LRU of the final `.pnts`/`.glb`/voxel-`.glb` bytes + strong ETag.
- Key = (collection, product, quantity, datetime, params, dims) **+ a data-version** hashed from `VolumeInfo.times` — ingesting/dropping a volume invalidates "latest" and nearest-time selections naturally, with no duplication of engine selection logic at the API layer.
- **Single-flight:** concurrent identical requests share one compute via a per-key async mutex; only the computing request acquires the render/voxel semaphore, so a 48-frame viewer preload no longer queues 48-deep on the shared semaphore (which also starved WMS).
- A 304 revalidation is now two cache lookups, not a recompute.
- `MC_3DTILES_CONTENT_CACHE_MB` (default 512, `0` disables).

### 2. Shared voxel-grid cache + column-resolved resampler (`engine-odim`)
- `VolumeEngine::read_voxel_grid` now returns **`Arc<VoxelGrid>`** served from a global LRU keyed (file, quantity, dims) — the isosurface, echo-top, and voxel products (and threshold changes, which only re-mesh) share one multi-million-cell resample. `MC_PVOL_VOXEL_GRID_CACHE_MB` (default 512).
- The resample now resolves each `(radius, height)` column **once** (`ColumnTarget`): the sweep choice, envelope/range guards, moment lookup, range bin, and pixel-cache lookup (which heap-allocated two `Arc<str>` per cell) are all azimuth-independent. Per-cell work becomes a table index + `sample_class` — at `med` that's 14 k resolutions instead of 5.2 M, guard-for-guard identical to `sample_polar_slant_class`.

### Cache-Control policy
Content/tilesets pinned to an explicit `?datetime=` are archived volumes → `public, max-age=86400, immutable` (the existing WMS explicit-`TIME` policy). The viewer pins every animation frame, so a page reload serves all frames straight from the browser cache. "Latest" keeps `max-age=60`.

### Observability
New `/metrics` series: `tiles3d_content_cache_{hits,misses,bytes,capacity_bytes}` and `pvol_voxel_grid_cache_{hits,misses,bytes,capacity_bytes}`, emitted only when the relevant collections are loaded.

## Smoke test (local fivih PVOL fixture, debug build)

| Request | Before-equivalent (cold) | Cached |
|---|---|---|
| isosurface `med` `.glb` (35 MB) | 4.93 s | **0.030 s** |
| echo-top `med` `.glb` after isosurface | ~4.9 s | **0.28 s** (shares the cached grid, only re-meshes) |
| 304 revalidation | ~4.9 s | **0.0008 s** |
| `.pnts` | 0.53 s | **0.005 s** |

Repeat bytes verified identical; `immutable` vs `max-age=60` headers verified; both cache metric series live.

## Tests
- New unit tests for the content cache (hit/miss, version invalidation, concurrent coalescing to one compute, error-not-cached + gate release, capacity-0 disable).
- New integration tests: repeated `.pnts` request hits the cache without touching the engine (counting mock), `.glb` 304 without recompute, pinned-vs-latest `Cache-Control`.
- `cargo test --workspace`, `cargo clippy --workspace --tests -- -D warnings`, `cargo fmt` all clean.

Follow-ups (from the same audit, not in this PR): viewer progressive preload + per-representation tileset reuse, dedicated points/mesh semaphore, #293 batch moment decode (S3 Q× transfer), isosurface field smoothing + smooth normals (visual quality).

🤖 Generated with [Claude Code](https://claude.com/claude-code)