### PR TITLE
chore(deps): drop hdf5-reader fork pin for published 0.6.1 (#394)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1714,8 +1714,9 @@ dependencies = [
 
 [[package]]
 name = "hdf5-reader"
-version = "0.6.0"
-source = "git+https://github.com/mrauhala/netcdf-rust.git?rev=767add81eb12d0fd123f3550637fc001c2f40ff7#767add81eb12d0fd123f3550637fc001c2f40ff7"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2d49abfb73b2ab63c3ae7a51f8c3779967402eac9e07f2490ba16e1dac5a9e"
 dependencies = [
  "flate2",
  "lru",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,18 +68,3 @@ debug = false
 # `cargo update` can't silently follow a moved branch tip.
 [patch.crates-io]
 icechunk = { git = "https://github.com/earth-mover/icechunk.git", rev = "5f56b13605745ea06ec6558bcd8ed4a8f5805a3e" }
-
-# Interim patch until upstream releases the fix.
-#
-# hdf5-reader's version 1 B-tree raw-data chunk-key parser read each
-# per-dimension chunk offset as `size_of_offsets` bytes, but the HDF5 format
-# spec fixes those key dimension offsets at 8 bytes regardless of the
-# superblock's offset size. On 32-bit-superblock files (`size_of_offsets = 4`)
-# — e.g. SMHI ODIM_H5 radar polar volumes — this misaligned the cursor, located
-# a garbage chunk address, and made every chunked-dataset read fail to
-# decompress ("corrupt deflate stream"), even though libhdf5/h5dump read the
-# same files fine. Fixed in our fork (read the dim offsets as fixed u64); PR
-# filed upstream (roteiro-gis/netcdf-rust#54). Pinned to an immutable `rev` so a
-# `cargo update` can't follow a moved branch. Remove once a crates.io release
-# > 0.6.0 carries the fix — tracked in #394.
-hdf5-reader = { git = "https://github.com/mrauhala/netcdf-rust.git", rev = "767add81eb12d0fd123f3550637fc001c2f40ff7" }

--- a/crates/engine-odim/Cargo.toml
+++ b/crates/engine-odim/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 ds-core = { path = "../core" }
 ds-storage = { path = "../storage" }
-hdf5-reader = "0.6"
+hdf5-reader = "0.6.1"
 ndarray = "0.17"
 chrono = { version = "0.4", features = ["serde"] }
 arc-swap = "1"


### PR DESCRIPTION
## Summary

Removes the interim `[patch.crates-io]` override that pinned `engine-odim`'s `hdf5-reader` to a personal fork (`mrauhala/netcdf-rust`), now that the fix is in a published crates.io release.

The fork carried the **version-1 B-tree raw-data chunk-key fix** for 32-bit-superblock HDF5 files (SMHI ODIM_H5 radar polar volumes) — the dim offsets in a type-1 B-tree key are fixed at 8 bytes regardless of the superblock's `size_of_offsets`, and reading them as `size_of_offsets` corrupted the cursor on `size_of_offsets = 4` files (every chunked read failed with "corrupt deflate stream"). Originally landed via the fork in #392.

Upstream PR [roteiro-gis/netcdf-rust#54](https://github.com/roteiro-gis/netcdf-rust/pull/54) merged (2026-06-11 17:27Z) and shipped in **hdf5-reader 0.6.1** (2026-06-11 18:42Z). Verified the published 0.6.1 source carries the fix (the "each chunk-offset value is always 8 bytes" parser + comment).

## Changes

- Remove the `hdf5-reader` entry from `[patch.crates-io]` in the root `Cargo.toml` (the `icechunk` interim patch #340 stays).
- Bump `engine-odim`'s dependency `0.6` → `0.6.1` (first release with the fix).
- `Cargo.lock` now resolves `hdf5-reader` from crates.io, not the git fork.

## Verification

- `cargo test -p engine-odim` — all 30 pass, including `pvol_smhi_signed_i16_moment_decodes` (exercises the 32-bit-superblock B-tree chunk-key path against the SMHI fixture).
- `cargo check --workspace` clean.

Closes #394.

🤖 Generated with [Claude Code](https://claude.com/claude-code)