### PR TITLE
feat(3dtiles): nested multi-threshold translucent isosurfaces + indexed smooth-shaded mesh

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -281,10 +281,33 @@ into a glTF `.glb` triangle mesh.
   carries the antenna ECEF as the tile **`transform`** (glTF content has no
   embedded origin, unlike `.pnts` `RTC_CENTER`); the geodetic `region` is
   unaffected by it. Demo: `cargo run -p engine-odim --example gen_isosurface`
-  (writes `.glb` + `tileset.json` + a token-free CesiumJS viewer). The mesh is
+  (writes `.glb` + `tileset.json` + a token-free CesiumJS viewer; takes a
+  comma-separated threshold list, default `20,35,50`). The mesh is
   **render-verified live** (CesiumJS 1.124): the shell sits correctly over the
   antenna, upright (so the Y-up→Z-up flip is right for direct 1.1 `.glb`
   content), and sealing closes the curtains into solid blobs.
+  **Nested multi-threshold shells (#363):** `encode_isosurfaces_glb(grid,
+  &[IsoShell], background)` meshes several thresholds into ONE `.glb` — one
+  primitive + material per shell; alpha < 255 ⇒ `alphaMode: "BLEND"` (opaque
+  shells stay OPAQUE to keep depth-writes), so the intense core glows through
+  translucent envelopes ("onion-skin"). `nested_shells(thresholds, colormap)`
+  is the shared colour/alpha-ramp policy (outer 35% → inner opaque; single
+  threshold = opaque, the classic #357 look). Primitives are emitted
+  **innermost-first** — glTF has no draw order, but nested shells share a
+  bounding-sphere centre so CesiumJS's back-to-front translucency sort ties and
+  primitive order breaks the tie (render-verified). The blur runs ONCE (shells
+  re-march the same smoothed field); a threshold above all data is **skipped**
+  (weak storm still shows its envelope), all-empty ⇒ `Empty`; `background` must
+  sit below the *lowest* threshold; the triangle cap bounds the SUM. API:
+  `?threshold=20,35,50` (comma list, ≤ 5 values, sorted+deduped into the
+  canonical `content.uri`; isosurface-only — a list on `echotop` is a 400).
+  **Indexed mesh + smooth normals (#382):** `MeshBuilder` interns vertices by
+  exact position bits (marching-tet shared crossings are bit-identical — no
+  quantisation) and accumulates area-weighted outward face normals, normalized
+  per vertex at encode — kills the flat-shaded "crumpled paper" facets and
+  shrinks the `.glb` by the vertex-sharing factor (~2.5×; 3 shells of the fivih
+  fixture = 2.7 MB). Keep the `out_ref` outward-orientation logic — it's what
+  keeps winding + normals consistent.
 - **Echo-top-height (#362, `ds-3dtiles/src/echo_top.rs`):** two encoders off the
   per-`(radius, azimuth)`-column echo top (highest cell ≥ `threshold`,
   crossing-interpolated), each a height-coloured glTF `.glb` (per-vertex

--- a/crates/api-3dtiles/src/handlers.rs
+++ b/crates/api-3dtiles/src/handlers.rs
@@ -50,7 +50,9 @@ const MAX_ISOSURFACE_SHELLS: usize = 5;
 /// for nested translucent isosurface shells (#363), e.g. `20,35,50`. Returns
 /// the values sorted ascending and de-duplicated (a duplicate would just mesh
 /// the same shell twice). Non-numeric, non-finite, empty, and over-long lists
-/// are a 400.
+/// are a 400 — the shell cap applies to the **deduped** count (what's actually
+/// meshed), so a list of repeats that collapses under the cap is fine. Parse
+/// work on the raw list is bounded by the HTTP stack's URL-length limit.
 fn parse_thresholds(s: &str) -> Result<Vec<f64>, Tiles3dError> {
     let mut vals = Vec::new();
     for part in s.split(',') {
@@ -63,14 +65,14 @@ fn parse_thresholds(s: &str) -> Result<Vec<f64>, Tiles3dError> {
         }
         vals.push(t);
     }
+    vals.sort_by(f64::total_cmp);
+    vals.dedup();
     if vals.len() > MAX_ISOSURFACE_SHELLS {
         return Err(Tiles3dError::BadRequest(format!(
             "too many thresholds ({}; at most {MAX_ISOSURFACE_SHELLS})",
             vals.len()
         )));
     }
-    vals.sort_by(f64::total_cmp);
-    vals.dedup();
     Ok(vals)
 }
 

--- a/crates/api-3dtiles/src/handlers.rs
+++ b/crates/api-3dtiles/src/handlers.rs
@@ -41,6 +41,63 @@ const ISOSURFACE_DEFAULT_THRESHOLD: f64 = 20.0;
 /// (e.g. `VRADH`) still validates against the −32 dBZ floor, which is meaningless
 /// for velocity. Per-quantity floors land with per-quantity colormaps (#350).
 const ECHO_TOP_DEFAULT_THRESHOLD: f64 = 18.0;
+/// Cap on nested isosurface shells per request (#363). Each extra shell is
+/// another full marching pass over the voxel grid (the blur + resample are
+/// shared), so an unbounded list would let one request buy unbounded CPU.
+const MAX_ISOSURFACE_SHELLS: usize = 5;
+
+/// Parse a `threshold` query value: a single number, or a comma-separated list
+/// for nested translucent isosurface shells (#363), e.g. `20,35,50`. Returns
+/// the values sorted ascending and de-duplicated (a duplicate would just mesh
+/// the same shell twice). Non-numeric, non-finite, empty, and over-long lists
+/// are a 400.
+fn parse_thresholds(s: &str) -> Result<Vec<f64>, Tiles3dError> {
+    let mut vals = Vec::new();
+    for part in s.split(',') {
+        let t: f64 = part.trim().parse().map_err(|_| {
+            Tiles3dError::BadRequest(format!("invalid threshold {part:?} (expected a number)"))
+        })?;
+        // `str::parse` accepts "NaN"/"inf"; a non-finite iso-value is meaningless.
+        if !t.is_finite() {
+            return Err(Tiles3dError::BadRequest("threshold must be finite".into()));
+        }
+        vals.push(t);
+    }
+    if vals.len() > MAX_ISOSURFACE_SHELLS {
+        return Err(Tiles3dError::BadRequest(format!(
+            "too many thresholds ({}; at most {MAX_ISOSURFACE_SHELLS})",
+            vals.len()
+        )));
+    }
+    vals.sort_by(f64::total_cmp);
+    vals.dedup();
+    Ok(vals)
+}
+
+/// The canonical query-string form of an applied threshold list (ascending,
+/// comma-joined — `,` is a legal query sub-delim, and finite f64 `Display` is
+/// URL-safe), used in `content.uri` so the content fetch is deterministic.
+fn thresholds_token(thresholds: &[f64]) -> String {
+    thresholds
+        .iter()
+        .map(f64::to_string)
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
+/// Fold the applied thresholds into [`ContentKey::param_bits`]: FNV-1a over the
+/// sorted bit patterns. A defaulted and an explicit-default request share one
+/// entry; every distinct shell list keys distinctly.
+fn thresholds_bits(thresholds: &[f64]) -> u64 {
+    let mut h: u64 = 0xcbf2_9ce4_8422_2325;
+    for t in thresholds {
+        for b in t.to_bits().to_le_bytes() {
+            h ^= b as u64;
+            h = h.wrapping_mul(0x0000_0100_0000_01b3);
+        }
+    }
+    h
+}
 
 /// Voxel-grid resolution tier for the glTF mesh products (isosurface, echo-top):
 /// `[radius, azimuth, height]`. Azimuth stays 360 (the native 1° ray spacing) at
@@ -240,9 +297,11 @@ pub struct TilesetParams {
     /// `points` only: drop points below this physical value (e.g. a dBZ floor);
     /// carried into the tileset's `content.uri` so the `.pnts` fetch applies it.
     pub min_value: Option<f64>,
-    /// `isosurface` only: the iso-value (e.g. dBZ) of the shell; carried into
-    /// the `.glb` `content.uri`. `None` → [`ISOSURFACE_DEFAULT_THRESHOLD`].
-    pub threshold: Option<f64>,
+    /// Mesh products only: the iso-value(s) (e.g. dBZ). For `isosurface`, a
+    /// comma-separated list (e.g. `20,35,50`) yields nested translucent shells
+    /// (#363); `echotop` takes exactly one. Carried into the `.glb`
+    /// `content.uri`. `None` → the product default.
+    pub threshold: Option<String>,
     /// Mesh products only (`isosurface`/`echotop`): voxel-grid detail tier
     /// (`low`/`med`/`high`); carried into the `.glb` `content.uri`. `None` →
     /// `med`. Ignored for `points` (the cloud is native-resolution).
@@ -261,10 +320,11 @@ pub struct ContentParams {
 pub struct GlbContentParams {
     pub quantity: Option<String>,
     pub datetime: Option<String>,
-    /// `isosurface`: iso-value of the shell; `echotop`: the reflectivity floor
-    /// for the echo top. `None` → [`ISOSURFACE_DEFAULT_THRESHOLD`] /
-    /// [`ECHO_TOP_DEFAULT_THRESHOLD`].
-    pub threshold: Option<f64>,
+    /// `isosurface`: iso-value(s) of the shell(s) — a comma-separated list
+    /// yields nested translucent shells (#363); `echotop`: the (single)
+    /// reflectivity floor for the echo top. `None` →
+    /// [`ISOSURFACE_DEFAULT_THRESHOLD`] / [`ECHO_TOP_DEFAULT_THRESHOLD`].
+    pub threshold: Option<String>,
     /// Which glTF product: `isosurface` (default) or `echotop`.
     pub representation: Option<String>,
     /// Voxel-grid detail tier (`low`/`med`/`high`). `None` → `med`.
@@ -531,11 +591,17 @@ pub async fn get_tileset(
             // don't sample the grid just to emit the tileset.
             let [olon, olat, oh] = caps.origin;
             let rtc = geodetic_to_ecef(olon, olat, oh);
-            if let Some(t) = params.threshold {
-                if !t.is_finite() {
-                    return Err(Tiles3dError::BadRequest("threshold must be finite".into()));
+            if let Some(raw) = &params.threshold {
+                let thresholds = parse_thresholds(raw)?;
+                // Nested shells are an isosurface feature; an echo top is one
+                // surface per column and has exactly one threshold.
+                if representation == Representation::EchoTop && thresholds.len() > 1 {
+                    return Err(Tiles3dError::BadRequest(
+                        "echotop takes a single threshold (nested shells are isosurface-only)"
+                            .into(),
+                    ));
                 }
-                query.push_str(&format!("&threshold={t}"));
+                query.push_str(&format!("&threshold={}", thresholds_token(&thresholds)));
             }
             // Carry the detail tier so the content fetch matches the tileset;
             // emit the canonical token even when the request omitted it, so the
@@ -711,22 +777,36 @@ pub async fn get_content_glb(
     // Detail tier (`low`/`med`/`high`, default `med`) → voxel-grid dims, applied
     // to both mesh products. A bad value is a 400 before the blocking task.
     let dims = Resolution::parse(params.resolution.as_deref())?.dims();
-    let threshold = params.threshold.unwrap_or(match representation {
-        Representation::EchoTop => ECHO_TOP_DEFAULT_THRESHOLD,
-        _ => ISOSURFACE_DEFAULT_THRESHOLD,
-    });
-    if !threshold.is_finite() {
-        return Err(Tiles3dError::BadRequest("threshold must be finite".into()));
+    // The applied threshold list (ascending, deduped): one value for echo-top,
+    // one or more nested shells for the isosurface (#363).
+    let thresholds = match params.threshold.as_deref() {
+        None => vec![match representation {
+            Representation::EchoTop => ECHO_TOP_DEFAULT_THRESHOLD,
+            _ => ISOSURFACE_DEFAULT_THRESHOLD,
+        }],
+        Some(raw) => parse_thresholds(raw)?,
+    };
+    if representation == Representation::EchoTop && thresholds.len() > 1 {
+        return Err(Tiles3dError::BadRequest(
+            "echotop takes a single threshold (nested shells are isosurface-only)".into(),
+        ));
     }
     // Both products lean on the engine's no-echo floor: the isosurface seals NaN
     // at it; an echo-top column needs its threshold above it (else clear air
     // would count as echo). (v1: the floor is dBZ for every quantity — #350.)
+    // Checking the lowest covers the whole ascending list.
     let floor = f64::from(ds_core::volume::NO_ECHO_FLOOR_DBZ);
-    if threshold <= floor {
+    if thresholds[0] <= floor {
         return Err(Tiles3dError::BadRequest(format!(
             "threshold must be above the no-echo floor ({floor})"
         )));
     }
+    // For error messages (e.g. "no isosurface at threshold 20, 35, 50").
+    let threshold_label = thresholds
+        .iter()
+        .map(f64::to_string)
+        .collect::<Vec<_>>()
+        .join(", ");
 
     let exact = exact_volume_time(&info, time);
     let key = ContentKey {
@@ -739,9 +819,10 @@ pub async fn get_content_glb(
             .clone()
             .unwrap_or_else(|| info.default_quantity.clone()),
         datetime: time,
-        // The *applied* threshold (default already folded in above), so a
-        // defaulted and an explicit-default request share one entry.
-        param_bits: Some(threshold.to_bits()),
+        // The *applied* thresholds (default already folded in above, sorted +
+        // deduped), so a defaulted and an explicit-default request share one
+        // entry whatever the spelling.
+        param_bits: Some(thresholds_bits(&thresholds)),
         dims,
         version: content_version(&info, exact),
     };
@@ -769,18 +850,21 @@ pub async fn get_content_glb(
                             engine.read_voxel_grid(quantity.as_deref(), time, Some(dims), None)?;
                         ds_3dtiles::encode_echo_top_columns_glb(
                             &grid,
-                            threshold,
+                            thresholds[0],
                             &*ECHO_TOP_COLORMAP,
                         )
                     }
                     Representation::Isosurface => {
                         let grid =
                             engine.read_voxel_grid(quantity.as_deref(), time, Some(dims), None)?;
-                        // Colour the shell at the threshold (v1: one colormap for all
-                        // quantities — #350); seal NaN at the no-echo floor so it
-                        // closes into solid blobs (`floor < threshold` guaranteed).
-                        let color = colormap.color(Some(threshold));
-                        ds_3dtiles::encode_isosurface_glb(&grid, threshold, color, Some(floor))
+                        // Colour each shell at its threshold, alpha ramped outer-
+                        // translucent → inner-opaque (#363; one threshold = one
+                        // opaque shell, the classic look; v1: one colormap for
+                        // all quantities — #350); seal NaN at the no-echo floor
+                        // so shells close into solid blobs (`floor <
+                        // thresholds[0]` guaranteed above).
+                        let shells = ds_3dtiles::nested_shells(&thresholds, colormap.as_ref());
+                        ds_3dtiles::encode_isosurfaces_glb(&grid, &shells, Some(floor))
                     }
                     // Rejected before the blocking task (see the `product` match).
                     Representation::Points => unreachable!("points rejected above"),
@@ -788,11 +872,11 @@ pub async fn get_content_glb(
                 let bytes = result.map_err(|e| match e {
                     // No surface / no columns (threshold above all echo) — 404.
                     ds_3dtiles::Tiles3dError::Empty => Tiles3dError::NotFound(format!(
-                        "no {product} at threshold {threshold} for collection '{id_for_err}'"
+                        "no {product} at threshold {threshold_label} for collection '{id_for_err}'"
                     )),
                     // Client-driven (threshold too low for this grid) — 400.
                     ds_3dtiles::Tiles3dError::TooLarge(_) => Tiles3dError::BadRequest(format!(
-                        "threshold {threshold} produces too large a {product}; raise it"
+                        "threshold {threshold_label} produces too large a {product}; raise it"
                     )),
                     // Unreachable (floor < threshold above) — defensive 400. Only
                     // the isosurface encoder emits this today, but this `map_err`

--- a/crates/api-3dtiles/src/handlers.rs
+++ b/crates/api-3dtiles/src/handlers.rs
@@ -603,6 +603,16 @@ pub async fn get_tileset(
                             .into(),
                     ));
                 }
+                // Same no-echo-floor gate as the content handler, so a bad
+                // threshold is a 400 HERE, not a surprise on the content fetch
+                // the tileset points at. (The lowest covers the whole ascending
+                // list; the `None` defaults are above the floor by construction.)
+                let floor = f64::from(ds_core::volume::NO_ECHO_FLOOR_DBZ);
+                if thresholds[0] <= floor {
+                    return Err(Tiles3dError::BadRequest(format!(
+                        "threshold must be above the no-echo floor ({floor})"
+                    )));
+                }
                 query.push_str(&format!("&threshold={}", thresholds_token(&thresholds)));
             }
             // Carry the detail tier so the content fetch matches the tileset;

--- a/crates/api-3dtiles/tests/integration.rs
+++ b/crates/api-3dtiles/tests/integration.rs
@@ -899,6 +899,13 @@ async fn bad_threshold_lists_are_400() {
         let (status, _b, _h) = get(path).await;
         assert_eq!(status, StatusCode::BAD_REQUEST, "{path}");
     }
+    // The shell cap counts DEDUPED values: six repeats collapse to one shell
+    // and pass, six distinct values are over the cap (asserted below).
+    let (status, _b, _h) = get(
+        "/collections/radar-fivih/tileset.json?representation=isosurface&threshold=20,20,20,20,20,20",
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "repeats collapse under the cap");
     // Junk inside a list, an empty slot, and an over-long list are all 400 on
     // both routes.
     for t in ["20,abc", "20,,35", "5,10,15,20,25,30"] {

--- a/crates/api-3dtiles/tests/integration.rs
+++ b/crates/api-3dtiles/tests/integration.rs
@@ -830,6 +830,100 @@ async fn non_finite_threshold_is_400() {
     }
 }
 
+#[tokio::test]
+async fn nested_isosurface_thresholds_yield_blended_primitives() {
+    // Tileset: an unsorted, duplicated list is canonicalised (sorted ascending,
+    // deduped) into the content.uri so spelling variants share one content URL.
+    let (status, body, _h) = get(
+        "/collections/radar-fivih/tileset.json?representation=isosurface&quantity=DBZH&threshold=35,20,35",
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(
+        v["root"]["content"]["uri"].as_str().unwrap(),
+        "content.glb?quantity=DBZH&threshold=20,35&resolution=med&representation=isosurface"
+    );
+
+    // Content: the mock grid's echo core is 40 dBZ, so 20 and 35 both yield a
+    // shell while 50 is empty (skipped, not an error — a weak storm without a
+    // 50 dBZ core must still show its envelope). One primitive + material per
+    // surviving shell, innermost first; translucent shells are alpha-BLENDed.
+    let (status, body, _h) =
+        get("/collections/radar-fivih/content.glb?quantity=DBZH&threshold=20,35,50").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(&body[0..4], b"glTF");
+    let jlen = u32::from_le_bytes(body[12..16].try_into().unwrap()) as usize;
+    let j: serde_json::Value = serde_json::from_slice(&body[20..20 + jlen]).unwrap();
+    let prims = j["meshes"][0]["primitives"].as_array().unwrap();
+    assert_eq!(prims.len(), 2, "50 dBZ shell is empty and skipped");
+    let materials = j["materials"].as_array().unwrap();
+    assert_eq!(materials.len(), 2);
+    // Both surviving shells are translucent (the opaque slot belonged to the
+    // empty 50 dBZ core) — alpha keyed to the REQUESTED list, so a frame where
+    // the core vanishes doesn't re-shade the envelope.
+    for m in materials {
+        assert_eq!(m["alphaMode"], "BLEND");
+        assert!(m["doubleSided"].as_bool().unwrap());
+        let a = m["pbrMetallicRoughness"]["baseColorFactor"][3]
+            .as_f64()
+            .unwrap();
+        assert!((0.0..1.0).contains(&a), "translucent alpha, got {a}");
+    }
+    // Innermost (35) first: its alpha is the higher of the two.
+    let alpha = |i: usize| {
+        materials[prims[i]["material"].as_u64().unwrap() as usize]["pbrMetallicRoughness"]
+            ["baseColorFactor"][3]
+            .as_f64()
+            .unwrap()
+    };
+    assert!(alpha(0) > alpha(1), "inner shell more opaque than outer");
+
+    // A single threshold keeps the classic fully-opaque shell (no alphaMode).
+    let (status, body, _h) =
+        get("/collections/radar-fivih/content.glb?quantity=DBZH&threshold=20").await;
+    assert_eq!(status, StatusCode::OK);
+    let jlen = u32::from_le_bytes(body[12..16].try_into().unwrap()) as usize;
+    let j: serde_json::Value = serde_json::from_slice(&body[20..20 + jlen]).unwrap();
+    assert_eq!(j["meshes"][0]["primitives"].as_array().unwrap().len(), 1);
+    assert!(j["materials"][0].get("alphaMode").is_none());
+}
+
+#[tokio::test]
+async fn bad_threshold_lists_are_400() {
+    // Echo-top takes exactly one threshold — a list is isosurface-only.
+    for path in [
+        "/collections/radar-fivih/tileset.json?representation=echotop&threshold=18,30",
+        "/collections/radar-fivih/content.glb?representation=echotop&threshold=18,30",
+    ] {
+        let (status, _b, _h) = get(path).await;
+        assert_eq!(status, StatusCode::BAD_REQUEST, "{path}");
+    }
+    // Junk inside a list, an empty slot, and an over-long list are all 400 on
+    // both routes.
+    for t in ["20,abc", "20,,35", "5,10,15,20,25,30"] {
+        let (ts, _b, _h) = get(&format!(
+            "/collections/radar-fivih/tileset.json?representation=isosurface&threshold={t}"
+        ))
+        .await;
+        assert_eq!(ts, StatusCode::BAD_REQUEST, "tileset rejects {t:?}");
+        let (cs, _b, _h) = get(&format!(
+            "/collections/radar-fivih/content.glb?threshold={t}"
+        ))
+        .await;
+        assert_eq!(cs, StatusCode::BAD_REQUEST, "content rejects {t:?}");
+    }
+    // A list whose LOWEST member is at/below the no-echo floor is rejected even
+    // when other members are fine.
+    let floor = f64::from(ds_core::volume::NO_ECHO_FLOOR_DBZ);
+    let (cs, _b, _h) = get(&format!(
+        "/collections/radar-fivih/content.glb?threshold={},20",
+        floor
+    ))
+    .await;
+    assert_eq!(cs, StatusCode::BAD_REQUEST);
+}
+
 // ---------------------------------------------------------------------------
 // Content cache + cache-control policy (hot-path audit, 2026-06)
 // ---------------------------------------------------------------------------

--- a/crates/api-3dtiles/tests/integration.rs
+++ b/crates/api-3dtiles/tests/integration.rs
@@ -785,7 +785,9 @@ async fn content_glb_is_valid_gltf_and_etagged() {
 #[tokio::test]
 async fn isosurface_threshold_at_or_below_floor_is_400() {
     // A threshold at/below the no-echo floor would place clear-air floor cells
-    // inside the surface (all clear air renders as echo) — rejected.
+    // inside the surface (all clear air renders as echo) — rejected, on the
+    // tileset route too (a bad threshold must 400 up front, not surprise the
+    // client on the content fetch the tileset points at).
     let floor = f64::from(ds_core::volume::NO_ECHO_FLOOR_DBZ);
     for t in [floor - 8.0, floor] {
         let (cs, _b, _h) = get(&format!(
@@ -796,6 +798,15 @@ async fn isosurface_threshold_at_or_below_floor_is_400() {
             cs,
             StatusCode::BAD_REQUEST,
             "threshold {t} <= floor must 400"
+        );
+        let (ts, _b, _h) = get(&format!(
+            "/collections/radar-fivih/tileset.json?representation=isosurface&threshold={t},20"
+        ))
+        .await;
+        assert_eq!(
+            ts,
+            StatusCode::BAD_REQUEST,
+            "tileset with lowest threshold {t} <= floor must 400"
         );
     }
     // Just above the floor is accepted.

--- a/crates/api-3dtiles/viewer/index.html
+++ b/crates/api-3dtiles/viewer/index.html
@@ -38,6 +38,7 @@
     border-radius: 6px; padding: 5px 8px; font: 13px system-ui; max-width: 320px;
   }
   #bar input[type=number] { width: 58px; }
+  #bar input[type=text] { width: 96px; }
   #status { margin-left: auto; opacity: .6; font-size: 12px; white-space: nowrap; }
   #status.err { color: #ff8a8a; opacity: .95; }
   /* Colour-scale legend for the point cloud (value → colour). */
@@ -147,21 +148,23 @@ const $timeLabel = document.getElementById("timeLabel");
 const setStatus = (msg, err) => { $status.textContent = msg; $status.className = err ? "err" : ""; };
 
 // Each representation's label for the numeric field + its default value:
-// point clouds drop echoes below `min_value`; isosurfaces draw the shell AT
-// `threshold`; echo-top columns rise to where reflectivity drops below
-// `threshold`. All a dBZ number, so one input serves them, relabelled.
-// `grid` products (isosurface/echotop/voxels) are resampled to a voxel grid, so
-// they take the low/med/high Resolution selector; the point cloud is native-res
-// and hides it. `voxels` is the CesiumJS VoxelPrimitive ray-march (its own load
-// path, not a tileset of tiles).
+// point clouds drop echoes below `min_value`; isosurfaces draw nested shells AT
+// the comma-separated `threshold` list (#363 — translucent envelopes around an
+// opaque core; a single value is one opaque shell); echo-top columns rise to
+// where reflectivity drops below `threshold`. All dBZ, so one input serves
+// them, relabelled — `multi` switches it to a free-text field accepting the
+// comma list. `grid` products (isosurface/echotop/voxels) are resampled to a
+// voxel grid, so they take the low/med/high Resolution selector; the point
+// cloud is native-res and hides it. `voxels` is the CesiumJS VoxelPrimitive
+// ray-march (its own load path, not a tileset of tiles).
 // `legend` = coloured by the reflectivity ramp (points + voxels show the colour
-// scale; isosurface is one threshold colour, echo-top a height ramp → no
-// reflectivity legend).
+// scale; isosurface is coloured per-shell threshold, echo-top a height ramp →
+// no reflectivity legend).
 const REP_META = {
-  points:     { label: "Point cloud", numLabel: "min dBZ",       numDefault: "5",  mesh: false, voxel: false, legend: true  },
-  isosurface: { label: "Isosurface",  numLabel: "threshold dBZ", numDefault: "20", mesh: true,  voxel: false, legend: false },
-  echotop:    { label: "Echo top",    numLabel: "threshold dBZ", numDefault: "18", mesh: true,  voxel: false, legend: false },
-  voxels:     { label: "Voxels",      numLabel: "min dBZ",       numDefault: "5",  mesh: true,  voxel: true,  legend: true  },
+  points:     { label: "Point cloud", numLabel: "min dBZ",        numDefault: "5",        mesh: false, voxel: false, legend: true  },
+  isosurface: { label: "Isosurface",  numLabel: "shells dBZ",     numDefault: "20,35,50", mesh: true,  voxel: false, legend: false, multi: true },
+  echotop:    { label: "Echo top",    numLabel: "threshold dBZ",  numDefault: "18",       mesh: true,  voxel: false, legend: false },
+  voxels:     { label: "Voxels",      numLabel: "min dBZ",        numDefault: "5",        mesh: true,  voxel: true,  legend: true  },
 };
 
 // Token-free CesiumJS: CARTO Dark Matter basemap, no Cesium Ion.
@@ -276,6 +279,9 @@ async function loadCollectionMeta(reframe) {
 function syncNumField() {
   const meta = REP_META[$rep.value] || REP_META.points;
   $numLabel.textContent = meta.numLabel;
+  // A multi-value field (isosurface shell list, e.g. "20,35,50") needs a text
+  // input — type=number silently rejects commas.
+  $num.type = meta.multi ? "text" : "number";
   $num.value = meta.numDefault;
   $resField.hidden = !meta.mesh;
   $legend.hidden = !meta.legend || !legendData;

--- a/crates/ds-3dtiles/src/isosurface.rs
+++ b/crates/ds-3dtiles/src/isosurface.rs
@@ -114,6 +114,14 @@ pub struct IsoShell {
 /// classic look. The one policy both the API layer and the demo use, kept here
 /// so they can't drift.
 pub fn nested_shells(thresholds: &[f64], colormap: &dyn ColorMap) -> Vec<IsoShell> {
+    // The alpha ramp keys off list POSITION (i=0 = outermost), so it is only
+    // meaningful for an ascending list — a descending one would silently
+    // produce inside-out translucency. Both call sites sort first; catch a
+    // future one that doesn't.
+    debug_assert!(
+        thresholds.windows(2).all(|w| w[0] <= w[1]),
+        "thresholds must be sorted ascending"
+    );
     let n = thresholds.len();
     thresholds
         .iter()

--- a/crates/ds-3dtiles/src/isosurface.rs
+++ b/crates/ds-3dtiles/src/isosurface.rs
@@ -46,20 +46,27 @@
 use crate::Tiles3dError;
 use ds_core::geo::{destination_point, geodetic_to_ecef};
 use ds_core::volume::VoxelGrid;
+use ds_render::ColorMap;
 use serde_json::json;
 
-/// Cap on emitted triangles. The mesh is non-indexed (3 vertices ×
-/// `POSITION`+`NORMAL` = 72 bytes/triangle), so this bounds the encode buffer at
-/// ~216 MB worst case. A radar reflectivity shell is far smaller; exceeding the
-/// cap means the threshold is too low or the grid too fine — fail loudly rather
-/// than allocate unbounded.
+/// Cap on emitted triangles. The mesh is indexed (#382): 12 bytes of `u32`
+/// indices per triangle plus 24 bytes (`POSITION`+`NORMAL`) per unique vertex —
+/// marching-tet surfaces share each crossing vertex ~5–6 ways, so this bounds
+/// the encode buffer at roughly 50 MB typical, ~250 MB in the no-sharing worst
+/// case. A radar reflectivity shell is far smaller; exceeding the cap means the
+/// threshold is too low or the grid too fine — fail loudly rather than allocate
+/// unbounded.
 const MAX_TRIANGLES: usize = 3_000_000;
 
-/// glTF component type `FLOAT` (5126) and primitive mode `TRIANGLES` (4).
+/// glTF component types `FLOAT` (5126) / `UNSIGNED_INT` (5125) and primitive
+/// mode `TRIANGLES` (4).
 const COMPONENT_FLOAT: u32 = 5126;
+const COMPONENT_UNSIGNED_INT: u32 = 5125;
 const MODE_TRIANGLES: u32 = 4;
-/// glTF `bufferView.target` `ARRAY_BUFFER` (34962).
+/// glTF `bufferView.target`s `ARRAY_BUFFER` (34962) / `ELEMENT_ARRAY_BUFFER`
+/// (34963).
 const TARGET_ARRAY_BUFFER: u32 = 34962;
+const TARGET_ELEMENT_ARRAY_BUFFER: u32 = 34963;
 
 /// Cube-corner offsets `(Δradius, Δangle, Δheight)`, indexed by the standard
 /// corner numbering `bit0=Δr, bit1=Δa, bit2=Δh`.
@@ -87,25 +94,104 @@ const TETS: [[usize; 4]; 6] = [
     [0, 4, 6, 7],
 ];
 
-/// Accumulates a non-indexed triangle mesh (one flat normal per face) plus the
-/// `POSITION` accessor's `min`/`max` (required by the glTF spec).
+/// One nested isosurface shell: the iso-value to extract plus the RGBA the
+/// shell's material gets. Alpha < 255 makes the material **alpha-blended**
+/// (`alphaMode: "BLEND"`), so an opaque core shows through translucent outer
+/// envelopes (#363). Build a conventional set with [`nested_shells`].
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct IsoShell {
+    /// Iso-value in the grid's physical units (e.g. dBZ).
+    pub threshold: f64,
+    /// Shell material colour `[r, g, b, a]`, 0–255.
+    pub color: [u8; 4],
+}
+
+/// Build the conventional "onion-skin" shell set from ascending `thresholds`:
+/// each shell is coloured by `colormap` at its threshold, with alpha ramped from
+/// translucent (outermost / lowest threshold) to opaque (innermost / highest),
+/// so the intense core glows through the weaker envelope. A single threshold
+/// yields one fully opaque shell — identical to [`encode_isosurface_glb`]'s
+/// classic look. The one policy both the API layer and the demo use, kept here
+/// so they can't drift.
+pub fn nested_shells(thresholds: &[f64], colormap: &dyn ColorMap) -> Vec<IsoShell> {
+    let n = thresholds.len();
+    thresholds
+        .iter()
+        .enumerate()
+        .map(|(i, &threshold)| {
+            let mut color = colormap.color(Some(threshold));
+            // Outer 35% opacity → inner fully opaque (linear in shell index, not
+            // threshold value, so the steps read evenly however the thresholds
+            // are spaced). n == 1 stays opaque.
+            color[3] = if n <= 1 {
+                255
+            } else {
+                let frac = 0.35 + 0.65 * (i as f64) / ((n - 1) as f64);
+                (frac * 255.0).round() as u8
+            };
+            IsoShell { threshold, color }
+        })
+        .collect()
+}
+
+/// Accumulates an **indexed** triangle mesh with **smooth vertex normals**
+/// (#382): vertices are interned by exact position (the marching-tet topology
+/// computes every shared edge crossing from the same corner values, so shared
+/// vertices are bit-identical — no quantisation needed), each accumulating the
+/// area-weighted outward face normal of every triangle that touches it. The
+/// per-vertex normalize happens in [`MeshBuilder::smooth_normals`]. Also tracks
+/// the `POSITION` accessor's `min`/`max` (required by the glTF spec). Indexed +
+/// smooth replaces the old non-indexed flat-shaded soup, killing the faceted
+/// "crumpled paper" look and shrinking the `.glb` by the vertex-sharing factor.
 struct MeshBuilder {
-    positions: Vec<f32>, // xyz per vertex, 3 vertices per triangle
-    normals: Vec<f32>,   // xyz per vertex
+    positions: Vec<f32>,  // xyz per unique vertex
+    normal_acc: Vec<f64>, // xyz accumulated area-weighted outward face normals
+    indices: Vec<u32>,    // 3 per triangle, wound to match the outward normal
+    /// Position bit-pattern → vertex index (exact match — see struct doc).
+    vertex_ids: std::collections::HashMap<[u32; 3], u32>,
     triangles: usize,
+    /// Triangle budget for THIS builder — [`MAX_TRIANGLES`] minus what earlier
+    /// shells in the same encode already used, so the cap bounds the whole
+    /// `.glb`, not each shell independently.
+    budget: usize,
     min: [f32; 3],
     max: [f32; 3],
 }
 
 impl MeshBuilder {
-    fn new() -> Self {
+    fn new(budget: usize) -> Self {
         Self {
             positions: Vec::new(),
-            normals: Vec::new(),
+            normal_acc: Vec::new(),
+            indices: Vec::new(),
+            vertex_ids: std::collections::HashMap::new(),
             triangles: 0,
+            budget,
             min: [f32::INFINITY; 3],
             max: [f32::NEG_INFINITY; 3],
         }
+    }
+
+    /// Intern a vertex position, returning its index (new vertices update
+    /// `min`/`max` and get a zeroed normal accumulator).
+    fn vertex(&mut self, p: [f32; 3]) -> u32 {
+        let key = [p[0].to_bits(), p[1].to_bits(), p[2].to_bits()];
+        if let Some(&i) = self.vertex_ids.get(&key) {
+            return i;
+        }
+        let i = (self.positions.len() / 3) as u32;
+        self.vertex_ids.insert(key, i);
+        for (k, &c) in p.iter().enumerate() {
+            self.positions.push(c);
+            if c < self.min[k] {
+                self.min[k] = c;
+            }
+            if c > self.max[k] {
+                self.max[k] = c;
+            }
+        }
+        self.normal_acc.extend_from_slice(&[0.0; 3]);
+        i
     }
 
     /// Append one triangle, with its face normal oriented outward. `out_ref` is
@@ -113,10 +199,12 @@ impl MeshBuilder {
     /// the outward direction is `out_ref − triangle_centroid`. The marching-tet
     /// cases don't emit a consistent winding on their own, so without this ~half
     /// the faces would have inward normals and render with inverted lighting;
-    /// here the winding is flipped to match outward so the stored normal always
-    /// points outward. Skips degenerate (zero-area) triangles so no `NaN` normal
-    /// reaches the buffer. Errors with [`Tiles3dError::TooLarge`] past
-    /// [`MAX_TRIANGLES`].
+    /// here the winding is flipped to match outward, and the **unnormalized**
+    /// (= area-weighted) outward face normal is accumulated onto each corner
+    /// vertex for the smooth-shading pass. Skips degenerate (zero-area)
+    /// triangles so no `NaN` reaches the accumulators. Errors with
+    /// [`Tiles3dError::TooLarge`] past the builder's `budget`
+    /// (≤ [`MAX_TRIANGLES`]).
     fn push(
         &mut self,
         p0: [f32; 3],
@@ -126,19 +214,18 @@ impl MeshBuilder {
     ) -> Result<(), Tiles3dError> {
         let u = [p1[0] - p0[0], p1[1] - p0[1], p1[2] - p0[2]];
         let v = [p2[0] - p0[0], p2[1] - p0[1], p2[2] - p0[2]];
-        let n = [
+        let mut n = [
             u[1] * v[2] - u[2] * v[1],
             u[2] * v[0] - u[0] * v[2],
             u[0] * v[1] - u[1] * v[0],
         ];
         let len = (n[0] * n[0] + n[1] * n[1] + n[2] * n[2]).sqrt();
-        // Positive comparison (not `!(len > 0.0)`) keeps it NaN-safe — a
-        // non-finite `len` falls to the `else` and is dropped — and clippy-clean.
-        let mut nrm = if len > 0.0 {
-            [n[0] / len, n[1] / len, n[2] / len]
-        } else {
+        // NaN-safe degenerate check: a non-finite `len` fails `is_finite`, a
+        // zero-area sliver fails `> 0.0` — both are dropped, so no `NaN`
+        // reaches the accumulators.
+        if !len.is_finite() || len <= 0.0 {
             return Ok(()); // degenerate sliver (zero area) — drop it
-        };
+        }
         // Outward = from the triangle's own centroid toward the outside ref.
         let centroid = [
             (p0[0] + p1[0] + p2[0]) / 3.0,
@@ -152,31 +239,54 @@ impl MeshBuilder {
         ];
         // Orient outward: if the geometric normal points the wrong way, flip the
         // normal AND the winding (swap p1/p2) so both stay consistent.
-        let dot = nrm[0] * outward[0] + nrm[1] * outward[1] + nrm[2] * outward[2];
+        let dot = n[0] * outward[0] + n[1] * outward[1] + n[2] * outward[2];
         let (a, b, c) = if dot < 0.0 {
-            nrm = [-nrm[0], -nrm[1], -nrm[2]];
+            n = [-n[0], -n[1], -n[2]];
             (p0, p2, p1)
         } else {
             (p0, p1, p2)
         };
 
         self.triangles += 1;
-        if self.triangles > MAX_TRIANGLES {
+        if self.triangles > self.budget {
             return Err(Tiles3dError::TooLarge("isosurface triangles"));
         }
         for p in [a, b, c] {
-            for k in 0..3 {
-                self.positions.push(p[k]);
-                self.normals.push(nrm[k]);
-                if p[k] < self.min[k] {
-                    self.min[k] = p[k];
-                }
-                if p[k] > self.max[k] {
-                    self.max[k] = p[k];
-                }
+            let i = self.vertex(p);
+            self.indices.push(i);
+            // `n` is the unnormalized cross product (|n| = 2·area), so summing
+            // it IS the area-weighted average — big faces steer the shared
+            // vertex normal more than slivers, the standard smoothing weight.
+            for (k, &nk) in n.iter().enumerate() {
+                self.normal_acc[i as usize * 3 + k] += f64::from(nk);
             }
         }
         Ok(())
+    }
+
+    /// The per-vertex smooth normals: normalized accumulated area-weighted face
+    /// normals. All contributions are outward-oriented, so they can only cancel
+    /// at a non-manifold pinch (two blobs touching at a point) — such a vertex
+    /// falls back to +Y rather than emitting a zero/NaN normal (invalid glTF).
+    fn smooth_normals(&self) -> Vec<f32> {
+        let mut out = Vec::with_capacity(self.normal_acc.len());
+        for acc in self.normal_acc.chunks_exact(3) {
+            let len = (acc[0] * acc[0] + acc[1] * acc[1] + acc[2] * acc[2]).sqrt();
+            if len > 0.0 {
+                out.extend_from_slice(&[
+                    (acc[0] / len) as f32,
+                    (acc[1] / len) as f32,
+                    (acc[2] / len) as f32,
+                ]);
+            } else {
+                out.extend_from_slice(&[0.0, 1.0, 0.0]);
+            }
+        }
+        out
+    }
+
+    fn vertex_count(&self) -> usize {
+        self.positions.len() / 3
     }
 }
 
@@ -380,22 +490,61 @@ pub fn encode_isosurface_glb(
     color: [u8; 4],
     background: Option<f64>,
 ) -> Result<Vec<u8>, Tiles3dError> {
-    if !threshold.is_finite() {
+    encode_isosurfaces_glb(grid, &[IsoShell { threshold, color }], background)
+}
+
+/// Encode **nested multi-threshold isosurfaces** (#363): one glTF primitive per
+/// [`IsoShell`], all in a single `.glb`, each with its own material. A shell
+/// whose alpha is < 255 gets `alphaMode: "BLEND"`, so e.g. an opaque 50 dBZ
+/// storm core glows through translucent 35/20 dBZ envelopes — the "onion-skin"
+/// of storm intensity. [`nested_shells`] builds the conventional shell set from
+/// a threshold list + colormap.
+///
+/// Shells are emitted **innermost-first** (sorted by threshold, descending)
+/// regardless of input order: glTF imposes no draw order, but when a renderer's
+/// back-to-front translucency sort ties — and nested shells share nearly the
+/// same bounding-sphere centre, so it does — primitive order is the tie-break,
+/// and inner-before-outer blends correctly from outside (CesiumJS render-
+/// verified). The scalar field is smoothed **once** and re-marched per shell,
+/// so extra shells cost only the march, not another blur.
+///
+/// A shell whose threshold is above all data is **skipped** (a weak storm has
+/// no 50 dBZ core — the outer shells still render); only when *every* shell is
+/// empty does this return [`Tiles3dError::Empty`] (and an empty `shells` slice
+/// is likewise `Empty`). `threshold`/`background` validation is per
+/// [`encode_isosurface_glb`], with `background` required to sit strictly below
+/// the *lowest* threshold. The [`MAX_TRIANGLES`] cap bounds the **sum** across
+/// shells. Callers should de-duplicate thresholds (a duplicate yields two
+/// identical primitives).
+pub fn encode_isosurfaces_glb(
+    grid: &VoxelGrid,
+    shells: &[IsoShell],
+    background: Option<f64>,
+) -> Result<Vec<u8>, Tiles3dError> {
+    if shells.is_empty() {
+        return Err(Tiles3dError::Empty);
+    }
+    if shells.iter().any(|s| !s.threshold.is_finite()) {
         return Err(Tiles3dError::NonFinite("threshold"));
     }
+    // Innermost (highest threshold) first — the translucency draw-order
+    // tie-break (see the doc above). Total order is safe: all finite.
+    let mut shells: Vec<IsoShell> = shells.to_vec();
+    shells.sort_by(|a, b| b.threshold.total_cmp(&a.threshold));
+    let min_threshold = shells.last().expect("non-empty").threshold;
     // A `Some` background must be finite (else it acts like `None` — a NaN fill
     // leaves the corner non-finite → tet skipped) AND representable as `f32`
     // (the seal narrows `bg as f32`; an out-of-range f64 would cast to ±inf and
-    // propagate through the dense blur) AND strictly below `threshold` (else
-    // unmeasured cells would seal as *inside* the surface, inverting it).
+    // propagate through the dense blur) AND strictly below every threshold
+    // (else unmeasured cells would seal as *inside* that shell, inverting it).
     if let Some(bg) = background {
         if !bg.is_finite() || bg.abs() > f64::from(f32::MAX) {
             return Err(Tiles3dError::NonFinite("background"));
         }
-        if bg >= threshold {
+        if bg >= min_threshold {
             return Err(Tiles3dError::BackgroundNotBelowThreshold {
                 background: bg,
-                threshold,
+                threshold: min_threshold,
             });
         }
     }
@@ -416,6 +565,7 @@ pub fn encode_isosurface_glb(
     // blur runs over finite values only; without one, the NaN-aware blur keeps
     // unmeasured cells `NaN` (still skipped below) and never bleeds them into
     // real echo — the open-boundary semantics (#360) survive the smoothing.
+    // One blur, shared by every shell — only the march repeats per threshold.
     const SMOOTH_PASSES: usize = 2;
     let field: Vec<f32> = match background {
         Some(bg) => {
@@ -431,74 +581,109 @@ pub fn encode_isosurface_glb(
         }
     };
 
-    let mut mesh = MeshBuilder::new();
-    // Iterate cubes. The angular seam (i_a = n_a−1 → 0) is not wrapped in v1, so
-    // a one-cell-wide gap remains at azimuth 0; acceptable for a visualisation
-    // shell (a closed radar volume is rarely intersected exactly there).
-    for i_r in 0..n_r.saturating_sub(1) {
-        for i_a in 0..n_a.saturating_sub(1) {
-            for i_h in 0..n_h.saturating_sub(1) {
-                let mut cvals = [0.0_f64; 8];
-                let mut cidx = [[0.0_f64; 3]; 8];
-                for (c, off) in CORNER.iter().enumerate() {
-                    let (ir, ia, ih) = (i_r + off[0], i_a + off[1], i_h + off[2]);
-                    // Sealed + smoothed (or NaN-aware-smoothed) value; a
-                    // remaining NaN means unmeasured with no seal → tet skipped.
-                    cvals[c] = field[grid.index(ir, ia, ih)] as f64;
-                    cidx[c] = [ir as f64, ia as f64, ih as f64];
-                }
-                for tet in TETS {
-                    march_tet(&mut mesh, grid, rtc, threshold, &cvals, &cidx, tet)?;
+    let mut meshes: Vec<(MeshBuilder, [u8; 4])> = Vec::with_capacity(shells.len());
+    let mut used = 0usize; // triangles emitted by earlier shells (shared cap)
+    for shell in &shells {
+        let mut mesh = MeshBuilder::new(MAX_TRIANGLES - used);
+        // Iterate cubes. The angular seam (i_a = n_a−1 → 0) is not wrapped in
+        // v1, so a one-cell-wide gap remains at azimuth 0; acceptable for a
+        // visualisation shell (a closed radar volume is rarely intersected
+        // exactly there).
+        for i_r in 0..n_r.saturating_sub(1) {
+            for i_a in 0..n_a.saturating_sub(1) {
+                for i_h in 0..n_h.saturating_sub(1) {
+                    let mut cvals = [0.0_f64; 8];
+                    let mut cidx = [[0.0_f64; 3]; 8];
+                    for (c, off) in CORNER.iter().enumerate() {
+                        let (ir, ia, ih) = (i_r + off[0], i_a + off[1], i_h + off[2]);
+                        // Sealed + smoothed (or NaN-aware-smoothed) value; a
+                        // remaining NaN means unmeasured with no seal → tet
+                        // skipped.
+                        cvals[c] = field[grid.index(ir, ia, ih)] as f64;
+                        cidx[c] = [ir as f64, ia as f64, ih as f64];
+                    }
+                    for tet in TETS {
+                        march_tet(&mut mesh, grid, rtc, shell.threshold, &cvals, &cidx, tet)?;
+                    }
                 }
             }
         }
+        used += mesh.triangles;
+        // A shell with no surface (threshold above all data) is skipped, not an
+        // error — a weak storm has no 50 dBZ core but its 20/35 shells render.
+        if mesh.triangles > 0 {
+            meshes.push((mesh, shell.color));
+        }
     }
 
-    if mesh.triangles == 0 {
+    if meshes.is_empty() {
         return Err(Tiles3dError::Empty);
     }
-    build_glb(&mesh, color)
+    build_glb(&meshes)
 }
 
-/// Assemble a single-mesh `.glb` from the accumulated triangles.
-fn build_glb(mesh: &MeshBuilder, color: [u8; 4]) -> Result<Vec<u8>, Tiles3dError> {
-    let vertex_count = mesh.positions.len() / 3;
-
-    // BIN buffer: POSITION (count·3·f32) then NORMAL (count·3·f32). Both are
-    // 12-byte-strided, so byte offsets stay 4-aligned for free.
-    let pos_bytes = mesh.positions.len() * 4;
-    let nrm_off = pos_bytes;
-    let mut bin = Vec::with_capacity(pos_bytes + mesh.normals.len() * 4);
-    for f in &mesh.positions {
-        bin.extend_from_slice(&f.to_le_bytes());
-    }
-    for f in &mesh.normals {
-        bin.extend_from_slice(&f.to_le_bytes());
-    }
-    // BIN chunk must be 4-byte aligned (count·24 already is, but stay defensive).
-    while !bin.len().is_multiple_of(4) {
-        bin.push(0);
-    }
-
-    let base_color = [
-        color[0] as f64 / 255.0,
-        color[1] as f64 / 255.0,
-        color[2] as f64 / 255.0,
-        color[3] as f64 / 255.0,
-    ];
-    let gltf = json!({
-        "asset": { "version": "2.0", "generator": "MeteoCore ds-3dtiles isosurface" },
-        "scene": 0,
-        "scenes": [ { "nodes": [0] } ],
-        "nodes": [ { "mesh": 0 } ],
-        "meshes": [ {
-            "primitives": [ {
-                "attributes": { "POSITION": 0, "NORMAL": 1 },
-                "material": 0,
-                "mode": MODE_TRIANGLES,
-            } ]
-        } ],
-        "materials": [ {
+/// Assemble a `.glb` from one or more accumulated shells: a single mesh with
+/// one **indexed** primitive + one material per shell (in slice order =
+/// innermost-first), all sharing one BIN buffer. A shell colour with alpha
+/// < 255 gets `alphaMode: "BLEND"` (the glTF default OPAQUE ignores alpha
+/// entirely).
+fn build_glb(meshes: &[(MeshBuilder, [u8; 4])]) -> Result<Vec<u8>, Tiles3dError> {
+    // BIN buffer: per shell, POSITION (count·3·f32), NORMAL (count·3·f32), then
+    // indices (3·triangles·u32). Every section is a multiple of 4 bytes, so
+    // byte offsets stay 4-aligned for free.
+    let total_bytes: usize = meshes
+        .iter()
+        .map(|(m, _)| (m.positions.len() + m.normal_acc.len()) * 4 + m.indices.len() * 4)
+        .sum();
+    let mut bin = Vec::with_capacity(total_bytes);
+    let mut primitives = Vec::with_capacity(meshes.len());
+    let mut materials = Vec::with_capacity(meshes.len());
+    let mut accessors = Vec::with_capacity(meshes.len() * 3);
+    let mut buffer_views = Vec::with_capacity(meshes.len() * 3);
+    for (i, (mesh, color)) in meshes.iter().enumerate() {
+        let vertex_count = mesh.vertex_count();
+        let normals = mesh.smooth_normals();
+        let pos_off = bin.len();
+        for f in &mesh.positions {
+            bin.extend_from_slice(&f.to_le_bytes());
+        }
+        let nrm_off = bin.len();
+        for f in &normals {
+            bin.extend_from_slice(&f.to_le_bytes());
+        }
+        let idx_off = bin.len();
+        for ix in &mesh.indices {
+            bin.extend_from_slice(&ix.to_le_bytes());
+        }
+        let pos_bytes = mesh.positions.len() * 4;
+        buffer_views.push(json!({
+            "buffer": 0, "byteOffset": pos_off, "byteLength": pos_bytes, "target": TARGET_ARRAY_BUFFER,
+        }));
+        buffer_views.push(json!({
+            "buffer": 0, "byteOffset": nrm_off, "byteLength": normals.len() * 4, "target": TARGET_ARRAY_BUFFER,
+        }));
+        buffer_views.push(json!({
+            "buffer": 0, "byteOffset": idx_off, "byteLength": mesh.indices.len() * 4, "target": TARGET_ELEMENT_ARRAY_BUFFER,
+        }));
+        accessors.push(json!({
+            "bufferView": 3 * i, "componentType": COMPONENT_FLOAT, "count": vertex_count,
+            "type": "VEC3", "min": mesh.min, "max": mesh.max,
+        }));
+        accessors.push(json!({
+            "bufferView": 3 * i + 1, "componentType": COMPONENT_FLOAT, "count": vertex_count,
+            "type": "VEC3",
+        }));
+        accessors.push(json!({
+            "bufferView": 3 * i + 2, "componentType": COMPONENT_UNSIGNED_INT, "count": mesh.indices.len(),
+            "type": "SCALAR",
+        }));
+        let base_color = [
+            color[0] as f64 / 255.0,
+            color[1] as f64 / 255.0,
+            color[2] as f64 / 255.0,
+            color[3] as f64 / 255.0,
+        ];
+        let mut material = json!({
             "pbrMetallicRoughness": {
                 "baseColorFactor": base_color,
                 "metallicFactor": 0.0,
@@ -506,23 +691,40 @@ fn build_glb(mesh: &MeshBuilder, color: [u8; 4]) -> Result<Vec<u8>, Tiles3dError
             },
             // Normals are oriented outward in `MeshBuilder::push`, so lighting
             // is correct from the front; `doubleSided` is belt-and-suspenders
-            // for grazing/back views (and any residual ambiguous quad).
+            // for grazing/back views (and any residual ambiguous quad) — and
+            // load-bearing for a translucent shell, whose back faces are
+            // visible through the front by design.
             "doubleSided": true,
-        } ],
-        "accessors": [
-            {
-                "bufferView": 0, "componentType": COMPONENT_FLOAT, "count": vertex_count,
-                "type": "VEC3", "min": mesh.min, "max": mesh.max,
-            },
-            {
-                "bufferView": 1, "componentType": COMPONENT_FLOAT, "count": vertex_count,
-                "type": "VEC3",
-            },
-        ],
-        "bufferViews": [
-            { "buffer": 0, "byteOffset": 0, "byteLength": pos_bytes, "target": TARGET_ARRAY_BUFFER },
-            { "buffer": 0, "byteOffset": nrm_off, "byteLength": mesh.normals.len() * 4, "target": TARGET_ARRAY_BUFFER },
-        ],
+        });
+        // Translucent shell → alpha-blend; the glTF default (OPAQUE) ignores
+        // the baseColorFactor alpha entirely. Opaque shells stay OPAQUE so
+        // they keep depth-writing (BLEND everywhere would make even the solid
+        // core depth-sorted, for no benefit).
+        if color[3] < 255 {
+            material["alphaMode"] = json!("BLEND");
+        }
+        materials.push(material);
+        primitives.push(json!({
+            "attributes": { "POSITION": 3 * i, "NORMAL": 3 * i + 1 },
+            "indices": 3 * i + 2,
+            "material": i,
+            "mode": MODE_TRIANGLES,
+        }));
+    }
+    // BIN chunk must be 4-byte aligned (f32-only, so it already is — defensive).
+    while !bin.len().is_multiple_of(4) {
+        bin.push(0);
+    }
+
+    let gltf = json!({
+        "asset": { "version": "2.0", "generator": "MeteoCore ds-3dtiles isosurface" },
+        "scene": 0,
+        "scenes": [ { "nodes": [0] } ],
+        "nodes": [ { "mesh": 0 } ],
+        "meshes": [ { "primitives": primitives } ],
+        "materials": materials,
+        "accessors": accessors,
+        "bufferViews": buffer_views,
         "buffers": [ { "byteLength": bin.len() } ],
     });
 
@@ -636,29 +838,47 @@ mod tests {
         assert_eq!(json["meshes"][0]["primitives"][0]["mode"], MODE_TRIANGLES);
         assert!(json["materials"][0]["doubleSided"].as_bool().unwrap());
 
-        // POSITION + NORMAL accessors, same non-zero count, POSITION has min/max.
+        // POSITION + NORMAL accessors, same non-zero count, POSITION has
+        // min/max; the indexed (#382) mesh shares vertices, so the vertex count
+        // is well BELOW 3·triangles while the index count is exactly that.
         let pos = &json["accessors"][0];
         let nrm = &json["accessors"][1];
+        let idx = &json["accessors"][2];
         let count = pos["count"].as_u64().unwrap();
-        assert!(
-            count > 0 && count % 3 == 0,
-            "vertex count {count} = 3·triangles"
-        );
+        assert!(count > 0);
         assert_eq!(nrm["count"].as_u64().unwrap(), count);
         assert_eq!(pos["min"].as_array().unwrap().len(), 3);
         assert_eq!(pos["max"].as_array().unwrap().len(), 3);
+        let icount = idx["count"].as_u64().unwrap();
+        assert!(icount > 0 && icount % 3 == 0, "indices {icount} = 3·tris");
+        assert!(count < icount, "indexed mesh shares vertices");
+        assert_eq!(idx["componentType"].as_u64().unwrap() as u32, 5125);
+        assert_eq!(
+            json["meshes"][0]["primitives"][0]["indices"]
+                .as_u64()
+                .unwrap(),
+            2
+        );
 
-        // BIN holds exactly POSITION + NORMAL (count·3·f32 each).
-        assert_eq!(bin.len(), (count as usize) * 3 * 4 * 2);
+        // BIN holds exactly POSITION + NORMAL (count·3·f32 each) + the indices.
+        assert_eq!(
+            bin.len(),
+            (count as usize) * 3 * 4 * 2 + (icount as usize) * 4
+        );
         // The buffer byteLength matches the BIN payload.
         assert_eq!(
             json["buffers"][0]["byteLength"].as_u64().unwrap(),
             bin.len() as u64
         );
 
-        // Every position/normal float is finite (no NaN leaked from nodata).
-        for w in bin.chunks_exact(4) {
+        // Every position/normal float is finite (no NaN leaked from nodata)…
+        let float_bytes = (count as usize) * 3 * 4 * 2;
+        for w in bin[..float_bytes].chunks_exact(4) {
             assert!(f32::from_le_bytes(w.try_into().unwrap()).is_finite());
+        }
+        // …and every index points at a real vertex.
+        for w in bin[float_bytes..].chunks_exact(4) {
+            assert!(u64::from(u32::from_le_bytes(w.try_into().unwrap())) < count);
         }
     }
 
@@ -793,9 +1013,11 @@ mod tests {
             .expect("crossing inside the finite region must mesh without a background");
         let (json, _bin) = parse_glb(&glb);
         let count = json["accessors"][0]["count"].as_u64().unwrap();
+        let icount = json["accessors"][2]["count"].as_u64().unwrap();
+        assert!(count > 0, "open surface has vertices: {count}");
         assert!(
-            count > 0 && count % 3 == 0,
-            "open surface has triangles: {count}"
+            icount > 0 && icount % 3 == 0,
+            "open surface has triangles: {icount}"
         );
     }
 
@@ -829,9 +1051,11 @@ mod tests {
             .expect("sealed surface");
         let (json, _bin) = parse_glb(&glb);
         let count = json["accessors"][0]["count"].as_u64().unwrap();
+        let icount = json["accessors"][2]["count"].as_u64().unwrap();
+        assert!(count > 0, "sealed blob has vertices: {count}");
         assert!(
-            count > 0 && count % 3 == 0,
-            "sealed blob has triangles: {count}"
+            icount > 0 && icount % 3 == 0,
+            "sealed blob has triangles: {icount}"
         );
     }
 
@@ -875,6 +1099,148 @@ mod tests {
         // Strictly below is accepted (the ramp has values 0..4, so 1.5 yields a
         // surface; background −32 < 1.5).
         assert!(encode_isosurface_glb(&grid, 1.5, [0, 0, 0, 255], Some(-32.0)).is_ok());
+    }
+
+    #[test]
+    fn nested_shells_ramp_alpha_outer_translucent_inner_opaque() {
+        use ds_render::{BuiltinColormap, LutColorMap};
+        let cm = LutColorMap::from_builtin(BuiltinColormap::RadarDbz, -32.0, 95.0);
+        // Single threshold → one fully opaque shell (the classic look).
+        let one = nested_shells(&[20.0], &cm);
+        assert_eq!(one.len(), 1);
+        assert_eq!(one[0].color[3], 255);
+        // Three thresholds → alpha strictly ascending, innermost opaque,
+        // outermost at the 35% floor.
+        let three = nested_shells(&[20.0, 35.0, 50.0], &cm);
+        assert_eq!(three.len(), 3);
+        assert_eq!(three[0].color[3], (0.35f64 * 255.0).round() as u8);
+        assert!(three[0].color[3] < three[1].color[3]);
+        assert!(three[1].color[3] < three[2].color[3]);
+        assert_eq!(three[2].color[3], 255);
+        // RGB comes from the colormap at each threshold.
+        for s in &three {
+            let c = cm.color(Some(s.threshold));
+            assert_eq!(&s.color[..3], &c[..3]);
+        }
+    }
+
+    #[test]
+    fn multi_shell_glb_emits_one_blended_primitive_per_shell_innermost_first() {
+        // value = i_h (0..4), so thresholds 1.5 and 3.5 each yield a horizontal
+        // sheet. Pass the shells OUTERMOST-first to prove the encoder re-sorts
+        // to innermost-first (the translucency draw-order tie-break).
+        let grid = ramp_grid(3, 8, 5);
+        let outer = IsoShell {
+            threshold: 1.5,
+            color: [0, 255, 0, 90],
+        };
+        let inner = IsoShell {
+            threshold: 3.5,
+            color: [255, 0, 0, 255],
+        };
+        let glb = encode_isosurfaces_glb(&grid, &[outer, inner], None).expect("encode");
+        let (json, bin) = parse_glb(&glb);
+
+        let prims = json["meshes"][0]["primitives"].as_array().unwrap();
+        assert_eq!(prims.len(), 2, "one primitive per shell");
+        let materials = json["materials"].as_array().unwrap();
+        assert_eq!(materials.len(), 2, "one material per shell");
+
+        // Primitive 0 = the INNER (3.5, opaque red) shell despite input order.
+        let m0 = &materials[prims[0]["material"].as_u64().unwrap() as usize];
+        let m1 = &materials[prims[1]["material"].as_u64().unwrap() as usize];
+        let c0 = m0["pbrMetallicRoughness"]["baseColorFactor"]
+            .as_array()
+            .unwrap();
+        assert_eq!(c0[0].as_f64().unwrap(), 1.0, "inner shell is red");
+        assert_eq!(c0[3].as_f64().unwrap(), 1.0, "inner shell opaque");
+        // Opaque shell: no alphaMode (glTF default OPAQUE keeps depth-writes).
+        assert!(m0.get("alphaMode").is_none());
+        // Outer shell: translucent → BLEND, alpha 90/255.
+        assert_eq!(m1["alphaMode"], "BLEND");
+        let c1 = m1["pbrMetallicRoughness"]["baseColorFactor"]
+            .as_array()
+            .unwrap();
+        assert!((c1[3].as_f64().unwrap() - 90.0 / 255.0).abs() < 1e-9);
+        assert!(m1["doubleSided"].as_bool().unwrap());
+
+        // Per-shell accessors/bufferViews tile the BIN exactly:
+        // POSITION+NORMAL+indices per shell (#382 — indexed), counts > 0,
+        // total bytes == bin length.
+        let accessors = json["accessors"].as_array().unwrap();
+        assert_eq!(accessors.len(), 6);
+        let mut total = 0usize;
+        for p in prims {
+            let pos = &accessors[p["attributes"]["POSITION"].as_u64().unwrap() as usize];
+            let nrm = &accessors[p["attributes"]["NORMAL"].as_u64().unwrap() as usize];
+            let idx = &accessors[p["indices"].as_u64().unwrap() as usize];
+            let count = pos["count"].as_u64().unwrap();
+            let icount = idx["count"].as_u64().unwrap();
+            assert!(count > 0);
+            assert!(icount > 0 && icount % 3 == 0);
+            assert_eq!(nrm["count"].as_u64().unwrap(), count);
+            total += (count as usize) * 3 * 4 * 2 + (icount as usize) * 4;
+        }
+        assert_eq!(total, bin.len(), "BIN holds exactly the shells' data");
+    }
+
+    #[test]
+    fn empty_shell_is_skipped_but_others_render() {
+        // 100 is above all data (values 0..4) → that shell is skipped, the 1.5
+        // shell still renders: a weak storm without a 50 dBZ core must still
+        // show its outer envelope.
+        let grid = ramp_grid(3, 8, 5);
+        let shells = [
+            IsoShell {
+                threshold: 1.5,
+                color: [0, 255, 0, 90],
+            },
+            IsoShell {
+                threshold: 100.0,
+                color: [255, 0, 0, 255],
+            },
+        ];
+        let glb = encode_isosurfaces_glb(&grid, &shells, None).expect("encode");
+        let (json, _bin) = parse_glb(&glb);
+        assert_eq!(json["meshes"][0]["primitives"].as_array().unwrap().len(), 1);
+        // All shells empty → Empty (and so is an empty shell list).
+        assert!(matches!(
+            encode_isosurfaces_glb(
+                &grid,
+                &[IsoShell {
+                    threshold: 100.0,
+                    color: [0, 0, 0, 255]
+                }],
+                None
+            ),
+            Err(Tiles3dError::Empty)
+        ));
+        assert!(matches!(
+            encode_isosurfaces_glb(&grid, &[], None),
+            Err(Tiles3dError::Empty)
+        ));
+    }
+
+    #[test]
+    fn multi_shell_background_must_be_below_lowest_threshold() {
+        let grid = ramp_grid(3, 8, 5);
+        let shells = [
+            IsoShell {
+                threshold: 1.5,
+                color: [0, 255, 0, 90],
+            },
+            IsoShell {
+                threshold: 3.5,
+                color: [255, 0, 0, 255],
+            },
+        ];
+        // bg = 2.0 sits below the inner threshold but NOT below the outer one —
+        // rejected against the lowest.
+        assert!(matches!(
+            encode_isosurfaces_glb(&grid, &shells, Some(2.0)),
+            Err(Tiles3dError::BackgroundNotBelowThreshold { threshold, .. }) if threshold == 1.5
+        ));
+        assert!(encode_isosurfaces_glb(&grid, &shells, Some(-32.0)).is_ok());
     }
 
     #[test]

--- a/crates/ds-3dtiles/src/isosurface.rs
+++ b/crates/ds-3dtiles/src/isosurface.rs
@@ -641,7 +641,7 @@ fn build_glb(meshes: &[(MeshBuilder, [u8; 4])]) -> Result<Vec<u8>, Tiles3dError>
     // byte offsets stay 4-aligned for free.
     let total_bytes: usize = meshes
         .iter()
-        .map(|(m, _)| (m.positions.len() + m.normal_acc.len()) * 4 + m.indices.len() * 4)
+        .map(|(m, _)| (m.vertex_count() * 6 + m.indices.len()) * 4)
         .sum();
     let mut bin = Vec::with_capacity(total_bytes);
     let mut primitives = Vec::with_capacity(meshes.len());

--- a/crates/ds-3dtiles/src/isosurface.rs
+++ b/crates/ds-3dtiles/src/isosurface.rs
@@ -106,27 +106,27 @@ pub struct IsoShell {
     pub color: [u8; 4],
 }
 
-/// Build the conventional "onion-skin" shell set from ascending `thresholds`:
-/// each shell is coloured by `colormap` at its threshold, with alpha ramped from
-/// translucent (outermost / lowest threshold) to opaque (innermost / highest),
-/// so the intense core glows through the weaker envelope. A single threshold
-/// yields one fully opaque shell — identical to [`encode_isosurface_glb`]'s
-/// classic look. The one policy both the API layer and the demo use, kept here
-/// so they can't drift.
+/// Build the conventional "onion-skin" shell set from `thresholds` (any order —
+/// sorted internally): each shell is coloured by `colormap` at its threshold,
+/// with alpha ramped from translucent (outermost / lowest threshold) to opaque
+/// (innermost / highest), so the intense core glows through the weaker
+/// envelope. The returned shells are in ascending-threshold order. A single
+/// threshold yields one fully opaque shell — identical to
+/// [`encode_isosurface_glb`]'s classic look. The one policy both the API layer
+/// and the demo use, kept here so they can't drift.
 pub fn nested_shells(thresholds: &[f64], colormap: &dyn ColorMap) -> Vec<IsoShell> {
-    // The alpha ramp keys off list POSITION (i=0 = outermost), so it is only
-    // meaningful for an ascending list — a descending one would silently
-    // produce inside-out translucency. Both call sites sort first; catch a
-    // future one that doesn't.
-    debug_assert!(
-        thresholds.windows(2).all(|w| w[0] <= w[1]),
-        "thresholds must be sorted ascending"
-    );
-    let n = thresholds.len();
-    thresholds
-        .iter()
+    // The alpha ramp keys off ascending rank (outermost = lowest threshold),
+    // so sort internally — self-enforcing, rather than a caller contract whose
+    // violation would only show as quietly-inverted translucency. No caller
+    // depends on positional correspondence with the input (the encoder
+    // re-sorts shells for draw order anyway).
+    let mut sorted = thresholds.to_vec();
+    sorted.sort_by(f64::total_cmp);
+    let n = sorted.len();
+    sorted
+        .into_iter()
         .enumerate()
-        .map(|(i, &threshold)| {
+        .map(|(i, threshold)| {
             let mut color = colormap.color(Some(threshold));
             // Outer 35% opacity → inner fully opaque (linear in shell index, not
             // threshold value, so the steps read evenly however the thresholds
@@ -719,7 +719,8 @@ fn build_glb(meshes: &[(MeshBuilder, [u8; 4])]) -> Result<Vec<u8>, Tiles3dError>
             "mode": MODE_TRIANGLES,
         }));
     }
-    // BIN chunk must be 4-byte aligned (f32-only, so it already is — defensive).
+    // BIN chunk must be 4-byte aligned; every section is a multiple of 4 bytes
+    // (f32 positions/normals, u32 indices), so this is a no-op — defensive.
     while !bin.len().is_multiple_of(4) {
         bin.push(0);
     }
@@ -737,8 +738,9 @@ fn build_glb(meshes: &[(MeshBuilder, [u8; 4])]) -> Result<Vec<u8>, Tiles3dError>
     });
 
     // Shared GLB assembler: 4-byte chunk padding + `u32`-checked total length +
-    // a serialize-error path instead of an `expect` panic. The BIN above is
-    // f32-only (always 4-aligned), so the helper's padding is a no-op here.
+    // a serialize-error path instead of an `expect` panic. The BIN above holds
+    // only 4-byte units (f32 attributes, u32 indices — always 4-aligned), so
+    // the helper's padding is a no-op here.
     crate::assemble_glb(&gltf, bin)
 }
 
@@ -1130,6 +1132,9 @@ mod tests {
             let c = cm.color(Some(s.threshold));
             assert_eq!(&s.color[..3], &c[..3]);
         }
+        // Input order doesn't matter — sorted internally, so an unsorted list
+        // can't quietly invert the translucency ramp.
+        assert_eq!(nested_shells(&[50.0, 20.0, 35.0], &cm), three);
     }
 
     #[test]

--- a/crates/ds-3dtiles/src/lib.rs
+++ b/crates/ds-3dtiles/src/lib.rs
@@ -23,9 +23,12 @@ use serde_json::json;
 
 /// Isosurface meshing of a [`ds_core::volume::VoxelGrid`] into glTF `.glb`
 /// triangle-mesh content (#357) — the verifiable, any-client 3-D path next to
-/// the `.pnts` point cloud.
+/// the `.pnts` point cloud. Supports nested multi-threshold translucent shells
+/// (#363) via [`encode_isosurfaces_glb`].
 pub mod isosurface;
-pub use isosurface::{encode_isosurface_glb, tileset_json_glb};
+pub use isosurface::{
+    encode_isosurface_glb, encode_isosurfaces_glb, nested_shells, tileset_json_glb, IsoShell,
+};
 
 /// Echo-top-height (ETH) draped-surface meshing of a
 /// [`ds_core::volume::VoxelGrid`] into a height-coloured glTF `.glb` (#362).

--- a/crates/engine-odim/examples/gen_isosurface.rs
+++ b/crates/engine-odim/examples/gen_isosurface.rs
@@ -12,16 +12,18 @@
 //! CesiumJS viewer.
 //!
 //! Usage:
-//!   cargo run -p engine-odim --example gen_isosurface -- [file.h5] [out_dir] [threshold_dbz]
-//!     file.h5        default: the (uncommitted) FMI Vihti fixture
-//!     out_dir        default: target/3dtiles-iso-fivih
-//!     threshold_dbz  default: 20.0  (the reflectivity shell to draw)
+//!   cargo run -p engine-odim --example gen_isosurface -- [file.h5] [out_dir] [thresholds_dbz]
+//!     file.h5         default: the (uncommitted) FMI Vihti fixture
+//!     out_dir         default: target/3dtiles-iso-fivih
+//!     thresholds_dbz  default: 20,35,50 — comma-separated reflectivity shells
+//!                     (#363): nested translucent envelopes around an opaque
+//!                     core; a single value draws one opaque shell (#357)
 
 use ds_core::config::OdimConfig;
 use ds_core::edr_engine::EdrEngine;
 use ds_core::geo::geodetic_to_ecef;
 use ds_core::volume::VolumeEngine;
-use ds_render::{BuiltinColormap, ColorMap, LutColorMap};
+use ds_render::{BuiltinColormap, LutColorMap};
 use engine_odim::PolarVolumeEngine;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -38,10 +40,16 @@ fn main() {
         args.next()
             .unwrap_or_else(|| "target/3dtiles-iso-fivih".to_string()),
     );
-    let threshold: f64 = args
+    let thresholds: Vec<f64> = args
         .next()
-        .map(|s| s.parse().expect("threshold_dbz must be a number"))
-        .unwrap_or(20.0);
+        .unwrap_or_else(|| "20,35,50".to_string())
+        .split(',')
+        .map(|s| {
+            s.trim()
+                .parse()
+                .expect("thresholds_dbz must be comma-separated numbers")
+        })
+        .collect();
 
     let file = Path::new(&file);
     if !file.exists() {
@@ -106,17 +114,21 @@ fn main() {
         grid.quantity
     );
 
-    // The shell's colour = the colormap at the threshold value.
+    // Nested shells (#363): each coloured by the colormap at its threshold,
+    // alpha ramped translucent (outer) → opaque (inner) so the intense core
+    // glows through the weaker envelope. One threshold = one opaque shell.
+    let mut sorted = thresholds.clone();
+    sorted.sort_by(f64::total_cmp);
     let colormap = LutColorMap::from_builtin(BuiltinColormap::RadarDbz, -32.0, 95.0);
-    let color = colormap.color(Some(threshold));
+    let shells = ds_3dtiles::nested_shells(&sorted, &colormap);
     // Seal at the shared no-echo floor (the engine fills clear air with it too,
-    // #360) so the shell closes into solid blobs (the preferred look);
+    // #360) so the shells close into solid blobs (the preferred look);
     // background=Some additionally seals the genuinely-unmeasured (NaN) cells, so
     // there are no open boundaries. (Pass None instead for honest open
     // boundaries — leaves the cone of silence / below-lowest-beam uncapped.)
     let background = Some(f64::from(ds_core::volume::NO_ECHO_FLOOR_DBZ));
-    let glb = ds_3dtiles::encode_isosurface_glb(&grid, threshold, color, background)
-        .expect("mesh the isosurface (try a lower threshold if this reports 'empty')");
+    let glb = ds_3dtiles::encode_isosurfaces_glb(&grid, &shells, background)
+        .expect("mesh the isosurfaces (try lower thresholds if this reports 'empty')");
 
     fs::create_dir_all(&out_dir).expect("mkdir out_dir");
     fs::write(out_dir.join("content.glb"), &glb).expect("write content.glb");
@@ -158,9 +170,15 @@ fn main() {
         .last()
         .map(|t| t.format("%Y-%m-%d %H:%MZ").to_string())
         .unwrap_or_default();
+    let shell_label = sorted
+        .iter()
+        .map(|t| format!("{t:.0}"))
+        .collect::<Vec<_>>()
+        .join("/");
     let hud = format!(
-        "{site_label} ({nod}) {} isosurface — {time_str} · {threshold:.0} dBZ shell",
-        grid.quantity
+        "{site_label} ({nod}) {} isosurface — {time_str} · {shell_label} dBZ shell{}",
+        grid.quantity,
+        if sorted.len() > 1 { "s" } else { "" }
     );
     write_viewer(&out_dir, &hud);
 


### PR DESCRIPTION
Implements #363 (nested multi-threshold translucent isosurfaces) and #382 (indexed mesh + smooth vertex normals) together — #382 rewrites the same `MeshBuilder`/`build_glb` the multi-shell change restructures, and faceting is most visible through translucent shells, so they review and render-verify as one change.

## Nested shells (#363)

- **`ds-3dtiles`**: new `encode_isosurfaces_glb(grid, &[IsoShell], background)` meshes several thresholds into **one `.glb`** — one primitive + one material per shell. A shell with alpha < 255 gets `alphaMode: "BLEND"` + `doubleSided`, so the opaque core glows through the translucent envelopes; opaque shells stay OPAQUE (keep depth-writes). `encode_isosurface_glb` is now a one-shell wrapper (all existing call sites unchanged).
- **`nested_shells(thresholds, colormap)`** is the shared colour/alpha policy (outer 35 % → inner opaque, linear in shell index; single threshold = fully opaque, the classic #357 look) — used by both the API handler and the demo so they can't drift.
- **Blend ordering**: primitives are emitted **innermost-first**. glTF has no draw order, but nested shells share nearly the same bounding-sphere centre, so CesiumJS's back-to-front translucency sort ties and primitive order is the tie-break — render-verified (see below).
- The pre-march blur runs **once**; each shell re-marches the same smoothed field. A threshold above all data is **skipped** (a weak storm still shows its envelope); all-empty ⇒ `Empty` → 404. `background` must sit below the *lowest* threshold; `MAX_TRIANGLES` bounds the **sum** across shells.
- **API**: `?threshold=` accepts a comma list (e.g. `20,35,50`) on the isosurface tileset + content routes — capped at 5 values, sorted + deduped into the canonical `content.uri`; a list on `echotop` is a 400; the lowest member must clear the no-echo floor. The content-cache key folds the list via FNV.
- **Viewer**: the isosurface threshold field becomes a free-text shell list, default `20,35,50`.
- **Demo**: `gen_isosurface` takes a comma-separated threshold list (default `20,35,50`).

## Indexed mesh + smooth normals (#382)

`MeshBuilder` now interns vertices by exact position bit-pattern (marching-tet shared edge crossings are computed from the same corner values, so shared vertices are **bit-identical** — no quantisation needed) and accumulates the **area-weighted outward face normal** per vertex (the unnormalized cross product, so big faces weigh more), normalized at encode. The `out_ref` outward-orientation logic is kept — it still fixes winding + normal direction. Output is `POSITION`+`NORMAL`+`u32` indices per primitive.

Result: the flat-shaded "crumpled paper" faceting is gone, and the `.glb` shrinks by the vertex-sharing factor — **3 shells of the fivih fixture = 2.7 MB** vs ~7 MB for the old single non-indexed shell.

## Render verification (CesiumJS, fivih 2026-05-19 10:50Z)

- Translucent green 20 dBZ envelope with the yellow 35 dBZ shells clearly glowing through; basemap visible through the outer shell (BLEND working).
- Shells sit correctly over southern Finland at the right location/orientation.
- Up close the surface is smooth — no marching-tet facets.

## Tests

- `ds-3dtiles`: multi-shell glb structure (one blended primitive/material per shell, innermost-first re-sort, indexed accessors tiling the BIN exactly, index bounds), empty-shell skip, all-empty ⇒ `Empty`, background-vs-lowest-threshold validation, `nested_shells` alpha ramp; existing tests updated for the indexed layout.
- `api-3dtiles` integration: canonicalised list in `content.uri`, blended multi-primitive content with the empty 50 dBZ shell skipped, single-threshold stays opaque, echotop list / junk list / over-long list / floor violations all 400.
- `cargo test --workspace`, `cargo clippy --workspace --all-targets` (0 warnings), `cargo fmt --check` all clean.

Closes #363
Closes #382

🤖 Generated with [Claude Code](https://claude.com/claude-code)