### PR TITLE
perf(engine-geotiff): park STAC metadata-load waiters on a condvar (#213)

### DIFF
--- a/crates/engine-geotiff/src/lib.rs
+++ b/crates/engine-geotiff/src/lib.rs
@@ -56,20 +56,30 @@ impl InFlightLoads {
     }
 
     /// Park until no other thread is loading `path`, then atomically either
-    /// observe the work done or claim the path. Returns `true` if `is_done`
-    /// reports the work complete (nothing left to do); `false` if the caller
-    /// is now the loader (path claimed — pair with `InFlightGuard`). If the
-    /// in-flight loader exceeds `CONCURRENT_LOAD_WAIT` the caller claims the
-    /// path anyway rather than failing the request.
+    /// observe the work done or claim the path. Returns `None` if `is_done`
+    /// reports the work complete (nothing left to do); `Some(guard)` if the
+    /// caller is now the loader — dropping the guard (on success, error, or
+    /// panic) releases the claim and wakes waiters, so the pairing is
+    /// compiler-enforced. If the in-flight loader exceeds
+    /// `CONCURRENT_LOAD_WAIT` the caller claims the path anyway rather than
+    /// failing the request.
     ///
     /// `is_done` is invoked while `self.paths` is held; it must not acquire
     /// that lock (directly or transitively) or the thread deadlocks itself.
-    fn wait_then_claim(&self, path: &Path, is_done: impl Fn() -> bool) -> bool {
+    fn wait_then_claim(
+        &self,
+        path: &Path,
+        is_done: impl Fn() -> bool,
+    ) -> Option<InFlightGuard<'_>> {
         let mut in_flight = self.paths.lock().unwrap_or_else(|e| e.into_inner());
         let deadline = std::time::Instant::now() + CONCURRENT_LOAD_WAIT;
         while in_flight.contains(path) {
             let now = std::time::Instant::now();
             if now >= deadline {
+                // Stuck loader: deliberately claim anyway (a duplicate fetch)
+                // rather than failing the request. The insert below is a
+                // no-op and whichever load finishes first clears the path —
+                // same liveness behavior as the old polling code.
                 break;
             }
             let (guard, _) = self
@@ -79,10 +89,11 @@ impl InFlightLoads {
             in_flight = guard;
         }
         if is_done() {
-            return true;
+            return None;
         }
         in_flight.insert(path.to_path_buf());
-        false
+        drop(in_flight);
+        Some(InFlightGuard::new(self, path.to_path_buf()))
     }
 }
 
@@ -761,11 +772,7 @@ impl GeoTiffEngine {
         timestamp: &DateTime<Utc>,
         asset_url: &str,
         file_size: u64,
-        path: &Path,
     ) -> Result<(), DataServerError> {
-        // RAII guard ensures path is removed from in-flight set even on panic
-        let _guard = InFlightGuard::new(&self.loading_in_flight, path.to_path_buf());
-
         let stub = catalog::StacStub {
             bbox: None, // Not needed for loading
             asset_url: asset_url.to_string(),
@@ -821,15 +828,17 @@ impl GeoTiffEngine {
         // Single-flight: park until any in-flight load of this path finishes,
         // then atomically either observe its result or claim the load. The
         // done-check happens under the in-flight lock, so two losers of the
-        // race can't both end up loading the same asset.
-        if self
+        // race can't both end up loading the same asset. The guard releases
+        // the claim and wakes waiters on drop — success, error, or panic.
+        let _guard = match self
             .loading_in_flight
             .wait_then_claim(&path, || self.is_metadata_loaded(timestamp))
         {
-            return Ok(());
-        }
+            None => return Ok(()),
+            Some(guard) => guard,
+        };
 
-        self.do_load_metadata(timestamp, &asset_url, file_size, &path)
+        self.do_load_metadata(timestamp, &asset_url, file_size)
     }
 
     /// Ensure entries exist and have metadata loaded for the requested datetime range.
@@ -2038,7 +2047,8 @@ mod tests {
         let done = Arc::new(std::sync::atomic::AtomicBool::new(false));
 
         // Loader claims the path.
-        assert!(!loads.wait_then_claim(&path, || false));
+        let loader_guard = loads.wait_then_claim(&path, || false);
+        assert!(loader_guard.is_some());
 
         let barrier = Arc::new(std::sync::Barrier::new(2));
         let waiter = {
@@ -2048,7 +2058,9 @@ mod tests {
             let barrier = Arc::clone(&barrier);
             std::thread::spawn(move || {
                 barrier.wait();
-                loads.wait_then_claim(&path, || done.load(Ordering::SeqCst))
+                loads
+                    .wait_then_claim(&path, || done.load(Ordering::SeqCst))
+                    .is_none()
             })
         };
 
@@ -2058,7 +2070,7 @@ mod tests {
         std::thread::sleep(Duration::from_millis(50));
         let start = std::time::Instant::now();
         done.store(true, Ordering::SeqCst);
-        drop(InFlightGuard::new(&loads, path.clone()));
+        drop(loader_guard);
 
         // Waiter observed the completed work — nothing left to do. If the
         // guard's notify were broken, a parked waiter would sleep out the
@@ -2076,7 +2088,8 @@ mod tests {
         let loads = Arc::new(InFlightLoads::new());
         let path = PathBuf::from("b.tif");
 
-        assert!(!loads.wait_then_claim(&path, || false));
+        let loader_guard = loads.wait_then_claim(&path, || false);
+        assert!(loader_guard.is_some());
 
         let barrier = Arc::new(std::sync::Barrier::new(2));
         let waiter = {
@@ -2085,32 +2098,42 @@ mod tests {
             let barrier = Arc::clone(&barrier);
             std::thread::spawn(move || {
                 barrier.wait();
-                loads.wait_then_claim(&path, || false)
+                let takeover = loads.wait_then_claim(&path, || false);
+                let claimed = takeover.is_some();
+                // While the takeover guard is alive, the claim is held.
+                if claimed {
+                    assert!(loads.paths.lock().unwrap().contains(&path));
+                }
+                claimed
             })
         };
 
         barrier.wait();
         std::thread::sleep(Duration::from_millis(50));
         let start = std::time::Instant::now();
-        drop(InFlightGuard::new(&loads, path.clone()));
+        drop(loader_guard);
 
-        assert!(!waiter.join().unwrap());
+        assert!(waiter.join().unwrap());
         assert!(start.elapsed() < CONCURRENT_LOAD_WAIT / 2);
-        // The waiter is now the loader and holds the claim.
+        // The waiter's guard dropped at thread end, releasing its claim.
         let in_flight = loads.paths.lock().unwrap();
-        assert!(in_flight.contains(&path));
+        assert!(!in_flight.contains(&path));
     }
 
     #[test]
     fn in_flight_unclaimed_path_claims_immediately() {
         let loads = InFlightLoads::new();
         let path = PathBuf::from("c.tif");
-        assert!(!loads.wait_then_claim(&path, || false));
+        let guard = loads.wait_then_claim(&path, || false);
+        assert!(guard.is_some());
         assert!(loads.paths.lock().unwrap().contains(&path));
-        // Already-done work short-circuits without claiming twice.
+        // Already-done work short-circuits without claiming.
         let other = PathBuf::from("d.tif");
-        assert!(loads.wait_then_claim(&other, || true));
+        assert!(loads.wait_then_claim(&other, || true).is_none());
         assert!(!loads.paths.lock().unwrap().contains(&other));
+        // Dropping the guard releases the claim.
+        drop(guard);
+        assert!(!loads.paths.lock().unwrap().contains(&path));
     }
 
     #[test]

--- a/crates/engine-geotiff/src/lib.rs
+++ b/crates/engine-geotiff/src/lib.rs
@@ -61,6 +61,9 @@ impl InFlightLoads {
     /// is now the loader (path claimed — pair with `InFlightGuard`). If the
     /// in-flight loader exceeds `CONCURRENT_LOAD_WAIT` the caller claims the
     /// path anyway rather than failing the request.
+    ///
+    /// `is_done` is invoked while `self.paths` is held; it must not acquire
+    /// that lock (directly or transitively) or the thread deadlocks itself.
     fn wait_then_claim(&self, path: &Path, is_done: impl Fn() -> bool) -> bool {
         let mut in_flight = self.paths.lock().unwrap_or_else(|e| e.into_inner());
         let deadline = std::time::Instant::now() + CONCURRENT_LOAD_WAIT;
@@ -2037,20 +2040,31 @@ mod tests {
         // Loader claims the path.
         assert!(!loads.wait_then_claim(&path, || false));
 
+        let barrier = Arc::new(std::sync::Barrier::new(2));
         let waiter = {
             let loads = Arc::clone(&loads);
             let path = path.clone();
             let done = Arc::clone(&done);
-            std::thread::spawn(move || loads.wait_then_claim(&path, || done.load(Ordering::SeqCst)))
+            let barrier = Arc::clone(&barrier);
+            std::thread::spawn(move || {
+                barrier.wait();
+                loads.wait_then_claim(&path, || done.load(Ordering::SeqCst))
+            })
         };
 
-        // Let the waiter park, then finish the load successfully.
+        // Sync to just before the waiter's call, give it a moment to park,
+        // then finish the load successfully.
+        barrier.wait();
         std::thread::sleep(Duration::from_millis(50));
+        let start = std::time::Instant::now();
         done.store(true, Ordering::SeqCst);
         drop(InFlightGuard::new(&loads, path.clone()));
 
-        // Waiter observed the completed work — nothing left to do.
+        // Waiter observed the completed work — nothing left to do. If the
+        // guard's notify were broken, a parked waiter would sleep out the
+        // full CONCURRENT_LOAD_WAIT, tripping the elapsed bound.
         assert!(waiter.join().unwrap());
+        assert!(start.elapsed() < CONCURRENT_LOAD_WAIT / 2);
         let in_flight = loads.paths.lock().unwrap();
         assert!(!in_flight.contains(&path));
     }
@@ -2064,16 +2078,24 @@ mod tests {
 
         assert!(!loads.wait_then_claim(&path, || false));
 
+        let barrier = Arc::new(std::sync::Barrier::new(2));
         let waiter = {
             let loads = Arc::clone(&loads);
             let path = path.clone();
-            std::thread::spawn(move || loads.wait_then_claim(&path, || false))
+            let barrier = Arc::clone(&barrier);
+            std::thread::spawn(move || {
+                barrier.wait();
+                loads.wait_then_claim(&path, || false)
+            })
         };
 
+        barrier.wait();
         std::thread::sleep(Duration::from_millis(50));
+        let start = std::time::Instant::now();
         drop(InFlightGuard::new(&loads, path.clone()));
 
         assert!(!waiter.join().unwrap());
+        assert!(start.elapsed() < CONCURRENT_LOAD_WAIT / 2);
         // The waiter is now the loader and holds the claim.
         let in_flight = loads.paths.lock().unwrap();
         assert!(in_flight.contains(&path));

--- a/crates/engine-geotiff/src/lib.rs
+++ b/crates/engine-geotiff/src/lib.rs
@@ -16,7 +16,7 @@ pub mod fuzz_exports {
 use std::collections::{BTreeMap, HashMap};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU32, Ordering};
-use std::sync::Mutex;
+use std::sync::{Condvar, Mutex};
 use std::time::Duration;
 
 use arc_swap::ArcSwap;
@@ -32,24 +32,78 @@ use ds_core::model::*;
 
 use crate::catalog::{scan_directory, scan_remote_with_limit, Catalog, PendingFile};
 
-/// RAII guard that removes a path from the `loading_in_flight` set on drop.
-/// Prevents paths from getting stuck if a thread panics during metadata loading.
+/// Tracks STAC entries currently being loaded, deduplicating concurrent
+/// loads: the first caller claims the path and loads, later callers park on
+/// the condvar until the loader finishes (success, error, or panic) instead
+/// of sleep-polling with a render permit held (#213).
+struct InFlightLoads {
+    paths: Mutex<std::collections::HashSet<PathBuf>>,
+    completed: Condvar,
+}
+
+/// Upper bound on how long a loser of the load race waits for the in-flight
+/// loader. Waiters wake immediately when the loader finishes, so this only
+/// bounds a stuck loader — it can be generous (a STAC asset fetch downloads
+/// the whole file, which can legitimately take seconds).
+const CONCURRENT_LOAD_WAIT: Duration = Duration::from_secs(10);
+
+impl InFlightLoads {
+    fn new() -> Self {
+        Self {
+            paths: Mutex::new(std::collections::HashSet::new()),
+            completed: Condvar::new(),
+        }
+    }
+
+    /// Park until no other thread is loading `path`, then atomically either
+    /// observe the work done or claim the path. Returns `true` if `is_done`
+    /// reports the work complete (nothing left to do); `false` if the caller
+    /// is now the loader (path claimed — pair with `InFlightGuard`). If the
+    /// in-flight loader exceeds `CONCURRENT_LOAD_WAIT` the caller claims the
+    /// path anyway rather than failing the request.
+    fn wait_then_claim(&self, path: &Path, is_done: impl Fn() -> bool) -> bool {
+        let mut in_flight = self.paths.lock().unwrap_or_else(|e| e.into_inner());
+        let deadline = std::time::Instant::now() + CONCURRENT_LOAD_WAIT;
+        while in_flight.contains(path) {
+            let now = std::time::Instant::now();
+            if now >= deadline {
+                break;
+            }
+            let (guard, _) = self
+                .completed
+                .wait_timeout(in_flight, deadline - now)
+                .unwrap_or_else(|e| e.into_inner());
+            in_flight = guard;
+        }
+        if is_done() {
+            return true;
+        }
+        in_flight.insert(path.to_path_buf());
+        false
+    }
+}
+
+/// RAII guard that removes a path from the `loading_in_flight` set on drop
+/// and wakes waiting threads. Prevents paths from getting stuck (and waiters
+/// from sleeping out their full timeout) if a thread panics during metadata
+/// loading.
 struct InFlightGuard<'a> {
-    set: &'a Mutex<std::collections::HashSet<PathBuf>>,
+    loads: &'a InFlightLoads,
     path: PathBuf,
 }
 
 impl<'a> InFlightGuard<'a> {
-    fn new(set: &'a Mutex<std::collections::HashSet<PathBuf>>, path: PathBuf) -> Self {
-        Self { set, path }
+    fn new(loads: &'a InFlightLoads, path: PathBuf) -> Self {
+        Self { loads, path }
     }
 }
 
 impl Drop for InFlightGuard<'_> {
     fn drop(&mut self) {
-        if let Ok(mut guard) = self.set.lock() {
-            guard.remove(&self.path);
-        }
+        let mut guard = self.loads.paths.lock().unwrap_or_else(|e| e.into_inner());
+        guard.remove(&self.path);
+        drop(guard);
+        self.loads.completed.notify_all();
     }
 }
 
@@ -106,7 +160,7 @@ pub struct GeoTiffEngine {
     /// Consecutive poll failures/empty results (for escalating warnings).
     consecutive_poll_failures: AtomicU32,
     /// Tracks STAC entries currently being loaded to prevent concurrent loads.
-    loading_in_flight: Mutex<std::collections::HashSet<PathBuf>>,
+    loading_in_flight: InFlightLoads,
     /// Circuit breaker: consecutive STAC API failures.
     stac_consecutive_failures: AtomicU32,
     /// Circuit breaker: last STAC API attempt time.
@@ -421,7 +475,7 @@ impl GeoTiffEngine {
             override_offset: config.offset,
             shutdown_tx,
             consecutive_poll_failures: AtomicU32::new(0),
-            loading_in_flight: Mutex::new(std::collections::HashSet::new()),
+            loading_in_flight: InFlightLoads::new(),
             stac_consecutive_failures: AtomicU32::new(0),
             stac_last_attempt: Mutex::new(None),
             catalog_updated_at: Mutex::new(Some(Utc::now())),
@@ -698,30 +752,6 @@ impl GeoTiffEngine {
         }
     }
 
-    /// Wait for another thread to finish loading metadata for the given path.
-    /// Returns `true` if another thread successfully loaded it.
-    fn wait_for_concurrent_load(&self, timestamp: &DateTime<Utc>, path: &Path) -> bool {
-        for attempt in 0u64..20 {
-            std::thread::sleep(Duration::from_millis(100 * (attempt + 1).min(5)));
-            let catalog = self.catalog.load();
-            if let Some(entry) = catalog.entries.get(timestamp) {
-                if entry.is_loaded() {
-                    return true;
-                }
-            }
-            // Check if still in-flight (other thread may have errored out)
-            let in_flight = self
-                .loading_in_flight
-                .lock()
-                .unwrap_or_else(|e| e.into_inner());
-            if !in_flight.contains(path) {
-                // Other thread finished (possibly with error), try loading ourselves
-                return false;
-            }
-        }
-        false
-    }
-
     /// Load metadata for a stub entry and update the catalog.
     fn do_load_metadata(
         &self,
@@ -785,26 +815,15 @@ impl GeoTiffEngine {
             (entry.path.clone(), stub.asset_url.clone(), entry.file_size)
         };
 
-        // Check/acquire in-flight lock
+        // Single-flight: park until any in-flight load of this path finishes,
+        // then atomically either observe its result or claim the load. The
+        // done-check happens under the in-flight lock, so two losers of the
+        // race can't both end up loading the same asset.
+        if self
+            .loading_in_flight
+            .wait_then_claim(&path, || self.is_metadata_loaded(timestamp))
         {
-            let in_flight = self
-                .loading_in_flight
-                .lock()
-                .unwrap_or_else(|e| e.into_inner());
-            if in_flight.contains(&path) {
-                drop(in_flight);
-                if self.wait_for_concurrent_load(timestamp, &path) {
-                    return Ok(());
-                }
-                // Fall through to try loading ourselves
-            }
-        }
-        {
-            let mut in_flight = self
-                .loading_in_flight
-                .lock()
-                .unwrap_or_else(|e| e.into_inner());
-            in_flight.insert(path.clone());
+            return Ok(());
         }
 
         self.do_load_metadata(timestamp, &asset_url, file_size, &path)
@@ -2006,6 +2025,71 @@ use parse::parse_coords;
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn in_flight_claim_then_done_wakes_waiter() {
+        // Loser of the load race parks on the condvar and wakes as soon as
+        // the loader's guard drops — no sleep-polling (#213).
+        let loads = Arc::new(InFlightLoads::new());
+        let path = PathBuf::from("a.tif");
+        let done = Arc::new(std::sync::atomic::AtomicBool::new(false));
+
+        // Loader claims the path.
+        assert!(!loads.wait_then_claim(&path, || false));
+
+        let waiter = {
+            let loads = Arc::clone(&loads);
+            let path = path.clone();
+            let done = Arc::clone(&done);
+            std::thread::spawn(move || loads.wait_then_claim(&path, || done.load(Ordering::SeqCst)))
+        };
+
+        // Let the waiter park, then finish the load successfully.
+        std::thread::sleep(Duration::from_millis(50));
+        done.store(true, Ordering::SeqCst);
+        drop(InFlightGuard::new(&loads, path.clone()));
+
+        // Waiter observed the completed work — nothing left to do.
+        assert!(waiter.join().unwrap());
+        let in_flight = loads.paths.lock().unwrap();
+        assert!(!in_flight.contains(&path));
+    }
+
+    #[test]
+    fn in_flight_loader_failure_hands_claim_to_waiter() {
+        // If the loader errors out (guard drops without the work done), the
+        // waiter takes over the claim instead of returning success.
+        let loads = Arc::new(InFlightLoads::new());
+        let path = PathBuf::from("b.tif");
+
+        assert!(!loads.wait_then_claim(&path, || false));
+
+        let waiter = {
+            let loads = Arc::clone(&loads);
+            let path = path.clone();
+            std::thread::spawn(move || loads.wait_then_claim(&path, || false))
+        };
+
+        std::thread::sleep(Duration::from_millis(50));
+        drop(InFlightGuard::new(&loads, path.clone()));
+
+        assert!(!waiter.join().unwrap());
+        // The waiter is now the loader and holds the claim.
+        let in_flight = loads.paths.lock().unwrap();
+        assert!(in_flight.contains(&path));
+    }
+
+    #[test]
+    fn in_flight_unclaimed_path_claims_immediately() {
+        let loads = InFlightLoads::new();
+        let path = PathBuf::from("c.tif");
+        assert!(!loads.wait_then_claim(&path, || false));
+        assert!(loads.paths.lock().unwrap().contains(&path));
+        // Already-done work short-circuits without claiming twice.
+        let other = PathBuf::from("d.tif");
+        assert!(loads.wait_then_claim(&other, || true));
+        assert!(!loads.paths.lock().unwrap().contains(&other));
+    }
 
     #[test]
     fn expand_prefix_static() {

--- a/crates/engine-geotiff/src/lib.rs
+++ b/crates/engine-geotiff/src/lib.rs
@@ -76,10 +76,13 @@ impl InFlightLoads {
         while in_flight.contains(path) {
             let now = std::time::Instant::now();
             if now >= deadline {
-                // Stuck loader: deliberately claim anyway (a duplicate fetch)
-                // rather than failing the request. The insert below is a
-                // no-op and whichever load finishes first clears the path —
-                // same liveness behavior as the old polling code.
+                // Stuck loader: deliberately claim anyway rather than fail
+                // the request. The insert below is a no-op and whichever
+                // load finishes first clears the path — same liveness
+                // behavior as the old polling code. Note dedup is best-effort
+                // past this point: the early clear lets later callers claim
+                // too, so a stuck loader can fan out to several parallel
+                // fetches of the same asset, not just one duplicate.
                 break;
             }
             let (guard, _) = self


### PR DESCRIPTION
## Summary

Fixes #213 — `wait_for_concurrent_load()` busy-polled with a blocking sleep (up to ~9 s in 100–500 ms steps) while occupying a `spawn_blocking` pool thread and a render-semaphore permit. STAC-backed GeoTIFF collections only; local `data_path` collections never reach this path.

## Changes

- **`InFlightLoads` (Mutex + Condvar) replaces the bare in-flight `HashSet`.** Losers of the load race now park on the condvar and wake immediately when the loader finishes — the wait lasts exactly as long as the actual load instead of sleep-poll quantums.
- **`InFlightGuard` notifies on drop**, so success, error, and panic all wake waiters (previously an errored loader left waiters sleeping out their backoff steps).
- **Fixes a TOCTOU race the issue didn't cover:** the "is another thread loading?" check and the "claim the load" insert were in separate lock scopes, so two losers could both fall through and download the same STAC asset twice. `wait_then_claim` does the done-check + claim atomically under one lock.
- **Worst-case bound:** the 10 s cap remains only as a stuck-loader fallback (a STAC asset fetch downloads the whole file, so the bound stays generous); on timeout the waiter takes over the load rather than failing the request, matching the old liveness behavior.

Not done from the issue's alternatives: moving render-permit acquisition after metadata load — that's an API-layer restructure, and with waiters now parked for exactly the load duration the permit hold matches what the loading request itself holds.

## Testing

- 3 new unit tests: waiter wakes on loader success, waiter takes over the claim on loader failure, unclaimed path claims immediately / done work short-circuits.
- `cargo test --workspace` green; `cargo clippy -p engine-geotiff --tests` and `cargo fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)