### PR TITLE
fix(odim): SMHI signed-i16 PVOL in 3D Tiles + raster

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1714,9 +1714,8 @@ dependencies = [
 
 [[package]]
 name = "hdf5-reader"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8840fbc5ba7a53641310daaa48dfbd2b37d9f5892269fe58d45cc16573c093e"
+version = "0.6.0"
+source = "git+https://github.com/mrauhala/netcdf-rust.git?rev=767add81eb12d0fd123f3550637fc001c2f40ff7#767add81eb12d0fd123f3550637fc001c2f40ff7"
 dependencies = [
  "flate2",
  "lru",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,3 +68,18 @@ debug = false
 # `cargo update` can't silently follow a moved branch tip.
 [patch.crates-io]
 icechunk = { git = "https://github.com/earth-mover/icechunk.git", rev = "5f56b13605745ea06ec6558bcd8ed4a8f5805a3e" }
+
+# Interim patch until upstream releases the fix.
+#
+# hdf5-reader's version 1 B-tree raw-data chunk-key parser read each
+# per-dimension chunk offset as `size_of_offsets` bytes, but the HDF5 format
+# spec fixes those key dimension offsets at 8 bytes regardless of the
+# superblock's offset size. On 32-bit-superblock files (`size_of_offsets = 4`)
+# — e.g. SMHI ODIM_H5 radar polar volumes — this misaligned the cursor, located
+# a garbage chunk address, and made every chunked-dataset read fail to
+# decompress ("corrupt deflate stream"), even though libhdf5/h5dump read the
+# same files fine. Fixed in our fork (read the dim offsets as fixed u64); PR
+# filed upstream (roteiro-gis/netcdf-rust). Pinned to an immutable `rev` so a
+# `cargo update` can't follow a moved branch. Remove once a crates.io release
+# > 0.6.0 carries the fix.
+hdf5-reader = { git = "https://github.com/mrauhala/netcdf-rust.git", rev = "767add81eb12d0fd123f3550637fc001c2f40ff7" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,7 +79,7 @@ icechunk = { git = "https://github.com/earth-mover/icechunk.git", rev = "5f56b13
 # a garbage chunk address, and made every chunked-dataset read fail to
 # decompress ("corrupt deflate stream"), even though libhdf5/h5dump read the
 # same files fine. Fixed in our fork (read the dim offsets as fixed u64); PR
-# filed upstream (roteiro-gis/netcdf-rust). Pinned to an immutable `rev` so a
+# filed upstream (roteiro-gis/netcdf-rust#54). Pinned to an immutable `rev` so a
 # `cargo update` can't follow a moved branch. Remove once a crates.io release
-# > 0.6.0 carries the fix.
+# > 0.6.0 carries the fix — tracked in #394.
 hdf5-reader = { git = "https://github.com/mrauhala/netcdf-rust.git", rev = "767add81eb12d0fd123f3550637fc001c2f40ff7" }

--- a/collections.d/radar-se-volume-local-h5.toml
+++ b/collections.d/radar-se-volume-local-h5.toml
@@ -19,7 +19,11 @@
 # and the dual-pol moments each get a fitting colormap and range rather
 # than one reflectivity palette stretched over every moment.
 #
-# data_path points at a local test fixture directory.
+# data_path points at a local test fixture directory. The fixtures
+# (testdata/radar-smhi-pvol/, ~113 MB) are NOT committed — like the FMI
+# `radar-fi-volume-local-h5` sibling. Without them this collection loads
+# but reports `degraded` (empty catalog) on /health; drop the .h5 volumes
+# in place to activate it, or rename this file `.toml.disabled` to skip it.
 
 id = "radar-se-volume-local-h5"
 title = "SMHI — radar polar volumes (local, ODIM_H5)"

--- a/collections.d/radar-se-volume-local-h5.toml
+++ b/collections.d/radar-se-volume-local-h5.toml
@@ -1,0 +1,95 @@
+# FMI weather-radar polar volumes (ODIM_H5 PVOL).
+#
+# Each radar site is a stack of elevation sweeps, each with multiple
+# dual-pol moments (TH, DBZH, VRADH, ZDR, RHOHV...). Under the
+# per-site collection model the odim-volume engine expands this one
+# source into **one OGC collection per radar site** (id =
+# `radar-fi-volume-local-h5-<nod>`, e.g. `…-fivih`). Within a site
+# collection the parameters are the **bare quantities** (`DBZH`,
+# `VRADH`, …) — the site is the collection (its EDR location, its
+# spatial/vertical extent), so it is not part of the parameter name.
+#
+# Because each quantity is now a bare parameter, WMS styling can be set
+# per quantity via `[[wms.parameters]]` below — reflectivity, velocity,
+# and the dual-pol moments each get a fitting colormap and range rather
+# than one reflectivity palette stretched over every moment.
+#
+# data_path points at a local test fixture directory; see
+# `radar-fi-volume-s3-h5` for the S3-streamed sibling.
+
+id = "radar-se-volume-local-h5"
+title = "SMHI — radar polar volumes (local, ODIM_H5)"
+description = "Swedish radar polar volumes (ODIM_H5 PVOL) from local sample files — every elevation sweep and dual-polarisation moment. One collection per radar site."
+engine_type = "odim-volume"
+apis = ["edr", "wms", "maps", "tiles", "3dtiles"]
+data_path = "testdata/radar-smhi-pvol"
+
+[odim]
+poll_interval_secs = 300
+
+[wms]
+# Collection-level fallback for any quantity without a per-parameter
+# override below (e.g. an unlisted moment renders on the dBZ palette).
+colormap = "radar_dbz"
+
+# Per-quantity colormaps. `name` is the bare ODIM quantity — matched
+# against the site collection's parameter list. Quantities the file
+# doesn't carry are simply ignored.
+
+# Horizontal reflectivity (uncorrected / corrected) — dBZ.
+[[wms.parameters]]
+name = "TH"
+colormap = "radar_dbz"
+[[wms.parameters]]
+name = "DBZH"
+colormap = "radar_dbz"
+
+# Doppler radial velocity — m/s, diverging blue→white→red about zero
+# (toward/away). FMI volumes are dealiased to a ±48 m/s Nyquist band.
+[[wms.parameters]]
+name = "VRADH"
+min = -48.0
+max = 48.0
+[[wms.parameters.color_stops]]
+value = -48.0
+color = "#1a1aff"
+[[wms.parameters.color_stops]]
+value = -24.0
+color = "#66ccff"
+[[wms.parameters.color_stops]]
+value = 0.0
+color = "#f5f5f5"
+[[wms.parameters.color_stops]]
+value = 24.0
+color = "#ff8c66"
+[[wms.parameters.color_stops]]
+value = 48.0
+color = "#cc0000"
+
+# Spectrum width — m/s.
+[[wms.parameters]]
+name = "WRADH"
+colormap = "viridis"
+min = 0.0
+max = 10.0
+
+# Differential reflectivity — dB.
+[[wms.parameters]]
+name = "ZDR"
+colormap = "viridis"
+min = -2.0
+max = 6.0
+
+# Co-polar correlation coefficient — unitless 0..1.
+[[wms.parameters]]
+name = "RHOHV"
+colormap = "viridis"
+min = 0.0
+max = 1.0
+
+# Specific differential phase — °/km.
+[[wms.parameters]]
+name = "KDP"
+colormap = "viridis"
+min = -1.0
+max = 6.0

--- a/collections.d/radar-se-volume-local-h5.toml
+++ b/collections.d/radar-se-volume-local-h5.toml
@@ -30,6 +30,12 @@ data_path = "testdata/radar-smhi-pvol"
 
 [odim]
 poll_interval_secs = 300
+# Retain at most the last 24 volumes per site (≈2 h at 5-min cadence).
+# Bounds the time-dynamic playback set and the viewer's tileset preload —
+# an unbounded source accumulates ~288 volumes/day/site. Raise this, or
+# add `time_window = "-PT6H"`, for a longer window. Omitting both is valid
+# for a static local fixture but not recommended for a production source.
+max_files = 24
 
 [wms]
 # Collection-level fallback for any quantity without a per-parameter

--- a/collections.d/radar-se-volume-local-h5.toml
+++ b/collections.d/radar-se-volume-local-h5.toml
@@ -1,21 +1,25 @@
-# FMI weather-radar polar volumes (ODIM_H5 PVOL).
+# SMHI weather-radar polar volumes (ODIM_H5 PVOL).
 #
 # Each radar site is a stack of elevation sweeps, each with multiple
-# dual-pol moments (TH, DBZH, VRADH, ZDR, RHOHV...). Under the
+# dual-pol moments (DBZH, VRADH, ZDR, RHOHV, WRADH...). Under the
 # per-site collection model the odim-volume engine expands this one
 # source into **one OGC collection per radar site** (id =
-# `radar-fi-volume-local-h5-<nod>`, e.g. `…-fivih`). Within a site
-# collection the parameters are the **bare quantities** (`DBZH`,
-# `VRADH`, …) — the site is the collection (its EDR location, its
-# spatial/vertical extent), so it is not part of the parameter name.
+# `radar-se-volume-local-h5-<nod>`, e.g. `…-sekrn` (Kiruna),
+# `…-sehem` (Hemse)). Within a site collection the parameters are the
+# **bare quantities** (`DBZH`, `VRADH`, …) — the site is the collection
+# (its EDR location, its spatial/vertical extent), so it is not part of
+# the parameter name.
+#
+# SMHI ships these as signed-i16 scaled integers in a 32-bit-superblock
+# HDF5 file — see engine-odim `reader::read_raw_pixels_2d` and the
+# `hdf5-reader` chunk-key patch in the root Cargo.toml.
 #
 # Because each quantity is now a bare parameter, WMS styling can be set
 # per quantity via `[[wms.parameters]]` below — reflectivity, velocity,
 # and the dual-pol moments each get a fitting colormap and range rather
 # than one reflectivity palette stretched over every moment.
 #
-# data_path points at a local test fixture directory; see
-# `radar-fi-volume-s3-h5` for the S3-streamed sibling.
+# data_path points at a local test fixture directory.
 
 id = "radar-se-volume-local-h5"
 title = "SMHI — radar polar volumes (local, ODIM_H5)"
@@ -45,7 +49,7 @@ name = "DBZH"
 colormap = "radar_dbz"
 
 # Doppler radial velocity — m/s, diverging blue→white→red about zero
-# (toward/away). FMI volumes are dealiased to a ±48 m/s Nyquist band.
+# (toward/away). The ±48 m/s span covers a typical C-band Nyquist range.
 [[wms.parameters]]
 name = "VRADH"
 min = -48.0

--- a/crates/engine-odim/Cargo.toml
+++ b/crates/engine-odim/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 ds-core = { path = "../core" }
 ds-storage = { path = "../storage" }
-hdf5-reader = "0.4"
+hdf5-reader = "0.6"
 ndarray = "0.17"
 chrono = { version = "0.4", features = ["serde"] }
 arc-swap = "1"

--- a/crates/engine-odim/src/pvol.rs
+++ b/crates/engine-odim/src/pvol.rs
@@ -143,8 +143,9 @@ fn parse_source(source: &str) -> (Option<String>, Option<String>, Option<String>
 }
 
 /// Read a `RawPixels` array of declared shape `(nrays, nbins)` from a
-/// `/datasetN/dataM/data` dataset, probing u8 → u16 → f64 — the same
-/// dtype-fallback chain [`crate::reader::read_composite`] uses.
+/// `/datasetN/dataM/data` dataset, selecting the storage type from the
+/// dataset's actual HDF5 datatype (u8/u16/i16/f64) — see
+/// [`crate::reader::read_raw_pixels_2d`].
 fn read_moment_array(
     file: &Hdf5File,
     path: &str,
@@ -154,42 +155,7 @@ fn read_moment_array(
     let ds = file
         .dataset(path)
         .map_err(|_| ReadError::MissingGroup(path.to_string()))?;
-    let shape = ds.shape();
-    if shape.len() != 2 {
-        return Err(ReadError::UnsupportedRank(shape.len()));
-    }
-
-    let check = |dim: (usize, usize)| -> Result<(), ReadError> {
-        if dim != (nrays, nbins) {
-            return Err(ReadError::DatasetRead(format!(
-                "{path}: array shape {dim:?} doesn't match sweep metadata {nrays}x{nbins}"
-            )));
-        }
-        Ok(())
-    };
-
-    if let Ok(arr) = ds.read_array::<u8>() {
-        let a2 = arr
-            .into_dimensionality::<ndarray::Ix2>()
-            .map_err(|e| ReadError::DatasetRead(format!("{path}: u8 reshape failed: {e}")))?;
-        check(a2.dim())?;
-        return Ok(RawPixels::U8(a2));
-    }
-    if let Ok(arr) = ds.read_array::<u16>() {
-        let a2 = arr
-            .into_dimensionality::<ndarray::Ix2>()
-            .map_err(|e| ReadError::DatasetRead(format!("{path}: u16 reshape failed: {e}")))?;
-        check(a2.dim())?;
-        return Ok(RawPixels::U16(a2));
-    }
-    if let Ok(arr) = ds.read_array::<f64>() {
-        let a2 = arr
-            .into_dimensionality::<ndarray::Ix2>()
-            .map_err(|e| ReadError::DatasetRead(format!("{path}: f64 reshape failed: {e}")))?;
-        check(a2.dim())?;
-        return Ok(RawPixels::F64(a2));
-    }
-    Err(ReadError::UnsupportedPixelType)
+    crate::reader::read_raw_pixels_2d(&ds, nrays, nbins, path)
 }
 
 /// Parse an ODIM_H5 polar volume from a byte slice. The whole file

--- a/crates/engine-odim/src/reader.rs
+++ b/crates/engine-odim/src/reader.rs
@@ -288,7 +288,11 @@ pub(crate) fn read_raw_pixels_2d(
     }
 
     let pixels = match ds.dtype() {
-        Datatype::FixedPoint { size: 1, .. } => read_2d!(u8, U8),
+        Datatype::FixedPoint {
+            size: 1,
+            signed: false,
+            ..
+        } => read_2d!(u8, U8),
         Datatype::FixedPoint {
             size: 2,
             signed: false,

--- a/crates/engine-odim/src/reader.rs
+++ b/crates/engine-odim/src/reader.rs
@@ -287,6 +287,11 @@ pub(crate) fn read_raw_pixels_2d(
         }};
     }
 
+    // `byte_order` is intentionally wildcarded: `read_array::<T>()` applies any
+    // byte-swapping internally, so the storage variant is fixed by (size, signed)
+    // alone. Matching on `signed` is what's load-bearing (the size-only read in
+    // hdf5-reader 0.6 would otherwise let a signed array bit-reinterpret as the
+    // unsigned reader type).
     let pixels = match ds.dtype() {
         Datatype::FixedPoint {
             size: 1,

--- a/crates/engine-odim/src/reader.rs
+++ b/crates/engine-odim/src/reader.rs
@@ -309,7 +309,13 @@ pub(crate) fn read_raw_pixels_2d(
             ..
         } => read_2d!(i16, I16),
         Datatype::FloatingPoint { size: 8, .. } => read_2d!(f64, F64),
-        _ => return Err(ReadError::UnsupportedPixelType),
+        // f32 storage is not yet supported (no observed ODIM producer uses it;
+        // tracked as a follow-up). Log the actual dtype so an operator hitting an
+        // unsupported source sees *which* type, not just "unsupported".
+        dt => {
+            tracing::debug!("ODIM unsupported pixel dtype {dt:?} at {path}");
+            return Err(ReadError::UnsupportedPixelType);
+        }
     };
     Ok(pixels)
 }

--- a/crates/engine-odim/src/reader.rs
+++ b/crates/engine-odim/src/reader.rs
@@ -14,7 +14,7 @@
 //! | Producer | ODIM version | Pixel type | Renders | Notes                                       |
 //! |----------|--------------|------------|---------|---------------------------------------------|
 //! | DMI      | v2.0         | u8         | yes     | No `/where/xsize`/`ysize`; gain/offset/nodata at root `/what`; quantity as attr on `/dataset1/data1` |
-//! | SMHI     | v2.2         | u8         | no      | Canonical layout; DEFLATE decompression fails in `hdf5-reader` 0.4 (upstream bug — `h5dump` reads the same file fine) |
+//! | SMHI     | v2.2 (PVOL)  | i16        | yes     | **Signed** scaled integers (gain=0.01, sentinels nodata=-32768/undetect=-32767); 32-bit superblock + single DEFLATE chunks — needed both the `i16` storage variant and the patched `hdf5-reader` v1-B-tree chunk-key fix (see root `Cargo.toml`) |
 //! | DWD      | v2.3         | u16        | yes     | Canonical layout; polar stere (lat_0=90, lat_ts=60); 250m grid over Germany; fine gain=0.00293, offset=-64 |
 //! | OPERA    | v2.4         | f64        | yes     | Canonical layout; LAEA grid (EPSG:3035-style); already-decoded physical dBZ with `nodata=-9999000`, `undetect=-8888000` |
 //!
@@ -36,15 +36,15 @@
 //!
 //! Phase 1 narrows the scope further than the format allows:
 //! - Single dataset (`/dataset1` only), single data layer (`/data1`)
-//! - Three raw pixel types: u8, u16, f64 (all the variants we've
-//!   actually encountered)
+//! - Four raw pixel types: u8, u16, i16, f64 (all the variants we've
+//!   actually encountered; i16 is SMHI's signed scaled-integer PVOL)
 //! - No quality layers, no `how/*` attributes, no PVOL volume data
 //!
 //! See [[project_odim_engine_plan]] for the full multi-phase plan.
 
 use chrono::{DateTime, NaiveDate, NaiveTime, Utc};
 use ds_core::geo::Crs;
-use hdf5_reader::{Attribute, Hdf5File};
+use hdf5_reader::{Attribute, Dataset, Datatype, Hdf5File};
 use ndarray::Array2;
 
 use crate::proj;
@@ -71,7 +71,7 @@ pub enum ReadError {
     #[error("dataset `/dataset1/data1/data` has unsupported shape: expected 2D, got {0}D")]
     UnsupportedRank(usize),
     #[error(
-        "dataset `/dataset1/data1/data` has unsupported pixel type (Phase 1: u8, u16, or f64)"
+        "dataset `/dataset1/data1/data` has unsupported pixel type (Phase 1: u8, u16, i16, or f64)"
     )]
     UnsupportedPixelType,
     #[error("dataset read failed: {0}")]
@@ -84,10 +84,12 @@ pub enum ReadError {
     NoMoments { dataset: String },
 }
 
-/// Raw pixel storage as it appears on disk. ODIM composites ship
+/// Raw pixel storage as it appears on disk. ODIM composites/volumes ship
 /// one of:
 /// - `u8`  — single-byte reflectivity classes (DMI v2.0)
-/// - `u16` — extended dynamic range (some EUMETNET v2.x producers)
+/// - `u16` — extended dynamic range (some EUMETNET v2.x producers, DWD v2.3)
+/// - `i16` — **signed** scaled integers (SMHI PVOL: `gain=0.01`, sentinels
+///   `nodata=-32768`/`undetect=-32767` — only representable as signed)
 /// - `f64` — already-decoded physical values (OPERA v2.4 ACRR/DBZH)
 ///
 /// For the integer variants the physical value is `raw * gain + offset`.
@@ -98,6 +100,7 @@ pub enum ReadError {
 pub enum RawPixels {
     U8(Array2<u8>),
     U16(Array2<u16>),
+    I16(Array2<i16>),
     F64(Array2<f64>),
 }
 
@@ -126,6 +129,7 @@ impl RawPixels {
         match self {
             RawPixels::U8(a) => a.dim(),
             RawPixels::U16(a) => a.dim(),
+            RawPixels::I16(a) => a.dim(),
             RawPixels::F64(a) => a.dim(),
         }
     }
@@ -182,6 +186,10 @@ impl RawPixels {
                 Some(v) => *v as f64,
                 None => return PixelClass::Masked,
             },
+            RawPixels::I16(a) => match a.get((row, col)) {
+                Some(v) => *v as f64,
+                None => return PixelClass::Masked,
+            },
             RawPixels::F64(a) => match a.get((row, col)) {
                 Some(v) => *v,
                 None => return PixelClass::Masked,
@@ -228,10 +236,73 @@ impl RawPixels {
         let elem = match self {
             RawPixels::U8(_) => 1,
             RawPixels::U16(_) => 2,
+            RawPixels::I16(_) => 2,
             RawPixels::F64(_) => 8,
         };
         h * w * elem
     }
+}
+
+/// Decode a 2-D ODIM pixel array into [`RawPixels`], selecting the storage
+/// variant from the dataset's **actual** HDF5 datatype rather than probing
+/// reader types in fallback order.
+///
+/// dtype inspection is load-bearing, not stylistic: `hdf5-reader` matches a
+/// typed `read_array::<T>()` on element **byte-size only**, not signedness. A
+/// signed `i16` moment (SMHI) therefore reads *successfully* — but with every
+/// value bit-reinterpreted — as `u16` (e.g. the `undetect` sentinel `-32767`
+/// becomes `32769`), so a u16-before-i16 probe order would silently return
+/// garbage. Branching on `Datatype` picks the one correct reader.
+///
+/// Supported ODIM element types: `u8`/`u16`/`i16` scaled integers (physical =
+/// `raw * gain + offset`) and `f64` pre-decoded physical values. Anything else
+/// (i8, i32, f32, …) is [`ReadError::UnsupportedPixelType`]. `path` only labels
+/// error messages.
+pub(crate) fn read_raw_pixels_2d(
+    ds: &Dataset,
+    rows: usize,
+    cols: usize,
+    path: &str,
+) -> Result<RawPixels, ReadError> {
+    let shape = ds.shape();
+    if shape.len() != 2 {
+        return Err(ReadError::UnsupportedRank(shape.len()));
+    }
+
+    macro_rules! read_2d {
+        ($t:ty, $variant:ident) => {{
+            let arr = ds
+                .read_array::<$t>()
+                .map_err(|e| ReadError::DatasetRead(format!("{path}: {e}")))?;
+            let a2 = arr
+                .into_dimensionality::<ndarray::Ix2>()
+                .map_err(|e| ReadError::DatasetRead(format!("{path}: reshape failed: {e}")))?;
+            if a2.dim() != (rows, cols) {
+                return Err(ReadError::DatasetRead(format!(
+                    "{path}: array shape {:?} doesn't match metadata {rows}x{cols}",
+                    a2.dim()
+                )));
+            }
+            RawPixels::$variant(a2)
+        }};
+    }
+
+    let pixels = match ds.dtype() {
+        Datatype::FixedPoint { size: 1, .. } => read_2d!(u8, U8),
+        Datatype::FixedPoint {
+            size: 2,
+            signed: false,
+            ..
+        } => read_2d!(u16, U16),
+        Datatype::FixedPoint {
+            size: 2,
+            signed: true,
+            ..
+        } => read_2d!(i16, I16),
+        Datatype::FloatingPoint { size: 8, .. } => read_2d!(f64, F64),
+        _ => return Err(ReadError::UnsupportedPixelType),
+    };
+    Ok(pixels)
 }
 
 /// A parsed ODIM composite ready for sampling. Carries the raw
@@ -572,79 +643,12 @@ pub fn read_composite(bytes: &[u8]) -> Result<OdimComposite, ReadError> {
             name: "quantity".into(),
         })?;
 
-    // Try u8 (DMI v2.0, SMHI v2.2), u16 (some EUMETNET v2.x, DWD
-    // v2.3), then f64 (OPERA v2.4 — pre-decoded physical values).
-    // `read_array` returns `Err` on dtype mismatch rather than
-    // panicking, so the fallback chain is safe. Per-probe errors
-    // are captured at `debug!` (every load of a DWD or OPERA file
-    // would otherwise spam the u8 error) and only escalated to
-    // `warn!` when every probe fails — at that point a likely
-    // upstream cause (hdf5-reader 0.4 silently mis-handling
-    // DEFLATE on certain SMHI files) is worth surfacing.
-    let u8_probe = ds.read_array::<u8>();
-    if let Err(ref e) = u8_probe {
-        tracing::debug!("ODIM u8 pixel-array probe failed: {e}");
-    }
-    let pixels = if let Ok(arr) = u8_probe {
-        let a2 = arr
-            .into_dimensionality::<ndarray::Ix2>()
-            .map_err(|e| ReadError::DatasetRead(format!("u8 reshape failed: {e}")))?;
-        if a2.dim() != (rows, cols) {
-            return Err(ReadError::DatasetRead(format!(
-                "u8 array shape {:?} doesn't match metadata {rows}x{cols}",
-                a2.dim()
-            )));
-        }
-        RawPixels::U8(a2)
-    } else {
-        let u16_probe = ds.read_array::<u16>();
-        if let Err(ref e) = u16_probe {
-            tracing::debug!("ODIM u16 pixel-array probe failed: {e}");
-        }
-        if let Ok(arr) = u16_probe {
-            let a2 = arr
-                .into_dimensionality::<ndarray::Ix2>()
-                .map_err(|e| ReadError::DatasetRead(format!("u16 reshape failed: {e}")))?;
-            if a2.dim() != (rows, cols) {
-                return Err(ReadError::DatasetRead(format!(
-                    "u16 array shape {:?} doesn't match metadata {rows}x{cols}",
-                    a2.dim()
-                )));
-            }
-            RawPixels::U16(a2)
-        } else {
-            let f64_probe = ds.read_array::<f64>();
-            if let Err(ref e) = f64_probe {
-                tracing::debug!("ODIM f64 pixel-array probe failed: {e}");
-            }
-            if let Ok(arr) = f64_probe {
-                let a2 = arr
-                    .into_dimensionality::<ndarray::Ix2>()
-                    .map_err(|e| ReadError::DatasetRead(format!("f64 reshape failed: {e}")))?;
-                if a2.dim() != (rows, cols) {
-                    return Err(ReadError::DatasetRead(format!(
-                        "f64 array shape {:?} doesn't match metadata {rows}x{cols}",
-                        a2.dim()
-                    )));
-                }
-                RawPixels::F64(a2)
-            } else {
-                // All three probes failed. This is the only point at
-                // which a u8 probe error indicates something genuinely
-                // wrong (a real u8 file that hdf5-reader couldn't
-                // decompress, or an unsupported dtype like i32). Log
-                // both the u8 and u16 errors at WARN since either may
-                // be the diagnostic clue an operator needs.
-                if let Err(e) = &u8_probe {
-                    tracing::warn!(
-                        "ODIM pixel-array unreadable as u8/u16/f64; u8 probe error \
-                         (possible hdf5-reader DEFLATE bug on SMHI files): {e}"
-                    );
-                }
-                return Err(ReadError::UnsupportedPixelType);
-            }
-        }
-    };
+    // Decode the raw pixel array, selecting the storage type from the
+    // dataset's actual HDF5 datatype: u8 (DMI v2.0), u16 (DWD v2.3), i16
+    // (SMHI — signed scaled integers), or f64 (OPERA v2.4 — pre-decoded
+    // physical values). See [`read_raw_pixels_2d`] for why dtype inspection
+    // (not type-probing) is required.
+    let pixels = read_raw_pixels_2d(&ds, rows, cols, "/dataset1/data1/data")?;
 
     Ok(OdimComposite {
         crs,

--- a/crates/engine-odim/src/reader.rs
+++ b/crates/engine-odim/src/reader.rs
@@ -310,10 +310,13 @@ pub(crate) fn read_raw_pixels_2d(
         } => read_2d!(i16, I16),
         Datatype::FloatingPoint { size: 8, .. } => read_2d!(f64, F64),
         // f32 storage is not yet supported (no observed ODIM producer uses it;
-        // tracked as a follow-up). Log the actual dtype so an operator hitting an
-        // unsupported source sees *which* type, not just "unsupported".
+        // tracked as a follow-up — #393). `warn!` (not `debug!`): an unsupported
+        // dtype means the data won't load at all, which an operator needs to see
+        // in production — and the actual dtype is the actionable detail the
+        // caller's generic "unsupported pixel type" error lacks. Matches the
+        // pre-dispatch probe chain, which also warned when every probe failed.
         dt => {
-            tracing::debug!("ODIM unsupported pixel dtype {dt:?} at {path}");
+            tracing::warn!("ODIM unsupported pixel dtype {dt:?} at {path}");
             return Err(ReadError::UnsupportedPixelType);
         }
     };

--- a/crates/engine-odim/src/volume_engine.rs
+++ b/crates/engine-odim/src/volume_engine.rs
@@ -1338,11 +1338,23 @@ fn derive_site_meta(list: &[VolumeEntry]) -> Option<SiteMeta> {
         (!levels.is_empty()).then(|| VerticalDimension::new(VerticalKind::ElevationAngle, levels));
 
     // Pre-build the 3D Tiles metadata snapshot once per catalog rebuild so the
-    // per-request `volume_info()` is an O(1) Arc clone (#211). The default
-    // quantity is `quantities.first()` — the *same* source `read_point_cloud`
-    // and `get_raster_tile` default to, so the advertised default matches what
-    // an unqualified request actually renders.
-    let default_quantity = quantities.first().cloned().unwrap_or_default();
+    // per-request `volume_info()` is an O(1) Arc clone (#211). The advertised
+    // default is the *same* value `read_point_cloud` and `get_raster_tile`
+    // default to (all read `volume_info.default_quantity`), so an unqualified
+    // request renders exactly what the metadata advertises.
+    //
+    // Prefer reflectivity — corrected `DBZH`, then total `TH` — as the default
+    // product. A bare `quantities.first()` is alphabetical, so a dual-pol volume
+    // whose moments sort `CCORH` < `DBZH` (e.g. SMHI) would default to a
+    // clutter-correction quality field: defined across the *whole* volume
+    // ("full cones") with near-zero values that wash out to white on the dBZ
+    // colormap. Every quantity stays selectable; only the default changes.
+    let default_quantity = ["DBZH", "TH"]
+        .into_iter()
+        .find(|q| quantities.iter().any(|x| x == q))
+        .map(str::to_string)
+        .or_else(|| quantities.first().cloned())
+        .unwrap_or_default();
     let default_unit = quantities::quantity_unit(&default_quantity).to_string();
     // 3D Tiles coverage region: the WGS84 coverage bbox (→ radians) plus a
     // generous vertical span (antenna height up to a 25 km ceiling — above any

--- a/crates/engine-odim/tests/integration.rs
+++ b/crates/engine-odim/tests/integration.rs
@@ -738,6 +738,91 @@ fn pvol_volume_engine_voxel_grid() {
     }
 }
 
+/// Regression guard for SMHI signed-integer PVOL: SMHI ships its moments as
+/// **signed `i16`** (DBZH `gain=0.01`, sentinels `nodata=-32768` /
+/// `undetect=-32767` — only representable as signed), which the original
+/// u8→u16→f64 probe chain rejected as `UnsupportedPixelType`. The moment then
+/// failed to decode, so every Swedish site returned no data on 3D Tiles / WMS /
+/// EDR (the symptom: a 404 with the quantity menu still populated). The added
+/// i16 probe fixes it. The 21 MB Kiruna fixture is **not committed to git**, so
+/// the test skips gracefully when absent.
+#[test]
+fn pvol_smhi_signed_i16_moment_decodes() {
+    use engine_odim::reader::RawPixels;
+
+    let fixture = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../testdata/radar-smhi-pvol/radar_kiruna_qcvol_202606111000.h5");
+    if !fixture.exists() {
+        eprintln!("skipping pvol_smhi_signed_i16_moment_decodes: fixture absent at {fixture:?}");
+        return;
+    }
+    let bytes = std::fs::read(&fixture).expect("read SMHI PVOL fixture bytes");
+    let volume = engine_odim::pvol::read_polar_volume(&bytes).expect("parse SMHI PVOL fixture");
+    assert_eq!(volume.site.nod.as_deref(), Some("sekrn"), "Kiruna NOD");
+
+    // The DBZH moment in the lowest sweep — SMHI's signed scaled-integer
+    // encoding (gain 0.01, signed-only sentinels).
+    let sweep = volume.sweeps.first().expect("at least one sweep");
+    let moment = sweep
+        .moments
+        .iter()
+        .find(|m| m.quantity == "DBZH")
+        .expect("DBZH moment present in the lowest sweep");
+    // gain is stored f32 in the file, so compare with tolerance; the
+    // signed-only sentinels are exact integers.
+    assert!(
+        (moment.gain - 0.01).abs() < 1e-6,
+        "gain ≈ 0.01, got {}",
+        moment.gain
+    );
+    assert_eq!(moment.nodata, -32768.0);
+    assert_eq!(moment.undetect, -32767.0);
+
+    // The decode that previously returned `Err(UnsupportedPixelType)`.
+    let raw = engine_odim::pvol::read_moment_pixels(
+        &bytes,
+        &moment.dataset_path,
+        sweep.nrays,
+        sweep.nbins,
+    )
+    .expect("decode the signed-i16 DBZH moment");
+    assert!(
+        matches!(raw, RawPixels::I16(_)),
+        "SMHI DBZH must decode as signed i16"
+    );
+    assert_eq!(raw.shape(), (sweep.nrays, sweep.nbins));
+
+    // The signed sentinels mask (→ None); real cells decode to a sane dBZ band
+    // via `raw * gain + offset`. Scan every sweep's DBZH moment so the
+    // "has echo" assertion doesn't hinge on a single clear-air sweep.
+    let mut finite = 0usize;
+    for sweep in &volume.sweeps {
+        let Some(m) = sweep.moments.iter().find(|m| m.quantity == "DBZH") else {
+            continue;
+        };
+        let raw = engine_odim::pvol::read_moment_pixels(
+            &bytes,
+            &m.dataset_path,
+            sweep.nrays,
+            sweep.nbins,
+        )
+        .expect("decode i16 DBZH moment");
+        let (h, w) = raw.shape();
+        for r in 0..h {
+            for c in 0..w {
+                if let Some(v) = raw.sample(r, c, m.gain, m.offset, m.nodata, Some(m.undetect)) {
+                    assert!((-40.0..100.0).contains(&v), "sane dBZ, got {v}");
+                    finite += 1;
+                }
+            }
+        }
+    }
+    assert!(
+        finite > 0,
+        "the SMHI volume must yield some finite echo cells once i16 decodes"
+    );
+}
+
 /// End-to-end `FeatureEngine` surface on the real FMI Vihti volume: the
 /// owning `PolarVolumeEngine` exposes its sites as a Features collection (one
 /// Point Feature per site). Skips when the uncommitted 15 MB fixture is absent.


### PR DESCRIPTION
## Summary

Swedish (SMHI) ODIM_H5 radar polar volumes failed across **3D Tiles / WMS / EDR** — a 404 with no error in the logs, the quantity menu populating but every content fetch empty. This fixes the full stack so SMHI sites render end-to-end.

Two stacked causes, plus two quality fixes:

### 1. SMHI moments are signed `i16`
SMHI stores DBZH (and friends) as **signed 16-bit** integers (`gain=0.01`, sentinels `nodata=-32768`/`undetect=-32767` — only representable as signed). The ODIM reader only handled `u8`/`u16`/`f64`, so every moment hit `UnsupportedPixelType`. Added a `RawPixels::I16` variant.

### 2. Upstream `hdf5-reader` B-tree bug (32-bit superblocks)
Once the i16 path was reachable it exposed an upstream bug: `hdf5-reader` read version-1 B-tree raw-data **chunk-key dimension offsets** as `size_of_offsets` bytes, but the HDF5 spec fixes them at **8 bytes** regardless. SMHI files use a 32-bit superblock (`size_of_offsets = 4`), so it mislocated the chunk address and failed to DEFLATE-decompress every chunk (`h5dump`/libhdf5 read the same files fine). Fixed in our fork and pinned via `[patch.crates-io]`:
- Upstream PR: roteiro-gis/netcdf-rust#54
- Bumps the engine to `hdf5-reader` 0.6 (API-compatible for our `from_bytes` usage).

### 3. dtype dispatch instead of type-probing
hdf5-reader 0.6 matches a typed `read_array::<T>()` on **element byte-size only**, not signedness — so a signed `i16` array reads *successfully* but bit-reinterpreted as `u16` (e.g. `-32767` → `32769`). The old "probe u8 → u16 → … in order" approach would silently pick `u16` and return garbage. New `reader::read_raw_pixels_2d` branches on the dataset's **actual** `Datatype`; both the COMP and PVOL paths share it.

### 4. Default quantity = reflectivity
The 3D Tiles / raster default was `quantities.first()` (alphabetical). For a dual-pol volume whose moments sort `CCORH < DBZH` (SMHI) that defaulted to a clutter-correction quality field — defined across the *whole* volume, near-zero values washing out on the dBZ colormap. Now prefers `DBZH`, then `TH`. Every quantity stays selectable.

## Testing
- `cargo test -p engine-odim` — 166 tests pass (DMI u8 COMP, FMI u16 PVOL, new SMHI i16 PVOL regression test that skips gracefully when the uncommitted fixture is absent).
- Server smoke test against the real SMHI fixture: `tileset.json` / `content.pnts` / `content.glb` / voxel `tileset.json` all 200 with valid payloads.
- Live render in the 3D Tiles viewer: real dBZ values (min −32, max 57.7, mean 10.2), proper cone of silence, precipitation structure resolves cleanly.

## Notes
- Ships the SMHI collection config (`collections.d/radar-se-volume-local-h5.toml`).
- The ~21 MB Kiruna test fixture is **not committed** (113 MB for the full set; matches the FMI PVOL fixture convention — tests skip when absent).
- `[patch.crates-io]` is interim; drop it once a `hdf5-reader` release > 0.6.0 carries the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)