### PR TITLE
feat(3dtiles): tune the voxel transfer function — cut the milky haze (#383)

### DIFF
--- a/crates/api-3dtiles/viewer/index.html
+++ b/crates/api-3dtiles/viewer/index.html
@@ -468,9 +468,17 @@ function voxelShader(quantity, legend, min) {
     `void fragmentMain(FragmentInput fsInput, inout czm_modelMaterial material){`,
     `  float v=fsInput.metadata.${quantity};`,
     `  material.diffuse=voxRamp(v);`,
-    // Density rises smoothly FROM 0 at the `min` threshold (no hard alpha step →
-    // no shell/"walls and floors" at the min isovalue), ~0.55 by +25 dBZ above it.
-    `  material.alpha=clamp((v-(${min.toFixed(2)}))*0.022,0.0,0.55);`,
+    // Opacity: a dead-band then a quadratic ramp to near-opaque (#383). The
+    // encoder fills unmeasured cells with the −32 dBZ no-echo floor, so the
+    // whole cylinder is a dense low-value field — the old slow linear ramp
+    // (0.022/dBZ from `min`, capped at 0.55) let weak echo + interpolated floor
+    // accumulate along every ray into a uniform milky haze while storm cores
+    // never read solid. Instead: fully transparent until 3 dBZ above `min`
+    // (kills the haze; still no hard alpha step — the quadratic rises smoothly
+    // from 0, so no shell/"walls and floors" at the min isovalue), then
+    // t² over the next 20 dBZ up to 0.95 so cores approach opacity.
+    `  float t=clamp((v-(${(min + 3.0).toFixed(2)}))/20.0,0.0,1.0);`,
+    `  material.alpha=t*t*0.95;`,
     `}`,
   ].join("\n");
   return new Cesium.CustomShader({ fragmentShaderText: fs });


### PR DESCRIPTION
## Summary

From the 3D Tiles visual audit (epic #346): the volumetric representation looked washed-out/milky. The encoder fills every unmeasured cell with the −32 dBZ no-echo floor (deliberate — an extreme sentinel trilinearly interpolates into hard walls), so the whole cylinder is a dense low-value field; the viewer's slow linear opacity ramp (`alpha = clamp((v - min) * 0.022, 0, 0.55)`) let weak echo + interpolated floor accumulate along every ray into a uniform haze, while capping cores at 0.55 kept storms translucent — low contrast both ways.

**Fix (viewer-only, pure shader-string change — no re-encode):** a dead-band + quadratic ramp:

```glsl
float t = clamp((v - (min + 3.0)) / 20.0, 0.0, 1.0);
material.alpha = t * t * 0.95;
```

- Fully transparent until **3 dBZ above `min`** — kills the floor/weak-echo haze. Still no hard alpha step: the quadratic rises smoothly (C1) from 0, so no shell/"walls and floors" appears at the min isovalue.
- **t² over the next 20 dBZ up to 0.95** — weak echo stays ~10× more transparent than before (e.g. +5 dBZ above min: alpha 0.01 vs 0.11), while ≥ ~23 dBZ above min approaches opacity so storm cores read solid (old cap: 0.55).

The optional opacity/contrast UI control from the issue is left out — the fixed curve reads well; can follow up if a knob proves necessary.

## Render verification

Fivih fixture, voxels next to the point cloud at the same min dBZ (5): the between-echo background is now fully transparent (basemap clearly visible), the echo footprint matches the point cloud, ~30 dBZ cores read solid green, and weak blue edges fade smoothly with no uniform milk.

Closes #383

🤖 Generated with [Claude Code](https://claude.com/claude-code)