### PR TITLE
feat(server): CLI startup overrides (--host/--port/--config) + no-config auto-port boot

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,24 @@ cargo run -p server          # Start server (reads config.toml)
 cargo check -p <crate>       # Type-check a single crate
 ```
 
+### Server CLI flags
+
+The `server` binary takes a small hand-rolled set of flags (no `clap`), each
+also accepting `--flag=value` (see `parse_cli_args` in `server/src/main.rs`):
+
+- `--collections <id1,id2,…>` — only load these collection IDs.
+- `--host <HOST>` / `--port <PORT>` — override `[server].host`/`port` (CLI wins
+  over config). `BASE_URL` still wins for link generation.
+- `--config <PATH>` — config file path (wins over `CONFIG_PATH` env, then
+  `./config.toml`). A missing `--config` path is a hard error.
+
+**No-config boot:** if the default config path is absent **and** no `--config`
+is given, the server starts from built-in defaults — host `127.0.0.1`, and it
+**auto-scans for the first free port at/above 8000** (up to 100 ports) — with no
+collections. A port pinned by config or `--port` does **not** auto-scan: a bind
+conflict is fatal. This is the base for pointing the server at a directory with
+no `config.toml` (auto-collections, #411).
+
 ### Fuzz testing
 
 Fuzz targets live in `fuzz/` (separate from workspace, uses `cargo-fuzz` + `libfuzzer`). Requires nightly.

--- a/README.md
+++ b/README.md
@@ -73,14 +73,39 @@ Options:
   --collections <id1,id2,...>   Only load collections with these IDs (comma-separated).
                                 All others are silently skipped. Useful for smoke-testing
                                 a single collection without editing config.toml.
+  --host <HOST>                 Bind host. Overrides [server].host (CLI wins over config).
+  --port <PORT>                 Bind port. Overrides [server].port (CLI wins over config).
+                                Must be 1..=65535.
+  --config <PATH>               Config file path. Overrides the CONFIG_PATH env var and the
+                                ./config.toml default. A path given here that does not exist
+                                is a hard error.
   -h, --help                    Print this help and exit.
+```
+
+Each flag also accepts the `--flag=value` spelling (e.g. `--port=8011`). The
+parser is hand-rolled (no `clap`); `BASE_URL` still wins over `--host`/`--port`
+for generated links.
+
+**No-config boot.** If the default config path (`./config.toml`) is absent **and**
+no `--config` is given, the server starts from built-in defaults — host
+`127.0.0.1`, **auto-selecting the first free port at or above 8000** (scanning up
+to 100 ports) — with no collections (it answers `/health` and an empty
+`/collections`, and can be populated via `POST /admin/collections/reload`). A port
+pinned by config or `--port` is **not** auto-scanned: a bind conflict is fatal.
+This is the base for pointing the server at a directory of data with no
+`config.toml` (auto-collections — see issue #411).
+
+```bash
+server                         # no config.toml present -> 127.0.0.1, first free port >= 8000
+server --port 9000             # explicit port; conflict is fatal (no scan)
+server --config /etc/mc.toml   # explicit config; missing path is an error
 ```
 
 ### Environment Variables
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `CONFIG_PATH` | `./config.toml` | Path to the server configuration file |
+| `CONFIG_PATH` | `./config.toml` | Path to the server configuration file (the `--config` flag takes priority) |
 | `LOG_FORMAT` | human-readable | Set to `json` for newline-delimited JSON logs (production / Loki ingestion) |
 | `RUST_LOG` | `info` | Log level filter, e.g. `server=debug,engine_geotiff=warn` |
 | `ADMIN_TOKEN` | _(none — unauthenticated)_ | Bearer token required for `POST /admin/collections/reload`. When unset, the admin endpoint is open. |

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -62,6 +62,31 @@ impl ServerSettings {
     }
 }
 
+impl ServerConfig {
+    /// Build a config for the no-config-file boot path: the server is started
+    /// without a `config.toml` (e.g. to be pointed at a directory with no
+    /// config — see #411 auto-collections). Host defaults to loopback and port
+    /// to 8000; when the port is not pinned by config or `--port`, the binary
+    /// auto-scans upward from there for the first free port. Collections and
+    /// style bundles start empty and can be added via reload.
+    pub fn default_for_auto() -> Self {
+        ServerConfig {
+            server: ServerSettings {
+                host: "127.0.0.1".to_string(),
+                port: 8000,
+                base_url: None,
+                admin_token: None,
+                collections_dir: None,
+                metatile_cache_mb: default_metatile_cache_mb(),
+                watch_collections_dir: false,
+                watch_debounce_ms: default_watch_debounce_ms(),
+            },
+            collections: Vec::new(),
+            style_bundles: Vec::new(),
+        }
+    }
+}
+
 /// Deserialize a keyword list, trimming surrounding whitespace from each entry
 /// and dropping exact duplicates (first occurrence wins, order preserved) so
 /// `["radar", "radar"]` can't produce doubled chips / `<Keyword>` elements / JSON
@@ -1744,6 +1769,22 @@ mod tests {
     use super::*;
     use std::fs;
     use tempfile::TempDir;
+
+    #[test]
+    fn default_for_auto_is_loopback_and_empty() {
+        let cfg = ServerConfig::default_for_auto();
+        assert_eq!(cfg.server.host, "127.0.0.1");
+        assert_eq!(cfg.server.port, 8000);
+        assert!(cfg.server.base_url.is_none());
+        assert!(!cfg.server.watch_collections_dir);
+        assert!(cfg.collections.is_empty());
+        assert!(cfg.style_bundles.is_empty());
+        // No BASE_URL env in the test process => derived from host:port.
+        // (Guard against a stray env var in the harness.)
+        if std::env::var("BASE_URL").is_err() {
+            assert_eq!(cfg.server.base_url(), "http://127.0.0.1:8000");
+        }
+    }
 
     fn minimal_collection_toml(id: &str) -> String {
         format!(

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -362,10 +362,14 @@ async fn main() {
         }
     };
     // Reflect the actually-bound port back into config so base_url() and any
-    // downstream use see the real value (the auto-scan may have moved it).
-    if let Ok(local) = listener.local_addr() {
-        config.server.port = local.port();
-    }
+    // downstream use see the real value (the auto-scan may have moved it). A
+    // just-bound listener always has a local address (plain getsockname), but
+    // don't swallow the impossible case: a wrong write-back would make
+    // base_url()/logs/reload silently report the wrong port.
+    config.server.port = listener
+        .local_addr()
+        .expect("bound TcpListener must have a local address")
+        .port();
 
     let base_url = config.server.base_url();
     info!("Base URL: {base_url}");
@@ -470,6 +474,16 @@ async fn main() {
         info!("Admin endpoint authentication enabled");
     } else {
         info!("Admin endpoint authentication disabled (no ADMIN_TOKEN set)");
+        // Loopback default is safe; a non-loopback bind (e.g. `--host 0.0.0.0`)
+        // with no token exposes POST /admin/collections/reload to the network.
+        let host = config.server.host.as_str();
+        if !matches!(host, "127.0.0.1" | "::1" | "localhost") {
+            tracing::warn!(
+                "Admin endpoint is UNAUTHENTICATED and bound to a non-loopback host ({host}): \
+                 POST /admin/collections/reload is reachable from the network. Set ADMIN_TOKEN, \
+                 or bind to 127.0.0.1."
+            );
+        }
     }
 
     // Resolve the collections_dir to watch (issue #318) before `config_path` is
@@ -824,17 +838,24 @@ mod tests {
 
     #[tokio::test]
     async fn bind_auto_port_picks_start_when_free() {
-        // Grab a free port from the OS, release it, then confirm the scan
-        // binds exactly that one when it's available.
+        // Grab a free port from the OS as the scan start. We can't release and
+        // re-bind it atomically, so don't assert an exact match (another process
+        // could claim it in the gap); instead assert the scan lands within the
+        // window starting at `free`. The skips-used-port test covers advancing
+        // past a held port.
         let probe = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let free = probe.local_addr().unwrap().port();
         drop(probe);
 
-        let (listener, addr) = bind_auto_port("127.0.0.1", free)
+        let (listener, _addr) = bind_auto_port("127.0.0.1", free)
             .await
-            .expect("should bind the free start port");
-        assert_eq!(listener.local_addr().unwrap().port(), free);
-        assert_eq!(addr, format!("127.0.0.1:{free}"));
+            .expect("should find a free port in the scan window");
+        let chosen = listener.local_addr().unwrap().port();
+        assert!(
+            chosen >= free && chosen < free.saturating_add(AUTO_PORT_SCAN),
+            "expected a port in [{free}, {}), got {chosen}",
+            free.saturating_add(AUTO_PORT_SCAN)
+        );
     }
 
     #[tokio::test]

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -89,17 +89,33 @@ struct CliArgs {
     /// all others are silently skipped. Useful for smoke-testing a single
     /// collection without editing `config.toml`.
     collections: Option<Vec<String>>,
+    /// Override `[server].host`. Takes priority over config.
+    host: Option<String>,
+    /// Override `[server].port`. Takes priority over config. When neither this
+    /// nor a config file is present, the binary auto-scans for a free port
+    /// starting at the default (8000).
+    port: Option<u16>,
+    /// Path to the config file. Takes priority over the `CONFIG_PATH` env var
+    /// and the `./config.toml` default. A path given here that does not exist
+    /// is a hard error (unlike the default path, which falls back to built-in
+    /// defaults when absent).
+    config: Option<String>,
 }
 
-/// Very small hand-rolled argv parser — the server only has a couple of
+/// Very small hand-rolled argv parser — the server only has a handful of
 /// flags, so pulling in clap would be overkill.
 ///
-/// Supported forms:
-///   --collections=id1,id2
+/// Supported forms (each flag also accepts the `--flag=value` spelling):
 ///   --collections id1,id2
+///   --host 0.0.0.0
+///   --port 8011
+///   --config /etc/meteocore/config.toml
 ///   -h / --help
 fn parse_cli_args() -> CliArgs {
     let mut collections: Option<Vec<String>> = None;
+    let mut host: Option<String> = None;
+    let mut port: Option<u16> = None;
+    let mut config: Option<String> = None;
     let mut args = std::env::args().skip(1);
     while let Some(arg) = args.next() {
         match arg.as_str() {
@@ -109,10 +125,17 @@ fn parse_cli_args() -> CliArgs {
                      \n\
                      Options:\n  \
                        --collections <id1,id2,...>   Only load collections with these IDs\n  \
+                       --host <HOST>                 Bind host (overrides [server].host)\n  \
+                       --port <PORT>                 Bind port (overrides [server].port)\n  \
+                       --config <PATH>               Config file path (overrides CONFIG_PATH)\n  \
                        -h, --help                    Show this help\n\
                      \n\
+                     With no config file and no --port, the server binds localhost\n  \
+                     and auto-selects the first free port at or above 8000.\n\
+                     \n\
                      Environment:\n  \
-                       CONFIG_PATH    Path to config.toml (default: ./config.toml)\n  \
+                       CONFIG_PATH    Path to config.toml (default: ./config.toml; --config wins)\n  \
+                       BASE_URL       External base URL for links (wins over --host/--port)\n  \
                        LOG_FORMAT     'json' for structured logs (default: human-readable)\n  \
                        RUST_LOG       Log filter (default: info)\n  \
                        ADMIN_TOKEN    Bearer token for admin endpoints"
@@ -130,13 +153,88 @@ fn parse_cli_args() -> CliArgs {
                 let list = &s["--collections=".len()..];
                 collections = Some(parse_collection_list(list));
             }
+            "--host" => {
+                let Some(value) = args.next() else {
+                    eprintln!("error: --host requires a value");
+                    std::process::exit(2);
+                };
+                host = Some(value);
+            }
+            s if s.starts_with("--host=") => {
+                host = Some(s["--host=".len()..].to_string());
+            }
+            "--port" => {
+                let Some(value) = args.next() else {
+                    eprintln!("error: --port requires a value");
+                    std::process::exit(2);
+                };
+                port = Some(parse_port(&value));
+            }
+            s if s.starts_with("--port=") => {
+                port = Some(parse_port(&s["--port=".len()..]));
+            }
+            "--config" => {
+                let Some(value) = args.next() else {
+                    eprintln!("error: --config requires a value");
+                    std::process::exit(2);
+                };
+                config = Some(value);
+            }
+            s if s.starts_with("--config=") => {
+                config = Some(s["--config=".len()..].to_string());
+            }
             other => {
                 eprintln!("error: unknown argument '{other}' (try --help)");
                 std::process::exit(2);
             }
         }
     }
-    CliArgs { collections }
+    CliArgs {
+        collections,
+        host,
+        port,
+        config,
+    }
+}
+
+/// Parse a `--port` value, exiting with code 2 on anything that isn't a valid
+/// TCP port (1..=65535). `u16::from_str` already rejects negatives and values
+/// above 65535; we additionally reject 0 (not a bindable listen port).
+fn parse_port(s: &str) -> u16 {
+    match s.trim().parse::<u16>() {
+        Ok(p) if p > 0 => p,
+        _ => {
+            eprintln!("error: --port must be a number in 1..=65535 (got '{s}')");
+            std::process::exit(2);
+        }
+    }
+}
+
+/// Number of consecutive ports to try when auto-selecting a free one.
+const AUTO_PORT_SCAN: u16 = 100;
+
+/// Bind `host` on the first free port at or above `start`, scanning up to
+/// [`AUTO_PORT_SCAN`] ports. Returns the listener and the address it bound.
+///
+/// Only "address in use" advances to the next port; any other bind error
+/// (permission denied, unresolvable host, …) won't be fixed by trying another
+/// port, so it stops and returns `None`.
+async fn bind_auto_port(host: &str, start: u16) -> Option<(tokio::net::TcpListener, String)> {
+    for offset in 0..AUTO_PORT_SCAN {
+        let port = start.checked_add(offset)?;
+        let addr = format!("{host}:{port}");
+        match tokio::net::TcpListener::bind(&addr).await {
+            Ok(listener) => return Some((listener, addr)),
+            Err(e) if e.kind() == std::io::ErrorKind::AddrInUse => {
+                tracing::debug!("Port {port} in use, trying next");
+            }
+            Err(e) => {
+                tracing::error!("Failed to bind {addr}: {e}");
+                return None;
+            }
+        }
+    }
+    None
 }
 
 fn parse_collection_list(s: &str) -> Vec<String> {
@@ -152,14 +250,43 @@ async fn main() {
 
     let cli = parse_cli_args();
 
-    let config_path = std::env::var("CONFIG_PATH").unwrap_or_else(|_| "config.toml".to_string());
-    let (mut config, config_warnings) = match ds_core::config::ServerConfig::from_file(&config_path)
-    {
-        Ok(result) => result,
-        Err(e) => {
-            tracing::error!("Failed to load {}: {}", config_path, e);
-            std::process::exit(1);
+    // Resolve the config path: --config flag > CONFIG_PATH env > ./config.toml.
+    let config_path = cli
+        .config
+        .clone()
+        .or_else(|| std::env::var("CONFIG_PATH").ok())
+        .unwrap_or_else(|| "config.toml".to_string());
+
+    // Whether a config file is actually present drives the no-config boot path
+    // (built-in defaults + auto-port) and whether an all-failed load is fatal.
+    let config_present = std::path::Path::new(&config_path).exists();
+
+    let (mut config, config_warnings) = if config_present {
+        match ds_core::config::ServerConfig::from_file(&config_path) {
+            Ok(result) => result,
+            Err(e) => {
+                tracing::error!("Failed to load {}: {}", config_path, e);
+                std::process::exit(1);
+            }
         }
+    } else if cli.config.is_some() {
+        // An explicitly requested config file that doesn't exist is a hard
+        // error — don't silently ignore a typo'd --config path.
+        tracing::error!("Config file not found: {}", config_path);
+        std::process::exit(1);
+    } else {
+        // No config file at the default path and none requested: boot from
+        // built-in defaults (localhost + auto-selected port, no collections).
+        // This is the base for pointing the server at a directory with no
+        // config.toml (auto-collections, #411).
+        tracing::warn!(
+            "No config file at '{config_path}'; starting with built-in defaults \
+             (localhost, auto-selected port, no collections)."
+        );
+        (
+            ds_core::config::ServerConfig::default_for_auto(),
+            Vec::new(),
+        )
     };
     for warning in &config_warnings {
         tracing::warn!("{warning}");
@@ -195,21 +322,53 @@ async fn main() {
         );
     }
 
-    let base_url = config.server.base_url();
-    info!("Base URL: {base_url}");
+    // CLI host/port overrides take priority over config.
+    if let Some(host) = &cli.host {
+        config.server.host = host.clone();
+    }
+    if let Some(port) = cli.port {
+        config.server.port = port;
+    }
+
+    // The port is "pinned" when it comes from a config file or an explicit
+    // --port: bind exactly that, and a conflict is fatal. With neither (the
+    // no-config-file boot), auto-scan upward from the default for a free port.
+    let port_pinned = config_present || cli.port.is_some();
 
     // Bind the listen socket before loading collections: engine
     // construction runs synchronous S3/disk scans that can take
     // minutes, so a port conflict must fail fast rather than after
     // that whole load. The listener is held until `axum::serve`.
-    let addr = format!("{}:{}", config.server.host, config.server.port);
-    let listener = match tokio::net::TcpListener::bind(&addr).await {
-        Ok(listener) => listener,
-        Err(e) => {
-            tracing::error!("Failed to bind {addr}: {e}");
-            std::process::exit(1);
+    let host = config.server.host.clone();
+    let (listener, addr) = if port_pinned {
+        let addr = format!("{host}:{}", config.server.port);
+        match tokio::net::TcpListener::bind(&addr).await {
+            Ok(listener) => (listener, addr),
+            Err(e) => {
+                tracing::error!("Failed to bind {addr}: {e}");
+                std::process::exit(1);
+            }
+        }
+    } else {
+        match bind_auto_port(&host, config.server.port).await {
+            Some(bound) => bound,
+            None => {
+                tracing::error!(
+                    "Failed to find a free port for {host} starting at {} (tried {AUTO_PORT_SCAN})",
+                    config.server.port
+                );
+                std::process::exit(1);
+            }
         }
     };
+    // Reflect the actually-bound port back into config so base_url() and any
+    // downstream use see the real value (the auto-scan may have moved it).
+    if let Ok(local) = listener.local_addr() {
+        config.server.port = local.port();
+    }
+
+    let base_url = config.server.base_url();
+    info!("Base URL: {base_url}");
     // The socket is bound + listening from here, but HTTP is not served
     // until `axum::serve` below — keep the message explicit so a
     // log-watching operator isn't misled. (A TCP-only readiness probe
@@ -230,17 +389,28 @@ async fn main() {
         .count();
 
     if loaded == 0 {
-        tracing::error!(
-            "No collections loaded successfully ({} configured). Refusing to start an empty server.",
+        if config.collections.is_empty() {
+            // Nothing was configured to fail — a legitimately empty server
+            // (e.g. the no-config-file boot). Start it: it answers /health and
+            // an empty /collections, and can be populated via reload.
+            tracing::warn!(
+                "Starting with no collections. The server responds to /health and an empty \
+                 /collections; add collections via config + POST /admin/collections/reload."
+            );
+        } else {
+            tracing::error!(
+                "No collections loaded successfully ({} configured). Refusing to start an empty server.",
+                config.collections.len()
+            );
+            std::process::exit(1);
+        }
+    } else {
+        info!(
+            "Loaded {}/{} collections successfully",
+            loaded,
             config.collections.len()
         );
-        std::process::exit(1);
     }
-    info!(
-        "Loaded {}/{} collections successfully",
-        loaded,
-        config.collections.len()
-    );
 
     // Spawn poll loops on the dedicated background runtime so their blocking
     // I/O never parks a request-serving worker (#221).
@@ -633,4 +803,53 @@ async fn root_landing_page(state: AdminState) -> impl IntoResponse {
             }
         ]
     }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_collection_list_trims_and_drops_empties() {
+        assert_eq!(parse_collection_list("a, b ,,c"), vec!["a", "b", "c"]);
+        assert!(parse_collection_list("  ,  ").is_empty());
+    }
+
+    #[test]
+    fn parse_port_accepts_valid() {
+        assert_eq!(parse_port("8080"), 8080);
+        assert_eq!(parse_port(" 1 "), 1);
+        assert_eq!(parse_port("65535"), 65535);
+    }
+
+    #[tokio::test]
+    async fn bind_auto_port_picks_start_when_free() {
+        // Grab a free port from the OS, release it, then confirm the scan
+        // binds exactly that one when it's available.
+        let probe = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let free = probe.local_addr().unwrap().port();
+        drop(probe);
+
+        let (listener, addr) = bind_auto_port("127.0.0.1", free)
+            .await
+            .expect("should bind the free start port");
+        assert_eq!(listener.local_addr().unwrap().port(), free);
+        assert_eq!(addr, format!("127.0.0.1:{free}"));
+    }
+
+    #[tokio::test]
+    async fn bind_auto_port_skips_used_port() {
+        // Hold a port, then confirm the scan moves past it to a higher one.
+        let held = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let start = held.local_addr().unwrap().port();
+
+        let (listener, _addr) = bind_auto_port("127.0.0.1", start)
+            .await
+            .expect("should find a free port above the held one");
+        let chosen = listener.local_addr().unwrap().port();
+        assert!(
+            chosen > start,
+            "expected a port above {start}, got {chosen}"
+        );
+    }
 }


### PR DESCRIPTION
Closes #271.

## What

Adds the CLI startup overrides from #271 and a **no-config-file boot path** so the binary can be launched without a `config.toml` (the foundation for auto-collections, #411).

### CLI flags (hand-rolled parser, no `clap`)

| Flag | Effect |
|---|---|
| `--port <u16>` | Override `[server].port` (CLI > config). Rejects non-`1..=65535` with exit 2. |
| `--host <str>` | Override `[server].host` (CLI > config). |
| `--config <path>` | Config file path (CLI flag > `CONFIG_PATH` env > `./config.toml`). A missing **explicit** path is a hard error. |

Each also accepts `--flag=value`. `BASE_URL` still wins for link generation.

### No-config boot + auto-port

When the default config path is absent **and** no `--config` is given, the server boots from built-in defaults — host `127.0.0.1`, **auto-scanning for the first free port at/above 8000** (up to 100 ports) — with no collections. It serves `/health` and an empty `/collections`, and can be populated via `POST /admin/collections/reload`.

A port **pinned** by config or `--port` is *not* auto-scanned — a bind conflict stays fatal (unchanged behavior). The "refuse to start empty" guard is relaxed only when nothing is configured; configured-but-all-failed is still fatal. The actually-bound port is written back into config so `base_url()` follows the auto-selected port.

> Per @-request, this is split from the auto-collection feature itself (#411). This PR is the flags + boot/auto-port plumbing; the directory→collections classifier is #411 and builds on `ServerConfig::default_for_auto()` added here.

## Tests

Unit tests: `parse_port`, `bind_auto_port` (picks free start / skips a held port), `parse_collection_list`, and `ServerConfig::default_for_auto`. `cargo test -p server -p ds-core` green; fmt + clippy `--tests` clean.

Manually verified end-to-end:
- `--help` lists the new flags + auto-port note
- `--port abc|0|99999` → error, exit 2
- `--config <missing>` → hard error, exit 1
- no config + no flags → WARN, bound `127.0.0.1:8000`, empty server answers `/health` + `/collections`
- auto-port: 8000 busy → bound `8001`, `base_url` follows
- `--port 8042` with config present → exact bind
- pinned conflict (config or `--port`) → "Failed to bind", **no** scan

## Docs

`README.md` Command-Line Options + `CLAUDE.md` Build & Run updated with the flags and the no-config/auto-port behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)