### PR TITLE
feat(3dtiles): viewer progressive frame preload + tileset reuse across control changes

### DIFF
--- a/crates/api-3dtiles/viewer/index.html
+++ b/crates/api-3dtiles/viewer/index.html
@@ -339,19 +339,20 @@ function cacheGet(url) {
   return ts;
 }
 function cachePut(url, ts) {
+  // Pinned = the active frames plus the entry being inserted (`frames[i] = ts`
+  // only happens after cachePut returns, so `ts` isn't in `frames` yet).
+  const pinned = new Set(frames);
+  pinned.add(ts);
   // Two overlapping builds can both fetch the same URL (the first superseded
   // mid-flight); overwriting the map entry would orphan the loser in the scene.
   // `prev` can never be a live frame today — a cached URL is pre-populated into
   // `frames` by cacheGet and excluded from `pending`, so no worker re-fetches
-  // it — the includes() is defence-in-depth: if that invariant ever breaks,
-  // leak the orphan rather than destroy a tileset that's on screen.
+  // it — the pinned check is defence-in-depth: if that invariant ever breaks,
+  // leak the orphan (it stays in the scene, unreachable by LRU eviction, until
+  // the next collection switch) rather than destroy a tileset that's on screen.
   const prev = tileCache.get(url);
-  if (prev && prev !== ts && !frames.includes(prev)) viewer.scene.primitives.remove(prev);
+  if (prev && prev !== ts && !pinned.has(prev)) viewer.scene.primitives.remove(prev);
   tileCache.set(url, ts);
-  // Pin the active frames AND the entry just inserted (`frames[i] = ts` only
-  // happens after cachePut returns, so `ts` isn't in `frames` yet).
-  const pinned = new Set(frames);
-  pinned.add(ts);
   for (const [u, old] of tileCache) {
     if (tileCache.size <= TILE_CACHE_MAX) break;
     if (pinned.has(old)) continue; // never evict a frame in active use
@@ -475,7 +476,12 @@ async function loadFrames(reframe = false) {
         ts = await Cesium.Cesium3DTileset.fromUrl(urls[i],
           { maximumScreenSpaceError: 1, show: false, preloadWhenHidden: true });
       } catch (e) { console.error("frame", frameTimes[i], e); }
-      if (ts && gen !== cacheGen) { ts.destroy(); ts = null; } // cache cleared mid-flight
+      // Distinct from the token guard below, which CACHES the superseded
+      // tileset (a control change may toggle back to it): a generation
+      // mismatch means the cache was cleared by a collection switch, so the
+      // tileset belongs to the dropped collection — destroy it instead. Don't
+      // fold this into the token check.
+      if (ts && gen !== cacheGen) { ts.destroy(); ts = null; }
       if (ts) {
         viewer.scene.primitives.add(ts);
         cachePut(urls[i], ts);

--- a/crates/api-3dtiles/viewer/index.html
+++ b/crates/api-3dtiles/viewer/index.html
@@ -347,8 +347,13 @@ function cachePut(url, ts) {
   }
 }
 // Collection switch: the cached frames belong to another volume entirely —
-// destroy them all rather than letting them age out of the LRU.
+// destroy them all rather than letting them age out of the LRU. Bumping
+// `cacheGen` makes in-flight workers from the old build discard what they
+// fetched instead of repopulating the just-cleared cache + scene (each build
+// captures the generation it started under).
+let cacheGen = 0;
 function clearFrameCache() {
+  cacheGen++;
   frames = [];
   for (const ts of tileCache.values()) viewer.scene.primitives.remove(ts);
   tileCache.clear();
@@ -378,6 +383,7 @@ async function loadFrames(reframe = false) {
   const num = $num.value.trim();
   if (!id || !q) return;
   const token = ++loadToken;
+  const gen = cacheGen; // cache generation this build belongs to
   stopPlaying();
   hideFrames();
   clearVoxel();
@@ -441,9 +447,11 @@ async function loadFrames(reframe = false) {
   // Bounded-concurrency fill: PRELOAD_CONCURRENCY workers pull from `pending`.
   // Each frame is created hidden; `preloadWhenHidden` is load-bearing — without
   // it a hidden tileset doesn't fetch tiles, so the first reveal would stall.
-  // `fromUrl` rejects on a 4xx (e.g. no data) → that slot stays null. A
-  // superseded build still caches what it fetched (it may be toggled back to);
-  // it just stops touching the live `frames`.
+  // `fromUrl` rejects on a 4xx (e.g. no data) → that slot stays null. A build
+  // superseded by a control change still caches what it fetched (it may be
+  // toggled back to) and just stops touching the live `frames`; a build that
+  // raced past a collection-switch clearFrameCache (gen mismatch) discards
+  // instead — its tilesets belong to the dropped collection.
   let next = 0;
   const worker = async () => {
     while (next < pending.length && token === loadToken) {
@@ -453,6 +461,7 @@ async function loadFrames(reframe = false) {
         ts = await Cesium.Cesium3DTileset.fromUrl(urls[i],
           { maximumScreenSpaceError: 1, show: false, preloadWhenHidden: true });
       } catch (e) { console.error("frame", frameTimes[i], e); }
+      if (ts && gen !== cacheGen) { ts.destroy(); ts = null; } // cache cleared mid-flight
       if (ts) {
         viewer.scene.primitives.add(ts);
         cachePut(urls[i], ts);

--- a/crates/api-3dtiles/viewer/index.html
+++ b/crates/api-3dtiles/viewer/index.html
@@ -258,6 +258,11 @@ async function loadCollectionMeta(reframe) {
       $rep.appendChild(o);
     }
     syncNumField();
+    // Drop the previous collection's cached frames only now that the new
+    // collection's metadata is in hand — if the fetch above failed, the old
+    // collection stays on screen instead of going blank. (On the initial load
+    // the cache is empty and this is a no-op.)
+    clearFrameCache();
     await loadFrames(reframe);
   } catch (e) {
     setStatus("error loading collection — " + e, true);
@@ -343,7 +348,10 @@ function cachePut(url, ts) {
   const prev = tileCache.get(url);
   if (prev && prev !== ts && !frames.includes(prev)) viewer.scene.primitives.remove(prev);
   tileCache.set(url, ts);
+  // Pin the active frames AND the entry just inserted (`frames[i] = ts` only
+  // happens after cachePut returns, so `ts` isn't in `frames` yet).
   const pinned = new Set(frames);
+  pinned.add(ts);
   for (const [u, old] of tileCache) {
     if (tileCache.size <= TILE_CACHE_MAX) break;
     if (pinned.has(old)) continue; // never evict a frame in active use
@@ -699,12 +707,12 @@ function stopPlaying() {
   if (playTimer) { clearInterval(playTimer); playTimer = null; }
 }
 
-// Collection switch → drop the frame cache (those tilesets are another volume,
-// likely elsewhere) and reframe. Every other control is an in-place change →
-// preserve the camera AND the cache, so toggling back is instant. (Arrow
-// wrappers are load-bearing: passing the handler bare would feed the DOM Event
-// as `reframe`, which is truthy and would reframe on every filter tweak.)
-$coll.addEventListener("change", () => { clearFrameCache(); loadCollectionMeta(true); });
+// Collection switch → drop the frame cache (inside loadCollectionMeta, once the
+// new metadata fetch succeeds) and reframe. Every other control is an in-place
+// change → preserve the camera AND the cache, so toggling back is instant.
+// (Arrow wrappers are load-bearing: passing the handler bare would feed the DOM
+// Event as `reframe`, which is truthy and would reframe on every filter tweak.)
+$coll.addEventListener("change", () => loadCollectionMeta(true));
 $qty.addEventListener("change", () => loadFrames(false));
 // Switching representation relabels + re-defaults the numeric field, toggles the
 // Resolution selector, then rebuilds the frames (camera preserved).

--- a/crates/api-3dtiles/viewer/index.html
+++ b/crates/api-3dtiles/viewer/index.html
@@ -469,8 +469,14 @@ async function loadFrames(reframe = false) {
     const ts = frames[frameIdx];
     if (!needReframe || !ts) return;
     needReframe = false;
-    await viewer.zoomTo(ts, new Cesium.HeadingPitchRange(
-      Cesium.Math.toRadians(45), Cesium.Math.toRadians(-28), 300000));
+    try {
+      await viewer.zoomTo(ts, new Cesium.HeadingPitchRange(
+        Cesium.Math.toRadians(45), Cesium.Math.toRadians(-28), 300000));
+    } catch (_) {
+      // A second collection switch during the ~1 s flight destroys `ts` via
+      // clearFrameCache and zoomTo throws on it — a superseded build, not an
+      // error to surface (the token check after each maybeReframe call exits).
+    }
   };
   await maybeReframe();
   if (token !== loadToken) return; // superseded during the zoomTo animation

--- a/crates/api-3dtiles/viewer/index.html
+++ b/crates/api-3dtiles/viewer/index.html
@@ -332,6 +332,15 @@ function tilesetUrl(time) {
 const tileCache = new Map(); // tileset URL → Cesium3DTileset (in scene.primitives, hidden)
 const TILE_CACHE_MAX = 2 * MAX_FRAMES;
 
+// Remove a tileset from the scene AND make sure its GPU buffers are freed.
+// remove() destroys only when the primitive collection has
+// destroyPrimitives:true (the CesiumJS default, but nothing asserts it) — the
+// explicit destroy() makes eviction leak-proof regardless of the flag.
+function dropTileset(ts) {
+  viewer.scene.primitives.remove(ts);
+  if (!ts.isDestroyed()) ts.destroy();
+}
+
 function cacheGet(url) {
   const ts = tileCache.get(url);
   if (!ts) return null;
@@ -345,27 +354,27 @@ function cachePut(url, ts) {
   pinned.add(ts);
   // Two overlapping builds can both fetch the same URL (the first superseded
   // mid-flight), so the slower one finds the winner already in the map. If the
-  // existing entry is hidden, it's the orphan — remove it and overwrite. But a
+  // existing entry is hidden, it's the orphan — drop it and overwrite. But a
   // stale worker can also land AFTER a newer build cached and displayed the
   // same URL (rapid A→B→A toggling): then `prev` is the live, pinned frame and
-  // the incoming `ts` is the stale duplicate — discard `ts` (it was added to
-  // the scene just before this call) and keep the map pointing at `prev`;
-  // overwriting would orphan the live tileset out of the cache, beyond the
-  // reach of both LRU eviction and clearFrameCache. (The stale caller's
-  // token guard fires right after this returns, so the destroyed `ts` is
-  // never assigned into `frames`.)
+  // the incoming `ts` is the stale duplicate — destroy `ts` (it was added to
+  // the scene just before this call), keep the map pointing at `prev`, and
+  // return false so the caller drops its now-dead reference; overwriting would
+  // orphan the live tileset out of the cache, beyond the reach of both LRU
+  // eviction and clearFrameCache.
   const prev = tileCache.get(url);
   if (prev && prev !== ts) {
-    if (pinned.has(prev)) { viewer.scene.primitives.remove(ts); return; }
-    viewer.scene.primitives.remove(prev);
+    if (pinned.has(prev)) { dropTileset(ts); return false; }
+    dropTileset(prev);
   }
   tileCache.set(url, ts);
   for (const [u, old] of tileCache) {
     if (tileCache.size <= TILE_CACHE_MAX) break;
     if (pinned.has(old)) continue; // never evict a frame in active use
     tileCache.delete(u);
-    viewer.scene.primitives.remove(old);
+    dropTileset(old);
   }
+  return true;
 }
 // Collection switch: the cached frames belong to another volume entirely —
 // destroy them all rather than letting them age out of the LRU. Bumping
@@ -377,7 +386,7 @@ function clearFrameCache() {
   stopPlaying(); // don't leave the play timer ticking over an emptied `frames`
   cacheGen++;
   frames = [];
-  for (const ts of tileCache.values()) viewer.scene.primitives.remove(ts);
+  for (const ts of tileCache.values()) dropTileset(ts);
   tileCache.clear();
 }
 
@@ -491,7 +500,7 @@ async function loadFrames(reframe = false) {
       if (ts && gen !== cacheGen) { ts.destroy(); ts = null; }
       if (ts) {
         viewer.scene.primitives.add(ts);
-        cachePut(urls[i], ts);
+        if (!cachePut(urls[i], ts)) ts = null; // stale dup of a live pinned frame — destroyed
       }
       if (token !== loadToken) return; // superseded — the tileset stays cached
       frames[i] = ts;

--- a/crates/api-3dtiles/viewer/index.html
+++ b/crates/api-3dtiles/viewer/index.html
@@ -178,10 +178,13 @@ viewer.scene.backgroundColor = Cesium.Color.BLACK;
 viewer.scene.globe.depthTestAgainstTerrain = false;
 
 // Time-dynamic playback: one preloaded tileset per available volume timestamp
-// (#350). All frames are built up front and kept hidden except the active one, so
-// scrubbing/playing just toggles `.show` — no per-frame network/reload stall. A
-// non-time-dynamic collection is just the degenerate 1-frame case.
-let frames = [];          // Cesium3DTileset per animated timestamp (parallel to `frameTimes`; null = failed)
+// (#350). All frames are kept hidden except the active one, so scrubbing/playing
+// just toggles `.show` — no per-frame network/reload stall. A non-time-dynamic
+// collection is just the degenerate 1-frame case. Frames load progressively
+// (active frame first, then newest→oldest, bounded concurrency) and every loaded
+// tileset is kept in an LRU cache keyed by its tileset URL, so toggling a
+// control and back is a pure visibility flip, not a refetch (#379).
+let frames = [];          // Cesium3DTileset per animated timestamp (parallel to `frameTimes`; null = failed/not yet loaded)
 let times = [];           // full volume-time manifest (ISO Z) from the collection doc
 let frameTimes = [];      // the timestamps actually animated = most-recent MAX_FRAMES of `times`
 let frameIdx = 0;         // active index into `frameTimes`
@@ -197,6 +200,7 @@ const MAX_FRAMES = 48;
 let loadToken = 0;        // guards against out-of-order async (re)builds
 let currentRep = null;    // representation of the active frames
 let pointsFetchFloor = null; // the min_value (dBZ) the point-cloud frames were fetched at
+let pointsStyleMin = null;   // the min currently applied to point styles (client-side filter)
 let legendData = null;    // colour-scale legend {title,unit,min,max,stops} from the collection doc
 let voxelPrimitive = null; // active Cesium VoxelPrimitive (the `voxels` representation)
 
@@ -313,26 +317,69 @@ function tilesetUrl(time) {
   return url;
 }
 
-// Remove every frame tileset from the scene (destroying its GPU buffers — the
-// primitive collection's destroyPrimitives:true does the destroy on remove()).
-function clearFrames() {
-  for (const ts of frames) if (ts) viewer.scene.primitives.remove(ts);
+// Frame cache (#379): every loaded tileset is keyed by its full tileset URL —
+// which encodes collection, quantity, representation, threshold/min_value,
+// resolution AND datetime — and kept in the scene hidden, so toggling a control
+// and back reuses the already-downloaded tileset instead of refetching every
+// frame. LRU-capped at the active frame set plus one full previous set; eviction
+// removes the tileset from the scene (the primitive collection's
+// destroyPrimitives:true destroys its GPU buffers on remove()).
+const tileCache = new Map(); // tileset URL → Cesium3DTileset (in scene.primitives, hidden)
+const TILE_CACHE_MAX = 2 * MAX_FRAMES;
+
+function cacheGet(url) {
+  const ts = tileCache.get(url);
+  if (!ts) return null;
+  tileCache.delete(url); tileCache.set(url, ts); // LRU bump
+  return ts;
+}
+function cachePut(url, ts) {
+  // Two overlapping builds can both fetch the same URL (the first superseded
+  // mid-flight); overwriting the map entry would orphan the loser in the scene.
+  const prev = tileCache.get(url);
+  if (prev && prev !== ts && !frames.includes(prev)) viewer.scene.primitives.remove(prev);
+  tileCache.set(url, ts);
+  for (const [u, old] of tileCache) {
+    if (tileCache.size <= TILE_CACHE_MAX) break;
+    if (frames.includes(old)) continue; // never evict a frame in active use
+    tileCache.delete(u);
+    viewer.scene.primitives.remove(old);
+  }
+}
+// Collection switch: the cached frames belong to another volume entirely —
+// destroy them all rather than letting them age out of the LRU.
+function clearFrameCache() {
+  frames = [];
+  for (const ts of tileCache.values()) viewer.scene.primitives.remove(ts);
+  tileCache.clear();
+}
+
+// Hide the current frame set. The tilesets stay in the scene + cache, so coming
+// back to the same params is a visibility flip; only LRU eviction or a
+// collection switch (clearFrameCache) actually destroys them.
+function hideFrames() {
+  for (const ts of frames) if (ts) ts.show = false;
   frames = [];
 }
 function clearVoxel() {
   if (voxelPrimitive) { viewer.scene.primitives.remove(voxelPrimitive); voxelPrimitive = null; }
 }
 
-// (Re)build the whole frame set for the current params: one preloaded, hidden
-// tileset per timestamp (or a single latest-volume frame when the collection has
-// no time axis). The active frame is revealed; on `reframe` the camera frames it.
+// (Re)build the frame set for the current params: one hidden tileset per
+// timestamp (or a single latest-volume frame when the collection has no time
+// axis). Cached frames appear instantly; missing ones load progressively — the
+// active frame first (shown + reframed as soon as it's ready), then the rest
+// newest→oldest with bounded concurrency — instead of one unthrottled
+// Promise.all over all 48 (#379).
+const PRELOAD_CONCURRENCY = 6;
+
 async function loadFrames(reframe = false) {
   const id = $coll.value, q = $qty.value, rep = $rep.value || "points";
   const num = $num.value.trim();
   if (!id || !q) return;
   const token = ++loadToken;
   stopPlaying();
-  clearFrames();
+  hideFrames();
   clearVoxel();
   currentRep = rep;
   pointsFetchFloor = rep === "points" ? (num === "" ? -Infinity : parseFloat(num)) : null;
@@ -358,33 +405,71 @@ async function loadFrames(reframe = false) {
   if (frameIdx >= frameTimes.length) frameIdx = frameTimes.length - 1;
   if (frameIdx < 0) frameIdx = 0;
   const capped = times.length > frameTimes.length ? ` (latest ${frameTimes.length} of ${times.length})` : "";
-  setStatus(`loading ${id} · ${q} · ${rep}${frameTimes.length > 1 ? ` · ${frameTimes.length} frames${capped}` : ""}…`);
 
-  // Preload all frames concurrently, each hidden. `preloadWhenHidden` is
-  // load-bearing: without it a hidden tileset doesn't fetch tiles, so the first
-  // reveal of each frame would stall — with it, every frame's content streams in
-  // the background and showing it is an instant visibility flip. (Bounded by the
-  // engine's retained-volume count; a sliding window would suit much longer
-  // sequences — a follow-up.) `fromUrl` rejects on a 4xx (e.g. no data).
-  const built = await Promise.all(frameTimes.map((t) =>
-    Cesium.Cesium3DTileset.fromUrl(tilesetUrl(t),
-      { maximumScreenSpaceError: 1, show: false, preloadWhenHidden: true })
-      .catch((e) => { console.error("frame", t, e); return null; })
-  ));
-  if (token !== loadToken) { for (const ts of built) if (ts) ts.destroy(); return; } // superseded
-
-  frames = built;
-  for (const ts of frames) if (ts) viewer.scene.primitives.add(ts);
+  // Satisfy what we can from the frame cache, then show it immediately — a
+  // control toggled back to cached params renders with zero network.
+  const urls = frameTimes.map((t) => tilesetUrl(t));
+  frames = urls.map((u) => cacheGet(u));
   if (rep === "points") applyPointStyle(pointsFetchFloor);
   syncTimeBar();
   showFrame(frameIdx);
 
-  if (reframe) {
+  // Load order for the misses: the active frame first (it's what's on screen),
+  // then the rest newest→oldest so recent frames fill in first.
+  const pending = [];
+  if (!frames[frameIdx]) pending.push(frameIdx);
+  for (let i = frames.length - 1; i >= 0; i--) if (i !== frameIdx && !frames[i]) pending.push(i);
+  const progress = () => {
+    const done = frames.filter(Boolean).length;
+    setStatus(`loading ${id} · ${q} · ${rep} · frame ${done}/${frameTimes.length}${capped}…`);
+  };
+  if (pending.length) progress();
+
+  // Reframe the camera as soon as the active frame exists (cached, or first to
+  // load) — don't hold the view hostage to the background fill.
+  let needReframe = reframe;
+  const maybeReframe = async () => {
     const ts = frames[frameIdx];
-    if (ts) await viewer.zoomTo(ts, new Cesium.HeadingPitchRange(
+    if (!needReframe || !ts) return;
+    needReframe = false;
+    await viewer.zoomTo(ts, new Cesium.HeadingPitchRange(
       Cesium.Math.toRadians(45), Cesium.Math.toRadians(-28), 300000));
-    if (token !== loadToken) return; // superseded during the zoomTo animation
-  }
+  };
+  await maybeReframe();
+  if (token !== loadToken) return; // superseded during the zoomTo animation
+
+  // Bounded-concurrency fill: PRELOAD_CONCURRENCY workers pull from `pending`.
+  // Each frame is created hidden; `preloadWhenHidden` is load-bearing — without
+  // it a hidden tileset doesn't fetch tiles, so the first reveal would stall.
+  // `fromUrl` rejects on a 4xx (e.g. no data) → that slot stays null. A
+  // superseded build still caches what it fetched (it may be toggled back to);
+  // it just stops touching the live `frames`.
+  let next = 0;
+  const worker = async () => {
+    while (next < pending.length && token === loadToken) {
+      const i = pending[next++];
+      let ts = null;
+      try {
+        ts = await Cesium.Cesium3DTileset.fromUrl(urls[i],
+          { maximumScreenSpaceError: 1, show: false, preloadWhenHidden: true });
+      } catch (e) { console.error("frame", frameTimes[i], e); }
+      if (ts) {
+        viewer.scene.primitives.add(ts);
+        cachePut(urls[i], ts);
+      }
+      if (token !== loadToken) return; // superseded — the tileset stays cached
+      frames[i] = ts;
+      if (ts) {
+        if (currentRep === "points") stylePointFrame(ts, pointsStyleMin);
+        syncTimeBar(); // unhides the time bar once the first frame exists
+        if (i === frameIdx) { showFrame(frameIdx); await maybeReframe(); }
+      }
+      progress();
+    }
+  };
+  await Promise.all(Array.from({ length: Math.min(PRELOAD_CONCURRENCY, pending.length) }, () => worker()));
+  if (token !== loadToken) return;
+
   if (!frames.some(Boolean)) setStatus("no data for this selection", true);
   else updateStatus();
 }
@@ -509,18 +594,20 @@ function showFrame(i) {
 // Point-cloud style applied to EVERY frame so the whole animation filters/sizes
 // consistently: drop points below `min` and scale each dot by its reflectivity
 // (the per-point `value` batch property). Both read `${value}` (a mesh ignores
-// both).
-function applyPointStyle(min) {
+// both). `pointsStyleMin` remembers the applied min so frames still arriving
+// from the progressive preload get the same style.
+function stylePointFrame(ts, min) {
   const cond = Number.isFinite(min) ? "${value} >= " + min : "true";
-  for (const ts of frames) {
-    if (!ts) continue;
-    ts.style = new Cesium.Cesium3DTileStyle({
-      show: cond,
-      // Steep ramp so weak vs strong reads clearly: ~1 px at 5 dBZ up to 16 px at
-      // 55 dBZ (slope 0.3). Weak clutter stays a speck; storm cores are fat dots.
-      pointSize: "clamp((${value} - 5.0) * 0.3 + 1.0, 1.0, 16.0)",
-    });
-  }
+  ts.style = new Cesium.Cesium3DTileStyle({
+    show: cond,
+    // Steep ramp so weak vs strong reads clearly: ~1 px at 5 dBZ up to 16 px at
+    // 55 dBZ (slope 0.3). Weak clutter stays a speck; storm cores are fat dots.
+    pointSize: "clamp((${value} - 5.0) * 0.3 + 1.0, 1.0, 16.0)",
+  });
+}
+function applyPointStyle(min) {
+  pointsStyleMin = min;
+  for (const ts of frames) if (ts) stylePointFrame(ts, min);
 }
 
 // The `min dBZ` field for a point cloud filters CLIENT-SIDE across all frames (no
@@ -571,13 +658,24 @@ function updateStatus(extra) {
   setStatus(extra ? `${base} · ${extra}` : base);
 }
 
+// Next loaded frame at-or-after `from` (wrapping): playback can start while the
+// progressive preload is still filling, so skip slots that are null (failed or
+// not yet loaded) rather than flashing empty frames.
+function nextLoadedFrame(from) {
+  for (let k = 0; k < frames.length; k++) {
+    const i = (((from + k) % frames.length) + frames.length) % frames.length;
+    if (frames[i]) return i;
+  }
+  return from;
+}
+
 function startPlaying() {
   // Need >1 frame AND at least one that actually loaded — otherwise play would
   // loop forever showing nothing (every frame's fromUrl can fail → all null).
   if (playing || frames.length <= 1 || !frames.some(Boolean)) return;
   playing = true;
   $play.textContent = "⏸";
-  playTimer = setInterval(() => showFrame(frameIdx + 1), FRAME_MS);
+  playTimer = setInterval(() => showFrame(nextLoadedFrame(frameIdx + 1)), FRAME_MS);
 }
 
 function stopPlaying() {
@@ -586,11 +684,12 @@ function stopPlaying() {
   if (playTimer) { clearInterval(playTimer); playTimer = null; }
 }
 
-// Collection switch → reframe (new volume, possibly elsewhere). Every other
-// control is an in-place change → preserve the camera. (Arrow wrappers are
-// load-bearing: passing the handler bare would feed the DOM Event as `reframe`,
-// which is truthy and would reframe on every filter tweak.)
-$coll.addEventListener("change", () => loadCollectionMeta(true));
+// Collection switch → drop the frame cache (those tilesets are another volume,
+// likely elsewhere) and reframe. Every other control is an in-place change →
+// preserve the camera AND the cache, so toggling back is instant. (Arrow
+// wrappers are load-bearing: passing the handler bare would feed the DOM Event
+// as `reframe`, which is truthy and would reframe on every filter tweak.)
+$coll.addEventListener("change", () => { clearFrameCache(); loadCollectionMeta(true); });
 $qty.addEventListener("change", () => loadFrames(false));
 // Switching representation relabels + re-defaults the numeric field, toggles the
 // Resolution selector, then rebuilds the frames (camera preserved).

--- a/crates/api-3dtiles/viewer/index.html
+++ b/crates/api-3dtiles/viewer/index.html
@@ -358,6 +358,7 @@ function cachePut(url, ts) {
 // captures the generation it started under).
 let cacheGen = 0;
 function clearFrameCache() {
+  stopPlaying(); // don't leave the play timer ticking over an emptied `frames`
   cacheGen++;
   frames = [];
   for (const ts of tileCache.values()) viewer.scene.primitives.remove(ts);
@@ -476,7 +477,7 @@ async function loadFrames(reframe = false) {
       if (ts) {
         if (currentRep === "points") stylePointFrame(ts, pointsStyleMin);
         syncTimeBar(); // unhides the time bar once the first frame exists
-        if (i === frameIdx) { showFrame(frameIdx); await maybeReframe(); }
+        if (i === frameIdx) { showFrame(frameIdx); await maybeReframe(); if (token !== loadToken) return; }
       }
       progress();
     }

--- a/crates/api-3dtiles/viewer/index.html
+++ b/crates/api-3dtiles/viewer/index.html
@@ -350,6 +350,9 @@ function cacheGet(url) {
 function cachePut(url, ts) {
   // Pinned = the active frames plus the entry being inserted (`frames[i] = ts`
   // only happens after cachePut returns, so `ts` isn't in `frames` yet).
+  // Deliberately reads the LIVE `frames`, not a per-build snapshot — a stale
+  // worker must see the NEWER build's frames to detect the A→B→A dup below;
+  // threading a snapshot through loadFrames would break that guard.
   const pinned = new Set(frames);
   pinned.add(ts);
   // Two overlapping builds can both fetch the same URL (the first superseded
@@ -368,6 +371,9 @@ function cachePut(url, ts) {
     dropTileset(prev);
   }
   tileCache.set(url, ts);
+  // Soft cap: pinned entries are skipped, not evicted, so the size can sit
+  // above TILE_CACHE_MAX until frames unpin (harmless — pins ≤ MAX_FRAMES + 1,
+  // and the cap is 2× that).
   for (const [u, old] of tileCache) {
     if (tileCache.size <= TILE_CACHE_MAX) break;
     if (pinned.has(old)) continue; // never evict a frame in active use

--- a/crates/api-3dtiles/viewer/index.html
+++ b/crates/api-3dtiles/viewer/index.html
@@ -336,12 +336,17 @@ function cacheGet(url) {
 function cachePut(url, ts) {
   // Two overlapping builds can both fetch the same URL (the first superseded
   // mid-flight); overwriting the map entry would orphan the loser in the scene.
+  // `prev` can never be a live frame today — a cached URL is pre-populated into
+  // `frames` by cacheGet and excluded from `pending`, so no worker re-fetches
+  // it — the includes() is defence-in-depth: if that invariant ever breaks,
+  // leak the orphan rather than destroy a tileset that's on screen.
   const prev = tileCache.get(url);
   if (prev && prev !== ts && !frames.includes(prev)) viewer.scene.primitives.remove(prev);
   tileCache.set(url, ts);
+  const pinned = new Set(frames);
   for (const [u, old] of tileCache) {
     if (tileCache.size <= TILE_CACHE_MAX) break;
-    if (frames.includes(old)) continue; // never evict a frame in active use
+    if (pinned.has(old)) continue; // never evict a frame in active use
     tileCache.delete(u);
     viewer.scene.primitives.remove(old);
   }

--- a/crates/api-3dtiles/viewer/index.html
+++ b/crates/api-3dtiles/viewer/index.html
@@ -344,14 +344,21 @@ function cachePut(url, ts) {
   const pinned = new Set(frames);
   pinned.add(ts);
   // Two overlapping builds can both fetch the same URL (the first superseded
-  // mid-flight); overwriting the map entry would orphan the loser in the scene.
-  // `prev` can never be a live frame today — a cached URL is pre-populated into
-  // `frames` by cacheGet and excluded from `pending`, so no worker re-fetches
-  // it — the pinned check is defence-in-depth: if that invariant ever breaks,
-  // leak the orphan (it stays in the scene, unreachable by LRU eviction, until
-  // the next collection switch) rather than destroy a tileset that's on screen.
+  // mid-flight), so the slower one finds the winner already in the map. If the
+  // existing entry is hidden, it's the orphan — remove it and overwrite. But a
+  // stale worker can also land AFTER a newer build cached and displayed the
+  // same URL (rapid A→B→A toggling): then `prev` is the live, pinned frame and
+  // the incoming `ts` is the stale duplicate — discard `ts` (it was added to
+  // the scene just before this call) and keep the map pointing at `prev`;
+  // overwriting would orphan the live tileset out of the cache, beyond the
+  // reach of both LRU eviction and clearFrameCache. (The stale caller's
+  // token guard fires right after this returns, so the destroyed `ts` is
+  // never assigned into `frames`.)
   const prev = tileCache.get(url);
-  if (prev && prev !== ts && !pinned.has(prev)) viewer.scene.primitives.remove(prev);
+  if (prev && prev !== ts) {
+    if (pinned.has(prev)) { viewer.scene.primitives.remove(ts); return; }
+    viewer.scene.primitives.remove(prev);
+  }
   tileCache.set(url, ts);
   for (const [u, old] of tileCache) {
     if (tileCache.size <= TILE_CACHE_MAX) break;


### PR DESCRIPTION
Implements #379 (3D Tiles hot-path audit follow-up; epic #346). Viewer-only change — no server code touched.

## What changed

**Progressive preload.** `loadFrames` no longer fires one unthrottled `Promise.all` over all `MAX_FRAMES` (48) tilesets. The active frame loads first and is shown (and, on a collection switch, reframed) the moment it's ready; the remaining frames fill in newest→oldest through a bounded pool of 6 concurrent workers, with a `frame n/total` progress status. Playback skips frames the fill hasn't delivered yet instead of flashing empty frames.

**Frame cache.** Every loaded tileset is kept (hidden, in the scene) in an LRU keyed by its full tileset URL — which already encodes collection, quantity, representation, threshold/min_value, resolution, and datetime. Control changes now *hide* the current frame set instead of destroying it, so toggling quantity/representation/threshold/resolution and back is a pure visibility flip with zero network. Details:

- Cap = `2 × MAX_FRAMES` (current set + one full previous set); eviction removes the tileset from the primitive collection, which destroys its GPU buffers. Frames in active use are never evicted.
- A collection switch drops the whole cache (different volume, usually a different place on the globe).
- A superseded build's completed fetches go into the cache (they may be toggled back to) instead of being destroyed; overlapping builds that double-fetch one URL can't orphan a tileset in the scene.

**Unchanged** (issue point 3): the client-side min-dBZ fast paths — points `show`-restyle and the voxel transfer-function shader rebuild. Frames still arriving from the progressive fill pick up the currently applied point-style min.

## Verification

Render-verified live (CesiumJS 1.142) against a 3-volume local PVOL fixture (`testdata/radar-fmi-vihti-h5`), counting requests via the page's resource timing log:

| action | new requests |
|---|---|
| initial load (points) | 6 (3 tileset.json + 3 content.pnts) |
| switch → isosurface | 6 (3 tileset.json + 3 content.glb) |
| back → points | **0** |
| → isosurface again | **0** |
| scrub time slider | **0** |
| raise min dBZ 5→20 | **0** (client restyle) |
| drop min dBZ below floor (→0) | 6 (new cache key — correct) |
| voxels representation | 1 + content (own path, unchanged) |

Playback advances frames, the time label/slider track, and the console is error-free throughout. `cargo test -p api-3dtiles`: 28 passed.

Closes #379

🤖 Generated with [Claude Code](https://claude.com/claude-code)