### PR TITLE
feat(ds-core,engine-odim): storm-cell extraction + tracking core (#367, 1/4)

### DIFF
--- a/crates/core/src/cells.rs
+++ b/crates/core/src/cells.rs
@@ -252,7 +252,11 @@ pub fn extract_cells(
         origin,
         cells: Vec::new(),
     };
-    if total == 0 || grid.values.len() != total || opts.max_cells == 0 {
+    // `u32::MAX` guards the packed BFS frontier indices; any real grid is
+    // orders of magnitude below it (engines cap cell counts in the tens of
+    // millions).
+    if total == 0 || grid.values.len() != total || opts.max_cells == 0 || total > u32::MAX as usize
+    {
         return set;
     }
 
@@ -269,13 +273,24 @@ pub fn extract_cells(
     let a_centre = |i_a: usize| grid.angle_range[0] + (i_a as f64 + 0.5) * da;
     let h_centre = |i_h: usize| grid.height_range[0] + (i_h as f64 + 0.5) * dh;
 
-    let threshold = opts.threshold as f32;
-    let member = |idx: usize| grid.values[idx] >= threshold; // NaN compares false
+    // Compare in f64: an f32-narrowed threshold (e.g. 35.1 → 35.09999847…)
+    // would silently lower the effective cutoff. NaN compares false.
+    let member = |idx: usize| (grid.values[idx] as f64) >= opts.threshold;
 
     // --- Pass 1: BFS connected components, scalar accumulation -------------
     let mut labels = vec![0u32; total];
     let mut comps: Vec<Comp> = Vec::new();
-    let mut queue: VecDeque<(usize, usize, usize)> = VecDeque::new();
+    // The frontier holds packed flat indices (u32, valid up to MAX_VOXELS),
+    // not (usize, usize, usize) triples — 4 B/slot instead of 24 keeps the
+    // worst case (a storm spanning a large fraction of a `high`-tier grid)
+    // at tens of MB transient instead of hundreds.
+    let mut queue: VecDeque<u32> = VecDeque::new();
+    let unpack_idx = |idx: u32| {
+        let idx = idx as usize;
+        let i_h = idx % n_h;
+        let rest = idx / n_h;
+        (rest / n_a, rest % n_a, i_h)
+    };
 
     for seed_r in 0..n_r {
         for seed_a in 0..n_a {
@@ -298,9 +313,10 @@ pub fn extract_cells(
                     max_ih: seed_h,
                 };
                 labels[seed_idx] = raw_label;
-                queue.push_back((seed_r, seed_a, seed_h));
-                while let Some((i_r, i_a, i_h)) = queue.pop_front() {
-                    let idx = VoxelGrid::index_of(grid.dims, i_r, i_a, i_h);
+                queue.push_back(seed_idx as u32);
+                while let Some(packed) = queue.pop_front() {
+                    let (i_r, i_a, i_h) = unpack_idx(packed);
+                    let idx = packed as usize;
                     let v = grid.values[idx] as f64;
                     let rc = r_centre(i_r);
                     comp.count += 1;
@@ -323,7 +339,7 @@ pub fn extract_cells(
                         let nidx = VoxelGrid::index_of(grid.dims, r, a, h);
                         if labels[nidx] == 0 && member(nidx) {
                             labels[nidx] = raw_label;
-                            queue.push_back((r, a, h));
+                            queue.push_back(nidx as u32);
                         }
                     };
                     if i_r > 0 {

--- a/crates/core/src/cells.rs
+++ b/crates/core/src/cells.rs
@@ -1,0 +1,1313 @@
+//! Storm-cell segmentation + tracking on cylindrical voxel grids (#367).
+//!
+//! [`extract_cells`] segments the connected echo regions of a [`VoxelGrid`]
+//! at or above a reflectivity threshold into discrete [`StormCell`]s, each
+//! carrying physical attributes (max dBZ, echo top/base, volume, area, VIL,
+//! centroid) and a geographic footprint ring. [`track_cells`] then matches
+//! cell centroids across consecutive volume scans into [`Track`]s with a
+//! per-step motion vector — the seed for a future motion/optical-flow field
+//! product (the per-cell `(u, v)` is exactly what a flow-field raster would
+//! interpolate).
+//!
+//! Everything here is pure geometry + physics on the domain type — no
+//! framework dependencies, no I/O — so any [`crate::volume::VolumeEngine`]
+//! with voxel-grid capability gets cells for free (see
+//! [`crate::volume::VolumeEngine::read_cells`]), and every API surface
+//! (3D Tiles, Features, WMS/Maps/Tiles) renders one shared product.
+//!
+//! Values are assumed to be radar reflectivity in dBZ: the linear-Z centroid
+//! weighting and the VIL integral are reflectivity physics. Callers gate the
+//! quantity (the ODIM engine only computes cells for dBZ-unit quantities).
+
+use crate::geo::{destination_point, EARTH_RADIUS_M};
+use crate::volume::VoxelGrid;
+use chrono::{DateTime, Utc};
+use std::collections::VecDeque;
+use std::sync::Arc;
+
+/// Liquid-water cap (dBZ) for the VIL integral: reflectivity above this is
+/// treated as hail contamination and clamped, per the standard NSSL practice.
+const VIL_DBZ_CAP: f64 = 56.0;
+/// VIL mass coefficient: `M = 3.44e-6 · Z^(4/7)` (g m⁻³, Z in mm⁶ m⁻³) —
+/// integrated over height it yields kg m⁻² directly.
+const VIL_COEFF: f64 = 3.44e-6;
+
+/// Knobs for [`extract_cells`]. `Default` is the canonical configuration
+/// (35 dBZ — the classic TITAN cell threshold — with a 5 km³ speckle floor).
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct CellExtractionOptions {
+    /// Segmentation threshold in the grid's physical unit (dBZ): a voxel is a
+    /// cell member iff `value >= threshold` (the isosurface convention).
+    pub threshold: f64,
+    /// Drop components smaller than this volume (km³) — beam-width speckle
+    /// and bird/clutter residue segment into many tiny components.
+    pub min_volume_km3: f64,
+    /// Hard cap on returned cells (the largest by volume are kept) — bounds
+    /// downstream encoding work on pathological scans.
+    pub max_cells: usize,
+}
+
+impl Default for CellExtractionOptions {
+    fn default() -> Self {
+        Self {
+            threshold: 35.0,
+            min_volume_km3: 5.0,
+            max_cells: 256,
+        }
+    }
+}
+
+/// One segmented storm cell. Geographic positions are WGS84 lon/lat degrees;
+/// heights are metres above mean sea level (the grid origin's height datum);
+/// the ENU bounding box is metres relative to the grid origin (the radar
+/// antenna), so the 3D Tiles encoder can place it antenna-relative without
+/// re-deriving the origin.
+#[derive(Debug, Clone, PartialEq)]
+pub struct StormCell {
+    /// Per-scan component label, 1-based, ordered by volume descending —
+    /// deterministic for a given grid + options, so it is usable in cache
+    /// keys and stable feature ids.
+    pub label: u32,
+    /// Maximum value (dBZ) in the cell.
+    pub max_dbz: f64,
+    /// Location of the maximum: `[lon_deg, lat_deg, height_m_msl]`.
+    pub max_dbz_pos: [f64; 3],
+    /// Linear-Z-weighted centroid: `[lon_deg, lat_deg, height_m_msl]`.
+    pub centroid: [f64; 3],
+    /// Top of the highest member voxel (m MSL).
+    pub echo_top_m: f64,
+    /// Bottom of the lowest member voxel (m MSL).
+    pub base_m: f64,
+    /// Cell volume (km³) — sum of member-voxel volumes (radius-dependent:
+    /// a cylindrical-grid voxel grows with ground range).
+    pub volume_km3: f64,
+    /// Footprint area (km²) — the union of the cell's `(radius, azimuth)`
+    /// columns projected to the ground.
+    pub area_km2: f64,
+    /// Maximum vertically-integrated liquid (kg m⁻²) over the footprint
+    /// columns, computed on the resampled grid (an approximation — beam
+    /// broadening and the 56 dBZ hail cap apply).
+    pub max_vil_kg_m2: f64,
+    /// Closed footprint ring (`first == last`), WGS84 `[lon_deg, lat_deg]`,
+    /// counter-clockwise (RFC 7946 exterior orientation), lightly simplified.
+    pub footprint: Vec<[f64; 2]>,
+    /// Axis-aligned local-ENU bounding box around the cell, metres relative
+    /// to the grid origin: `[min_e, min_n, min_u, max_e, max_n, max_u]`
+    /// (`u` is height above the origin, not MSL).
+    pub bbox_enu_m: [f64; 6],
+}
+
+/// All cells segmented from one volume scan.
+#[derive(Debug, Clone, PartialEq)]
+pub struct CellSet {
+    /// Valid time of the scanned volume.
+    pub time: DateTime<Utc>,
+    /// Quantity the grid was sampled from (e.g. `"DBZH"`).
+    pub quantity: String,
+    /// Threshold the segmentation used (dBZ).
+    pub threshold: f64,
+    /// Grid origin (radar antenna): `[lon_deg, lat_deg, height_m_msl]`.
+    pub origin: [f64; 3],
+    /// Cells, ordered by volume descending (label order).
+    pub cells: Vec<StormCell>,
+}
+
+impl CellSet {
+    /// A scan with no cells (no echo at/above the threshold) — still a valid
+    /// tracking input (every track alive at the previous scan dies here).
+    pub fn empty(
+        time: DateTime<Utc>,
+        quantity: impl Into<String>,
+        threshold: f64,
+        origin: [f64; 3],
+    ) -> Self {
+        Self {
+            time,
+            quantity: quantity.into(),
+            threshold,
+            origin,
+            cells: Vec::new(),
+        }
+    }
+}
+
+/// One observation of a tracked cell.
+#[derive(Debug, Clone, PartialEq)]
+pub struct TrackPoint {
+    /// Scan valid time.
+    pub time: DateTime<Utc>,
+    /// Cell centroid at this scan (WGS84 degrees / m MSL).
+    pub lon: f64,
+    pub lat: f64,
+    pub height_m: f64,
+    /// The cell's label in that scan's [`CellSet`] (joins a track point back
+    /// to its full [`StormCell`]).
+    pub label: u32,
+    /// The cell's maximum value at this scan (dBZ).
+    pub max_dbz: f64,
+}
+
+/// A cell-centroid trajectory across consecutive scans.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Track {
+    /// `"{first scan time:%Y%m%dT%H%M%SZ}-{first label}"` — deterministic for
+    /// a given scan window. Known limitation (stateless recompute): when the
+    /// retention window slides past the track's first scan, the id changes.
+    pub id: String,
+    /// Observations, ascending in time. Always non-empty.
+    pub points: Vec<TrackPoint>,
+    /// Motion from the most recent matched step: `(u east, v north)` m s⁻¹.
+    /// `None` for a track observed only once.
+    pub motion_ms: Option<(f64, f64)>,
+}
+
+impl Track {
+    /// `(speed m s⁻¹, bearing°)` of the latest motion — bearing is the
+    /// compass direction the cell is moving **toward** (0° = north,
+    /// clockwise). `None` for a single-observation track.
+    pub fn speed_direction(&self) -> Option<(f64, f64)> {
+        let (u, v) = self.motion_ms?;
+        let speed = u.hypot(v);
+        let dir = u.atan2(v).to_degrees().rem_euclid(360.0);
+        Some((speed, dir))
+    }
+}
+
+/// All tracks over a scan window, ordered by (first time, first label).
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct TrackSet {
+    pub tracks: Vec<Track>,
+}
+
+impl TrackSet {
+    /// The track containing the cell `label` observed at `time` (exact scan
+    /// time), if any. Linear scan — cell counts are tiny.
+    pub fn track_for(&self, time: DateTime<Utc>, label: u32) -> Option<&Track> {
+        self.tracks
+            .iter()
+            .find(|t| t.points.iter().any(|p| p.time == time && p.label == label))
+    }
+}
+
+/// Knobs for [`track_cells`]. The gate is `max_speed_ms · Δt + base_gate_m`:
+/// the speed term scales with scan cadence, the base term absorbs centroid
+/// jitter between scans.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct TrackingOptions {
+    /// Fastest plausible cell motion (m s⁻¹). 40 m s⁻¹ ≈ 144 km h⁻¹ covers
+    /// fast-moving squall lines.
+    pub max_speed_ms: f64,
+    /// Constant gate slack (m) for centroid jitter.
+    pub base_gate_m: f64,
+}
+
+impl Default for TrackingOptions {
+    fn default() -> Self {
+        Self {
+            max_speed_ms: 40.0,
+            base_gate_m: 5_000.0,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Extraction
+// ---------------------------------------------------------------------------
+
+/// Per-component accumulator for the labeling pass.
+struct Comp {
+    count: usize,
+    volume_m3: f64,
+    /// Linear-Z weighted ENU sums (metres relative to the grid origin).
+    sum_w: f64,
+    sum_we: f64,
+    sum_wn: f64,
+    sum_wu: f64,
+    max_dbz: f64,
+    max_idx: (usize, usize, usize),
+    min_ih: usize,
+    max_ih: usize,
+}
+
+/// Segment the connected echo regions of `grid` with `value >= threshold`
+/// into [`StormCell`]s. Connectivity is 6-neighbour (±radius, ±azimuth,
+/// ±height) with the azimuth axis wrapping when the grid spans the full
+/// circle. `NaN` (unmeasured) and sub-threshold cells are background.
+///
+/// `time` is the scan's valid time, carried into the [`CellSet`] (a grid does
+/// not know its own time).
+pub fn extract_cells(
+    grid: &VoxelGrid,
+    time: DateTime<Utc>,
+    opts: &CellExtractionOptions,
+) -> CellSet {
+    let [n_r, n_a, n_h] = grid.dims;
+    let total = n_r * n_a * n_h;
+    let origin = [grid.origin_lon, grid.origin_lat, grid.origin_height];
+    let mut set = CellSet {
+        time,
+        quantity: grid.quantity.clone(),
+        threshold: opts.threshold,
+        origin,
+        cells: Vec::new(),
+    };
+    if total == 0 || grid.values.len() != total || opts.max_cells == 0 {
+        return set;
+    }
+
+    let dr = (grid.radius_range[1] - grid.radius_range[0]) / n_r as f64;
+    let da = (grid.angle_range[1] - grid.angle_range[0]) / n_a as f64;
+    let dh = (grid.height_range[1] - grid.height_range[0]) / n_h as f64;
+    if !(dr.is_finite() && dr > 0.0 && da.is_finite() && da > 0.0 && dh.is_finite() && dh > 0.0) {
+        return set;
+    }
+    // Azimuth wraps only on a full-circle grid (guard for future sector scans).
+    let wrap = (grid.angle_range[1] - grid.angle_range[0] - std::f64::consts::TAU).abs() < 1e-9;
+
+    let r_centre = |i_r: usize| grid.radius_range[0] + (i_r as f64 + 0.5) * dr;
+    let a_centre = |i_a: usize| grid.angle_range[0] + (i_a as f64 + 0.5) * da;
+    let h_centre = |i_h: usize| grid.height_range[0] + (i_h as f64 + 0.5) * dh;
+
+    let threshold = opts.threshold as f32;
+    let member = |idx: usize| grid.values[idx] >= threshold; // NaN compares false
+
+    // --- Pass 1: BFS connected components, scalar accumulation -------------
+    let mut labels = vec![0u32; total];
+    let mut comps: Vec<Comp> = Vec::new();
+    let mut queue: VecDeque<(usize, usize, usize)> = VecDeque::new();
+
+    for seed_r in 0..n_r {
+        for seed_a in 0..n_a {
+            for seed_h in 0..n_h {
+                let seed_idx = VoxelGrid::index_of(grid.dims, seed_r, seed_a, seed_h);
+                if labels[seed_idx] != 0 || !member(seed_idx) {
+                    continue;
+                }
+                let raw_label = comps.len() as u32 + 1;
+                let mut comp = Comp {
+                    count: 0,
+                    volume_m3: 0.0,
+                    sum_w: 0.0,
+                    sum_we: 0.0,
+                    sum_wn: 0.0,
+                    sum_wu: 0.0,
+                    max_dbz: f64::NEG_INFINITY,
+                    max_idx: (seed_r, seed_a, seed_h),
+                    min_ih: seed_h,
+                    max_ih: seed_h,
+                };
+                labels[seed_idx] = raw_label;
+                queue.push_back((seed_r, seed_a, seed_h));
+                while let Some((i_r, i_a, i_h)) = queue.pop_front() {
+                    let idx = VoxelGrid::index_of(grid.dims, i_r, i_a, i_h);
+                    let v = grid.values[idx] as f64;
+                    let rc = r_centre(i_r);
+                    comp.count += 1;
+                    comp.volume_m3 += dr * (rc * da) * dh;
+                    let w = 10f64.powf(v / 10.0); // linear Z
+                    let az = a_centre(i_a);
+                    comp.sum_w += w;
+                    comp.sum_we += w * rc * az.sin();
+                    comp.sum_wn += w * rc * az.cos();
+                    comp.sum_wu += w * h_centre(i_h);
+                    if v > comp.max_dbz {
+                        comp.max_dbz = v;
+                        comp.max_idx = (i_r, i_a, i_h);
+                    }
+                    comp.min_ih = comp.min_ih.min(i_h);
+                    comp.max_ih = comp.max_ih.max(i_h);
+
+                    // 6-connectivity: ±r, ±a (wrapping), ±h.
+                    let mut visit = |r: usize, a: usize, h: usize| {
+                        let nidx = VoxelGrid::index_of(grid.dims, r, a, h);
+                        if labels[nidx] == 0 && member(nidx) {
+                            labels[nidx] = raw_label;
+                            queue.push_back((r, a, h));
+                        }
+                    };
+                    if i_r > 0 {
+                        visit(i_r - 1, i_a, i_h);
+                    }
+                    if i_r + 1 < n_r {
+                        visit(i_r + 1, i_a, i_h);
+                    }
+                    if i_h > 0 {
+                        visit(i_r, i_a, i_h - 1);
+                    }
+                    if i_h + 1 < n_h {
+                        visit(i_r, i_a, i_h + 1);
+                    }
+                    if i_a > 0 {
+                        visit(i_r, i_a - 1, i_h);
+                    } else if wrap && n_a > 1 {
+                        visit(i_r, n_a - 1, i_h);
+                    }
+                    if i_a + 1 < n_a {
+                        visit(i_r, i_a + 1, i_h);
+                    } else if wrap && n_a > 1 {
+                        visit(i_r, 0, i_h);
+                    }
+                }
+                comps.push(comp);
+            }
+        }
+    }
+    if comps.is_empty() {
+        return set;
+    }
+
+    // --- Filter + rank: volume floor, largest first, hard cap --------------
+    let min_volume_m3 = opts.min_volume_km3 * 1e9;
+    let mut ranked: Vec<usize> = (0..comps.len())
+        .filter(|&i| comps[i].volume_m3 >= min_volume_m3)
+        .collect();
+    ranked.sort_by(|&a, &b| {
+        comps[b]
+            .volume_m3
+            .partial_cmp(&comps[a].volume_m3)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then(a.cmp(&b)) // deterministic tie-break: discovery order
+    });
+    ranked.truncate(opts.max_cells);
+    if ranked.is_empty() {
+        return set;
+    }
+    // raw label (1-based) → final rank (0-based)
+    let mut rank_of = vec![usize::MAX; comps.len() + 1];
+    for (rank, &ci) in ranked.iter().enumerate() {
+        rank_of[ci + 1] = rank;
+    }
+
+    // --- Pass 2: per-kept-cell footprint mask, column VIL, ENU bbox --------
+    // Azimuth-boundary sin/cos tables (n_a + 1 boundaries) for the bbox
+    // corner math, instead of 4 trig calls per member voxel.
+    let a_boundary: Vec<(f64, f64)> = (0..=n_a)
+        .map(|i| (grid.angle_range[0] + i as f64 * da).sin_cos())
+        .collect();
+
+    struct Detail {
+        mask: Vec<bool>, // (r, a) footprint columns, n_r × n_a
+        max_vil: f64,
+        bbox: [f64; 6],
+    }
+    let mut details: Vec<Detail> = ranked
+        .iter()
+        .map(|_| Detail {
+            mask: vec![false; n_r * n_a],
+            max_vil: 0.0,
+            bbox: [
+                f64::INFINITY,
+                f64::INFINITY,
+                f64::INFINITY,
+                f64::NEG_INFINITY,
+                f64::NEG_INFINITY,
+                f64::NEG_INFINITY,
+            ],
+        })
+        .collect();
+
+    // Per-column scratch: (rank, accumulated VIL) — a column rarely holds
+    // more than one or two distinct cells.
+    let mut col_vil: Vec<(usize, f64)> = Vec::with_capacity(4);
+    for i_r in 0..n_r {
+        let r_lo = grid.radius_range[0] + i_r as f64 * dr;
+        let r_hi = r_lo + dr;
+        for i_a in 0..n_a {
+            col_vil.clear();
+            for i_h in 0..n_h {
+                let idx = VoxelGrid::index_of(grid.dims, i_r, i_a, i_h);
+                let raw = labels[idx] as usize;
+                if raw == 0 {
+                    continue;
+                }
+                let rank = rank_of[raw];
+                if rank == usize::MAX {
+                    continue;
+                }
+                let d = &mut details[rank];
+                d.mask[i_r * n_a + i_a] = true;
+
+                // VIL layer contribution: M(Z)·Δh with the hail cap.
+                let dbz = (grid.values[idx] as f64).min(VIL_DBZ_CAP);
+                let z_lin = 10f64.powf(dbz / 10.0);
+                let m = VIL_COEFF * z_lin.powf(4.0 / 7.0) * dh;
+                match col_vil.iter_mut().find(|(r, _)| *r == rank) {
+                    Some((_, vil)) => *vil += m,
+                    None => col_vil.push((rank, m)),
+                }
+
+                // ENU bbox over the voxel's 4 (r, az) corners + height span.
+                let (s_lo, c_lo) = a_boundary[i_a];
+                let (s_hi, c_hi) = a_boundary[i_a + 1];
+                for (r, (s, c)) in [
+                    (r_lo, (s_lo, c_lo)),
+                    (r_lo, (s_hi, c_hi)),
+                    (r_hi, (s_lo, c_lo)),
+                    (r_hi, (s_hi, c_hi)),
+                ] {
+                    let e = r * s;
+                    let n = r * c;
+                    d.bbox[0] = d.bbox[0].min(e);
+                    d.bbox[1] = d.bbox[1].min(n);
+                    d.bbox[3] = d.bbox[3].max(e);
+                    d.bbox[4] = d.bbox[4].max(n);
+                }
+                let h_lo = grid.height_range[0] + i_h as f64 * dh;
+                d.bbox[2] = d.bbox[2].min(h_lo);
+                d.bbox[5] = d.bbox[5].max(h_lo + dh);
+            }
+            for &(rank, vil) in &col_vil {
+                if vil > details[rank].max_vil {
+                    details[rank].max_vil = vil;
+                }
+            }
+        }
+    }
+
+    // --- Assemble StormCells ------------------------------------------------
+    let to_lonlat = |ground_m: f64, bearing_rad: f64| -> (f64, f64) {
+        destination_point(
+            grid.origin_lon,
+            grid.origin_lat,
+            ground_m,
+            bearing_rad.to_degrees(),
+        )
+    };
+    let enu_to_lonlat = |e: f64, n: f64| -> (f64, f64) {
+        let ground = e.hypot(n);
+        if ground <= f64::EPSILON {
+            (grid.origin_lon, grid.origin_lat)
+        } else {
+            to_lonlat(ground, e.atan2(n))
+        }
+    };
+    // Simplification tolerance: half a radial cell — keeps the ring faithful
+    // at the grid's own resolution without GeoJSON bloat.
+    let simplify_tol_m = 0.5 * dr;
+
+    for (rank, &ci) in ranked.iter().enumerate() {
+        let comp = &comps[ci];
+        let d = &details[rank];
+
+        let (ce, cn, cu) = if comp.sum_w > 0.0 {
+            (
+                comp.sum_we / comp.sum_w,
+                comp.sum_wn / comp.sum_w,
+                comp.sum_wu / comp.sum_w,
+            )
+        } else {
+            (0.0, 0.0, 0.0)
+        };
+        let (clon, clat) = enu_to_lonlat(ce, cn);
+
+        let (mr, ma, mh) = comp.max_idx;
+        let (mlon, mlat) = to_lonlat(r_centre(mr), a_centre(ma));
+
+        // Footprint area: Σ over set columns of Δr · (r_c · Δa).
+        let mut area_m2 = 0.0;
+        for i_r in 0..n_r {
+            let cell_area = dr * (r_centre(i_r) * da);
+            for i_a in 0..n_a {
+                if d.mask[i_r * n_a + i_a] {
+                    area_m2 += cell_area;
+                }
+            }
+        }
+
+        let footprint = footprint_ring(
+            &d.mask,
+            n_r,
+            n_a,
+            wrap,
+            grid.radius_range[0],
+            dr,
+            grid.angle_range[0],
+            da,
+            simplify_tol_m,
+            &to_lonlat,
+        );
+
+        set.cells.push(StormCell {
+            label: rank as u32 + 1,
+            max_dbz: comp.max_dbz,
+            max_dbz_pos: [mlon, mlat, origin[2] + h_centre(mh)],
+            centroid: [clon, clat, origin[2] + cu],
+            echo_top_m: origin[2] + grid.height_range[0] + (comp.max_ih as f64 + 1.0) * dh,
+            base_m: origin[2] + grid.height_range[0] + comp.min_ih as f64 * dh,
+            volume_km3: comp.volume_m3 / 1e9,
+            area_km2: area_m2 / 1e6,
+            max_vil_kg_m2: d.max_vil,
+            footprint,
+            bbox_enu_m: d.bbox,
+        });
+    }
+    set
+}
+
+// ---------------------------------------------------------------------------
+// Footprint contour
+// ---------------------------------------------------------------------------
+
+/// Trace the outer boundary of a cell's `(radius, azimuth)` column mask into
+/// a closed WGS84 ring.
+///
+/// The boundary follows voxel-column **edges** (the exact outline of the
+/// union of grid cells, not an interpolated level set). For a full-circle
+/// grid the mask is rotated so the occupied arc is seam-free before tracing
+/// (a storm spanning azimuth 359°→1° yields one ring, not two halves); a mask
+/// occupying every azimuth (a full annulus — vanishingly rare) falls back to
+/// the outer-radius circle, ignoring the inner hole. When several boundary
+/// rings exist (pinched shapes), the largest by enclosed ENU area wins; holes
+/// are dropped. The ring is simplified (Douglas–Peucker, `tol_m`) and
+/// oriented counter-clockwise.
+#[allow(clippy::too_many_arguments)]
+fn footprint_ring(
+    mask: &[bool],
+    n_r: usize,
+    n_a: usize,
+    wrap: bool,
+    r0: f64,
+    dr: f64,
+    a0: f64,
+    da: f64,
+    tol_m: f64,
+    to_lonlat: &dyn Fn(f64, f64) -> (f64, f64),
+) -> Vec<[f64; 2]> {
+    // Rotate azimuth indices so the occupied region doesn't cross the seam:
+    // find an azimuth column with no occupied cell and make it the last one.
+    let occupied_col = |a: usize| (0..n_r).any(|r| mask[r * n_a + a]);
+    let shift = if wrap {
+        match (0..n_a).find(|&a| !occupied_col(a)) {
+            // Empty column `gap`: rotate so it lands at shifted index n_a-1,
+            // i.e. original index a maps to shifted (a + n_a - 1 - gap) % n_a.
+            Some(gap) => (n_a - 1 - gap) % n_a,
+            None => {
+                // Full annulus: outer-radius circle (inner hole dropped).
+                let max_r = (0..n_r)
+                    .rev()
+                    .find(|&r| (0..n_a).any(|a| mask[r * n_a + a]))
+                    .map(|r| r0 + (r as f64 + 1.0) * dr)
+                    .unwrap_or(r0);
+                let mut ring: Vec<[f64; 2]> = (0..=n_a)
+                    .map(|a| {
+                        let (lon, lat) = to_lonlat(max_r, a0 + a as f64 * da);
+                        [lon, lat]
+                    })
+                    .collect();
+                if let Some(first) = ring.first().copied() {
+                    *ring.last_mut().expect("non-empty ring") = first; // exact closure
+                }
+                return ring;
+            }
+        }
+    } else {
+        0
+    };
+    // shifted column s → original column (s + n_a - shift) % n_a
+    let orig_a = |s: usize| (s + n_a - shift) % n_a;
+    let at = |r: usize, s: usize| mask[r * n_a + orig_a(s)];
+
+    // Directed boundary edges in (x = radius index, y = shifted azimuth
+    // index) corner space, interior on the left (CCW in x/y).
+    // Encoded as start-vertex → end-vertex; vertices packed as y * (n_r+1) + x.
+    let pack = |x: usize, y: usize| y * (n_r + 1) + x;
+    let mut edges_from: std::collections::HashMap<usize, Vec<usize>> =
+        std::collections::HashMap::new();
+    let mut edge_count = 0usize;
+    for x in 0..n_r {
+        for y in 0..n_a {
+            if !at(x, y) {
+                continue;
+            }
+            let mut emit = |sx: usize, sy: usize, ex: usize, ey: usize| {
+                edges_from
+                    .entry(pack(sx, sy))
+                    .or_default()
+                    .push(pack(ex, ey));
+                edge_count += 1;
+            };
+            // Neighbours in shifted space: outside the array = unoccupied
+            // (the seam column is empty by construction, so no wrap checks).
+            if y == 0 || !at(x, y - 1) {
+                emit(x, y, x + 1, y); // bottom, heading +x
+            }
+            if x + 1 >= n_r || !at(x + 1, y) {
+                emit(x + 1, y, x + 1, y + 1); // right, heading +y
+            }
+            if y + 1 >= n_a || !at(x, y + 1) {
+                emit(x + 1, y + 1, x, y + 1); // top, heading -x
+            }
+            if x == 0 || !at(x - 1, y) {
+                emit(x, y + 1, x, y); // left, heading -y
+            }
+        }
+    }
+
+    // Chain edges into closed rings. At an ambiguous (pinch) vertex with two
+    // outgoing edges, prefer the leftmost turn relative to the incoming
+    // direction — keeps each ring tightly wound with interior on the left.
+    let unpack = |v: usize| ((v % (n_r + 1)) as i64, (v / (n_r + 1)) as i64);
+    let mut rings: Vec<Vec<usize>> = Vec::new();
+    let mut consumed = 0usize;
+    while consumed < edge_count {
+        // Take any remaining start vertex.
+        let (&start, _) = match edges_from.iter().find(|(_, v)| !v.is_empty()) {
+            Some(kv) => kv,
+            None => break,
+        };
+        let mut ring = vec![start];
+        let mut current = start;
+        let mut dir: Option<(i64, i64)> = None;
+        loop {
+            let outs = match edges_from.get_mut(&current) {
+                Some(o) if !o.is_empty() => o,
+                _ => break, // dangling (shouldn't happen on a well-formed mask)
+            };
+            let next = if outs.len() == 1 {
+                outs.remove(0)
+            } else {
+                // Leftmost turn: maximise the CCW angle from the incoming
+                // direction (cross asc, then dot desc ranks left > straight
+                // > right > U-turn).
+                let (cx, cy) = unpack(current);
+                let score = |&cand: &usize| {
+                    let (nx, ny) = unpack(cand);
+                    let d = (nx - cx, ny - cy);
+                    match dir {
+                        None => 0i64,
+                        Some(p) => {
+                            let cross = p.0 * d.1 - p.1 * d.0;
+                            let dot = p.0 * d.0 + p.1 * d.1;
+                            // left: cross>0 → 3; straight: dot>0 → 2;
+                            // right: cross<0 → 1; back: → 0
+                            if cross > 0 {
+                                3
+                            } else if dot > 0 {
+                                2
+                            } else if cross < 0 {
+                                1
+                            } else {
+                                0
+                            }
+                        }
+                    }
+                };
+                let best = (0..outs.len())
+                    .max_by_key(|i| score(&outs[*i]))
+                    .expect("non-empty outs");
+                outs.remove(best)
+            };
+            consumed += 1;
+            let (cx, cy) = unpack(current);
+            let (nx, ny) = unpack(next);
+            dir = Some((nx - cx, ny - cy));
+            if next == start {
+                rings.push(ring);
+                break;
+            }
+            ring.push(next);
+            current = next;
+        }
+    }
+    if rings.is_empty() {
+        return Vec::new();
+    }
+
+    // Vertex (x, y) → ENU metres (for area + simplification) and lon/lat.
+    let vertex_polar = |v: usize| {
+        let (x, y) = unpack(v);
+        let radius = r0 + x as f64 * dr;
+        let angle = a0 + (y as usize + shift) as f64 * da;
+        (radius, angle)
+    };
+    let vertex_enu = |v: usize| {
+        let (radius, angle) = vertex_polar(v);
+        (radius * angle.sin(), radius * angle.cos())
+    };
+
+    // Largest |area| ring is the outer boundary; holes are dropped.
+    let ring = rings
+        .into_iter()
+        .max_by(|a, b| {
+            let area = |r: &Vec<usize>| shoelace(r.iter().map(|&v| vertex_enu(v))).abs();
+            area(a)
+                .partial_cmp(&area(b))
+                .unwrap_or(std::cmp::Ordering::Equal)
+        })
+        .expect("non-empty rings");
+
+    // Orient CCW in ENU (east/north), per RFC 7946 exterior convention.
+    let mut ring = ring;
+    if shoelace(ring.iter().map(|&v| vertex_enu(v))) < 0.0 {
+        ring.reverse();
+    }
+
+    // Simplify in ENU, then materialise lon/lat and close the ring.
+    let enu: Vec<(f64, f64)> = ring.iter().map(|&v| vertex_enu(v)).collect();
+    let keep = douglas_peucker_closed(&enu, tol_m);
+    let mut out: Vec<[f64; 2]> = keep
+        .iter()
+        .map(|&i| {
+            let (radius, angle) = vertex_polar(ring[i]);
+            let (lon, lat) = to_lonlat(radius, angle);
+            [lon, lat]
+        })
+        .collect();
+    if let Some(&first) = out.first() {
+        out.push(first);
+    }
+    out
+}
+
+/// Signed shoelace area of a (not-necessarily-closed) vertex loop.
+fn shoelace(points: impl Iterator<Item = (f64, f64)>) -> f64 {
+    let pts: Vec<(f64, f64)> = points.collect();
+    let n = pts.len();
+    if n < 3 {
+        return 0.0;
+    }
+    let mut sum = 0.0;
+    for (i, &(x0, y0)) in pts.iter().enumerate() {
+        let (x1, y1) = pts[(i + 1) % n];
+        sum += x0 * y1 - x1 * y0;
+    }
+    sum / 2.0
+}
+
+/// Douglas–Peucker on a closed loop: anchor the two farthest-apart vertices,
+/// simplify each arc, return kept indices (ascending). Always keeps ≥ 3
+/// vertices so the ring stays a polygon.
+fn douglas_peucker_closed(points: &[(f64, f64)], tol: f64) -> Vec<usize> {
+    let n = points.len();
+    if n <= 4 {
+        return (0..n).collect();
+    }
+    // Anchors: vertex 0 and the vertex farthest from it.
+    let far = (1..n)
+        .max_by(|&a, &b| {
+            let d = |i: usize| {
+                let (x, y) = points[i];
+                let (x0, y0) = points[0];
+                (x - x0).hypot(y - y0)
+            };
+            d(a).partial_cmp(&d(b)).unwrap_or(std::cmp::Ordering::Equal)
+        })
+        .expect("n > 1");
+    let mut keep = vec![false; n];
+    keep[0] = true;
+    keep[far] = true;
+    dp_arc(points, 0, far, tol, &mut keep);
+    dp_arc_wrapping(points, far, n, tol, &mut keep);
+    let kept: Vec<usize> = (0..n).filter(|&i| keep[i]).collect();
+    if kept.len() < 3 {
+        // Degenerate (collinear loop) — keep a triangle's worth of vertices.
+        return vec![0, n / 3, 2 * n / 3];
+    }
+    kept
+}
+
+/// Simplify the open arc `points[i0..=i1]` in place (marks kept indices).
+fn dp_arc(points: &[(f64, f64)], i0: usize, i1: usize, tol: f64, keep: &mut [bool]) {
+    if i1 <= i0 + 1 {
+        return;
+    }
+    let (ax, ay) = points[i0];
+    let (bx, by) = points[i1];
+    let (dx, dy) = (bx - ax, by - ay);
+    let len = dx.hypot(dy);
+    let mut worst = (0usize, 0.0f64);
+    for (i, &(px, py)) in points.iter().enumerate().take(i1).skip(i0 + 1) {
+        let dist = if len <= f64::EPSILON {
+            (px - ax).hypot(py - ay)
+        } else {
+            ((px - ax) * dy - (py - ay) * dx).abs() / len
+        };
+        if dist > worst.1 {
+            worst = (i, dist);
+        }
+    }
+    if worst.1 > tol {
+        keep[worst.0] = true;
+        dp_arc(points, i0, worst.0, tol, keep);
+        dp_arc(points, worst.0, i1, tol, keep);
+    }
+}
+
+/// Simplify the arc from `i0` back around to vertex 0 (i.e. `i0..n` plus the
+/// implicit wrap to index 0).
+fn dp_arc_wrapping(points: &[(f64, f64)], i0: usize, n: usize, tol: f64, keep: &mut [bool]) {
+    // Materialise the wrapped arc with the closing vertex appended; indices
+    // map back as (i0 + k) % n.
+    let arc: Vec<(f64, f64)> = (i0..=n).map(|k| points[k % n]).collect();
+    let mut arc_keep = vec![false; arc.len()];
+    arc_keep[0] = true;
+    *arc_keep.last_mut().expect("non-empty arc") = true;
+    dp_arc(&arc, 0, arc.len() - 1, tol, &mut arc_keep);
+    for (k, &kept) in arc_keep.iter().enumerate() {
+        if kept {
+            keep[(i0 + k) % n] = true;
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tracking
+// ---------------------------------------------------------------------------
+
+/// East/north displacement (metres) from `from` to `to` (`[lon, lat]`-ish
+/// triples; only the first two components are read), via the equirectangular
+/// approximation around the mid-latitude — exact enough at storm-tracking
+/// scales (≤ a few hundred km).
+fn local_delta_m(from: &[f64; 3], to: &[f64; 3]) -> (f64, f64) {
+    let mut dlon = to[0] - from[0];
+    // Shortest way around the antimeridian.
+    if dlon > 180.0 {
+        dlon -= 360.0;
+    } else if dlon < -180.0 {
+        dlon += 360.0;
+    }
+    let mid_lat = ((from[1] + to[1]) / 2.0).to_radians();
+    let de = dlon.to_radians() * mid_lat.cos() * EARTH_RADIUS_M;
+    let dn = (to[1] - from[1]).to_radians() * EARTH_RADIUS_M;
+    (de, dn)
+}
+
+/// Match cells across consecutive scans into [`Track`]s.
+///
+/// `history` is ascending in time (the natural [`crate::volume::CellProduct`]
+/// order). Matching between each consecutive pair is greedy minimum-cost:
+/// the cost is the distance between a previous cell's **predicted** centroid
+/// (constant-velocity extrapolation when the track already has a motion
+/// estimate) and a current cell's centroid; pairs beyond the gate
+/// (`max_speed_ms · Δt + base_gate_m`) are never matched. Unmatched previous
+/// cells end their track; unmatched current cells start a new one. A merge or
+/// split therefore resolves as "nearest wins" — the losing branch dies or is
+/// born — which is the documented v1 behaviour.
+pub fn track_cells(history: &[(DateTime<Utc>, Arc<CellSet>)], opts: &TrackingOptions) -> TrackSet {
+    struct Build {
+        points: Vec<TrackPoint>,
+        motion: Option<(f64, f64)>,
+        first_label: u32,
+    }
+    let mut tracks: Vec<Build> = Vec::new();
+    // Track index per cell (by position in the scan's `cells`) of the
+    // previous scan.
+    let mut prev_assign: Vec<usize> = Vec::new();
+
+    let point_of = |set: &CellSet, cell: &StormCell| TrackPoint {
+        time: set.time,
+        lon: cell.centroid[0],
+        lat: cell.centroid[1],
+        height_m: cell.centroid[2],
+        label: cell.label,
+        max_dbz: cell.max_dbz,
+    };
+
+    for (scan_idx, (_, set)) in history.iter().enumerate() {
+        let mut assign: Vec<Option<usize>> = vec![None; set.cells.len()];
+
+        if scan_idx > 0 {
+            let (_, prev_set) = &history[scan_idx - 1];
+            let dt = (set.time - prev_set.time).num_milliseconds() as f64 / 1000.0;
+            if dt > 0.0 && !prev_set.cells.is_empty() && !set.cells.is_empty() {
+                let gate = opts.max_speed_ms * dt + opts.base_gate_m;
+                // (cost, prev cell idx, cur cell idx) for every in-gate pair.
+                let mut candidates: Vec<(f64, usize, usize)> = Vec::new();
+                for (pi, pcell) in prev_set.cells.iter().enumerate() {
+                    let track_idx = prev_assign[pi];
+                    let motion = tracks[track_idx].motion;
+                    for (cj, ccell) in set.cells.iter().enumerate() {
+                        let (de, dn) = local_delta_m(&pcell.centroid, &ccell.centroid);
+                        let (pe, pn) = match motion {
+                            Some((u, v)) => (u * dt, v * dt),
+                            None => (0.0, 0.0),
+                        };
+                        let cost = (de - pe).hypot(dn - pn);
+                        if cost <= gate {
+                            candidates.push((cost, pi, cj));
+                        }
+                    }
+                }
+                candidates.sort_by(|a, b| {
+                    a.0.partial_cmp(&b.0)
+                        .unwrap_or(std::cmp::Ordering::Equal)
+                        .then(a.1.cmp(&b.1))
+                        .then(a.2.cmp(&b.2))
+                });
+                let mut prev_used = vec![false; prev_set.cells.len()];
+                for (_, pi, cj) in candidates {
+                    if prev_used[pi] || assign[cj].is_some() {
+                        continue;
+                    }
+                    prev_used[pi] = true;
+                    let track_idx = prev_assign[pi];
+                    let pcell = &prev_set.cells[pi];
+                    let ccell = &set.cells[cj];
+                    let (de, dn) = local_delta_m(&pcell.centroid, &ccell.centroid);
+                    let t = &mut tracks[track_idx];
+                    t.points.push(point_of(set, ccell));
+                    t.motion = Some((de / dt, dn / dt));
+                    assign[cj] = Some(track_idx);
+                }
+            }
+        }
+
+        // Births: every unmatched current cell starts a track.
+        for (cj, cell) in set.cells.iter().enumerate() {
+            if assign[cj].is_none() {
+                assign[cj] = Some(tracks.len());
+                tracks.push(Build {
+                    points: vec![point_of(set, cell)],
+                    motion: None,
+                    first_label: cell.label,
+                });
+            }
+        }
+        prev_assign = assign.into_iter().map(|a| a.expect("assigned")).collect();
+    }
+
+    let mut out: Vec<Track> = tracks
+        .into_iter()
+        .map(|b| Track {
+            id: format!(
+                "{}-{}",
+                b.points[0].time.format("%Y%m%dT%H%M%SZ"),
+                b.first_label
+            ),
+            points: b.points,
+            motion_ms: b.motion,
+        })
+        .collect();
+    out.sort_by(|a, b| {
+        (a.points[0].time, a.points[0].label).cmp(&(b.points[0].time, b.points[0].label))
+    });
+    TrackSet { tracks: out }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    /// Synthetic full-circle grid: 20 radial × 36 azimuth × 10 height cells
+    /// over 100 km / 10 km, all background (`NaN`).
+    fn empty_grid() -> VoxelGrid {
+        let dims = [20, 36, 10];
+        VoxelGrid {
+            origin_lon: 24.5,
+            origin_lat: 60.5,
+            origin_height: 100.0,
+            dims,
+            radius_range: [0.0, 100_000.0],
+            angle_range: [0.0, std::f64::consts::TAU],
+            height_range: [0.0, 10_000.0],
+            values: vec![f32::NAN; dims[0] * dims[1] * dims[2]],
+            quantity: "DBZH".into(),
+            unit: "dBZ".into(),
+        }
+    }
+
+    fn fill(
+        grid: &mut VoxelGrid,
+        r: std::ops::Range<usize>,
+        a: &[usize],
+        h: std::ops::Range<usize>,
+        v: f32,
+    ) {
+        for i_r in r {
+            for &i_a in a {
+                for i_h in h.clone() {
+                    let idx = grid.index(i_r, i_a, i_h);
+                    grid.values[idx] = v;
+                }
+            }
+        }
+    }
+
+    fn t0() -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(2026, 6, 1, 12, 0, 0).unwrap()
+    }
+
+    fn opts() -> CellExtractionOptions {
+        CellExtractionOptions {
+            threshold: 35.0,
+            min_volume_km3: 0.0,
+            max_cells: 256,
+        }
+    }
+
+    #[test]
+    fn two_separated_blobs_make_two_cells_ordered_by_volume() {
+        let mut g = empty_grid();
+        // Big blob: radii 4..8, azimuths 9..12, heights 2..6 (echoes 45 dBZ).
+        fill(&mut g, 4..8, &[9, 10, 11], 2..6, 45.0);
+        // Small blob far away in azimuth: one column, 50 dBZ.
+        fill(&mut g, 14..15, &[27], 1..3, 50.0);
+        let set = extract_cells(&g, t0(), &opts());
+        assert_eq!(set.cells.len(), 2);
+        // Label 1 = the larger.
+        assert!(set.cells[0].volume_km3 > set.cells[1].volume_km3);
+        assert_eq!(set.cells[0].label, 1);
+        assert_eq!(set.cells[1].label, 2);
+        assert_eq!(set.cells[0].max_dbz, 45.0);
+        assert_eq!(set.cells[1].max_dbz, 50.0);
+        // Footprints are closed rings.
+        for c in &set.cells {
+            let f = &c.footprint;
+            assert!(f.len() >= 4, "ring has at least a triangle + closure");
+            assert_eq!(f.first(), f.last(), "ring closed");
+        }
+    }
+
+    #[test]
+    fn azimuth_seam_blob_is_one_cell_with_one_ring() {
+        let mut g = empty_grid();
+        // Blob spanning the 0/2π seam: azimuth columns 34, 35, 0, 1.
+        fill(&mut g, 5..9, &[34, 35, 0, 1], 2..5, 42.0);
+        let set = extract_cells(&g, t0(), &opts());
+        assert_eq!(set.cells.len(), 1, "seam blob must not split");
+        let cell = &set.cells[0];
+        assert_eq!(cell.footprint.first(), cell.footprint.last());
+        // Centroid bearing ≈ north (azimuth ≈ 0): the centroid must sit
+        // north of the origin and essentially on its meridian.
+        assert!(cell.centroid[1] > g.origin_lat);
+        assert!((cell.centroid[0] - g.origin_lon).abs() < 0.2);
+        // 4 azimuth columns × 3 height cells per radius ring.
+        let da = std::f64::consts::TAU / 36.0;
+        let (dr, dh) = (5_000.0, 1_000.0);
+        let expected_vol: f64 = (5..9)
+            .map(|i_r| {
+                let rc = (i_r as f64 + 0.5) * dr;
+                dr * rc * da * dh * 4.0 * 3.0
+            })
+            .sum::<f64>()
+            / 1e9;
+        assert!(
+            (cell.volume_km3 - expected_vol).abs() / expected_vol < 1e-9,
+            "volume {} vs expected {}",
+            cell.volume_km3,
+            expected_vol
+        );
+    }
+
+    #[test]
+    fn min_volume_filter_and_max_cells_cap() {
+        let mut g = empty_grid();
+        fill(&mut g, 4..8, &[9, 10, 11], 2..6, 45.0); // big
+        fill(&mut g, 14..15, &[27], 1..2, 50.0); // tiny (1 column, 1 cell high)
+        let set = extract_cells(
+            &g,
+            t0(),
+            &CellExtractionOptions {
+                threshold: 35.0,
+                // The tiny blob is one voxel ≈ 63 km³ at these coarse dims;
+                // the big one is ≈ 1200 km³.
+                min_volume_km3: 100.0,
+                max_cells: 256,
+            },
+        );
+        assert_eq!(set.cells.len(), 1);
+        assert_eq!(set.cells[0].max_dbz, 45.0);
+
+        let capped = extract_cells(
+            &g,
+            t0(),
+            &CellExtractionOptions {
+                threshold: 35.0,
+                min_volume_km3: 0.0,
+                max_cells: 1,
+            },
+        );
+        assert_eq!(capped.cells.len(), 1, "max_cells keeps the largest");
+        assert_eq!(capped.cells[0].max_dbz, 45.0);
+    }
+
+    #[test]
+    fn single_voxel_cell_attributes_are_hand_checkable() {
+        let mut g = empty_grid();
+        let (i_r, i_a, i_h) = (10, 9, 4); // azimuth column 9 → bearing 95°E-ish
+        let idx = g.index(i_r, i_a, i_h);
+        g.values[idx] = 40.0;
+        let set = extract_cells(&g, t0(), &opts());
+        assert_eq!(set.cells.len(), 1);
+        let c = &set.cells[0];
+
+        let dr = 5_000.0;
+        let da = std::f64::consts::TAU / 36.0;
+        let dh = 1_000.0;
+        let rc = (i_r as f64 + 0.5) * dr; // 52.5 km
+        assert!((c.volume_km3 - dr * rc * da * dh / 1e9).abs() < 1e-12);
+        assert!((c.area_km2 - dr * rc * da / 1e6).abs() < 1e-12);
+        // Echo top/base: heights are MSL (origin at 100 m).
+        assert!((c.base_m - (100.0 + 4_000.0)).abs() < 1e-9);
+        assert!((c.echo_top_m - (100.0 + 5_000.0)).abs() < 1e-9);
+        // VIL: one 1 km layer at 40 dBZ.
+        let z = 10f64.powf(4.0);
+        let expected_vil = 3.44e-6 * z.powf(4.0 / 7.0) * dh;
+        assert!((c.max_vil_kg_m2 - expected_vil).abs() / expected_vil < 1e-12);
+        // Centroid = the voxel centre, azimuth (9.5/36)·360 = 95°.
+        let (elon, elat) = destination_point(24.5, 60.5, rc, 95.0);
+        assert!((c.centroid[0] - elon).abs() < 1e-9);
+        assert!((c.centroid[1] - elat).abs() < 1e-9);
+        assert!((c.centroid[2] - (100.0 + 4_500.0)).abs() < 1e-9);
+        assert_eq!(c.max_dbz, 40.0);
+        // Footprint ring should enclose the centroid's neighbourhood: all
+        // four ring corners are distinct and the ring is closed.
+        assert!(c.footprint.len() >= 5);
+        assert_eq!(c.footprint.first(), c.footprint.last());
+        // ENU bbox: radius span [50, 55] km, height span [4, 5] km.
+        assert!((c.bbox_enu_m[2] - 4_000.0).abs() < 1e-9);
+        assert!((c.bbox_enu_m[5] - 5_000.0).abs() < 1e-9);
+        let diag_e = c.bbox_enu_m[3] - c.bbox_enu_m[0];
+        assert!(diag_e > 0.0 && diag_e < 12_000.0);
+    }
+
+    #[test]
+    fn vil_caps_hail_at_56_dbz() {
+        let mut g = empty_grid();
+        let idx = g.index(5, 0, 0);
+        g.values[idx] = 70.0; // hail spike
+        let set = extract_cells(&g, t0(), &opts());
+        let z_capped = 10f64.powf(5.6);
+        let expected = 3.44e-6 * z_capped.powf(4.0 / 7.0) * 1_000.0;
+        assert!((set.cells[0].max_vil_kg_m2 - expected).abs() / expected < 1e-12);
+    }
+
+    #[test]
+    fn no_echo_grid_yields_empty_set() {
+        let g = empty_grid();
+        let set = extract_cells(&g, t0(), &opts());
+        assert!(set.cells.is_empty());
+        // Clear-air floor (-32 dBZ) is also background at any sane threshold.
+        let mut g2 = empty_grid();
+        g2.values.fill(crate::volume::NO_ECHO_FLOOR_DBZ);
+        assert!(extract_cells(&g2, t0(), &opts()).cells.is_empty());
+    }
+
+    // --- tracking -----------------------------------------------------------
+
+    /// One-cell set with the cell centred `km_east` km east of the origin.
+    fn set_at(time: DateTime<Utc>, km_east: f64, label: u32) -> Arc<CellSet> {
+        let (lon, lat) = destination_point(24.5, 60.5, km_east * 1_000.0, 90.0);
+        Arc::new(CellSet {
+            time,
+            quantity: "DBZH".into(),
+            threshold: 35.0,
+            origin: [24.5, 60.5, 100.0],
+            cells: vec![StormCell {
+                label,
+                max_dbz: 45.0,
+                max_dbz_pos: [lon, lat, 5_000.0],
+                centroid: [lon, lat, 5_000.0],
+                echo_top_m: 8_000.0,
+                base_m: 1_000.0,
+                volume_km3: 50.0,
+                area_km2: 25.0,
+                max_vil_kg_m2: 10.0,
+                footprint: vec![[lon, lat]; 4],
+                bbox_enu_m: [0.0; 6],
+            }],
+        })
+    }
+
+    fn minutes(m: i64) -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(2026, 6, 1, 12, 0, 0).unwrap() + chrono::Duration::minutes(m)
+    }
+
+    #[test]
+    fn moving_blob_tracks_with_expected_motion() {
+        // 10 km east per 5 min ⇒ u ≈ 33.3 m/s, v ≈ 0.
+        let history = vec![
+            (minutes(0), set_at(minutes(0), 0.0, 1)),
+            (minutes(5), set_at(minutes(5), 10.0, 1)),
+            (minutes(10), set_at(minutes(10), 20.0, 1)),
+        ];
+        let tracks = track_cells(&history, &TrackingOptions::default());
+        assert_eq!(tracks.tracks.len(), 1);
+        let t = &tracks.tracks[0];
+        assert_eq!(t.points.len(), 3);
+        let (u, v) = t.motion_ms.expect("motion after a matched step");
+        assert!((u - 10_000.0 / 300.0).abs() < 0.5, "u = {u}");
+        assert!(v.abs() < 0.5, "v = {v}");
+        let (speed, dir) = t.speed_direction().unwrap();
+        assert!((speed - 33.3).abs() < 0.5);
+        assert!((dir - 90.0).abs() < 1.0, "moving east, dir = {dir}");
+        assert_eq!(t.id, format!("{}-1", minutes(0).format("%Y%m%dT%H%M%SZ")));
+        // track_for joins a scan's cell back to its track.
+        assert!(tracks.track_for(minutes(5), 1).is_some());
+        assert!(tracks.track_for(minutes(5), 2).is_none());
+    }
+
+    #[test]
+    fn gate_rejects_teleporting_blob_and_births_a_new_track() {
+        // 80 km in 5 min ⇒ 266 m/s ≫ the 40 m/s gate.
+        let history = vec![
+            (minutes(0), set_at(minutes(0), 0.0, 1)),
+            (minutes(5), set_at(minutes(5), 80.0, 1)),
+        ];
+        let tracks = track_cells(&history, &TrackingOptions::default());
+        assert_eq!(tracks.tracks.len(), 2, "no match across the gate");
+        assert!(tracks.tracks.iter().all(|t| t.points.len() == 1));
+        assert!(tracks.tracks.iter().all(|t| t.motion_ms.is_none()));
+    }
+
+    #[test]
+    fn death_and_empty_scan_are_handled() {
+        let history = vec![
+            (minutes(0), set_at(minutes(0), 0.0, 1)),
+            (
+                minutes(5),
+                Arc::new(CellSet::empty(
+                    minutes(5),
+                    "DBZH",
+                    35.0,
+                    [24.5, 60.5, 100.0],
+                )),
+            ),
+            (minutes(10), set_at(minutes(10), 0.0, 1)),
+        ];
+        let tracks = track_cells(&history, &TrackingOptions::default());
+        // The original dies at the empty scan; the reappearance is a birth.
+        assert_eq!(tracks.tracks.len(), 2);
+        assert!(tracks.tracks.iter().all(|t| t.points.len() == 1));
+    }
+
+    #[test]
+    fn merge_resolves_as_nearest_wins() {
+        // Two cells converge on one: the nearer keeps the track, the other dies.
+        let two = |t: DateTime<Utc>| {
+            let mut s = (*set_at(t, 0.0, 1)).clone();
+            let far = set_at(t, 8.0, 2);
+            s.cells.push(far.cells[0].clone());
+            Arc::new(s)
+        };
+        let history = vec![
+            (minutes(0), two(minutes(0))),
+            (minutes(5), set_at(minutes(5), 1.0, 1)), // near the first cell
+        ];
+        let tracks = track_cells(&history, &TrackingOptions::default());
+        assert_eq!(tracks.tracks.len(), 2);
+        let continued: Vec<_> = tracks
+            .tracks
+            .iter()
+            .filter(|t| t.points.len() == 2)
+            .collect();
+        assert_eq!(continued.len(), 1, "exactly one track continues");
+        assert_eq!(continued[0].points[0].label, 1, "the nearer cell wins");
+    }
+
+    #[test]
+    fn footprint_ring_is_ccw() {
+        let mut g = empty_grid();
+        fill(&mut g, 4..8, &[9, 10, 11], 2..6, 45.0);
+        let set = extract_cells(&g, t0(), &opts());
+        let ring = &set.cells[0].footprint;
+        // Shoelace in lon/lat (a fine orientation proxy at this scale away
+        // from the antimeridian).
+        let mut area = 0.0;
+        for w in ring.windows(2) {
+            area += w[0][0] * w[1][1] - w[1][0] * w[0][1];
+        }
+        assert!(area > 0.0, "exterior ring must be counter-clockwise");
+    }
+}

--- a/crates/core/src/cells.rs
+++ b/crates/core/src/cells.rs
@@ -388,6 +388,7 @@ pub fn extract_cells(
 
     struct Detail {
         mask: Vec<bool>, // (r, a) footprint columns, n_r × n_a
+        area_m2: f64,    // Σ over claimed columns of Δr · (r_c · Δa)
         max_vil: f64,
         bbox: [f64; 6],
     }
@@ -395,6 +396,7 @@ pub fn extract_cells(
         .iter()
         .map(|_| Detail {
             mask: vec![false; n_r * n_a],
+            area_m2: 0.0,
             max_vil: 0.0,
             bbox: [
                 f64::INFINITY,
@@ -426,7 +428,13 @@ pub fn extract_cells(
                     continue;
                 }
                 let d = &mut details[rank];
-                d.mask[i_r * n_a + i_a] = true;
+                // First claim of this column for this cell: count its ground
+                // area here, in the voxel pass — a per-cell mask sweep after
+                // the loop would cost O(max_cells × n_r × n_a) (#404 review).
+                if !d.mask[i_r * n_a + i_a] {
+                    d.mask[i_r * n_a + i_a] = true;
+                    d.area_m2 += dr * (r_centre(i_r) * da);
+                }
 
                 // VIL layer contribution: M(Z)·Δh with the hail cap.
                 let dbz = (grid.values[idx] as f64).min(VIL_DBZ_CAP);
@@ -504,17 +512,6 @@ pub fn extract_cells(
         let (mr, ma, mh) = comp.max_idx;
         let (mlon, mlat) = to_lonlat(r_centre(mr), a_centre(ma));
 
-        // Footprint area: Σ over set columns of Δr · (r_c · Δa).
-        let mut area_m2 = 0.0;
-        for i_r in 0..n_r {
-            let cell_area = dr * (r_centre(i_r) * da);
-            for i_a in 0..n_a {
-                if d.mask[i_r * n_a + i_a] {
-                    area_m2 += cell_area;
-                }
-            }
-        }
-
         let footprint = footprint_ring(
             &d.mask,
             n_r,
@@ -536,7 +533,7 @@ pub fn extract_cells(
             echo_top_m: origin[2] + grid.height_range[0] + (comp.max_ih as f64 + 1.0) * dh,
             base_m: origin[2] + grid.height_range[0] + comp.min_ih as f64 * dh,
             volume_km3: comp.volume_m3 / 1e9,
-            area_km2: area_m2 / 1e6,
+            area_km2: d.area_m2 / 1e6,
             max_vil_kg_m2: d.max_vil,
             footprint,
             bbox_enu_m: d.bbox,

--- a/crates/core/src/cells.rs
+++ b/crates/core/src/cells.rs
@@ -430,7 +430,7 @@ pub fn extract_cells(
                 let d = &mut details[rank];
                 // First claim of this column for this cell: count its ground
                 // area here, in the voxel pass — a per-cell mask sweep after
-                // the loop would cost O(max_cells × n_r × n_a) (#404 review).
+                // the loop would cost O(max_cells × n_r × n_a).
                 if !d.mask[i_r * n_a + i_a] {
                     d.mask[i_r * n_a + i_a] = true;
                     d.area_m2 += dr * (r_centre(i_r) * da);
@@ -1080,8 +1080,8 @@ mod tests {
         // Every ring vertex must sit where the blob actually is: azimuth
         // boundaries 340°–20° (columns 34..1 of 36), radius boundaries
         // 25–45 km (rows 5..9). A wrong seam-rotation inverse rotates the
-        // whole ring around the radar (review on #404) — these bounds catch
-        // any such constant-angle offset.
+        // whole ring around the radar — these bounds catch any such
+        // constant-angle offset.
         for v in &cell.footprint {
             let de = (v[0] - g.origin_lon).to_radians()
                 * g.origin_lat.to_radians().cos()

--- a/crates/core/src/cells.rs
+++ b/crates/core/src/cells.rs
@@ -580,20 +580,31 @@ fn footprint_ring(
             // i.e. original index a maps to shifted (a + n_a - 1 - gap) % n_a.
             Some(gap) => (n_a - 1 - gap) % n_a,
             None => {
-                // Full annulus: outer-radius circle (inner hole dropped).
+                // Full annulus: outer-radius circle (inner hole dropped),
+                // simplified like the normal path — Douglas–Peucker keeps
+                // only the vertices a `tol_m` chord deviation requires, so
+                // a 360-column circle collapses to a few dozen points.
                 let max_r = (0..n_r)
                     .rev()
                     .find(|&r| (0..n_a).any(|a| mask[r * n_a + a]))
                     .map(|r| r0 + (r as f64 + 1.0) * dr)
                     .unwrap_or(r0);
-                let mut ring: Vec<[f64; 2]> = (0..=n_a)
+                let enu: Vec<(f64, f64)> = (0..n_a)
                     .map(|a| {
+                        let angle = a0 + a as f64 * da;
+                        (max_r * angle.sin(), max_r * angle.cos())
+                    })
+                    .collect();
+                let keep = douglas_peucker_closed(&enu, tol_m);
+                let mut ring: Vec<[f64; 2]> = keep
+                    .iter()
+                    .map(|&a| {
                         let (lon, lat) = to_lonlat(max_r, a0 + a as f64 * da);
                         [lon, lat]
                     })
                     .collect();
                 if let Some(first) = ring.first().copied() {
-                    *ring.last_mut().expect("non-empty ring") = first; // exact closure
+                    ring.push(first);
                 }
                 return ring;
             }
@@ -734,20 +745,24 @@ fn footprint_ring(
         (radius * angle.sin(), radius * angle.cos())
     };
 
-    // Largest |area| ring is the outer boundary; holes are dropped.
-    let ring = rings
+    // Largest |area| ring is the outer boundary; holes are dropped. The
+    // signed area is computed once per ring — magnitude selects the ring,
+    // sign settles its orientation.
+    let (mut ring, signed_area) = rings
         .into_iter()
+        .map(|r| {
+            let area = shoelace(r.iter().map(|&v| vertex_enu(v)));
+            (r, area)
+        })
         .max_by(|a, b| {
-            let area = |r: &Vec<usize>| shoelace(r.iter().map(|&v| vertex_enu(v))).abs();
-            area(a)
-                .partial_cmp(&area(b))
+            a.1.abs()
+                .partial_cmp(&b.1.abs())
                 .unwrap_or(std::cmp::Ordering::Equal)
         })
         .expect("non-empty rings");
 
     // Orient CCW in ENU (east/north), per RFC 7946 exterior convention.
-    let mut ring = ring;
-    if shoelace(ring.iter().map(|&v| vertex_enu(v))) < 0.0 {
+    if signed_area < 0.0 {
         ring.reverse();
     }
 

--- a/crates/core/src/cells.rs
+++ b/crates/core/src/cells.rs
@@ -28,8 +28,9 @@ use std::sync::Arc;
 /// Liquid-water cap (dBZ) for the VIL integral: reflectivity above this is
 /// treated as hail contamination and clamped, per the standard NSSL practice.
 const VIL_DBZ_CAP: f64 = 56.0;
-/// VIL mass coefficient: `M = 3.44e-6 · Z^(4/7)` (g m⁻³, Z in mm⁶ m⁻³) —
-/// integrated over height it yields kg m⁻² directly.
+/// VIL mass coefficient: `M = 3.44e-6 · Z^(4/7)` (**kg m⁻³**, Z in mm⁶ m⁻³;
+/// the textbook form is `3.44e-3 g m⁻³`) — integrated over height in metres
+/// it yields kg m⁻² directly.
 const VIL_COEFF: f64 = 3.44e-6;
 
 /// Knobs for [`extract_cells`]. `Default` is the canonical configuration
@@ -714,10 +715,21 @@ fn footprint_ring(
     }
 
     // Vertex (x, y) → ENU metres (for area + simplification) and lon/lat.
+    // The azimuth must be mapped back through the **inverse** of the seam
+    // rotation (the same `orig_a` mapping the occupancy lookups use) —
+    // `y + shift` would rotate the whole ring around the radar. The modulo
+    // is only valid on a full-circle grid (where the angle is periodic);
+    // a sector grid never rotates (`shift == 0`), so `y` is already the
+    // original boundary there.
     let vertex_polar = |v: usize| {
         let (x, y) = unpack(v);
         let radius = r0 + x as f64 * dr;
-        let angle = a0 + (y as usize + shift) as f64 * da;
+        let boundary = if wrap {
+            (y as usize + n_a - shift) % n_a
+        } else {
+            y as usize
+        };
+        let angle = a0 + boundary as f64 * da;
         (radius, angle)
     };
     let vertex_enu = |v: usize| {
@@ -1068,6 +1080,28 @@ mod tests {
         assert_eq!(set.cells.len(), 1, "seam blob must not split");
         let cell = &set.cells[0];
         assert_eq!(cell.footprint.first(), cell.footprint.last());
+        // Every ring vertex must sit where the blob actually is: azimuth
+        // boundaries 340°–20° (columns 34..1 of 36), radius boundaries
+        // 25–45 km (rows 5..9). A wrong seam-rotation inverse rotates the
+        // whole ring around the radar (review on #404) — these bounds catch
+        // any such constant-angle offset.
+        for v in &cell.footprint {
+            let de = (v[0] - g.origin_lon).to_radians()
+                * g.origin_lat.to_radians().cos()
+                * crate::geo::EARTH_RADIUS_M;
+            let dn = (v[1] - g.origin_lat).to_radians() * crate::geo::EARTH_RADIUS_M;
+            let bearing = de.atan2(dn).to_degrees().rem_euclid(360.0);
+            let from_north = bearing.min(360.0 - bearing);
+            assert!(
+                from_north <= 20.5,
+                "vertex bearing {bearing}° outside the blob's 340°–20° span"
+            );
+            let ground = de.hypot(dn);
+            assert!(
+                (24_500.0..=45_500.0).contains(&ground),
+                "vertex ground range {ground} m outside the blob's 25–45 km span"
+            );
+        }
         // Centroid bearing ≈ north (azimuth ≈ 0): the centroid must sit
         // north of the origin and essentially on its meridian.
         assert!(cell.centroid[1] > g.origin_lat);

--- a/crates/core/src/cells.rs
+++ b/crates/core/src/cells.rs
@@ -33,6 +33,14 @@ const VIL_DBZ_CAP: f64 = 56.0;
 /// it yields kg m⁻² directly.
 const VIL_COEFF: f64 = 3.44e-6;
 
+/// Hard ceiling on how many scans a tracking window may walk
+/// ([`crate::volume::CellQuery::track_scans`] is clamped to this). Each scan
+/// in the window costs one `read_voxel_grid` — sequential blocking reads on
+/// one thread for a remote-backed engine — so an unbounded caller value
+/// would multiply that stall arbitrarily. 24 covers two hours of 5-minute
+/// radar cadence.
+pub const MAX_TRACK_SCANS: usize = 24;
+
 /// Knobs for [`extract_cells`]. `Default` is the canonical configuration
 /// (35 dBZ — the classic TITAN cell threshold — with a 5 km³ speckle floor).
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -675,9 +683,17 @@ fn footprint_ring(
     let mut rings: Vec<Vec<usize>> = Vec::new();
     let mut consumed = 0usize;
     while consumed < edge_count {
-        // Take any remaining start vertex.
-        let (&start, _) = match edges_from.iter().find(|(_, v)| !v.is_empty()) {
-            Some(kv) => kv,
+        // Start each ring at the smallest remaining vertex id — HashMap
+        // iteration order is per-process random, and the start vertex fixes
+        // the output vertex sequence, which must be deterministic (stable
+        // GeoJSON bytes / ETags for identical inputs).
+        let start = match edges_from
+            .iter()
+            .filter(|(_, v)| !v.is_empty())
+            .map(|(&k, _)| k)
+            .min()
+        {
+            Some(k) => k,
             None => break,
         };
         let mut ring = vec![start];
@@ -1356,6 +1372,21 @@ mod tests {
             .collect();
         assert_eq!(continued.len(), 1, "exactly one track continues");
         assert_eq!(continued[0].points[0].label, 1, "the nearer cell wins");
+    }
+
+    #[test]
+    fn extraction_is_deterministic() {
+        // The ring tracer must not inherit HashMap iteration order: two
+        // extractions of the same grid (fresh HashMaps with different
+        // RandomState seeds) must produce byte-identical cell sets, or
+        // Features ETags / cached GeoJSON would churn across restarts.
+        let mut g = empty_grid();
+        fill(&mut g, 4..8, &[9, 10, 11], 2..6, 45.0);
+        fill(&mut g, 12..16, &[20, 21], 1..4, 38.0);
+        fill(&mut g, 5..9, &[34, 35, 0, 1], 2..5, 42.0); // seam blob
+        let a = extract_cells(&g, t0(), &opts());
+        let b = extract_cells(&g, t0(), &opts());
+        assert_eq!(a, b);
     }
 
     #[test]

--- a/crates/core/src/cells.rs
+++ b/crates/core/src/cells.rs
@@ -613,8 +613,13 @@ fn footprint_ring(
                     .find(|&r| (0..n_a).any(|a| mask[r * n_a + a]))
                     .map(|r| r0 + (r as f64 + 1.0) * dr)
                     .unwrap_or(r0);
-                let enu: Vec<(f64, f64)> = (0..n_a)
-                    .map(|a| {
+                // Walk azimuth boundaries in DECREASING order: compass
+                // azimuth increases clockwise on the ground, so the CCW
+                // exterior ring (RFC 7946) traces the circle backwards.
+                let boundaries: Vec<usize> = (0..n_a).rev().collect();
+                let enu: Vec<(f64, f64)> = boundaries
+                    .iter()
+                    .map(|&a| {
                         let angle = a0 + a as f64 * da;
                         (max_r * angle.sin(), max_r * angle.cos())
                     })
@@ -622,8 +627,8 @@ fn footprint_ring(
                 let keep = douglas_peucker_closed(&enu, tol_m);
                 let mut ring: Vec<[f64; 2]> = keep
                     .iter()
-                    .map(|&a| {
-                        let (lon, lat) = to_lonlat(max_r, a0 + a as f64 * da);
+                    .map(|&i| {
+                        let (lon, lat) = to_lonlat(max_r, a0 + boundaries[i] as f64 * da);
                         [lon, lat]
                     })
                     .collect();
@@ -1372,6 +1377,40 @@ mod tests {
             .collect();
         assert_eq!(continued.len(), 1, "exactly one track continues");
         assert_eq!(continued[0].points[0].label, 1, "the nearer cell wins");
+    }
+
+    #[test]
+    fn full_annulus_footprint_is_ccw_at_outer_radius() {
+        // Echo in every azimuth column (a rain shield wrapped around the
+        // radar) takes the annulus fallback: outer-radius circle, which must
+        // still be CCW (RFC 7946) and sit at the component's outer boundary.
+        let mut g = empty_grid();
+        let all: Vec<usize> = (0..36).collect();
+        fill(&mut g, 10..12, &all, 2..4, 40.0);
+        let set = extract_cells(&g, t0(), &opts());
+        assert_eq!(set.cells.len(), 1);
+        let ring = &set.cells[0].footprint;
+        assert_eq!(ring.first(), ring.last());
+        let mut area = 0.0;
+        for w in ring.windows(2) {
+            area += w[0][0] * w[1][1] - w[1][0] * w[0][1];
+        }
+        assert!(
+            area > 0.0,
+            "annulus fallback ring must be counter-clockwise"
+        );
+        // Every vertex sits on the outer radius boundary (12 × 5 km = 60 km).
+        for v in &ring[..ring.len() - 1] {
+            let de = (v[0] - g.origin_lon).to_radians()
+                * g.origin_lat.to_radians().cos()
+                * crate::geo::EARTH_RADIUS_M;
+            let dn = (v[1] - g.origin_lat).to_radians() * crate::geo::EARTH_RADIUS_M;
+            let ground = de.hypot(dn);
+            assert!(
+                (ground - 60_000.0).abs() < 600.0,
+                "vertex at {ground} m, expected ≈60 km"
+            );
+        }
     }
 
     #[test]

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod cells;
 pub mod collection_search;
 pub mod config;
 pub mod datetime;

--- a/crates/core/src/volume.rs
+++ b/crates/core/src/volume.rs
@@ -318,6 +318,13 @@ pub trait VolumeEngine: Send + Sync {
     /// **Concurrency contract:** same as [`Self::read_voxel_grid`] — call
     /// from a context where that method is callable (the 3D Tiles / raster
     /// paths run it under `spawn_blocking`).
+    ///
+    /// **Performance:** the default walks `track_scans + 1` scans with one
+    /// [`Self::read_voxel_grid`] call each — for an engine backed by remote
+    /// storage that is N sequential blocking reads on one thread, exactly
+    /// the stall-multiplying pattern the engine concurrency rules prohibit.
+    /// Such engines must override `read_cells` to cache per-scan
+    /// segmentations (as the ODIM engine does) or batch the reads.
     fn read_cells(&self, query: &CellQuery) -> Result<CellProduct, DataServerError> {
         let info = self.volume_info();
         let Some(caps) = info.voxel_grid else {

--- a/crates/core/src/volume.rs
+++ b/crates/core/src/volume.rs
@@ -12,6 +12,9 @@
 //! Like the other engine traits, `VolumeEngine` returns domain types only —
 //! colorization and byte encoding live in `ds-3dtiles`, not here.
 
+use crate::cells::{
+    extract_cells, track_cells, CellExtractionOptions, CellSet, TrackSet, TrackingOptions,
+};
 use crate::error::DataServerError;
 use chrono::{DateTime, Utc};
 use std::sync::Arc;
@@ -173,6 +176,53 @@ impl VoxelGrid {
     }
 }
 
+/// Query for [`VolumeEngine::read_cells`]: the usual selection knobs
+/// (quantity / time / dims / reference time) plus the segmentation +
+/// tracking options. Bundled in one struct so the trait method stays
+/// readable and future knobs (e.g. a motion-field request) don't churn
+/// every implementor.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct CellQuery {
+    /// Quantity to segment (`None` → the engine default). Engines may
+    /// restrict cells to reflectivity-like quantities (the VIL / linear-Z
+    /// math assumes dBZ).
+    pub quantity: Option<String>,
+    /// Target scan: nearest retained volume (`None` → latest), the same
+    /// selection rule as [`VolumeEngine::read_voxel_grid`].
+    pub time: Option<DateTime<Utc>>,
+    /// Voxel-grid resolution to segment on (`None` → engine default).
+    /// Cells don't need a fine grid — callers typically pass a low tier.
+    pub dims: Option<[usize; 3]>,
+    /// Segmentation knobs (threshold, speckle floor, cap).
+    pub extraction: CellExtractionOptions,
+    /// Centroid-matching knobs.
+    pub tracking: TrackingOptions,
+    /// How many scans **before** the target to segment and track across
+    /// (`0` → the target scan only, no trajectories).
+    pub track_scans: usize,
+    /// Forecast model run (`None` → latest; ignored by non-forecast engines).
+    pub reference_time: Option<DateTime<Utc>>,
+}
+
+/// The cells + tracks product for one scan window — what every API surface
+/// (3D Tiles, Features, WMS/Maps/Tiles) renders.
+#[derive(Debug, Clone, PartialEq)]
+pub struct CellProduct {
+    /// Per-scan cell sets, ascending in time; the **last** entry is the
+    /// target scan. A scan with no echo at the threshold is present as an
+    /// empty set (so tracking sees the death). Never empty.
+    pub cell_sets: Vec<(DateTime<Utc>, Arc<CellSet>)>,
+    /// Trajectories across the window.
+    pub tracks: TrackSet,
+}
+
+impl CellProduct {
+    /// The target scan's cells.
+    pub fn target(&self) -> &(DateTime<Utc>, Arc<CellSet>) {
+        self.cell_sets.last().expect("cell_sets is never empty")
+    }
+}
+
 /// An engine that samples a collection's data into a volumetric point cloud
 /// for OGC 3D Tiles delivery.
 ///
@@ -239,6 +289,81 @@ pub trait VolumeEngine: Send + Sync {
         ))
     }
 
+    /// Segment storm cells on the target scan and track them across the
+    /// preceding `query.track_scans` scans (#367).
+    ///
+    /// **Generic by default:** any engine with voxel-grid capability
+    /// ([`VolumeInfo::voxel_grid`] is `Some`) gets cells for free — the
+    /// default implementation walks [`VolumeInfo::times`] backwards from the
+    /// target, reads one grid per scan via [`Self::read_voxel_grid`], runs
+    /// [`extract_cells`] per scan and [`track_cells`] over the window.
+    /// Engines override only to add caching (the ODIM engine memoizes
+    /// per-volume cell sets — volume files are immutable).
+    ///
+    /// Returns `Ok` with an **empty** target set when the scan simply has no
+    /// echo at the threshold (Features needs "no cells now" as a valid empty
+    /// collection; the 3D Tiles layer maps all-empty to its 404) — unlike
+    /// `read_point_cloud`/`read_voxel_grid`, whose empty case is an error.
+    /// [`DataServerError::LocationNotFound`] is reserved for "this engine /
+    /// collection has no voxel-grid capability or no volumes at all".
+    ///
+    /// **Concurrency contract:** same as [`Self::read_voxel_grid`] — call
+    /// from a context where that method is callable (the 3D Tiles / raster
+    /// paths run it under `spawn_blocking`).
+    fn read_cells(&self, query: &CellQuery) -> Result<CellProduct, DataServerError> {
+        let info = self.volume_info();
+        let Some(caps) = info.voxel_grid else {
+            return Err(DataServerError::LocationNotFound(
+                "storm cells not supported: engine has no voxel-grid capability".into(),
+            ));
+        };
+        if info.times.is_empty() {
+            return Err(DataServerError::LocationNotFound(
+                "storm cells: no volumes retained".into(),
+            ));
+        }
+        // Nearest retained scan (latest if None) — the read_voxel_grid rule.
+        let target_idx = match query.time {
+            Some(t) => info
+                .times
+                .iter()
+                .enumerate()
+                .min_by_key(|(_, vt)| (**vt - t).num_seconds().abs())
+                .map(|(i, _)| i)
+                .expect("times is non-empty"),
+            None => info.times.len() - 1,
+        };
+        let start = target_idx.saturating_sub(query.track_scans);
+        let quantity_label = query
+            .quantity
+            .clone()
+            .unwrap_or_else(|| info.default_quantity.clone());
+
+        let mut cell_sets = Vec::with_capacity(target_idx - start + 1);
+        for &t in &info.times[start..=target_idx] {
+            let set = match self.read_voxel_grid(
+                query.quantity.as_deref(),
+                Some(t),
+                query.dims,
+                query.reference_time,
+            ) {
+                Ok(grid) => Arc::new(extract_cells(&grid, t, &query.extraction)),
+                // The voxel-grid convention reports "no echo" as
+                // LocationNotFound; for cells that is a valid empty scan.
+                Err(DataServerError::LocationNotFound(_)) => Arc::new(CellSet::empty(
+                    t,
+                    quantity_label.clone(),
+                    query.extraction.threshold,
+                    caps.origin,
+                )),
+                Err(e) => return Err(e),
+            };
+            cell_sets.push((t, set));
+        }
+        let tracks = track_cells(&cell_sets, &query.tracking);
+        Ok(CellProduct { cell_sets, tracks })
+    }
+
     /// Metadata for the volumetric collection (quantities, valid times).
     ///
     /// Returns a shared snapshot so it stays **O(1) on a per-request path** (no
@@ -279,5 +404,154 @@ mod tests {
         g.values[i] = 35.0;
         g.values[5] = f32::INFINITY; // non-finite is not "valid"
         assert_eq!(g.valid_count(), 1);
+    }
+
+    use chrono::TimeZone;
+
+    /// Stub engine: three retained scans; the blob sits at azimuth column 0
+    /// in scan 0 and 1, and the middle scan has no echo (exercises the
+    /// empty-set path). Grids are rebuilt per call (no caching — that's the
+    /// point of the default impl).
+    struct StubVolumes {
+        times: Vec<DateTime<Utc>>,
+        info: Arc<VolumeInfo>,
+    }
+
+    impl StubVolumes {
+        fn new() -> Self {
+            let t0 = Utc.with_ymd_and_hms(2026, 6, 1, 12, 0, 0).unwrap();
+            let times: Vec<_> = (0..3)
+                .map(|i| t0 + chrono::Duration::minutes(5 * i))
+                .collect();
+            let info = Arc::new(VolumeInfo {
+                quantities: vec![("DBZH".into(), "Reflectivity".into())],
+                times: times.clone(),
+                default_quantity: "DBZH".into(),
+                default_unit: "dBZ".into(),
+                region: None,
+                voxel_grid: Some(VoxelGridCaps {
+                    origin: [24.5, 60.5, 100.0],
+                    radius_m: 100_000.0,
+                    height_m: 10_000.0,
+                }),
+            });
+            Self { times, info }
+        }
+
+        fn grid_with_blob(&self) -> VoxelGrid {
+            let dims = [20, 36, 10];
+            let mut g = VoxelGrid {
+                origin_lon: 24.5,
+                origin_lat: 60.5,
+                origin_height: 100.0,
+                dims,
+                radius_range: [0.0, 100_000.0],
+                angle_range: [0.0, std::f64::consts::TAU],
+                height_range: [0.0, 10_000.0],
+                values: vec![f32::NAN; 20 * 36 * 10],
+                quantity: "DBZH".into(),
+                unit: "dBZ".into(),
+            };
+            for i_r in 4..8 {
+                for i_h in 2..6 {
+                    let idx = g.index(i_r, 9, i_h);
+                    g.values[idx] = 45.0;
+                }
+            }
+            g
+        }
+    }
+
+    impl VolumeEngine for StubVolumes {
+        fn read_point_cloud(
+            &self,
+            _quantity: Option<&str>,
+            _time: Option<DateTime<Utc>>,
+            _min_value: Option<f64>,
+            _reference_time: Option<DateTime<Utc>>,
+        ) -> Result<VolumePointCloud, DataServerError> {
+            unimplemented!("not used by read_cells")
+        }
+
+        fn read_voxel_grid(
+            &self,
+            _quantity: Option<&str>,
+            time: Option<DateTime<Utc>>,
+            _dims: Option<[usize; 3]>,
+            _reference_time: Option<DateTime<Utc>>,
+        ) -> Result<Arc<VoxelGrid>, DataServerError> {
+            // Middle scan: no echo ⇒ the voxel-grid 404 convention.
+            if time == Some(self.times[1]) {
+                return Err(DataServerError::LocationNotFound("no echoes".into()));
+            }
+            Ok(Arc::new(self.grid_with_blob()))
+        }
+
+        fn volume_info(&self) -> Arc<VolumeInfo> {
+            Arc::clone(&self.info)
+        }
+    }
+
+    #[test]
+    fn default_read_cells_segments_window_and_tracks() {
+        let engine = StubVolumes::new();
+        let query = CellQuery {
+            extraction: CellExtractionOptions {
+                threshold: 35.0,
+                min_volume_km3: 0.0,
+                max_cells: 16,
+            },
+            track_scans: 2,
+            ..CellQuery::default()
+        };
+        let product = engine.read_cells(&query).expect("cells");
+        assert_eq!(product.cell_sets.len(), 3);
+        // Scan 0 and 2 have the blob; scan 1 is the empty set, not an error.
+        assert_eq!(product.cell_sets[0].1.cells.len(), 1);
+        assert!(product.cell_sets[1].1.cells.is_empty());
+        assert_eq!(product.cell_sets[2].1.cells.len(), 1);
+        assert_eq!(product.target().0, engine.times[2]);
+        // The empty middle scan breaks the trajectory: two 1-point tracks.
+        assert_eq!(product.tracks.tracks.len(), 2);
+
+        // track_scans = 0 ⇒ target scan only.
+        let solo = engine
+            .read_cells(&CellQuery {
+                extraction: query.extraction,
+                ..CellQuery::default()
+            })
+            .expect("cells");
+        assert_eq!(solo.cell_sets.len(), 1);
+
+        // Explicit target pinned to the empty middle scan.
+        let pinned = engine
+            .read_cells(&CellQuery {
+                time: Some(engine.times[1]),
+                extraction: query.extraction,
+                ..CellQuery::default()
+            })
+            .expect("cells");
+        assert!(pinned.target().1.cells.is_empty());
+    }
+
+    #[test]
+    fn read_cells_without_voxel_caps_is_not_found() {
+        struct NoCaps;
+        impl VolumeEngine for NoCaps {
+            fn read_point_cloud(
+                &self,
+                _q: Option<&str>,
+                _t: Option<DateTime<Utc>>,
+                _m: Option<f64>,
+                _r: Option<DateTime<Utc>>,
+            ) -> Result<VolumePointCloud, DataServerError> {
+                unimplemented!()
+            }
+            fn volume_info(&self) -> Arc<VolumeInfo> {
+                Arc::new(VolumeInfo::default())
+            }
+        }
+        let err = NoCaps.read_cells(&CellQuery::default()).unwrap_err();
+        assert!(matches!(err, DataServerError::LocationNotFound(_)));
     }
 }

--- a/crates/core/src/volume.rs
+++ b/crates/core/src/volume.rs
@@ -307,6 +307,14 @@ pub trait VolumeEngine: Send + Sync {
     /// [`DataServerError::LocationNotFound`] is reserved for "this engine /
     /// collection has no voxel-grid capability or no volumes at all".
     ///
+    /// **Quantity contract:** the quantity selected via [`CellQuery::quantity`]
+    /// **must** be a radar reflectivity in dBZ — the linear-Z centroid
+    /// weighting and the VIL integral in [`extract_cells`] are reflectivity
+    /// physics and produce garbage for wind speed, temperature, etc. This
+    /// default cannot check units generically, so an implementor whose
+    /// quantities are not all reflectivity must gate (the ODIM override
+    /// rejects non-dBZ-unit quantities with `InvalidParameter` → 400).
+    ///
     /// **Concurrency contract:** same as [`Self::read_voxel_grid`] — call
     /// from a context where that method is callable (the 3D Tiles / raster
     /// paths run it under `spawn_blocking`).

--- a/crates/core/src/volume.rs
+++ b/crates/core/src/volume.rs
@@ -14,6 +14,7 @@
 
 use crate::cells::{
     extract_cells, track_cells, CellExtractionOptions, CellSet, TrackSet, TrackingOptions,
+    MAX_TRACK_SCANS,
 };
 use crate::error::DataServerError;
 use chrono::{DateTime, Utc};
@@ -348,7 +349,10 @@ pub trait VolumeEngine: Send + Sync {
                 .expect("times is non-empty"),
             None => info.times.len() - 1,
         };
-        let start = target_idx.saturating_sub(query.track_scans);
+        // Clamp the window: each scan is one sequential blocking
+        // read_voxel_grid, so an unbounded caller value would multiply the
+        // stall arbitrarily (see the performance note above).
+        let start = target_idx.saturating_sub(query.track_scans.min(MAX_TRACK_SCANS));
         let quantity_label = query
             .quantity
             .clone()

--- a/crates/engine-odim/src/cells.rs
+++ b/crates/engine-odim/src/cells.rs
@@ -26,10 +26,12 @@ use std::sync::Arc;
 /// regardless of storm activity.
 const DEFAULT_CELL_SET_CACHE_MB: u64 = 64;
 
-/// Cache key: source-qualified volume file id + quantity + grid dims + a
-/// bit-fold of the extraction options. Volumes are immutable once scanned,
-/// so the key needs no data-version (the `VOXEL_GRID_CACHE` argument).
-type CellSetKey = (Arc<str>, Arc<str>, [usize; 3], u64);
+/// Cache key: source-qualified volume file id + quantity + grid dims + the
+/// extraction options **verbatim** (threshold/min-volume bit patterns and
+/// the cell cap — not a hash of them, so distinct options can never collide
+/// onto one entry). Volumes are immutable once scanned, so the key needs no
+/// data-version (the `VOXEL_GRID_CACHE` argument).
+type CellSetKey = (Arc<str>, Arc<str>, [usize; 3], (u64, u64, u64));
 
 /// Approximate resident bytes of a cached [`CellSet`]: the struct itself,
 /// per-cell fixed fields, and each footprint ring's vertices — the term that
@@ -87,19 +89,14 @@ pub fn cell_set_cache_metrics() -> (u64, u64, u64, u64) {
     )
 }
 
-/// FNV-1a fold of the extraction options into the cache key — the same idiom
-/// the 3D Tiles content cache uses for threshold lists. Bit-exact: two
-/// requests share an entry only when every knob matches exactly.
-fn extraction_bits(opts: &ds_core::cells::CellExtractionOptions) -> u64 {
-    let mut h: u64 = 0xcbf29ce484222325;
-    let mut fold = |v: u64| {
-        h ^= v;
-        h = h.wrapping_mul(0x100000001b3);
-    };
-    fold(opts.threshold.to_bits());
-    fold(opts.min_volume_km3.to_bits());
-    fold(opts.max_cells as u64);
-    h
+/// The extraction options as an exact key component: two requests share an
+/// entry iff every knob is bit-identical (no hash, no collision).
+fn extraction_key(opts: &ds_core::cells::CellExtractionOptions) -> (u64, u64, u64) {
+    (
+        opts.threshold.to_bits(),
+        opts.min_volume_km3.to_bits(),
+        opts.max_cells as u64,
+    )
 }
 
 impl PolarVolumeSiteView {
@@ -148,7 +145,7 @@ impl PolarVolumeSiteView {
             .unwrap_or(volumes.len().saturating_sub(1));
         let start = target_idx.saturating_sub(query.track_scans);
         let dims = query.dims.unwrap_or(DEFAULT_VOXEL_DIMS);
-        let opts_bits = extraction_bits(&query.extraction);
+        let opts_key = extraction_key(&query.extraction);
 
         let mut cell_sets = Vec::with_capacity(target_idx - start + 1);
         for entry in &volumes[start..=target_idx] {
@@ -156,7 +153,7 @@ impl PolarVolumeSiteView {
                 Arc::from(pixel_cache_id(&self.source, &entry.id).as_ref()),
                 Arc::from(quantity.as_str()),
                 dims,
-                opts_bits,
+                opts_key,
             );
             let mut computed = false;
             let set = CELL_SET_CACHE.get_or_insert_with(&key, || {

--- a/crates/engine-odim/src/cells.rs
+++ b/crates/engine-odim/src/cells.rs
@@ -29,7 +29,10 @@ const DEFAULT_CELL_SET_CACHE_ENTRIES: usize = 4096;
 type CellSetKey = (Arc<str>, Arc<str>, [usize; 3], u64);
 
 /// Process-global memo of per-volume segmentations, shared across every PVOL
-/// collection. `0` (via the env var) disables — every request re-segments.
+/// collection. `MC_PVOL_CELL_SET_CACHE=0` *effectively* disables it — the
+/// `max(1)` below still builds a 1-entry LRU (quick_cache has no zero
+/// capacity), which hits only on an exact back-to-back repeat and evicts on
+/// every new `(file, quantity, dims, opts)` key.
 static CELL_SET_CACHE: std::sync::LazyLock<quick_cache::sync::Cache<CellSetKey, Arc<CellSet>>> =
     std::sync::LazyLock::new(|| {
         let entries = std::env::var("MC_PVOL_CELL_SET_CACHE")

--- a/crates/engine-odim/src/cells.rs
+++ b/crates/engine-odim/src/cells.rs
@@ -1,0 +1,155 @@
+//! Storm-cell extraction + tracking for PVOL per-site collections (#367).
+//!
+//! The algorithms live in `ds_core::cells` (pure geometry/physics on a
+//! [`ds_core::volume::VoxelGrid`]); this module adds the engine-side
+//! plumbing: a process-global memo of per-volume [`CellSet`]s (a volume file
+//! is immutable, so a scan's segmentation never goes stale) and the
+//! window-walk that feeds [`ds_core::cells::track_cells`].
+//!
+//! [`PolarVolumeSiteView::cell_product`] is the one entry point; the
+//! [`ds_core::volume::VolumeEngine::read_cells`] override delegates here
+//! with the `spawn_blocking` runtime bridge, while engine-internal callers
+//! on a request worker (the Features path) pass `handle: None`.
+
+use crate::quantities;
+use crate::volume_engine::{pixel_cache_id, PolarVolumeSiteView, DEFAULT_VOXEL_DIMS};
+use ds_core::cells::{extract_cells, track_cells, CellSet};
+use ds_core::error::DataServerError;
+use ds_core::volume::{CellProduct, CellQuery};
+use std::sync::Arc;
+
+/// Default [`CELL_SET_CACHE`] entry count when `MC_PVOL_CELL_SET_CACHE` is
+/// unset. Entries are KB-sized (attributes + a simplified footprint ring per
+/// cell), so this is a few MB at worst — bounded by count, not bytes.
+const DEFAULT_CELL_SET_CACHE_ENTRIES: usize = 4096;
+
+/// Cache key: source-qualified volume file id + quantity + grid dims + a
+/// bit-fold of the extraction options. Volumes are immutable once scanned,
+/// so the key needs no data-version (the `VOXEL_GRID_CACHE` argument).
+type CellSetKey = (Arc<str>, Arc<str>, [usize; 3], u64);
+
+/// Process-global memo of per-volume segmentations, shared across every PVOL
+/// collection. `0` (via the env var) disables — every request re-segments.
+static CELL_SET_CACHE: std::sync::LazyLock<quick_cache::sync::Cache<CellSetKey, Arc<CellSet>>> =
+    std::sync::LazyLock::new(|| {
+        let entries = std::env::var("MC_PVOL_CELL_SET_CACHE")
+            .ok()
+            .and_then(|s| s.trim().parse::<usize>().ok())
+            .unwrap_or(DEFAULT_CELL_SET_CACHE_ENTRIES);
+        quick_cache::sync::Cache::new(entries.max(1))
+    });
+
+/// Cumulative `(hits, misses)` of [`CELL_SET_CACHE`], for `/metrics`.
+static CELL_SET_HITS: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+static CELL_SET_MISSES: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+/// Snapshot of the process-global cell-set cache for `/metrics`:
+/// `(hits, misses, entries)`.
+pub fn cell_set_cache_metrics() -> (u64, u64, u64) {
+    (
+        CELL_SET_HITS.load(std::sync::atomic::Ordering::Relaxed),
+        CELL_SET_MISSES.load(std::sync::atomic::Ordering::Relaxed),
+        CELL_SET_CACHE.len() as u64,
+    )
+}
+
+/// FNV-1a fold of the extraction options into the cache key — the same idiom
+/// the 3D Tiles content cache uses for threshold lists. Bit-exact: two
+/// requests share an entry only when every knob matches exactly.
+fn extraction_bits(opts: &ds_core::cells::CellExtractionOptions) -> u64 {
+    let mut h: u64 = 0xcbf29ce484222325;
+    let mut fold = |v: u64| {
+        h ^= v;
+        h = h.wrapping_mul(0x100000001b3);
+    };
+    fold(opts.threshold.to_bits());
+    fold(opts.min_volume_km3.to_bits());
+    fold(opts.max_cells as u64);
+    h
+}
+
+impl PolarVolumeSiteView {
+    /// Segment + track storm cells for this site (the engine-side
+    /// [`ds_core::volume::VolumeEngine::read_cells`], plus a `handle`
+    /// parameter so both runtime contexts can call it — see
+    /// `volume_engine::blocking_pixel_handle` for the contract; the trait
+    /// override passes the `spawn_blocking` bridge, a request-worker caller
+    /// passes `None`).
+    ///
+    /// Cells are reflectivity physics (linear-Z weighting, VIL), so only
+    /// dBZ-unit quantities are accepted — anything else is
+    /// [`DataServerError::InvalidParameter`] (→ 400).
+    ///
+    /// Each scan's segmentation is memoized in the process-global
+    /// [`CELL_SET_CACHE`]; in steady state only the newest volume pays the
+    /// resample + extraction, so a poll-cadence animation window stays cheap.
+    pub fn cell_product(
+        &self,
+        query: &CellQuery,
+        handle: Option<&tokio::runtime::Handle>,
+    ) -> Result<CellProduct, DataServerError> {
+        let catalog = self.catalog.load();
+        // Validates the quantity, resolves the default, selects the volume
+        // nearest `query.time` (latest if `None`), guards the antenna.
+        let (target, quantity) =
+            self.select_entry_and_quantity(&catalog, query.quantity.as_deref(), query.time)?;
+        if quantities::quantity_unit(&quantity) != "dBZ" {
+            return Err(DataServerError::InvalidParameter(format!(
+                "[{}] storm cells require a reflectivity (dBZ) quantity, `{}` is not one",
+                self.collection_id, quantity
+            )));
+        }
+        let volumes = catalog.by_site.get(&self.nod).ok_or_else(|| {
+            DataServerError::LocationNotFound(format!(
+                "[{}] radar site `{}` has no current volumes",
+                self.collection_id, self.nod
+            ))
+        })?;
+        // The tracking window: up to `track_scans` volumes preceding the
+        // target, from the site's time-sorted list.
+        let target_time = target.volume.time;
+        let target_idx = volumes
+            .iter()
+            .position(|e| e.volume.time == target_time)
+            .unwrap_or(volumes.len().saturating_sub(1));
+        let start = target_idx.saturating_sub(query.track_scans);
+        let dims = query.dims.unwrap_or(DEFAULT_VOXEL_DIMS);
+        let opts_bits = extraction_bits(&query.extraction);
+
+        let mut cell_sets = Vec::with_capacity(target_idx - start + 1);
+        for entry in &volumes[start..=target_idx] {
+            let key: CellSetKey = (
+                Arc::from(pixel_cache_id(&self.source, &entry.id).as_ref()),
+                Arc::from(quantity.as_str()),
+                dims,
+                opts_bits,
+            );
+            let mut computed = false;
+            let set = CELL_SET_CACHE.get_or_insert_with(&key, || {
+                computed = true;
+                let (grid, valid) = self.voxel_grid_cached(entry, &quantity, dims, handle)?;
+                let set = if valid == 0 {
+                    // No echo anywhere in the volume: a valid empty scan
+                    // (tracking sees the death) — cached like any other.
+                    CellSet::empty(
+                        entry.volume.time,
+                        quantity.as_str(),
+                        query.extraction.threshold,
+                        [grid.origin_lon, grid.origin_lat, grid.origin_height],
+                    )
+                } else {
+                    extract_cells(&grid, entry.volume.time, &query.extraction)
+                };
+                Ok::<_, DataServerError>(Arc::new(set))
+            })?;
+            if computed {
+                CELL_SET_MISSES.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            } else {
+                CELL_SET_HITS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            }
+            cell_sets.push((entry.volume.time, set));
+        }
+        let tracks = track_cells(&cell_sets, &query.tracking);
+        Ok(CellProduct { cell_sets, tracks })
+    }
+}

--- a/crates/engine-odim/src/cells.rs
+++ b/crates/engine-odim/src/cells.rs
@@ -13,7 +13,7 @@
 
 use crate::quantities;
 use crate::volume_engine::{pixel_cache_id, PolarVolumeSiteView, DEFAULT_VOXEL_DIMS};
-use ds_core::cells::{extract_cells, track_cells, CellSet};
+use ds_core::cells::{extract_cells, track_cells, CellSet, MAX_TRACK_SCANS};
 use ds_core::error::DataServerError;
 use ds_core::volume::{CellProduct, CellQuery};
 use std::sync::Arc;
@@ -142,8 +142,18 @@ impl PolarVolumeSiteView {
         let target_idx = volumes
             .iter()
             .position(|e| e.volume.time == target_time)
-            .unwrap_or(volumes.len().saturating_sub(1));
-        let start = target_idx.saturating_sub(query.track_scans);
+            .ok_or_else(|| {
+                // `target` came from this same slice, so a miss is a logic
+                // error — surface it rather than silently tracking against
+                // the wrong window.
+                DataServerError::Engine(format!(
+                    "[{}] selected volume at {target_time} not found in site `{}` volume list",
+                    self.collection_id, self.nod
+                ))
+            })?;
+        // Same window ceiling as the trait default: even with the per-scan
+        // memo, a cold window is one grid resample per scan.
+        let start = target_idx.saturating_sub(query.track_scans.min(MAX_TRACK_SCANS));
         let dims = query.dims.unwrap_or(DEFAULT_VOXEL_DIMS);
         let opts_key = extraction_key(&query.extraction);
 

--- a/crates/engine-odim/src/cells.rs
+++ b/crates/engine-odim/src/cells.rs
@@ -18,46 +18,72 @@ use ds_core::error::DataServerError;
 use ds_core::volume::{CellProduct, CellQuery};
 use std::sync::Arc;
 
-/// Default [`CELL_SET_CACHE`] entry count when `MC_PVOL_CELL_SET_CACHE` is
-/// unset. Each entry holds a `CellSet` whose dominant cost is the per-cell
-/// footprint ring: on the default grid a single entry can reach ~400 KB at
-/// the 256-cell cap with complex rings, so 4096 entries is a ~1.6 GB
-/// *pathological* ceiling — unlike the byte-weighted `VOXEL_GRID_CACHE`,
-/// this cache is count-bounded only. In practice a scan carries a handful
-/// of cells with simplified rings (entries well under ~10 KB); tune down
-/// via the env var if memory is tight.
-const DEFAULT_CELL_SET_CACHE_ENTRIES: usize = 4096;
+/// Default [`CELL_SET_CACHE`] size (MB) when `MC_PVOL_CELL_SET_CACHE_MB` is
+/// unset. An entry's dominant cost is the per-cell footprint ring; a typical
+/// scan's `CellSet` is well under ~10 KB, the 256-cell cap with complex
+/// rings ~400 KB — 64 MB holds whole networks' worth of either, and the
+/// byte weighting (mirroring `VOXEL_GRID_CACHE`) keeps the ceiling exact
+/// regardless of storm activity.
+const DEFAULT_CELL_SET_CACHE_MB: u64 = 64;
 
 /// Cache key: source-qualified volume file id + quantity + grid dims + a
 /// bit-fold of the extraction options. Volumes are immutable once scanned,
 /// so the key needs no data-version (the `VOXEL_GRID_CACHE` argument).
 type CellSetKey = (Arc<str>, Arc<str>, [usize; 3], u64);
 
+/// Approximate resident bytes of a cached [`CellSet`]: the struct itself,
+/// per-cell fixed fields, and each footprint ring's vertices — the term that
+/// actually varies (everything else is a few hundred bytes).
+fn cell_set_weight_bytes(key: &CellSetKey, set: &Arc<CellSet>) -> u64 {
+    let cells: u64 = set
+        .cells
+        .iter()
+        .map(|c| (std::mem::size_of_val(c) + c.footprint.len() * 16) as u64)
+        .sum();
+    cells + (std::mem::size_of::<CellSet>() + key.0.len() + key.1.len() + 64) as u64
+}
+
+/// Byte-weights each entry (see [`cell_set_weight_bytes`]).
+#[derive(Clone)]
+struct CellSetWeighter;
+
+impl quick_cache::Weighter<CellSetKey, Arc<CellSet>> for CellSetWeighter {
+    fn weight(&self, key: &CellSetKey, val: &Arc<CellSet>) -> u64 {
+        cell_set_weight_bytes(key, val)
+    }
+}
+
 /// Process-global memo of per-volume segmentations, shared across every PVOL
-/// collection. `MC_PVOL_CELL_SET_CACHE=0` *effectively* disables it — the
-/// `max(1)` below still builds a 1-entry LRU (quick_cache has no zero
-/// capacity), which hits only on an exact back-to-back repeat and evicts on
-/// every new `(file, quantity, dims, opts)` key.
-static CELL_SET_CACHE: std::sync::LazyLock<quick_cache::sync::Cache<CellSetKey, Arc<CellSet>>> =
-    std::sync::LazyLock::new(|| {
-        let entries = std::env::var("MC_PVOL_CELL_SET_CACHE")
-            .ok()
-            .and_then(|s| s.trim().parse::<usize>().ok())
-            .unwrap_or(DEFAULT_CELL_SET_CACHE_ENTRIES);
-        quick_cache::sync::Cache::new(entries.max(1))
-    });
+/// collection, byte-bounded like `VOXEL_GRID_CACHE`.
+/// `MC_PVOL_CELL_SET_CACHE_MB=0` *effectively* disables it — quick_cache has
+/// no zero capacity, so a 1-byte budget rejects every real entry on insert
+/// (every request re-segments).
+static CELL_SET_CACHE: std::sync::LazyLock<
+    quick_cache::sync::Cache<CellSetKey, Arc<CellSet>, CellSetWeighter>,
+> = std::sync::LazyLock::new(|| {
+    let capacity_bytes = std::env::var("MC_PVOL_CELL_SET_CACHE_MB")
+        .ok()
+        .and_then(|s| s.trim().parse::<u64>().ok())
+        .unwrap_or(DEFAULT_CELL_SET_CACHE_MB)
+        .saturating_mul(1024 * 1024);
+    // Estimate item slots at ~16 KB each; `max(...)` keeps a zero capacity
+    // valid (an effectively-disabled cache that can hold nothing).
+    let estimated_items = ((capacity_bytes / (16 * 1024)).max(4)) as usize;
+    quick_cache::sync::Cache::with_weighter(estimated_items, capacity_bytes.max(1), CellSetWeighter)
+});
 
 /// Cumulative `(hits, misses)` of [`CELL_SET_CACHE`], for `/metrics`.
 static CELL_SET_HITS: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
 static CELL_SET_MISSES: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
 
 /// Snapshot of the process-global cell-set cache for `/metrics`:
-/// `(hits, misses, entries)`.
-pub fn cell_set_cache_metrics() -> (u64, u64, u64) {
+/// `(hits, misses, resident_bytes, capacity_bytes)`.
+pub fn cell_set_cache_metrics() -> (u64, u64, u64, u64) {
     (
         CELL_SET_HITS.load(std::sync::atomic::Ordering::Relaxed),
         CELL_SET_MISSES.load(std::sync::atomic::Ordering::Relaxed),
-        CELL_SET_CACHE.len() as u64,
+        CELL_SET_CACHE.weight(),
+        CELL_SET_CACHE.capacity(),
     )
 }
 

--- a/crates/engine-odim/src/cells.rs
+++ b/crates/engine-odim/src/cells.rs
@@ -19,8 +19,13 @@ use ds_core::volume::{CellProduct, CellQuery};
 use std::sync::Arc;
 
 /// Default [`CELL_SET_CACHE`] entry count when `MC_PVOL_CELL_SET_CACHE` is
-/// unset. Entries are KB-sized (attributes + a simplified footprint ring per
-/// cell), so this is a few MB at worst — bounded by count, not bytes.
+/// unset. Each entry holds a `CellSet` whose dominant cost is the per-cell
+/// footprint ring: on the default grid a single entry can reach ~400 KB at
+/// the 256-cell cap with complex rings, so 4096 entries is a ~1.6 GB
+/// *pathological* ceiling — unlike the byte-weighted `VOXEL_GRID_CACHE`,
+/// this cache is count-bounded only. In practice a scan carries a handful
+/// of cells with simplified rings (entries well under ~10 KB); tune down
+/// via the env var if memory is tight.
 const DEFAULT_CELL_SET_CACHE_ENTRIES: usize = 4096;
 
 /// Cache key: source-qualified volume file id + quantity + grid dims + a

--- a/crates/engine-odim/src/lib.rs
+++ b/crates/engine-odim/src/lib.rs
@@ -20,6 +20,7 @@
 //! minimal PROJ-string parser in `proj.rs`.
 
 pub mod catalog;
+pub mod cells;
 pub mod edr;
 pub mod engine;
 pub mod pixel_cache;
@@ -29,6 +30,7 @@ pub mod quantities;
 pub mod reader;
 pub mod volume_engine;
 
+pub use cells::cell_set_cache_metrics;
 pub use engine::{EngineError, OdimEngine};
 pub use pixel_cache::PixelCache;
 pub use volume_engine::{

--- a/crates/engine-odim/src/volume_engine.rs
+++ b/crates/engine-odim/src/volume_engine.rs
@@ -69,7 +69,9 @@ use ds_core::model::{
     VerticalCoord,
 };
 use ds_core::vertical::{VerticalDimension, VerticalKind};
-use ds_core::volume::{VolumeEngine, VolumeInfo, VolumePoint, VolumePointCloud, VoxelGrid};
+use ds_core::volume::{
+    CellProduct, CellQuery, VolumeEngine, VolumeInfo, VolumePoint, VolumePointCloud, VoxelGrid,
+};
 use tokio::sync::Notify;
 
 use ds_storage::discovery::{expand_prefix_for_dates, expand_prefix_pattern, TimeWindow};
@@ -376,7 +378,7 @@ pub(crate) fn ground_height_to_slant(
 /// Mirrors [`crate::engine::OdimEngine`]'s `Source` exactly: a local
 /// filesystem directory or an S3/HTTP object store.
 #[derive(Clone)]
-enum Source {
+pub(crate) enum Source {
     /// A local filesystem directory, scanned with `read_dir`.
     Local { data_dir: PathBuf },
     /// An S3/HTTP object store. `prefix_pattern` may carry strftime
@@ -476,7 +478,7 @@ fn source_label(source: &Source) -> String {
 /// different buckets collide in the process-global cache and silently serve
 /// each other's pixels (PR #290 review). The bare `file_id` is still used as
 /// the object path for the fetch itself.
-fn pixel_cache_id<'a>(source: &Source, file_id: &'a str) -> std::borrow::Cow<'a, str> {
+pub(crate) fn pixel_cache_id<'a>(source: &Source, file_id: &'a str) -> std::borrow::Cow<'a, str> {
     match source {
         Source::Local { .. } => std::borrow::Cow::Borrowed(file_id),
         Source::Remote {
@@ -491,7 +493,7 @@ fn pixel_cache_id<'a>(source: &Source, file_id: &'a str) -> std::borrow::Cow<'a,
 /// request-worker query paths pass `None` instead. Uses `try_current` (not
 /// `current`) so unit tests that invoke the trait methods outside any runtime
 /// — always with a `Local` source that ignores the handle — don't panic.
-fn blocking_pixel_handle() -> Option<tokio::runtime::Handle> {
+pub(crate) fn blocking_pixel_handle() -> Option<tokio::runtime::Handle> {
     tokio::runtime::Handle::try_current().ok()
 }
 
@@ -609,13 +611,13 @@ impl Pixels<'_> {
 /// `Arc` so the catalog can be cheaply cloned out of the `ArcSwap`
 /// snapshot without re-parsing HDF5.
 #[derive(Clone)]
-struct VolumeEntry {
+pub(crate) struct VolumeEntry {
     /// Source file identity — the parse-cache key (local path string or
     /// S3 object key); used to evict cache entries the (`max_files`-
     /// capped) catalog no longer references.
-    id: FileId,
+    pub(crate) id: FileId,
     /// Parsed volume — `Arc` so repeated requests share one parse.
-    volume: Arc<PolarVolume>,
+    pub(crate) volume: Arc<PolarVolume>,
 }
 
 /// Per-site derived metadata, computed once per scan in [`derive_catalog`].
@@ -626,7 +628,7 @@ struct VolumeEntry {
 /// from sweeps on every request. Mirrors the union fields on [`Catalog`]
 /// but scoped to one radar `nod`.
 #[derive(Clone)]
-struct SiteMeta {
+pub(crate) struct SiteMeta {
     /// Antenna longitude (WGS84).
     lon: f64,
     /// Antenna latitude (WGS84).
@@ -665,15 +667,15 @@ struct SiteMeta {
 /// There is no network-level collection — each radar site is
 /// its own collection — so the catalog carries only the per-site index and
 /// no union/aggregate metadata.
-struct Catalog {
+pub(crate) struct Catalog {
     /// Volumes grouped by `site.nod`, each list sorted by `time`
     /// ascending.
-    by_site: HashMap<String, Vec<VolumeEntry>>,
+    pub(crate) by_site: HashMap<String, Vec<VolumeEntry>>,
     /// Per-site derived metadata keyed by `nod` — the snapshot each
     /// [`PolarVolumeSiteView`] answers capability queries from. Keys
     /// match `by_site` (a site with no derivable metadata, e.g. every
     /// sweep malformed, is simply absent here).
-    by_site_meta: HashMap<String, SiteMeta>,
+    pub(crate) by_site_meta: HashMap<String, SiteMeta>,
     /// `by_site_meta` keys pre-sorted at build time, so the network-inventory
     /// `FeatureEngine` never sorts per request (CLAUDE.md hot-path rule).
     sorted_nods: Vec<String>,
@@ -3084,14 +3086,14 @@ impl FeatureEngine for PolarVolumeEngine {
 /// owning engine.
 pub struct PolarVolumeSiteView {
     /// Live catalog shared with the owning [`PolarVolumeEngine`].
-    catalog: Arc<ArcSwap<Catalog>>,
+    pub(crate) catalog: Arc<ArcSwap<Catalog>>,
     /// The owning engine's file source, shared so the view can lazily
     /// re-fetch a volume's bytes to decode a moment's pixels on demand.
-    source: Arc<Source>,
+    pub(crate) source: Arc<Source>,
     /// ODIM NOD code this view is scoped to.
-    nod: String,
+    pub(crate) nod: String,
     /// Per-site OGC collection id (`{base}-{nod}`), for error messages.
-    collection_id: String,
+    pub(crate) collection_id: String,
 }
 
 impl MapEngine for PolarVolumeSiteView {
@@ -3340,7 +3342,7 @@ fn volume_point_cloud(
 /// Default voxel grid resolution `[n_radius, n_angle, n_height]`: 1° azimuth
 /// bins (matching radar rays), ~2 km radial and ~420 m vertical cells over the
 /// ranges below. ~2.2M cells.
-const DEFAULT_VOXEL_DIMS: [usize; 3] = [128, 360, 48];
+pub(crate) const DEFAULT_VOXEL_DIMS: [usize; 3] = [128, 360, 48];
 /// Hard cap on requested voxel-grid cell count (memory + sample-loop bound).
 const MAX_VOXELS: usize = 32_000_000;
 /// Height ceiling (metres above antenna) for the voxel grid — above any echo.
@@ -3568,7 +3570,7 @@ impl PolarVolumeSiteView {
     /// `reference_time` is deliberately not a parameter: ODIM PVOL has no
     /// model-run machinery (radar volumes aren't forecasts), so both callers
     /// accept-and-ignore it — see the `ds_core::instances` engine contract.
-    fn select_entry_and_quantity<'c>(
+    pub(crate) fn select_entry_and_quantity<'c>(
         &self,
         catalog: &'c Catalog,
         quantity: Option<&str>,
@@ -3628,6 +3630,61 @@ impl PolarVolumeSiteView {
         }
         Ok((entry, quantity))
     }
+
+    /// The [`VOXEL_GRID_CACHE`] fill for one `(volume, quantity, dims)` —
+    /// the body of [`VolumeEngine::read_voxel_grid`], factored out so the
+    /// storm-cell path (`cells.rs`) can drive it from **either** runtime
+    /// context: `handle` is the async→sync bridge selector for a remote
+    /// pixel fetch (`Some` on a `spawn_blocking` pool thread, where
+    /// `block_in_place` panics; `None` on a request worker, where
+    /// `block_in_place` is the valid bridge — see [`Pixels::handle`]).
+    ///
+    /// Returns the shared grid plus its echo-cell count; the caller owns the
+    /// "no echo ⇒ 404 or empty set" decision.
+    pub(crate) fn voxel_grid_cached(
+        &self,
+        entry: &VolumeEntry,
+        quantity: &str,
+        dims: [usize; 3],
+        handle: Option<&tokio::runtime::Handle>,
+    ) -> Result<(Arc<VoxelGrid>, usize), DataServerError> {
+        // A volume file is immutable once scanned, so `(file, quantity, dims)`
+        // fully determines the resample — no data-version in the key. The
+        // 3D Tiles mesh products (isosurface, echo-top, voxels), the storm-
+        // cell extractor, and repeated threshold/animation requests all share
+        // one cached grid. The empty (`valid == 0`) result is cached too, so
+        // the no-echo case is cheap.
+        let key: VoxelGridKey = (
+            Arc::from(pixel_cache_id(&self.source, &entry.id).as_ref()),
+            Arc::from(quantity),
+            dims,
+        );
+        // `get_or_insert_with` is the single-flight: quick_cache's placeholder
+        // guard runs the closure for exactly one caller per key and blocks
+        // concurrent callers until it finishes — so simultaneous first-time
+        // requests for *different representations* of the same grid (whose
+        // content-cache keys differ, hence separate gates there) still share
+        // one polar resample (PR #378 review). Blocking the calling thread is
+        // acceptable in both caller contexts (a `spawn_blocking` pool thread,
+        // or a request worker that would have done the resample itself).
+        let mut computed = false;
+        let result = VOXEL_GRID_CACHE.get_or_insert_with(&key, || {
+            computed = true;
+            let pix = Pixels {
+                source: &self.source,
+                handle,
+            };
+            let (grid, valid) =
+                voxel_grid_from_volume(&entry.volume, &entry.id, pix, quantity, Some(dims))?;
+            Ok::<_, DataServerError>((Arc::new(grid), valid))
+        })?;
+        if computed {
+            VOXEL_GRID_MISSES.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        } else {
+            VOXEL_GRID_HITS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        }
+        Ok(result)
+    }
 }
 
 impl VolumeEngine for PolarVolumeSiteView {
@@ -3673,40 +3730,10 @@ impl VolumeEngine for PolarVolumeSiteView {
         // default-dims request share one entry.
         let dims = dims.unwrap_or(DEFAULT_VOXEL_DIMS);
 
-        // A volume file is immutable once scanned, so `(file, quantity, dims)`
-        // fully determines the resample — no data-version in the key. The three
-        // 3D Tiles mesh products (isosurface, echo-top, voxels) and repeated
-        // threshold/animation requests all share one cached grid. The empty
-        // (`valid == 0`) result is cached too, so the no-echo 404 is cheap.
-        let key: VoxelGridKey = (
-            Arc::from(pixel_cache_id(&self.source, &entry.id).as_ref()),
-            Arc::from(quantity.as_str()),
-            dims,
-        );
-        // `get_or_insert_with` is the single-flight: quick_cache's placeholder
-        // guard runs the closure for exactly one caller per key and blocks
-        // concurrent callers until it finishes — so simultaneous first-time
-        // requests for *different representations* of the same grid (whose
-        // content-cache keys differ, hence separate gates there) still share
-        // one polar resample (PR #378 review). Blocking the calling thread is
-        // fine: every caller is on a `spawn_blocking` pool by contract.
-        let mut computed = false;
-        let (grid, valid) = VOXEL_GRID_CACHE.get_or_insert_with(&key, || {
-            computed = true;
-            let handle = blocking_pixel_handle();
-            let pix = Pixels {
-                source: &self.source,
-                handle: handle.as_ref(),
-            };
-            let (grid, valid) =
-                voxel_grid_from_volume(&entry.volume, &entry.id, pix, &quantity, Some(dims))?;
-            Ok::<_, DataServerError>((Arc::new(grid), valid))
-        })?;
-        if computed {
-            VOXEL_GRID_MISSES.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        } else {
-            VOXEL_GRID_HITS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        }
+        // Every `read_voxel_grid` caller is on a `spawn_blocking` pool by
+        // contract, so the remote pixel fetch bridges via the runtime handle.
+        let handle = blocking_pixel_handle();
+        let (grid, valid) = self.voxel_grid_cached(entry, &quantity, dims, handle.as_ref())?;
 
         // No sampled cell (every cell outside the beam fan / nodata) ⇒ 404,
         // matching the other engines' "no data in window" convention.
@@ -3730,6 +3757,14 @@ impl VolumeEngine for PolarVolumeSiteView {
             .get(&self.nod)
             .map(|m| Arc::clone(&m.volume_info))
             .unwrap_or_default()
+    }
+
+    fn read_cells(&self, query: &CellQuery) -> Result<CellProduct, DataServerError> {
+        // Same runtime contract as `read_voxel_grid` (spawn_blocking callers);
+        // engine-internal callers on a request worker (the Features path,
+        // #367 follow-up) call `cell_product` with `handle: None` directly.
+        let handle = blocking_pixel_handle();
+        self.cell_product(query, handle.as_ref())
     }
 }
 

--- a/crates/engine-odim/tests/integration.rs
+++ b/crates/engine-odim/tests/integration.rs
@@ -738,6 +738,128 @@ fn pvol_volume_engine_voxel_grid() {
     }
 }
 
+/// `VolumeEngine::read_cells` (#367) on the real FMI Vihti volume, which holds
+/// a strong (≈59 dBZ) convective storm: segmentation must find at least one
+/// cell with physically sane attributes, and the per-volume cell-set memo must
+/// hit on a repeat call. Skips when the uncommitted fixture is absent.
+#[test]
+fn pvol_volume_engine_read_cells() {
+    use ds_core::cells::CellExtractionOptions;
+    use ds_core::volume::{CellQuery, VolumeEngine};
+
+    let fixture = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../testdata/radar-fmi-pvol/202605191050_fivih_PVOL.h5");
+    if !fixture.exists() {
+        eprintln!("skipping pvol_volume_engine_read_cells: fixture absent at {fixture:?}");
+        return;
+    }
+    let data_dir = fixture.parent().unwrap().to_str().unwrap();
+    let config = OdimConfig {
+        filename_template: None,
+        filename_pattern: None,
+        timestamp_format: None,
+        parameter: None,
+        unit: None,
+        nodata: None,
+        gain: None,
+        offset: None,
+        poll_interval_secs: 30,
+        max_files: None,
+        endpoint: None,
+        bucket: None,
+        prefix_pattern: None,
+        time_window: None,
+        discovery: None,
+        cadence_secs: None,
+    };
+    let engine = engine_odim::PolarVolumeEngine::new("fivih-cells-test", Some(data_dir), &config)
+        .expect("PolarVolumeEngine::new");
+    let view = engine.site_view("fivih", "fivih-cells-test-fivih");
+
+    let query = CellQuery {
+        quantity: Some("DBZH".into()),
+        dims: Some([48, 180, 24]), // modest grid keeps the test quick
+        extraction: CellExtractionOptions {
+            threshold: 35.0,
+            min_volume_km3: 5.0,
+            max_cells: 64,
+        },
+        track_scans: 4, // only one volume retained — window clamps to it
+        ..CellQuery::default()
+    };
+
+    let (_, _, m0) = engine_odim::cell_set_cache_metrics();
+    let product = view.read_cells(&query).expect("read_cells over the volume");
+
+    // One retained volume ⇒ one scan in the window, even with track_scans=4.
+    assert_eq!(product.cell_sets.len(), 1);
+    let (time, set) = product.target();
+    assert_eq!(set.time, *time);
+    assert_eq!(set.quantity, "DBZH");
+    assert!(
+        !set.cells.is_empty(),
+        "the fixture's 59 dBZ storm must segment into at least one cell"
+    );
+    let strongest = set
+        .cells
+        .iter()
+        .map(|c| c.max_dbz)
+        .fold(f64::NEG_INFINITY, f64::max);
+    // The native-resolution peak is ≈59 dBZ; cell-centre resampling onto the
+    // modest test grid smooths it to ≈43 dBZ (≈46 at the default dims).
+    assert!(
+        (40.0..50.0).contains(&strongest),
+        "fixture storm peak on this grid ≈43 dBZ, got {strongest}"
+    );
+    for cell in &set.cells {
+        assert!(cell.max_dbz >= 35.0, "member values reach the threshold");
+        assert!(
+            cell.echo_top_m > cell.base_m && cell.echo_top_m < 20_000.0 + 1_000.0,
+            "echo top within the sampled ceiling: {} vs base {}",
+            cell.echo_top_m,
+            cell.base_m
+        );
+        assert!(cell.volume_km3 >= 5.0, "speckle floor respected");
+        assert!(cell.area_km2 > 0.0);
+        assert!(cell.max_vil_kg_m2 > 0.0, "a 59 dBZ storm carries VIL");
+        assert!(
+            cell.footprint.len() >= 4 && cell.footprint.first() == cell.footprint.last(),
+            "closed footprint ring"
+        );
+        // Footprint and centroid sit within coverage of the Vihti radar.
+        for v in &cell.footprint {
+            assert!((v[0] - 24.5).abs() < 5.0 && (v[1] - 60.6).abs() < 3.0);
+        }
+        let [min_e, min_n, min_u, max_e, max_n, max_u] = cell.bbox_enu_m;
+        assert!(min_e < max_e && min_n < max_n && min_u < max_u);
+    }
+    // Single scan ⇒ one single-point track per cell, no motion yet.
+    assert_eq!(product.tracks.tracks.len(), set.cells.len());
+    assert!(product.tracks.tracks.iter().all(|t| t.motion_ms.is_none()));
+    let (_, _, m1) = engine_odim::cell_set_cache_metrics();
+    assert!(m1 > m0, "first segmentation is a cache miss");
+
+    // Repeat: the per-volume memo must serve the second call.
+    let (h0, _, _) = engine_odim::cell_set_cache_metrics();
+    let again = view.read_cells(&query).expect("read_cells repeat");
+    let (h1, _, _) = engine_odim::cell_set_cache_metrics();
+    assert!(h1 > h0, "repeat segmentation is a cache hit");
+    assert_eq!(again.cell_sets[0].1.cells.len(), set.cells.len());
+
+    // A non-reflectivity quantity is a clean 400, not a panic or a bogus run.
+    let bad = view.read_cells(&CellQuery {
+        quantity: Some("VRADH".into()),
+        ..query.clone()
+    });
+    assert!(
+        matches!(
+            bad,
+            Err(ds_core::error::DataServerError::InvalidParameter(_))
+        ),
+        "cells on a velocity quantity must be InvalidParameter"
+    );
+}
+
 /// Regression guard for SMHI signed-integer PVOL: SMHI ships its moments as
 /// **signed `i16`** (DBZH `gain=0.01`, sentinels `nodata=-32768` /
 /// `undetect=-32767` — only representable as signed), which the original

--- a/crates/engine-odim/tests/integration.rs
+++ b/crates/engine-odim/tests/integration.rs
@@ -788,7 +788,7 @@ fn pvol_volume_engine_read_cells() {
         ..CellQuery::default()
     };
 
-    let (_, _, m0) = engine_odim::cell_set_cache_metrics();
+    let (_, m0, _, _) = engine_odim::cell_set_cache_metrics();
     let product = view.read_cells(&query).expect("read_cells over the volume");
 
     // One retained volume ⇒ one scan in the window, even with track_scans=4.
@@ -836,13 +836,13 @@ fn pvol_volume_engine_read_cells() {
     // Single scan ⇒ one single-point track per cell, no motion yet.
     assert_eq!(product.tracks.tracks.len(), set.cells.len());
     assert!(product.tracks.tracks.iter().all(|t| t.motion_ms.is_none()));
-    let (_, _, m1) = engine_odim::cell_set_cache_metrics();
+    let (_, m1, _, _) = engine_odim::cell_set_cache_metrics();
     assert!(m1 > m0, "first segmentation is a cache miss");
 
     // Repeat: the per-volume memo must serve the second call.
-    let (h0, _, _) = engine_odim::cell_set_cache_metrics();
+    let (h0, _, _, _) = engine_odim::cell_set_cache_metrics();
     let again = view.read_cells(&query).expect("read_cells repeat");
-    let (h1, _, _) = engine_odim::cell_set_cache_metrics();
+    let (h1, _, _, _) = engine_odim::cell_set_cache_metrics();
     assert!(h1 > h0, "repeat segmentation is a cache hit");
     assert_eq!(again.cell_sets[0].1.cells.len(), set.cells.len());
 

--- a/crates/server/src/admin.rs
+++ b/crates/server/src/admin.rs
@@ -335,6 +335,39 @@ static PVOL_VOXEL_GRID_CACHE_CAPACITY_BYTES: LazyLock<IntGauge> = LazyLock::new(
     gauge
 });
 
+// Storm-cell segmentation memo (#367) — per-volume `CellSet`s, so an
+// animation window / repeated tracking request re-segments only the newest
+// volume.
+static PVOL_CELL_SET_CACHE_HITS: LazyLock<IntCounter> = LazyLock::new(|| {
+    let counter = IntCounter::new(
+        "pvol_cell_set_cache_hits_total",
+        "PVOL storm-cell set cache hits",
+    )
+    .unwrap();
+    REGISTRY.register(Box::new(counter.clone())).unwrap();
+    counter
+});
+
+static PVOL_CELL_SET_CACHE_MISSES: LazyLock<IntCounter> = LazyLock::new(|| {
+    let counter = IntCounter::new(
+        "pvol_cell_set_cache_misses_total",
+        "PVOL storm-cell set cache misses (full segmentations)",
+    )
+    .unwrap();
+    REGISTRY.register(Box::new(counter.clone())).unwrap();
+    counter
+});
+
+static PVOL_CELL_SET_CACHE_ENTRIES: LazyLock<IntGauge> = LazyLock::new(|| {
+    let gauge = IntGauge::new(
+        "pvol_cell_set_cache_entries",
+        "Entries currently held in the PVOL storm-cell set cache",
+    )
+    .unwrap();
+    REGISTRY.register(Box::new(gauge.clone())).unwrap();
+    gauge
+});
+
 // Meta-tile pixel cache (#202) — global, decoded-RGBA tiles for the Web
 // Mercator WMS meta-tiling path. Distinct from the per-collection GeoTIFF
 // compressed-byte tile cache (`tile_cache_*`).
@@ -466,6 +499,8 @@ struct CacheCounterState {
     pvol_pixel: (u64, u64, u64),
     /// PVOL voxel-grid cache `(hits, misses)` — global cache, monotonic.
     pvol_voxel_grid: (u64, u64),
+    /// PVOL storm-cell set cache `(hits, misses)` — global cache, monotonic.
+    pvol_cell_set: (u64, u64),
     /// 3D Tiles encoded-content cache `(hits, misses)` — global, monotonic.
     tiles3d_content: (u64, u64),
 }
@@ -2870,6 +2905,14 @@ pub async fn metrics_handler(State(state): State<AdminState>) -> impl IntoRespon
         counter_state.pvol_voxel_grid = (v_hits, v_misses);
         PVOL_VOXEL_GRID_CACHE_BYTES.set(v_bytes as i64);
         PVOL_VOXEL_GRID_CACHE_CAPACITY_BYTES.set(v_cap as i64);
+
+        // Storm-cell set cache: same process-global monotonic-counter shape.
+        let (s_hits, s_misses, s_entries) = engine_odim::cell_set_cache_metrics();
+        let (last_sh, last_sm) = counter_state.pvol_cell_set;
+        PVOL_CELL_SET_CACHE_HITS.inc_by(s_hits.saturating_sub(last_sh));
+        PVOL_CELL_SET_CACHE_MISSES.inc_by(s_misses.saturating_sub(last_sm));
+        counter_state.pvol_cell_set = (s_hits, s_misses);
+        PVOL_CELL_SET_CACHE_ENTRIES.set(s_entries as i64);
     }
 
     // 3D Tiles encoded-content cache: process-global + monotonic, like the

--- a/crates/server/src/admin.rs
+++ b/crates/server/src/admin.rs
@@ -358,10 +358,20 @@ static PVOL_CELL_SET_CACHE_MISSES: LazyLock<IntCounter> = LazyLock::new(|| {
     counter
 });
 
-static PVOL_CELL_SET_CACHE_ENTRIES: LazyLock<IntGauge> = LazyLock::new(|| {
+static PVOL_CELL_SET_CACHE_BYTES: LazyLock<IntGauge> = LazyLock::new(|| {
     let gauge = IntGauge::new(
-        "pvol_cell_set_cache_entries",
-        "Entries currently held in the PVOL storm-cell set cache",
+        "pvol_cell_set_cache_bytes",
+        "Bytes currently held in the PVOL storm-cell set cache",
+    )
+    .unwrap();
+    REGISTRY.register(Box::new(gauge.clone())).unwrap();
+    gauge
+});
+
+static PVOL_CELL_SET_CACHE_CAPACITY_BYTES: LazyLock<IntGauge> = LazyLock::new(|| {
+    let gauge = IntGauge::new(
+        "pvol_cell_set_cache_capacity_bytes",
+        "Configured PVOL storm-cell set cache capacity in bytes",
     )
     .unwrap();
     REGISTRY.register(Box::new(gauge.clone())).unwrap();
@@ -2907,12 +2917,13 @@ pub async fn metrics_handler(State(state): State<AdminState>) -> impl IntoRespon
         PVOL_VOXEL_GRID_CACHE_CAPACITY_BYTES.set(v_cap as i64);
 
         // Storm-cell set cache: same process-global monotonic-counter shape.
-        let (s_hits, s_misses, s_entries) = engine_odim::cell_set_cache_metrics();
+        let (s_hits, s_misses, s_bytes, s_cap) = engine_odim::cell_set_cache_metrics();
         let (last_sh, last_sm) = counter_state.pvol_cell_set;
         PVOL_CELL_SET_CACHE_HITS.inc_by(s_hits.saturating_sub(last_sh));
         PVOL_CELL_SET_CACHE_MISSES.inc_by(s_misses.saturating_sub(last_sm));
         counter_state.pvol_cell_set = (s_hits, s_misses);
-        PVOL_CELL_SET_CACHE_ENTRIES.set(s_entries as i64);
+        PVOL_CELL_SET_CACHE_BYTES.set(s_bytes as i64);
+        PVOL_CELL_SET_CACHE_CAPACITY_BYTES.set(s_cap as i64);
     }
 
     // 3D Tiles encoded-content cache: process-global + monotonic, like the


### PR DESCRIPTION
First of four PRs implementing #367 (storm-cell object extraction + tracking), generalized beyond 3D Tiles: the same cell/track product will be surfaced on WMS/Maps/Tiles (PR 2), 3D Tiles `representation=cells` (PR 3), and OGC API Features (PR 4). This PR is the engine-side foundation only — **no API surface changes**.

## What's here

### `ds_core::cells` (new module — pure geometry/physics, framework-free)
- **`extract_cells(grid, time, opts)`**: 3-D connected components on the cylindrical `VoxelGrid` (6-connectivity; the azimuth axis wraps on full-circle grids, guarded for future sector scans) at `value >= threshold` (default 35 dBZ, the classic TITAN cell threshold). Per cell: max dBZ + its position, linear-Z-weighted centroid, echo top/base (MSL), **radius-dependent** voxel volume (`Δr·(r_c·Δa)·Δh` — constant cell volume would overweight far range ~4×), footprint area, column-max VIL (`Σ 3.44e-6·Z^(4/7)·Δh`, dBZ capped at 56 for hail), a geographic footprint ring, and a local-ENU AABB (for the future 3D bounding-box product).
- **Footprint ring**: exact boundary trace of the cell's `(radius, azimuth)` column mask along voxel-column edges — seam-spanning storms are rotated seam-free before tracing so they yield **one** ring; largest ring wins (holes dropped, v1); CCW per RFC 7946; Douglas–Peucker simplified at half a radial cell. (Plan note: this replaces the planned marching squares — same goal, but the traced boundary is *exact* for a binary column mask, with no interpolation cases to get wrong.)
- **`track_cells(history, opts)`**: greedy minimum-cost centroid matching between consecutive scans with constant-velocity prediction and a `max_speed·Δt + base_gate` gate; births/deaths on no match; merges/splits resolve as nearest-wins (documented v1). Track ids are deterministic (`{first-scan-stamp}-{label}`); **known limitation** (documented): the id changes when the retention window slides past a track's origin scan. Per-track `motion_ms (u, v)` + `speed_direction()` are first-class — the seed for the future motion/optical-flow field product.

### `VolumeEngine::read_cells` (default-implemented — the *generic* hook)
Any engine whose `volume_info()` advertises voxel-grid capability gets cells + tracks for free: the default impl walks `times` back from the target scan, reads one grid per scan, extracts and tracks. Empty scans are **valid empty results** (Features will need "no cells now" as an empty collection; 3D Tiles maps all-empty to 404) — unlike `read_voxel_grid`, whose empty case is an error; `LocationNotFound` is reserved for capability/no-volumes gaps.

### engine-odim
- `read_voxel_grid`'s cache fill refactored into a **handle-parametric** `voxel_grid_cached(entry, quantity, dims, handle)` so the cells path can run from *either* runtime context: `Some(handle)` on a `spawn_blocking` pool thread (3D Tiles/raster), `None` on a request worker (the Features path, where `block_in_place` is the valid bridge) — per the established `Pixels::handle` rules. Behaviour of the existing path is unchanged.
- New `CELL_SET_CACHE`: process-global, count-bounded memo of per-volume segmentations keyed `(file, quantity, dims, opts-bits)` — volume files are immutable, so entries never go stale (the `VOXEL_GRID_CACHE` argument). In steady state only the newest volume pays resample + extraction. Byte-weighted like `VOXEL_GRID_CACHE` (footprint rings dominate the entry size): `MC_PVOL_CELL_SET_CACHE_MB` (default 64 MB; `0` rejects every entry).
- Cells are gated to **dBZ-unit quantities** (linear-Z/VIL math is reflectivity physics) — anything else is a clean 400.
- `/metrics`: `pvol_cell_set_cache_{hits,misses}_total` + `pvol_cell_set_cache_entries`.

## Plan deviations (called out)
- Footprint contour = exact column-edge boundary trace, not marching squares (see above).
- The `[odim]` config defaults (`cell_threshold_dbz` etc.) are deferred to the Features PR where the engine first *consumes* them — shipping unread config fields in this PR would be dead surface. The 3D Tiles/raster PRs pass options from the API layer (query params + API defaults), matching how `threshold` works today.
- The fivih integration test pins the segmented peak at ≈43 dBZ (40–50 band), not the memory'd "59 dBZ": 59 is the native-resolution point peak; cell-centre resampling onto the test grid smooths it (≈46 at default dims). Verified by probing the actual grid.

## Tests
- `ds-core` unit suite on synthetic grids: blob separation + volume ordering, **azimuth-seam blob = one cell/one ring**, hand-checked single-voxel volume/area/VIL/centroid/echo-top, VIL hail cap, speckle floor + `max_cells` cap, CCW ring; tracking: expected u/v + speed/direction on a moving blob, gate rejection, death on empty scan, merge=nearest-wins; default `read_cells` window/empty-scan/no-caps behaviour via a stub engine.
- `engine-odim` integration (fivih fixture, skips if absent): ≥1 cell with sane physics, closed in-coverage footprint, cache miss-then-hit, 400 on `VRADH`.
- `cargo test --workspace` green; clippy clean.

Refs #367 (do not close — 3 follow-up PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
