### PR TITLE
feat(3dtiles): smooth the scalar field before isosurface marching (#381)

### DIFF
--- a/crates/api-3dtiles/tests/integration.rs
+++ b/crates/api-3dtiles/tests/integration.rs
@@ -72,16 +72,20 @@ impl VolumeEngine for MockVolume {
                 return Err(DataServerError::InvalidParameter(format!("unknown {q}")));
             }
         }
-        let dims = dims.unwrap_or([4, 8, 4]);
+        let dims = dims.unwrap_or([16, 16, 16]);
         let [n_r, n_a, n_h] = dims;
         // Clear air is the finite no-echo floor (matching the post-#360 engine
-        // fill), with a finite >threshold echo core in the middle — so the
-        // isosurface (which the handler seals with `background=Some(floor)`)
-        // produces a non-empty mesh.
+        // fill), with a finite >threshold echo core spanning the middle half of
+        // the radius/height axes (full angle ring) — so the isosurface (which
+        // the handler seals with `background=Some(floor)` and then smooths
+        // before marching, #381) produces a non-empty mesh: the core scales
+        // with the requested grid and its interior survives the blur against
+        // the floor, like a physical echo spanning many cells (a fixed
+        // 2-cell-wide ring would smooth entirely below the threshold).
         let mut values = vec![ds_core::volume::NO_ECHO_FLOOR_DBZ; n_r * n_a * n_h];
-        for i_r in 1..n_r.min(3) {
+        for i_r in n_r / 4..(n_r * 3 / 4) {
             for i_a in 0..n_a {
-                for i_h in 1..n_h.min(3) {
+                for i_h in n_h / 4..(n_h * 3 / 4) {
                     values[VoxelGrid::index_of(dims, i_r, i_a, i_h)] = 40.0;
                 }
             }

--- a/crates/ds-3dtiles/src/isosurface.rs
+++ b/crates/ds-3dtiles/src/isosurface.rs
@@ -344,6 +344,11 @@ fn march_tet(
 /// mesh shaded a single `color` (`[r, g, b, a]`, 0–255) — typically the
 /// colormap colour at `threshold`, i.e. "the 20 dBZ shell".
 ///
+/// The scalar field is lightly smoothed before marching (#381 — see
+/// `crate::smoothing`), so the shell follows the echo, not the cell lattice;
+/// expect extracted values to deviate from the raw grid by up to the
+/// cell-to-cell contrast near sharp gradients and clamped grid edges.
+///
 /// ## `background` — sealing the surface against clear air
 ///
 /// A radar volume stores **`NaN` for both** "the radar looked and saw nothing"
@@ -392,13 +397,37 @@ pub fn encode_isosurface_glb(
             });
         }
     }
-    // `NaN` corners map to this: the finite background (seal) or `NaN` (skip).
-    let nan_fill = background.unwrap_or(f64::NAN);
     let rtc = geodetic_to_ecef(grid.origin_lon, grid.origin_lat, grid.origin_height);
     if rtc.iter().any(|c| !c.is_finite()) {
         return Err(Tiles3dError::NonFinite("rtc_center"));
     }
     let [n_r, n_a, n_h] = grid.dims;
+
+    // Smooth the scalar field before marching (#381). Radar echo is cellular
+    // (each cell a local reflectivity maximum), so a shell extracted from the
+    // raw grid inherits the cell lattice as stair-steps along the contour —
+    // worst at range, where 1° azimuth bins are km-wide. 2 passes (sigma ≈ 1
+    // cell) round the contour without erasing storm-core structure (the voxel
+    // ray-march uses 4 — see `crate::smoothing` — but a mesh shows its lattice
+    // less than a volume seen from inside). `NaN` handling follows the sealing
+    // decision: with a `background` the field is sealed FIRST and the dense
+    // blur runs over finite values only; without one, the NaN-aware blur keeps
+    // unmeasured cells `NaN` (still skipped below) and never bleeds them into
+    // real echo — the open-boundary semantics (#360) survive the smoothing.
+    const SMOOTH_PASSES: usize = 2;
+    let field: Vec<f32> = match background {
+        Some(bg) => {
+            let sealed = grid
+                .values
+                .iter()
+                .map(|&v| if v.is_finite() { v } else { bg as f32 })
+                .collect();
+            crate::smoothing::smooth_grid(sealed, grid.dims, SMOOTH_PASSES)
+        }
+        None => {
+            crate::smoothing::smooth_grid_nan_aware(grid.values.clone(), grid.dims, SMOOTH_PASSES)
+        }
+    };
 
     let mut mesh = MeshBuilder::new();
     // Iterate cubes. The angular seam (i_a = n_a−1 → 0) is not wrapped in v1, so
@@ -411,9 +440,9 @@ pub fn encode_isosurface_glb(
                 let mut cidx = [[0.0_f64; 3]; 8];
                 for (c, off) in CORNER.iter().enumerate() {
                     let (ir, ia, ih) = (i_r + off[0], i_a + off[1], i_h + off[2]);
-                    let raw = grid.values[grid.index(ir, ia, ih)] as f64;
-                    // Clear air / unmeasured → background (seal) or NaN (skip).
-                    cvals[c] = if raw.is_finite() { raw } else { nan_fill };
+                    // Sealed + smoothed (or NaN-aware-smoothed) value; a
+                    // remaining NaN means unmeasured with no seal → tet skipped.
+                    cvals[c] = field[grid.index(ir, ia, ih)] as f64;
                     cidx[c] = [ir as f64, ia as f64, ih as f64];
                 }
                 for tet in TETS {
@@ -633,16 +662,20 @@ mod tests {
 
     #[test]
     fn isosurface_sits_at_the_expected_height() {
-        // value = i_h, threshold 1.5 → the surface is a sheet where the field
-        // crosses 1.5, i.e. fractional height index 1.5. With height_range
-        // [0,10000] over 5 cells (cell centres 1000,3000,5000,…), index 1.5 maps
-        // to height (1.5+0.5)·2000 = 4000 m above the origin — and ONLY there,
-        // since the field depends solely on height. Use a small 5 km disc so
-        // earth-curvature/up-deflection over the span is negligible, then
-        // reconstruct each vertex's height above the antenna and assert ≈4000 m.
-        let mut grid = ramp_grid(4, 16, 5);
+        // value = i_h, threshold 4.5 → the surface is a sheet where the field
+        // crosses 4.5, i.e. fractional height index 4.5. With height_range
+        // [0,9000] over 9 cells (cell centres 500,1500,…), index 4.5 maps to
+        // height (4.5+0.5)·1000 = 5000 m above the origin — and ONLY there,
+        // since the field depends solely on height. The pre-march smoothing
+        // (#381) preserves a linear ramp exactly except within `passes` (=2)
+        // cells of the clamped height ends, so a crossing between cells 4 and 5
+        // of 9 is untouched. Use a small 5 km disc so earth-curvature/
+        // up-deflection over the span is negligible, then reconstruct each
+        // vertex's height above the antenna and assert ≈5000 m.
+        let mut grid = ramp_grid(4, 16, 9);
         grid.radius_range = [0.0, 5_000.0];
-        let glb = encode_isosurface_glb(&grid, 1.5, [0, 128, 255, 255], None).unwrap();
+        grid.height_range = [0.0, 9_000.0];
+        let glb = encode_isosurface_glb(&grid, 4.5, [0, 128, 255, 255], None).unwrap();
         let (json, bin) = parse_glb(&glb);
 
         let rtc = geodetic_to_ecef(grid.origin_lon, grid.origin_lat, grid.origin_height);
@@ -661,7 +694,7 @@ mod tests {
             // (x,−z,y); height above antenna = offset · up.
             let offset = [v[0] as f64, -(v[2] as f64), v[1] as f64];
             let h = offset[0] * up[0] + offset[1] * up[1] + offset[2] * up[2];
-            assert!((h - 4000.0).abs() < 50.0, "vertex height {h} ≉ 4000 m");
+            assert!((h - 5000.0).abs() < 50.0, "vertex height {h} ≉ 5000 m");
         }
     }
 
@@ -727,12 +760,15 @@ mod tests {
         // the surface can't close (Empty). With background = Some(below-threshold),
         // the NaN corners are treated as no-echo and the surface seals into a
         // closed blob — exactly the fix for the "curtains" artifact.
-        let mut grid = ramp_grid(6, 16, 6);
+        let mut grid = ramp_grid(8, 16, 8);
         grid.values.iter_mut().for_each(|v| *v = f32::NAN);
-        // A 2×2×2 finite >threshold core in the interior, rest NaN.
-        for ir in 2..4 {
-            for ia in 7..9 {
-                for ih in 2..4 {
+        // A 4×4×4 finite >threshold core in the interior, rest NaN. Big enough
+        // that the pre-march smoothing (2 passes against the sealed −32 floor)
+        // leaves its centre well above the 20 dBZ threshold (a 2×2×2 core would
+        // smooth entirely below it — physical echoes span many cells).
+        for ir in 2..6 {
+            for ia in 6..10 {
+                for ih in 2..6 {
                     let idx = grid.index(ir, ia, ih);
                     grid.values[idx] = 40.0;
                 }

--- a/crates/ds-3dtiles/src/isosurface.rs
+++ b/crates/ds-3dtiles/src/isosurface.rs
@@ -384,10 +384,12 @@ pub fn encode_isosurface_glb(
         return Err(Tiles3dError::NonFinite("threshold"));
     }
     // A `Some` background must be finite (else it acts like `None` — a NaN fill
-    // leaves the corner non-finite → tet skipped) AND strictly below `threshold`
-    // (else unmeasured cells would seal as *inside* the surface, inverting it).
+    // leaves the corner non-finite → tet skipped) AND representable as `f32`
+    // (the seal narrows `bg as f32`; an out-of-range f64 would cast to ±inf and
+    // propagate through the dense blur) AND strictly below `threshold` (else
+    // unmeasured cells would seal as *inside* the surface, inverting it).
     if let Some(bg) = background {
-        if !bg.is_finite() {
+        if !bg.is_finite() || bg.abs() > f64::from(f32::MAX) {
             return Err(Tiles3dError::NonFinite("background"));
         }
         if bg >= threshold {
@@ -773,7 +775,12 @@ mod tests {
                 }
             }
         }
-        // …with a 40 dBZ core in its middle, ≥2 finite cells from any NaN.
+        // …with a 40 dBZ core in its middle. The 40↔0 crossing must sit
+        // ≥ SMOOTH_PASSES (= 2) finite cells from any NaN: the NaN-aware blur
+        // renormalizes over finite neighbours, so finite cells within `passes`
+        // cells of the open boundary shift toward their finite neighbours — a
+        // crossing closer than that could move or vanish. If SMOOTH_PASSES is
+        // bumped, widen the shell margin here to match.
         for ir in 3..7 {
             for ia in 6..10 {
                 for ih in 3..7 {
@@ -838,6 +845,12 @@ mod tests {
         // A Some(non-finite) background is rejected (would silently act like None).
         assert!(matches!(
             encode_isosurface_glb(&grid, 1.5, [0, 0, 0, 255], Some(f64::INFINITY)),
+            Err(Tiles3dError::NonFinite("background"))
+        ));
+        // A finite f64 beyond f32 range is rejected too (the seal narrows to
+        // f32, so 1e39 would cast to -inf and poison the dense blur).
+        assert!(matches!(
+            encode_isosurface_glb(&grid, 1.5, [0, 0, 0, 255], Some(-1e39)),
             Err(Tiles3dError::NonFinite("background"))
         ));
     }

--- a/crates/ds-3dtiles/src/isosurface.rs
+++ b/crates/ds-3dtiles/src/isosurface.rs
@@ -755,6 +755,44 @@ mod tests {
     }
 
     #[test]
+    fn open_surface_meshes_crossings_inside_finite_region_only() {
+        // background = None with a crossing entirely INSIDE the finite region:
+        // a 40 dBZ core wrapped in a finite 0 dBZ shell, all surrounded by NaN.
+        // The NaN-aware pre-smoothing must keep the finite 40↔0 crossing intact
+        // (no erosion from the NaN surroundings) and the mesher must emit the
+        // surface there while still skipping every NaN-touching tetrahedron —
+        // closing the gap between the smoothing unit tests and the mesher.
+        let mut grid = ramp_grid(10, 16, 10);
+        grid.values.iter_mut().for_each(|v| *v = f32::NAN);
+        // Finite shell (0 dBZ) spanning r/h 1..9, a 3..13…
+        for ir in 1..9 {
+            for ia in 3..13 {
+                for ih in 1..9 {
+                    let idx = grid.index(ir, ia, ih);
+                    grid.values[idx] = 0.0;
+                }
+            }
+        }
+        // …with a 40 dBZ core in its middle, ≥2 finite cells from any NaN.
+        for ir in 3..7 {
+            for ia in 6..10 {
+                for ih in 3..7 {
+                    let idx = grid.index(ir, ia, ih);
+                    grid.values[idx] = 40.0;
+                }
+            }
+        }
+        let glb = encode_isosurface_glb(&grid, 20.0, [0, 200, 0, 255], None)
+            .expect("crossing inside the finite region must mesh without a background");
+        let (json, _bin) = parse_glb(&glb);
+        let count = json["accessors"][0]["count"].as_u64().unwrap();
+        assert!(
+            count > 0 && count % 3 == 0,
+            "open surface has triangles: {count}"
+        );
+    }
+
+    #[test]
     fn background_seals_echo_surrounded_by_clear_air() {
         // A compact echo core embedded in NaN (clear air). With background = None
         // the surface can't close (Empty). With background = Some(below-threshold),

--- a/crates/ds-3dtiles/src/lib.rs
+++ b/crates/ds-3dtiles/src/lib.rs
@@ -32,6 +32,10 @@ pub use isosurface::{encode_isosurface_glb, tileset_json_glb};
 pub mod echo_top;
 pub use echo_top::{encode_echo_top_columns_glb, encode_echo_top_glb};
 
+/// Separable 3-D smoothing of a cylindrical voxel field (#381) — shared by the
+/// voxel encoder and the isosurface mesher.
+mod smoothing;
+
 /// True cylindrical voxels (#351): `VoxelGrid` → `EXT_primitive_voxels` glTF
 /// `.glb` + `3DTILES_content_voxels` tileset for CesiumJS volume ray-marching.
 pub mod voxels;

--- a/crates/ds-3dtiles/src/smoothing.rs
+++ b/crates/ds-3dtiles/src/smoothing.rs
@@ -195,6 +195,28 @@ mod tests {
     }
 
     #[test]
+    fn nan_aware_renormalizes_weights_exactly() {
+        // Non-uniform values against a NaN boundary pin the renormalization
+        // arithmetic itself (a uniform plateau can't — any weighting of equal
+        // inputs returns the input). One pass over a [1, 1, 3] column
+        // [NaN, 10, 30]: only the height sweep does real work (the radius and
+        // angle axes are size 1, so their clamped/periodic neighbours are the
+        // cell itself and blur(v, v, v) = v).
+        //   cell 1: NaN neighbour dropped → (0.5·10 + 0.25·30) / 0.75 = 50/3
+        //   cell 2: clamped end (hi = self) → 0.25·10 + 0.75·30 = 25
+        //   cell 0: NaN stays NaN
+        let dims = [1, 1, 3];
+        let out = smooth_grid_nan_aware(vec![f32::NAN, 10.0, 30.0], dims, 1);
+        assert!(out[0].is_nan(), "NaN cell must stay NaN: {}", out[0]);
+        assert!(
+            (out[1] - 50.0 / 3.0).abs() < 1e-4,
+            "renormalized over finite neighbours only: {}",
+            out[1]
+        );
+        assert!((out[2] - 25.0).abs() < 1e-4, "clamped end: {}", out[2]);
+    }
+
+    #[test]
     fn zero_passes_is_identity() {
         let vals = fill(|r, a, h| (r * 100 + a * 10 + h) as f32);
         assert_eq!(smooth_grid(vals.clone(), DIMS, 0), vals);

--- a/crates/ds-3dtiles/src/smoothing.rs
+++ b/crates/ds-3dtiles/src/smoothing.rs
@@ -1,0 +1,196 @@
+//! Separable 3-D smoothing of a cylindrical voxel field in its native
+//! `[radius, angle, height]` index order (#381) — shared by the voxel encoder
+//! (which dissolves the cell lattice before GPU trilinear interpolation) and
+//! the isosurface mesher (which otherwise inherits the lattice as stair-step
+//! artifacts along the extracted shell).
+//!
+//! Radar echo is **cellular**: each ~native-resolution cell is a local
+//! reflectivity maximum, so any C0 reconstruction (trilinear sampling, linear
+//! edge interpolation in marching tetrahedra) shows the cell boundaries.
+//! Repeated passes of a `[0.25, 0.5, 0.25]` kernel along each axis widen the
+//! effective Gaussian (`sigma ≈ sqrt(passes/2)` cells), dropping cell-to-cell
+//! contrast until the field reads as a continuous volume. Angle wraps (full
+//! circle); radius/height clamp at the ends.
+
+use ds_core::volume::VoxelGrid;
+
+/// Smooth a **dense** (all-finite) field: `passes` applications of the
+/// `[0.25, 0.5, 0.25]` kernel along each axis. Callers fill `NaN` cells first
+/// (the voxel encoder's no-echo floor, the isosurface's `background` seal).
+///
+/// Each axis sweep ping-pongs `src`↔`dst`, so the result is always in `src`
+/// regardless of the pass count.
+pub(crate) fn smooth_grid(vals: Vec<f32>, dims: [usize; 3], passes: usize) -> Vec<f32> {
+    smooth_with(vals, dims, passes, |lo, mid, hi| {
+        0.25 * lo + 0.5 * mid + 0.25 * hi
+    })
+}
+
+/// Smooth a field that still contains `NaN` (unmeasured) cells **without
+/// eroding them**: a `NaN` cell stays `NaN`, and a finite cell averages only
+/// its finite neighbours (the kernel weights renormalize over what's present).
+/// This keeps the isosurface's open-boundary semantics (`background = None`
+/// skips any tetrahedron touching a `NaN` corner) intact — the smoothing
+/// neither fabricates values inside the unmeasured region nor lets the
+/// sentinel bleed into real echo.
+pub(crate) fn smooth_grid_nan_aware(vals: Vec<f32>, dims: [usize; 3], passes: usize) -> Vec<f32> {
+    smooth_with(vals, dims, passes, |lo, mid, hi| {
+        if !mid.is_finite() {
+            return f32::NAN;
+        }
+        let mut sum = 0.5 * mid;
+        let mut weight = 0.5_f32;
+        if lo.is_finite() {
+            sum += 0.25 * lo;
+            weight += 0.25;
+        }
+        if hi.is_finite() {
+            sum += 0.25 * hi;
+            weight += 0.25;
+        }
+        sum / weight
+    })
+}
+
+/// The shared separable sweep: applies `blur(lo, mid, hi)` along height
+/// (clamped), angle (periodic), and radius (clamped), `passes` times.
+/// Monomorphized per blur kernel, so the dense path keeps its tight inner
+/// loops. The loop orders are cache-driven: `h` (stride 1) is always
+/// innermost and `r` (stride `n_a·n_h`) outermost, so every sweep walks the
+/// three touched rows stride-1; the angle sweep hoists its periodic neighbour
+/// indices out of the `h` loop.
+fn smooth_with<F>(vals: Vec<f32>, dims: [usize; 3], passes: usize, blur: F) -> Vec<f32>
+where
+    F: Fn(f32, f32, f32) -> f32 + Copy,
+{
+    let [n_r, n_a, n_h] = dims;
+    let idx = |r: usize, a: usize, h: usize| VoxelGrid::index_of(dims, r, a, h);
+
+    let mut src = vals;
+    let mut dst = vec![0.0f32; src.len()];
+
+    for _ in 0..passes {
+        // Height (clamp).
+        for r in 0..n_r {
+            for a in 0..n_a {
+                for h in 0..n_h {
+                    let lo = src[idx(r, a, h.saturating_sub(1))];
+                    let hi = src[idx(r, a, (h + 1).min(n_h - 1))];
+                    dst[idx(r, a, h)] = blur(lo, src[idx(r, a, h)], hi);
+                }
+            }
+        }
+        std::mem::swap(&mut src, &mut dst);
+        // Angle (periodic).
+        for r in 0..n_r {
+            for a in 0..n_a {
+                let a_lo = (a + n_a - 1) % n_a;
+                let a_hi = (a + 1) % n_a;
+                for h in 0..n_h {
+                    let lo = src[idx(r, a_lo, h)];
+                    let hi = src[idx(r, a_hi, h)];
+                    dst[idx(r, a, h)] = blur(lo, src[idx(r, a, h)], hi);
+                }
+            }
+        }
+        std::mem::swap(&mut src, &mut dst);
+        // Radius (clamp).
+        for r in 0..n_r {
+            for a in 0..n_a {
+                for h in 0..n_h {
+                    let lo = src[idx(r.saturating_sub(1), a, h)];
+                    let hi = src[idx((r + 1).min(n_r - 1), a, h)];
+                    dst[idx(r, a, h)] = blur(lo, src[idx(r, a, h)], hi);
+                }
+            }
+        }
+        std::mem::swap(&mut src, &mut dst);
+    }
+    src
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const DIMS: [usize; 3] = [5, 8, 7];
+
+    fn fill<F: Fn(usize, usize, usize) -> f32>(f: F) -> Vec<f32> {
+        let [n_r, n_a, n_h] = DIMS;
+        let mut v = vec![0.0f32; n_r * n_a * n_h];
+        for r in 0..n_r {
+            for a in 0..n_a {
+                for h in 0..n_h {
+                    v[VoxelGrid::index_of(DIMS, r, a, h)] = f(r, a, h);
+                }
+            }
+        }
+        v
+    }
+
+    #[test]
+    fn linear_field_is_invariant_away_from_clamped_ends() {
+        // The [0.25, 0.5, 0.25] kernel preserves linear functions exactly; only
+        // the clamped boundary cells shift (the boundary perturbation travels
+        // one cell inward per pass). value = h, two passes ⇒ cells 2..n_h−3 of
+        // every column must be untouched.
+        let vals = fill(|_, _, h| h as f32);
+        let out = smooth_grid(vals, DIMS, 2);
+        let [n_r, n_a, n_h] = DIMS;
+        for r in 0..n_r {
+            for a in 0..n_a {
+                for h in 2..n_h - 2 {
+                    let v = out[VoxelGrid::index_of(DIMS, r, a, h)];
+                    assert!((v - h as f32).abs() < 1e-5, "({r},{a},{h}) = {v}");
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn angle_axis_wraps_periodically() {
+        // value = f(angle) with a single spike at a = 0: after one pass the
+        // spike must leak into BOTH angular neighbours, including a = n_a−1
+        // (the wrap) — a clamped angle axis would leave the far side at 0.
+        let [_, n_a, _] = DIMS;
+        let vals = fill(|_, a, _| if a == 0 { 8.0 } else { 0.0 });
+        let out = smooth_grid(vals, DIMS, 1);
+        let at = |a: usize| out[VoxelGrid::index_of(DIMS, 2, a, 3)];
+        assert!(at(1) > 0.0, "forward neighbour gets a share");
+        assert!(
+            (at(n_a - 1) - at(1)).abs() < 1e-6,
+            "wrap neighbour gets the same share: {} vs {}",
+            at(n_a - 1),
+            at(1)
+        );
+    }
+
+    #[test]
+    fn nan_aware_preserves_nan_and_never_bleeds_it() {
+        // A finite plateau bordered by NaN: the NaN cells must stay NaN (no
+        // fabrication), and the finite cells must stay finite at the plateau
+        // value (renormalized weights — averaging 40 with 40 is 40, regardless
+        // of how many NaN neighbours were dropped).
+        let vals = fill(|r, _, _| if r < 3 { 40.0 } else { f32::NAN });
+        let out = smooth_grid_nan_aware(vals, DIMS, 2);
+        let [n_r, n_a, n_h] = DIMS;
+        for r in 0..n_r {
+            for a in 0..n_a {
+                for h in 0..n_h {
+                    let v = out[VoxelGrid::index_of(DIMS, r, a, h)];
+                    if r < 3 {
+                        assert!((v - 40.0).abs() < 1e-4, "({r},{a},{h}) = {v}");
+                    } else {
+                        assert!(v.is_nan(), "({r},{a},{h}) = {v} must stay NaN");
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn zero_passes_is_identity() {
+        let vals = fill(|r, a, h| (r * 100 + a * 10 + h) as f32);
+        assert_eq!(smooth_grid(vals.clone(), DIMS, 0), vals);
+    }
+}

--- a/crates/ds-3dtiles/src/smoothing.rs
+++ b/crates/ds-3dtiles/src/smoothing.rs
@@ -21,6 +21,12 @@ use ds_core::volume::VoxelGrid;
 /// Each axis sweep ping-pongs `src`↔`dst`, so the result is always in `src`
 /// regardless of the pass count.
 pub(crate) fn smooth_grid(vals: Vec<f32>, dims: [usize; 3], passes: usize) -> Vec<f32> {
+    // A NaN slipping in would propagate to every touched neighbour and silently
+    // empty the output (debug-only: a full scan of up to MAX_VOXELS cells).
+    debug_assert!(
+        vals.iter().all(|v| v.is_finite()),
+        "smooth_grid expects a dense (all-finite) field; seal NaN first or use smooth_grid_nan_aware"
+    );
     smooth_with(vals, dims, passes, |lo, mid, hi| {
         0.25 * lo + 0.5 * mid + 0.25 * hi
     })

--- a/crates/ds-3dtiles/src/voxels.rs
+++ b/crates/ds-3dtiles/src/voxels.rs
@@ -91,9 +91,15 @@ pub fn encode_voxels_glb(grid: &VoxelGrid) -> Result<Vec<u8>, Tiles3dError> {
     // reflectivity maximum, so even with GPU trilinear interpolation a raw render
     // shows one blob per cell (a visible grid of cells at close zoom). A light
     // separable 3-D smoothing merges adjacent cells into a continuous field — the
-    // standard radar-volume reconstruction. Angle is periodic (full circle);
-    // radius/height clamp at the ends.
-    let native = smooth_grid(native, grid.dims);
+    // standard radar-volume reconstruction (see `crate::smoothing`).
+    //
+    // 4 passes ⇒ sigma ≈ 1.4 cells (FWHM ≈ 3.3): dissolves the cell lattice —
+    // height floors and the fainter angular-sector walls — at close zoom under
+    // GPU trilinear interpolation (which is only C0, so every cell boundary is a
+    // faint crease whose visibility scales with cell-to-cell contrast, and the
+    // height layers are coarse at ~300 m) without smearing storm cores into a
+    // flat haze.
+    let native = crate::smoothing::smooth_grid(native, grid.dims, 4);
 
     // Transpose the smoothed grid from native `[radius, angle, height]`
     // (height-fastest) into the glTF cylinder layout `[radius, height, angle]`
@@ -182,79 +188,6 @@ fn grid_azimuth_index(slot: usize, n_a: usize) -> usize {
     (bearing_deg / 360.0 * n_a as f64 - 0.5)
         .round()
         .rem_euclid(n_a as f64) as usize
-}
-
-/// Separable 3-D smoothing of the (NaN-filled) grid in its native
-/// `[radius, angle, height]` index order — `PASSES` applications of a
-/// `[0.25, 0.5, 0.25]` kernel along each axis.
-///
-/// Radar echo is **cellular** (each native cell a local reflectivity maximum)
-/// and the voxel grid is coarse in height (~300 m layers), so a *single* pass
-/// still leaves the cell floors (height-layer boundaries) and walls
-/// (radial/angular boundaries) visible under GPU trilinear interpolation when
-/// the camera is close or inside the volume — trilinear is only C0, so every
-/// cell boundary is a faint crease whose visibility scales with the field's
-/// cell-to-cell contrast. Repeated passes widen the effective Gaussian
-/// (`sigma ≈ sqrt(PASSES/2)` cells), dropping that contrast until the field
-/// reads as a continuous volume. Angle wraps (full circle); radius/height clamp
-/// at the ends. Each axis sweep ping-pongs `src`↔`dst`, so the result is always
-/// in `src` regardless of the pass count.
-fn smooth_grid(vals: Vec<f32>, dims: [usize; 3]) -> Vec<f32> {
-    // 4 passes ⇒ sigma ≈ 1.4 cells (FWHM ≈ 3.3): dissolves the cell lattice —
-    // height floors and the fainter angular-sector walls — at close zoom without
-    // smearing storm cores into a flat haze.
-    const PASSES: usize = 4;
-    let [n_r, n_a, n_h] = dims;
-    let idx = |r: usize, a: usize, h: usize| VoxelGrid::index_of(dims, r, a, h);
-    let blur = |lo: f32, mid: f32, hi: f32| 0.25 * lo + 0.5 * mid + 0.25 * hi;
-
-    let mut src = vals;
-    let mut dst = vec![0.0f32; src.len()];
-
-    for _ in 0..PASSES {
-        // Height (clamp).
-        for r in 0..n_r {
-            for a in 0..n_a {
-                for h in 0..n_h {
-                    let lo = src[idx(r, a, h.saturating_sub(1))];
-                    let hi = src[idx(r, a, (h + 1).min(n_h - 1))];
-                    dst[idx(r, a, h)] = blur(lo, src[idx(r, a, h)], hi);
-                }
-            }
-        }
-        std::mem::swap(&mut src, &mut dst);
-        // Angle (periodic). `h` (stride 1) innermost, `a` (stride n_h) in the
-        // middle: an `a`-innermost sweep would jump `n_h` elements per step.
-        // Hoist the periodic neighbour indices out of the `h` loop. Same result,
-        // stride-1 access on all three touched rows.
-        for r in 0..n_r {
-            for a in 0..n_a {
-                let a_lo = (a + n_a - 1) % n_a;
-                let a_hi = (a + 1) % n_a;
-                for h in 0..n_h {
-                    let lo = src[idx(r, a_lo, h)];
-                    let hi = src[idx(r, a_hi, h)];
-                    dst[idx(r, a, h)] = blur(lo, src[idx(r, a, h)], hi);
-                }
-            }
-        }
-        std::mem::swap(&mut src, &mut dst);
-        // Radius (clamp). Loop with `r` OUTERMOST and `h` (the fastest-varying
-        // axis, stride 1) innermost: `r` has the largest stride (`n_a*n_h`), so
-        // an `r`-innermost sweep would miss cache on nearly every step. Same
-        // result, cache-friendly access.
-        for r in 0..n_r {
-            for a in 0..n_a {
-                for h in 0..n_h {
-                    let lo = src[idx(r.saturating_sub(1), a, h)];
-                    let hi = src[idx((r + 1).min(n_r - 1), a, h)];
-                    dst[idx(r, a, h)] = blur(lo, src[idx(r, a, h)], hi);
-                }
-            }
-        }
-        std::mem::swap(&mut src, &mut dst);
-    }
-    src
 }
 
 /// The `EXT_structural_metadata` schema for one scalar voxel property named


### PR DESCRIPTION
## Summary

From the 3D Tiles visual audit (epic #346): the isosurface shell looked blocky/aliased because the mesher marched the **raw** voxel grid while the voxel representation already dissolves the cellular radar field with a multi-pass separable blur. Radar echo is cellular (each cell a local max), so the extracted shell inherited the cell lattice — stair-steps along the contour, worst at range where 1° azimuth bins are km-wide.

- **Shared `smoothing` module** (`ds-3dtiles/src/smoothing.rs`): the `[0.25, 0.5, 0.25]` separable sweep factored out of `voxels.rs`, with a pass-count parameter. The generic sweep is monomorphized per kernel, so the voxel path (4 passes) keeps its cache-tuned loop orders unchanged.
- **`encode_isosurface_glb` smooths before marching**: 2 passes (sigma ≈ 1 cell) — enough to round the contour without erasing storm-core structure (a mesh shows its lattice less than a ray-marched volume seen from inside).
- **NaN handling follows the sealing decision** (preserves the #360 open-boundary semantics):
  - `background = Some(bg)` (the API default): seal NaN → bg **first**, then the dense blur — the same order the voxel path uses.
  - `background = None`: a NaN-aware blur keeps unmeasured cells `NaN` (still skipped) and renormalizes kernel weights over finite neighbours — never bleeds the boundary into real echo, never fabricates values inside the unmeasured region.

## Test updates

- New unit tests for the smoothing module: linear-field invariance away from clamped ends, periodic angle wrap, NaN preservation/non-bleed, zero-pass identity.
- `isosurface_sits_at_the_expected_height` moved its crossing to the grid interior (n_h 5 → 9): the kernel preserves a linear ramp exactly, but the clamped-boundary perturbation travels one cell inward per pass, so the assertion now pins the *smoothed* mesher to the same exact height.
- The sealed-blob test core grew 2×2×2 → 4×4×4 (a 2-cell core smooths below threshold against the −32 floor; physical echoes span many cells).

## Render verification

`cargo run -p engine-odim --example gen_isosurface` against the fivih fixture, viewed in CesiumJS: the 20 dBZ shell is smooth and organic with no visible cell lattice, including at range (the far blobs ~100+ km from the antenna), sitting correctly over southern Finland.

Closes #381

🤖 Generated with [Claude Code](https://claude.com/claude-code)