### PR TITLE
feat(server): auto-collection mode (--auto-collections <dir>) — phase 1 (#411)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,13 +23,31 @@ also accepting `--flag=value` (see `parse_cli_args` in `server/src/main.rs`):
   over config). `BASE_URL` still wins for link generation.
 - `--config <PATH>` — config file path (wins over `CONFIG_PATH` env, then
   `./config.toml`). A missing `--config` path is a hard error.
+- `--auto-collections <DIR>` — auto-discover collections from a directory tree
+  (repeatable); see below.
 
 **No-config boot:** if the default config path is absent **and** no `--config`
 is given, the server starts from built-in defaults — host `127.0.0.1`, and it
-**auto-scans for the first free port at/above 8000** (up to 100 ports) — with no
-collections. A port pinned by config or `--port` does **not** auto-scan: a bind
-conflict is fatal. This is the base for pointing the server at a directory with
-no `config.toml` (auto-collections, #411).
+**auto-scans for the first free port at/above 8000** (up to 100 ports). A port
+pinned by config or `--port` does **not** auto-scan: a bind conflict is fatal.
+Combine with `--auto-collections` for a zero-config `server --auto-collections
+./data`.
+
+**Auto-collections (`server/src/auto.rs`, #411 phase 1):** `--auto-collections
+<DIR>` synthesizes `CollectionConfig`s from data files on disk (no TOML). Mapping
+is **per-subdirectory + loose files**: each immediate subdir → a collection;
+loose files in the root → grouped under the root name. Detection (first match
+wins): zarr store (`zarr.json`/`.zgroup`/`*.zarr` name) → `zarr`; `*.sqd` →
+`querydata`; `*.grib2`+index sidecars → `grib` (`.idx`→wgrib2, `.index`→ecmwf-json;
+**no index ⇒ skipped**, the engine never builds them); `*.tif`/`*.h5` → **phase 2,
+skipped** (need filename-template inference + ODIM COMP/PVOL probe); `*.geojson`
+and `*.csv` → one collection **per file**. Raster/grid auto-collections are
+**EDR-only** (no inferable colormap → no WMS/Maps/Tiles). Synthesized configs are
+appended to `config.collections` and run through the same `ServerConfig::validate()`
+as TOML (duplicate ids rejected). Resolved once at startup (reload does not
+re-scan auto roots in v1). Engine-config defaults come from
+`{QueryData,Grib,Zarr}Config::auto_*` constructors in `ds-core` (reuse the serde
+default fns — keep them DRY).
 
 ### Fuzz testing
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,9 @@ appended to `config.collections` and run through the same `ServerConfig::validat
 as TOML (duplicate ids rejected). Resolved once at startup (reload does not
 re-scan auto roots in v1). Engine-config defaults come from
 `{QueryData,Grib,Zarr}Config::auto_*` constructors in `ds-core` (reuse the serde
-default fns — keep them DRY).
+default fns — keep them DRY). The root may itself be a Zarr store (not just its
+parent). **Symlinks are followed** (`is_dir`/`is_file` resolve them) — same trust
+model as `collections_dir` (whoever can write the scan root controls what's served).
 
 ### Fuzz testing
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -251,7 +251,7 @@ don't collide. **Maps/Tiles `reference_time` query parameter is still a follow-u
 | Engine | Traits | APIs |
 |--------|--------|------|
 | CSV | `EdrEngine` + `FeatureEngine` | EDR (locations only), Features |
-| GeoJSON | `FeatureEngine` | Features |
+| GeoJSON | `FeatureEngine` | Features, Tiles (MVT) |
 | GeoTIFF | `EdrEngine` + `MapEngine` | EDR (position, area), WMS, Maps, Tiles |
 | GRIB | `EdrEngine` + `MapEngine` | EDR, WMS, Maps, Tiles |
 | ODIM COMP | `EdrEngine` + `MapEngine` | EDR (position, area), WMS, Maps, Tiles |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,8 +41,13 @@ wins): zarr store (`zarr.json`/`.zgroup`/`*.zarr` name) → `zarr`; `*.sqd` →
 `querydata`; `*.grib2`+index sidecars → `grib` (`.idx`→wgrib2, `.index`→ecmwf-json;
 **no index ⇒ skipped**, the engine never builds them); `*.tif`/`*.h5` → **phase 2,
 skipped** (need filename-template inference + ODIM COMP/PVOL probe); `*.geojson`
-and `*.csv` → one collection **per file**. Raster/grid auto-collections are
-**EDR-only** (no inferable colormap → no WMS/Maps/Tiles). Synthesized configs are
+and `*.csv` → one collection **per file**. Each collection enables **all APIs
+relevant to its type** (mirroring the `engine_type → supported_apis` allowlist):
+raster/grid (zarr/grib/querydata) get edr+wms+maps+tiles, csv gets edr+features,
+geojson gets features+tiles — so the data renders + shows a parameter selector in
+`/preview` without a `[wms]` block (the render path falls back to a default
+viridis colormap; range is generic `0..1` until a per-collection `[wms]`
+colormap/min-max is set — #320). Synthesized configs are
 appended to `config.collections` and run through the same `ServerConfig::validate()`
 as TOML (duplicate ids rejected). Resolved once at startup (reload does not
 re-scan auto roots in v1). Engine-config defaults come from

--- a/README.md
+++ b/README.md
@@ -126,6 +126,13 @@ the same way under the root's name. Detection per directory (first match wins):
 | `*.geojson` | one `geojson` collection **per file** | Features |
 | `*.csv` | one `csv` collection **per file** | EDR + Features; columns are positional: `location,latitude,longitude,time,<params…>` |
 
+Pointing `--auto-collections` directly at a single Zarr store (rather than its
+parent) also works. **Symlinks are followed** — a symlinked subdirectory or data
+file is scanned like a real one (operators commonly symlink data into a serving
+directory). This is the same trust model as `collections_dir`: whoever can write
+the scan root controls what is served, so keep it writable only by trusted
+principals.
+
 **Phase 1 limitations:** raster/grid collections come up **EDR-only** — WMS/Maps/
 Tiles need a colormap that can't be inferred, so configure those via `config.toml`.
 GeoTIFF and ODIM (the filename-timestamped formats) are deferred to phase 2.

--- a/README.md
+++ b/README.md
@@ -116,15 +116,23 @@ collections and validated together (duplicate ids are rejected).
 slugified directory name); data files sitting **loose** in the root are grouped
 the same way under the root's name. Detection per directory (first match wins):
 
-| On disk | Becomes | Notes |
-|---------|---------|-------|
-| `zarr.json` / `.zgroup` / `.zarray`, or a `*.zarr` dir name | one `zarr` collection | EDR |
-| `*.sqd` | one `querydata` collection | EDR; model runs from the files |
-| `*.grib2`/`*.grb2` **with** `*.index`/`*.idx` sidecars | one `grib` collection | EDR; `index_format` inferred (`.idx`→wgrib2, `.index`→ecmwf-json) |
+| On disk | Becomes | APIs |
+|---------|---------|------|
+| `zarr.json` / `.zgroup` / `.zarray`, or a `*.zarr` dir name | one `zarr` collection | EDR, WMS, Maps, Tiles |
+| `*.sqd` | one `querydata` collection | EDR, WMS, Maps, Tiles; model runs from the files |
+| `*.grib2`/`*.grb2` **with** `*.index`/`*.idx` sidecars | one `grib` collection | EDR, WMS, Maps, Tiles; `index_format` inferred (`.idx`→wgrib2, `.index`→ecmwf-json) |
 | `*.grib2` **without** index sidecars | _(skipped)_ | the GRIB engine needs prebuilt indexes |
 | `*.tif`/`*.tiff` (GeoTIFF), `*.h5`/`*.hdf5` (ODIM) | _(skipped)_ | **phase 2** — needs filename-template inference (#411) |
-| `*.geojson` | one `geojson` collection **per file** | Features |
-| `*.csv` | one `csv` collection **per file** | EDR + Features; columns are positional: `location,latitude,longitude,time,<params…>` |
+| `*.geojson` | one `geojson` collection **per file** | Features, Tiles (MVT) |
+| `*.csv` | one `csv` collection **per file** | EDR, Features; columns are positional: `location,latitude,longitude,time,<params…>` |
+
+Each collection enables **all APIs relevant to its type** so the data is
+browsable in `/preview` (with a parameter selector) out of the box. Raster/grid
+collections (zarr/grib/querydata) render via a **default colormap** when no
+`[wms]` block is configured — the colormap *range* is generic (viridis `0..1`),
+so weather data in physical units renders but with poor colour contrast until you
+add a per-collection `[wms]` colormap with `min`/`max` (or auto-scaling lands,
+[#320](https://github.com/mrauhala/meteocore/issues/320)).
 
 Pointing `--auto-collections` directly at a single Zarr store (rather than its
 parent) also works. **Symlinks are followed** — a symlinked subdirectory or data
@@ -133,11 +141,10 @@ directory). This is the same trust model as `collections_dir`: whoever can write
 the scan root controls what is served, so keep it writable only by trusted
 principals.
 
-**Phase 1 limitations:** raster/grid collections come up **EDR-only** — WMS/Maps/
-Tiles need a colormap that can't be inferred, so configure those via `config.toml`.
-GeoTIFF and ODIM (the filename-timestamped formats) are deferred to phase 2.
-Auto-collections are resolved once at startup; `POST /admin/collections/reload`
-re-reads `config.toml`/`collections_dir` but does not re-scan the auto roots.
+**Phase 1 limitations:** GeoTIFF and ODIM (the filename-timestamped formats) are
+deferred to phase 2. Auto-collections are resolved once at startup;
+`POST /admin/collections/reload` re-reads `config.toml`/`collections_dir` but does
+not re-scan the auto roots.
 
 ### Environment Variables
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,9 @@ Options:
   --config <PATH>               Config file path. Overrides the CONFIG_PATH env var and the
                                 ./config.toml default. A path given here that does not exist
                                 is a hard error.
+  --auto-collections <DIR>      Auto-discover collections from a directory (repeatable).
+                                Synthesizes collections from the data files found, with no
+                                config.toml. zarr/grib/querydata/csv/geojson (see below).
   -h, --help                    Print this help and exit.
 ```
 
@@ -89,17 +92,45 @@ for generated links.
 **No-config boot.** If the default config path (`./config.toml`) is absent **and**
 no `--config` is given, the server starts from built-in defaults — host
 `127.0.0.1`, **auto-selecting the first free port at or above 8000** (scanning up
-to 100 ports) — with no collections (it answers `/health` and an empty
-`/collections`, and can be populated via `POST /admin/collections/reload`). A port
-pinned by config or `--port` is **not** auto-scanned: a bind conflict is fatal.
-This is the base for pointing the server at a directory of data with no
-`config.toml` (auto-collections — see issue #411).
+to 100 ports). With no `--auto-collections` it comes up empty (it answers
+`/health` and an empty `/collections`, and can be populated via
+`POST /admin/collections/reload`). A port pinned by config or `--port` is **not**
+auto-scanned: a bind conflict is fatal.
 
 ```bash
-server                         # no config.toml present -> 127.0.0.1, first free port >= 8000
-server --port 9000             # explicit port; conflict is fatal (no scan)
-server --config /etc/mc.toml   # explicit config; missing path is an error
+server                                 # no config.toml -> 127.0.0.1, first free port >= 8000
+server --port 9000                     # explicit port; conflict is fatal (no scan)
+server --config /etc/mc.toml           # explicit config; missing path is an error
+server --auto-collections ./data       # serve a directory of data with no config.toml
 ```
+
+#### Auto-collections (`--auto-collections <DIR>`)
+
+Point the server at a directory and it **synthesizes collections from the data
+files on disk** — no `config.toml` needed (combine with the no-config boot above
+for a zero-config `server --auto-collections ./data`). The flag is repeatable to
+scan several roots. Synthesized collections are merged with any config-file
+collections and validated together (duplicate ids are rejected).
+
+**Mapping:** each immediate **subdirectory** of a root becomes a collection (id =
+slugified directory name); data files sitting **loose** in the root are grouped
+the same way under the root's name. Detection per directory (first match wins):
+
+| On disk | Becomes | Notes |
+|---------|---------|-------|
+| `zarr.json` / `.zgroup` / `.zarray`, or a `*.zarr` dir name | one `zarr` collection | EDR |
+| `*.sqd` | one `querydata` collection | EDR; model runs from the files |
+| `*.grib2`/`*.grb2` **with** `*.index`/`*.idx` sidecars | one `grib` collection | EDR; `index_format` inferred (`.idx`→wgrib2, `.index`→ecmwf-json) |
+| `*.grib2` **without** index sidecars | _(skipped)_ | the GRIB engine needs prebuilt indexes |
+| `*.tif`/`*.tiff` (GeoTIFF), `*.h5`/`*.hdf5` (ODIM) | _(skipped)_ | **phase 2** — needs filename-template inference (#411) |
+| `*.geojson` | one `geojson` collection **per file** | Features |
+| `*.csv` | one `csv` collection **per file** | EDR + Features; columns are positional: `location,latitude,longitude,time,<params…>` |
+
+**Phase 1 limitations:** raster/grid collections come up **EDR-only** — WMS/Maps/
+Tiles need a colormap that can't be inferred, so configure those via `config.toml`.
+GeoTIFF and ODIM (the filename-timestamped formats) are deferred to phase 2.
+Auto-collections are resolved once at startup; `POST /admin/collections/reload`
+re-reads `config.toml`/`collections_dir` but does not re-scan the auto roots.
 
 ### Environment Variables
 

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -496,6 +496,18 @@ pub struct QueryDataConfig {
     pub max_runs: usize,
 }
 
+impl QueryDataConfig {
+    /// Defaults for an auto-discovered local `.sqd` directory (#411): no WMS
+    /// parameter selected (the first is used for rendering), default poll/runs.
+    pub fn auto_default() -> Self {
+        QueryDataConfig {
+            wms_parameter: None,
+            poll_interval_secs: default_poll_interval(),
+            max_runs: default_querydata_max_runs(),
+        }
+    }
+}
+
 /// Configuration for the ODIM_H5 weather-radar engine
 /// (`engine_type = "odim"`).
 ///
@@ -646,6 +658,35 @@ pub struct GribConfig {
     pub filename_contains: Option<String>,
 }
 
+impl GribConfig {
+    /// Defaults for an auto-discovered local directory of GRIB2 + index
+    /// sidecars (#411). `data_path` is the directory; the index/data suffixes
+    /// and index format come from what was found on disk.
+    pub fn auto_local(
+        data_path: String,
+        index_suffix: String,
+        data_suffix: String,
+        index_format: Option<String>,
+    ) -> Self {
+        GribConfig {
+            data_path: Some(data_path),
+            endpoint: None,
+            bucket: None,
+            prefix_pattern: None,
+            index_suffix: Some(index_suffix),
+            data_suffix: Some(data_suffix),
+            poll_interval_secs: default_grib_poll_interval(),
+            max_runs: None,
+            time_window: None,
+            parameters: None,
+            grid_cache_mb: default_grid_cache_mb(),
+            run_hours: None,
+            index_format,
+            filename_contains: None,
+        }
+    }
+}
+
 fn default_zarr_poll_interval() -> u64 {
     300
 }
@@ -697,6 +738,25 @@ pub struct ZarrConfig {
     /// (local) or `endpoint`+`bucket`+`path` (S3); this table selects the
     /// version to read. See issue #335.
     pub icechunk: Option<IcechunkConfig>,
+}
+
+impl ZarrConfig {
+    /// Defaults for an auto-discovered local Zarr store directory (#411):
+    /// `data_path` is the store root, version auto-detected, every variable
+    /// exposed, default poll/cache.
+    pub fn auto_local(data_path: String) -> Self {
+        ZarrConfig {
+            data_path: Some(data_path),
+            endpoint: None,
+            bucket: None,
+            path: None,
+            zarr_version: None,
+            parameters: None,
+            poll_interval_secs: default_zarr_poll_interval(),
+            cache_mb: default_zarr_cache_mb(),
+            icechunk: None,
+        }
+    }
 }
 
 /// Icechunk version selector for `[collections.zarr.icechunk]`.

--- a/crates/server/src/auto.rs
+++ b/crates/server/src/auto.rs
@@ -17,6 +17,12 @@
 //! The synthesized configs are appended to the live config and run through the
 //! same [`ServerConfig::validate`](ds_core::config::ServerConfig::validate) as
 //! TOML collections (so e.g. duplicate ids are rejected uniformly).
+//!
+//! **Symlinks are followed** (`is_dir`/`is_file` resolve them): a symlinked
+//! subdirectory or data file is scanned like a real one — operators commonly
+//! symlink data into a serving directory. This is the same trust model as
+//! `collections_dir`: whoever can write the scan root already controls what the
+//! server serves, so keep it writable only by trusted principals.
 
 use ds_core::config::{CollectionConfig, GribConfig, QueryDataConfig, ZarrConfig};
 use std::path::Path;
@@ -47,6 +53,12 @@ pub fn scan_roots(roots: &[String]) -> Vec<CollectionConfig> {
 fn scan_one_root(root: &Path) -> Result<Vec<CollectionConfig>, String> {
     if !root.is_dir() {
         return Err(format!("not a directory: {}", root.display()));
+    }
+    // The root may itself be a Zarr store (user pointed --auto-collections at the
+    // store rather than its parent). Detect it before enumerating, so its chunk
+    // subdirectories aren't each mis-scanned as candidate collections.
+    if dir_is_zarr_store(root) {
+        return Ok(mk_zarr(root).into_iter().collect());
     }
     let mut subdirs = Vec::new();
     let mut loose_files = Vec::new();
@@ -113,8 +125,19 @@ fn classify_files(
         return vec![];
     }
 
+    let has_grib_data = files
+        .iter()
+        .any(|f| has_ext(f, "grib2") || has_ext(f, "grb2"));
+
     // 1. QueryData — a directory of .sqd (time + params read from the file).
     if files.iter().any(|f| has_ext(f, "sqd")) {
+        if has_grib_data {
+            tracing::warn!(
+                "--auto-collections: {} has both .sqd and GRIB2 data — using querydata, \
+                 ignoring the GRIB files",
+                dir.display()
+            );
+        }
         return mk_querydata(dir, id_hint).into_iter().collect();
     }
 
@@ -128,9 +151,18 @@ fn classify_files(
     };
     if let Some(data_suffix) = data_suffix {
         // `.index` => ECMWF JSON-lines (engine default); `.idx` => wgrib2.
-        let index = if files.iter().any(|f| has_ext(f, "index")) {
+        let has_index = files.iter().any(|f| has_ext(f, "index"));
+        let has_idx = files.iter().any(|f| has_ext(f, "idx"));
+        if has_index && has_idx {
+            tracing::warn!(
+                "--auto-collections: {} has both .index and .idx sidecars — using .index \
+                 (ecmwf-json)",
+                dir.display()
+            );
+        }
+        let index = if has_index {
             Some((".index", Some("ecmwf-json")))
-        } else if files.iter().any(|f| has_ext(f, "idx")) {
+        } else if has_idx {
             Some((".idx", Some("wgrib2")))
         } else {
             None
@@ -623,6 +655,24 @@ mod tests {
             config.validate().is_err(),
             "duplicate collection ids must fail validate()",
         );
+    }
+
+    #[test]
+    fn root_that_is_itself_a_zarr_store() {
+        // Pointing --auto-collections directly at a Zarr store (marker file, name
+        // not ending in .zarr) yields one zarr collection and does NOT descend
+        // into chunk subdirectories.
+        let root = TempDir::new().unwrap();
+        let r = root.path();
+        touch(r, "zarr.json");
+        let chunk = r.join("c");
+        fs::create_dir(&chunk).unwrap();
+        touch(&chunk, "0.0.0");
+
+        let cfgs = scan_roots(&[r.to_str().unwrap().to_string()]);
+        assert_eq!(cfgs.len(), 1, "{:?}", ids(&cfgs));
+        assert_eq!(cfgs[0].engine_type, "zarr");
+        assert!(cfgs[0].zarr.is_some());
     }
 
     #[test]

--- a/crates/server/src/auto.rs
+++ b/crates/server/src/auto.rs
@@ -233,6 +233,14 @@ fn classify_files(
 }
 
 // ---- engine-specific synthesizers -----------------------------------------
+//
+// `apis` is the full set relevant to each engine type (mirroring the
+// `engine_type -> supported_apis` allowlist in `admin.rs`): raster/grid engines
+// get edr + wms + maps + tiles, csv gets edr + features, geojson gets features +
+// tiles. WMS/Maps/Tiles load without a `[wms]` block — the render path falls
+// back to a default colormap — so the data is browsable in `/preview` out of the
+// box. The default colormap range is generic (viridis 0..1); a per-collection
+// `[wms]` colormap/min-max gives correct colours for the data's domain (#320).
 
 fn mk_zarr(dir: &Path) -> Option<CollectionConfig> {
     let path = path_str(dir)?;
@@ -243,7 +251,7 @@ fn mk_zarr(dir: &Path) -> Option<CollectionConfig> {
     Some(mk_collection(
         id,
         "zarr",
-        vec!["edr".into()],
+        vec!["edr".into(), "wms".into(), "maps".into(), "tiles".into()],
         None,
         Some(ZarrConfig::auto_local(path)),
         None,
@@ -257,7 +265,7 @@ fn mk_querydata(dir: &Path, id_hint: &str) -> Option<CollectionConfig> {
     Some(mk_collection(
         slug_id(id_hint, dir)?,
         "querydata",
-        vec!["edr".into()],
+        vec!["edr".into(), "wms".into(), "maps".into(), "tiles".into()],
         Some(path), // querydata reads collection.data_path
         None,
         None,
@@ -277,7 +285,7 @@ fn mk_grib(
     Some(mk_collection(
         slug_id(id_hint, dir)?,
         "grib",
-        vec!["edr".into()],
+        vec!["edr".into(), "wms".into(), "maps".into(), "tiles".into()],
         None, // grib reads GribConfig.data_path
         None,
         Some(GribConfig::auto_local(
@@ -297,7 +305,7 @@ fn mk_geojson(file: &Path) -> Option<CollectionConfig> {
     Some(mk_collection(
         id,
         "geojson",
-        vec!["features".into()],
+        vec!["features".into(), "tiles".into()],
         Some(path),
         None,
         None,
@@ -520,6 +528,11 @@ mod tests {
         assert!(got.contains(&("era5".into(), "zarr".into())), "{got:?}");
         // grib-without-index produced nothing
         assert!(!got.iter().any(|(id, _)| id == "noidx"), "{got:?}");
+
+        // Raster/grid engines enable the full relevant API set so they render
+        // and surface a parameter selector in /preview (not EDR-only).
+        let meps = cfgs.iter().find(|c| c.id == "meps").unwrap();
+        assert_eq!(meps.apis, vec!["edr", "wms", "maps", "tiles"]);
     }
 
     #[test]

--- a/crates/server/src/auto.rs
+++ b/crates/server/src/auto.rs
@@ -1,0 +1,561 @@
+//! Auto-collection discovery (#411, phase 1).
+//!
+//! Turns a directory tree of data files into synthesized [`CollectionConfig`]s
+//! for the `--auto-collections <DIR>` flag — no `config.toml` required. The
+//! mapping is **per-subdirectory + loose files**: each immediate subdirectory
+//! of a root becomes a collection (or, for the single-file formats, one per
+//! file), and data files sitting loose in the root are grouped the same way
+//! under the root's name.
+//!
+//! Phase 1 covers the **self-describing / directory-native** engines (time and
+//! parameters come from inside the data or a directory listing, so no filename
+//! templating is needed): `zarr`, `grib` (with index sidecars), `querydata`,
+//! and the single-file `csv` / `geojson`. `geotiff` and `odim` encode time in
+//! the filename and need template inference + (for ODIM) a COMP/PVOL probe —
+//! deferred to phase 2; they are detected and skipped with a log here.
+//!
+//! The synthesized configs are appended to the live config and run through the
+//! same [`ServerConfig::validate`](ds_core::config::ServerConfig::validate) as
+//! TOML collections (so e.g. duplicate ids are rejected uniformly).
+
+use ds_core::config::{CollectionConfig, GribConfig, QueryDataConfig, ZarrConfig};
+use std::path::Path;
+
+/// Scan each root directory and return the synthesized collection configs.
+///
+/// Unrecognized directories, GRIB without index sidecars, and the phase-2
+/// formats are skipped with a `warn!`/`info!` log rather than failing — one bad
+/// directory should not sink the whole launch.
+pub fn scan_roots(roots: &[String]) -> Vec<CollectionConfig> {
+    let mut out = Vec::new();
+    for root in roots {
+        match scan_one_root(Path::new(root)) {
+            Ok(mut cfgs) => {
+                tracing::info!(
+                    "--auto-collections: '{root}' yielded {} collection(s)",
+                    cfgs.len()
+                );
+                out.append(&mut cfgs);
+            }
+            Err(e) => tracing::warn!("--auto-collections: skipping '{root}': {e}"),
+        }
+    }
+    out
+}
+
+/// Scan one root: classify each immediate subdirectory, then the loose files.
+fn scan_one_root(root: &Path) -> Result<Vec<CollectionConfig>, String> {
+    if !root.is_dir() {
+        return Err(format!("not a directory: {}", root.display()));
+    }
+    let mut subdirs = Vec::new();
+    let mut loose_files = Vec::new();
+    for entry in std::fs::read_dir(root).map_err(|e| e.to_string())? {
+        let path = entry.map_err(|e| e.to_string())?.path();
+        if path.is_dir() {
+            subdirs.push(path);
+        } else if path.is_file() {
+            loose_files.push(path);
+        }
+    }
+    subdirs.sort();
+    loose_files.sort();
+
+    let mut out = Vec::new();
+    // Each immediate subdirectory => its own collection(s).
+    for subdir in &subdirs {
+        let hint = file_name(subdir);
+        out.extend(classify_dir(subdir, &hint));
+    }
+    // Loose data files in the root => collection(s) named after the root.
+    let root_hint = file_name(root);
+    out.extend(classify_files(&loose_files, root, &root_hint));
+    Ok(out)
+}
+
+/// Classify a directory (a subdirectory of a root) into zero or more
+/// collections. A Zarr store is recognized by the directory itself; everything
+/// else is decided from the files directly inside it.
+fn classify_dir(dir: &Path, id_hint: &str) -> Vec<CollectionConfig> {
+    if dir_is_zarr_store(dir) {
+        return match mk_zarr(dir) {
+            Some(c) => vec![c],
+            None => vec![],
+        };
+    }
+    let files: Vec<std::path::PathBuf> = match std::fs::read_dir(dir) {
+        Ok(rd) => rd
+            .filter_map(|e| e.ok().map(|e| e.path()))
+            .filter(|p| p.is_file())
+            .collect(),
+        Err(e) => {
+            tracing::warn!("--auto-collections: cannot read {}: {e}", dir.display());
+            return vec![];
+        }
+    };
+    classify_files(&files, dir, id_hint)
+}
+
+/// Classify a set of files in `dir` (first match wins, per the detection order
+/// in #411). `dir` is the data directory passed to directory-native engines;
+/// `id_hint` names a directory-native collection (single-file formats are named
+/// per file instead).
+fn classify_files(
+    files: &[std::path::PathBuf],
+    dir: &Path,
+    id_hint: &str,
+) -> Vec<CollectionConfig> {
+    if files.is_empty() {
+        return vec![];
+    }
+
+    // 1. QueryData — a directory of .sqd (time + params read from the file).
+    if files.iter().any(|f| has_ext(f, "sqd")) {
+        return mk_querydata(dir, id_hint).into_iter().collect();
+    }
+
+    // 2. GRIB — .grib2/.grb2 *with* index sidecars (the engine never builds them).
+    let data_suffix = if files.iter().any(|f| has_ext(f, "grib2")) {
+        Some(".grib2")
+    } else if files.iter().any(|f| has_ext(f, "grb2")) {
+        Some(".grb2")
+    } else {
+        None
+    };
+    if let Some(data_suffix) = data_suffix {
+        // `.index` => ECMWF JSON-lines (engine default); `.idx` => wgrib2.
+        let index = if files.iter().any(|f| has_ext(f, "index")) {
+            Some((".index", Some("ecmwf-json")))
+        } else if files.iter().any(|f| has_ext(f, "idx")) {
+            Some((".idx", Some("wgrib2")))
+        } else {
+            None
+        };
+        return match index {
+            Some((index_suffix, fmt)) => mk_grib(dir, id_hint, index_suffix, data_suffix, fmt)
+                .into_iter()
+                .collect(),
+            None => {
+                tracing::warn!(
+                    "--auto-collections: {} has GRIB2 data but no .index/.idx sidecars — \
+                     GRIB needs prebuilt indexes; skipping",
+                    dir.display()
+                );
+                vec![]
+            }
+        };
+    }
+
+    // 3. GeoTIFF — phase 2 (filename-template inference).
+    if files
+        .iter()
+        .any(|f| has_ext(f, "tif") || has_ext(f, "tiff"))
+    {
+        tracing::info!(
+            "--auto-collections: {} looks like GeoTIFF — auto-detection is phase 2 (#411); skipping",
+            dir.display()
+        );
+        return vec![];
+    }
+
+    // 4. ODIM HDF5 — phase 2 (COMP/PVOL probe + template inference).
+    if files.iter().any(|f| has_ext(f, "h5") || has_ext(f, "hdf5")) {
+        tracing::info!(
+            "--auto-collections: {} looks like ODIM HDF5 — auto-detection is phase 2 (#411); skipping",
+            dir.display()
+        );
+        return vec![];
+    }
+
+    // 5 + 6. Single-file leaf formats — one collection per file. GeoJSON and
+    // CSV don't conflict (unlike the directory-native formats above, which are
+    // first-match-wins), so a directory holding both yields both.
+    let mut single = Vec::new();
+    single.extend(
+        files
+            .iter()
+            .filter(|f| has_ext(f, "geojson"))
+            .filter_map(|f| mk_geojson(f)),
+    );
+    single.extend(
+        files
+            .iter()
+            .filter(|f| has_ext(f, "csv"))
+            .filter_map(|f| mk_csv(f)),
+    );
+    if !single.is_empty() {
+        return single;
+    }
+
+    tracing::info!(
+        "--auto-collections: no recognized data files in {}; skipping",
+        dir.display()
+    );
+    vec![]
+}
+
+// ---- engine-specific synthesizers -----------------------------------------
+
+fn mk_zarr(dir: &Path) -> Option<CollectionConfig> {
+    let path = path_str(dir)?;
+    // Strip a trailing ".zarr" from the store directory name for the id.
+    let raw = file_name(dir);
+    let stem = raw.strip_suffix(".zarr").unwrap_or(&raw);
+    let id = slugify(stem);
+    Some(mk_collection(
+        id,
+        "zarr",
+        vec!["edr".into()],
+        None,
+        Some(ZarrConfig::auto_local(path)),
+        None,
+        None,
+        &dir.display().to_string(),
+    ))
+}
+
+fn mk_querydata(dir: &Path, id_hint: &str) -> Option<CollectionConfig> {
+    let path = path_str(dir)?;
+    Some(mk_collection(
+        slugify(id_hint),
+        "querydata",
+        vec!["edr".into()],
+        Some(path), // querydata reads collection.data_path
+        None,
+        None,
+        Some(QueryDataConfig::auto_default()),
+        &dir.display().to_string(),
+    ))
+}
+
+fn mk_grib(
+    dir: &Path,
+    id_hint: &str,
+    index_suffix: &str,
+    data_suffix: &str,
+    index_format: Option<&str>,
+) -> Option<CollectionConfig> {
+    let path = path_str(dir)?;
+    Some(mk_collection(
+        slugify(id_hint),
+        "grib",
+        vec!["edr".into()],
+        None, // grib reads GribConfig.data_path
+        None,
+        Some(GribConfig::auto_local(
+            path,
+            index_suffix.to_string(),
+            data_suffix.to_string(),
+            index_format.map(|s| s.to_string()),
+        )),
+        None,
+        &dir.display().to_string(),
+    ))
+}
+
+fn mk_geojson(file: &Path) -> Option<CollectionConfig> {
+    let path = path_str(file)?;
+    let id = slugify(&file_stem(file));
+    Some(mk_collection(
+        id,
+        "geojson",
+        vec!["features".into()],
+        Some(path),
+        None,
+        None,
+        None,
+        &file.display().to_string(),
+    ))
+}
+
+fn mk_csv(file: &Path) -> Option<CollectionConfig> {
+    let path = path_str(file)?;
+    let id = slugify(&file_stem(file));
+    Some(mk_collection(
+        id,
+        "csv",
+        vec!["edr".into(), "features".into()],
+        Some(path),
+        None,
+        None,
+        None,
+        &file.display().to_string(),
+    ))
+}
+
+/// Build a `CollectionConfig` with the auto-discovery defaults (no keywords /
+/// license / preview, the relevant engine sub-table set, the rest `None`). The
+/// title is humanized from the id; the description records the source.
+#[allow(clippy::too_many_arguments)]
+fn mk_collection(
+    id: String,
+    engine_type: &str,
+    apis: Vec<String>,
+    data_path: Option<String>,
+    zarr: Option<ZarrConfig>,
+    grib: Option<GribConfig>,
+    querydata: Option<QueryDataConfig>,
+    source: &str,
+) -> CollectionConfig {
+    CollectionConfig {
+        title: humanize(&id),
+        description: format!("Auto-generated collection from {source}"),
+        id,
+        keywords: Vec::new(),
+        license: None,
+        data_path,
+        apis,
+        engine_type: engine_type.to_string(),
+        geotiff: None,
+        querydata,
+        grib,
+        zarr,
+        odim: None,
+        wms: None,
+        postgis: None,
+        preview: None,
+    }
+}
+
+// ---- helpers ---------------------------------------------------------------
+
+/// A directory is a Zarr store if its name ends in `.zarr` or it holds Zarr
+/// group/array metadata (`zarr.json` for V3, `.zgroup`/`.zarray` for V2).
+fn dir_is_zarr_store(dir: &Path) -> bool {
+    file_name(dir).to_ascii_lowercase().ends_with(".zarr")
+        || dir.join("zarr.json").exists()
+        || dir.join(".zgroup").exists()
+        || dir.join(".zarray").exists()
+}
+
+fn has_ext(path: &Path, ext: &str) -> bool {
+    path.extension()
+        .and_then(|e| e.to_str())
+        .is_some_and(|e| e.eq_ignore_ascii_case(ext))
+}
+
+fn file_name(path: &Path) -> String {
+    path.file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or_default()
+        .to_string()
+}
+
+fn file_stem(path: &Path) -> String {
+    path.file_stem()
+        .and_then(|n| n.to_str())
+        .unwrap_or_default()
+        .to_string()
+}
+
+fn path_str(path: &Path) -> Option<String> {
+    match path.to_str() {
+        Some(s) => Some(s.to_string()),
+        None => {
+            tracing::warn!(
+                "--auto-collections: skipping non-UTF-8 path {}",
+                path.display()
+            );
+            None
+        }
+    }
+}
+
+/// Lowercase, map every run of non-`[a-z0-9]` to a single `-`, trim leading and
+/// trailing `-`. Keeps ids URL-safe (aligns with #305).
+fn slugify(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut pending_dash = false;
+    for c in s.chars() {
+        let lc = c.to_ascii_lowercase();
+        if lc.is_ascii_alphanumeric() {
+            if pending_dash && !out.is_empty() {
+                out.push('-');
+            }
+            pending_dash = false;
+            out.push(lc);
+        } else {
+            pending_dash = true;
+        }
+    }
+    out
+}
+
+/// Title-case a slug for the collection title (e.g. `radar-fmi` -> `Radar Fmi`).
+/// Falls back to the slug if it has no word characters.
+fn humanize(slug: &str) -> String {
+    let title = slug
+        .split('-')
+        .filter(|w| !w.is_empty())
+        .map(|w| {
+            let mut chars = w.chars();
+            match chars.next() {
+                Some(first) => first.to_ascii_uppercase().to_string() + chars.as_str(),
+                None => String::new(),
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ");
+    if title.is_empty() {
+        slug.to_string()
+    } else {
+        title
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn touch(dir: &Path, name: &str) {
+        fs::write(dir.join(name), b"").unwrap();
+    }
+
+    fn ids(cfgs: &[CollectionConfig]) -> Vec<(String, String)> {
+        cfgs.iter()
+            .map(|c| (c.id.clone(), c.engine_type.clone()))
+            .collect()
+    }
+
+    #[test]
+    fn slugify_and_humanize() {
+        assert_eq!(slugify("Radar_FMI 2"), "radar-fmi-2");
+        assert_eq!(slugify("era5.zarr"), "era5-zarr");
+        assert_eq!(slugify("--weird__name--"), "weird-name");
+        assert_eq!(humanize("radar-fmi"), "Radar Fmi");
+    }
+
+    #[test]
+    fn classifies_subdirs_per_format() {
+        let root = TempDir::new().unwrap();
+        let r = root.path();
+
+        // querydata subdir
+        let qd = r.join("meps");
+        fs::create_dir(&qd).unwrap();
+        touch(&qd, "20260405T180000Z_meps.sqd");
+
+        // grib subdir with index sidecars
+        let grib = r.join("ecmwf");
+        fs::create_dir(&grib).unwrap();
+        touch(&grib, "run.grib2");
+        touch(&grib, "run.index");
+
+        // grib subdir WITHOUT index -> skipped
+        let bad = r.join("noidx");
+        fs::create_dir(&bad).unwrap();
+        touch(&bad, "x.grib2");
+
+        // zarr store (V3 marker)
+        let zarr = r.join("era5.zarr");
+        fs::create_dir(&zarr).unwrap();
+        touch(&zarr, "zarr.json");
+
+        let cfgs = scan_roots(&[r.to_str().unwrap().to_string()]);
+        let got = ids(&cfgs);
+        assert!(
+            got.contains(&("meps".into(), "querydata".into())),
+            "{got:?}"
+        );
+        assert!(got.contains(&("ecmwf".into(), "grib".into())), "{got:?}");
+        assert!(got.contains(&("era5".into(), "zarr".into())), "{got:?}");
+        // grib-without-index produced nothing
+        assert!(!got.iter().any(|(id, _)| id == "noidx"), "{got:?}");
+    }
+
+    #[test]
+    fn grib_index_format_inferred_from_suffix() {
+        let root = TempDir::new().unwrap();
+        let gfs = root.path().join("gfs");
+        fs::create_dir(&gfs).unwrap();
+        touch(&gfs, "f006.grib2");
+        touch(&gfs, "f006.idx");
+
+        let cfgs = scan_roots(&[root.path().to_str().unwrap().to_string()]);
+        let grib = cfgs.iter().find(|c| c.engine_type == "grib").unwrap();
+        let g = grib.grib.as_ref().unwrap();
+        assert_eq!(g.index_format.as_deref(), Some("wgrib2"));
+        assert_eq!(g.index_suffix.as_deref(), Some(".idx"));
+        assert_eq!(g.data_suffix.as_deref(), Some(".grib2"));
+        assert!(g.data_path.is_some());
+    }
+
+    #[test]
+    fn loose_single_files_are_one_collection_each() {
+        let root = TempDir::new().unwrap();
+        let r = root.path();
+        touch(r, "weather.csv");
+        touch(r, "stations.csv");
+        touch(r, "regions.geojson");
+
+        let cfgs = scan_roots(&[r.to_str().unwrap().to_string()]);
+        let got = ids(&cfgs);
+        // GeoJSON and CSV are independent single-file formats: a directory with
+        // both yields one collection per file of each.
+        assert!(
+            got.contains(&("regions".into(), "geojson".into())),
+            "{got:?}"
+        );
+        assert!(got.contains(&("weather".into(), "csv".into())), "{got:?}");
+        assert!(got.contains(&("stations".into(), "csv".into())), "{got:?}");
+        assert_eq!(got.len(), 3, "{got:?}");
+    }
+
+    #[test]
+    fn loose_csv_only_emits_per_file() {
+        let root = TempDir::new().unwrap();
+        let r = root.path();
+        touch(r, "weather.csv");
+        touch(r, "stations.csv");
+
+        let cfgs = scan_roots(&[r.to_str().unwrap().to_string()]);
+        let mut got = ids(&cfgs);
+        got.sort();
+        assert_eq!(
+            got,
+            vec![
+                ("stations".to_string(), "csv".to_string()),
+                ("weather".to_string(), "csv".to_string()),
+            ]
+        );
+        // csv enables both EDR and Features
+        let csv = cfgs.iter().find(|c| c.id == "weather").unwrap();
+        assert_eq!(csv.apis, vec!["edr".to_string(), "features".to_string()]);
+        assert!(csv.data_path.as_deref().unwrap().ends_with("weather.csv"));
+    }
+
+    #[test]
+    fn empty_and_unknown_dirs_yield_nothing() {
+        let root = TempDir::new().unwrap();
+        let r = root.path();
+        let empty = r.join("empty");
+        fs::create_dir(&empty).unwrap();
+        let junk = r.join("junk");
+        fs::create_dir(&junk).unwrap();
+        touch(&junk, "readme.txt");
+
+        let cfgs = scan_roots(&[r.to_str().unwrap().to_string()]);
+        assert!(cfgs.is_empty(), "{:?}", ids(&cfgs));
+    }
+
+    #[test]
+    fn geotiff_and_odim_are_deferred_to_phase2() {
+        let root = TempDir::new().unwrap();
+        let r = root.path();
+        let tif = r.join("radar-tif");
+        fs::create_dir(&tif).unwrap();
+        touch(&tif, "radar_20260101T0000Z.tif");
+        let h5 = r.join("radar-h5");
+        fs::create_dir(&h5).unwrap();
+        touch(&h5, "202601011200_radar.h5");
+
+        let cfgs = scan_roots(&[r.to_str().unwrap().to_string()]);
+        assert!(
+            cfgs.is_empty(),
+            "phase-2 formats must be skipped: {:?}",
+            ids(&cfgs)
+        );
+    }
+}

--- a/crates/server/src/auto.rs
+++ b/crates/server/src/auto.rs
@@ -201,7 +201,7 @@ fn mk_zarr(dir: &Path) -> Option<CollectionConfig> {
     // Strip a trailing ".zarr" from the store directory name for the id.
     let raw = file_name(dir);
     let stem = raw.strip_suffix(".zarr").unwrap_or(&raw);
-    let id = slugify(stem);
+    let id = slug_id(stem, dir)?;
     Some(mk_collection(
         id,
         "zarr",
@@ -217,7 +217,7 @@ fn mk_zarr(dir: &Path) -> Option<CollectionConfig> {
 fn mk_querydata(dir: &Path, id_hint: &str) -> Option<CollectionConfig> {
     let path = path_str(dir)?;
     Some(mk_collection(
-        slugify(id_hint),
+        slug_id(id_hint, dir)?,
         "querydata",
         vec!["edr".into()],
         Some(path), // querydata reads collection.data_path
@@ -237,7 +237,7 @@ fn mk_grib(
 ) -> Option<CollectionConfig> {
     let path = path_str(dir)?;
     Some(mk_collection(
-        slugify(id_hint),
+        slug_id(id_hint, dir)?,
         "grib",
         vec!["edr".into()],
         None, // grib reads GribConfig.data_path
@@ -255,7 +255,7 @@ fn mk_grib(
 
 fn mk_geojson(file: &Path) -> Option<CollectionConfig> {
     let path = path_str(file)?;
-    let id = slugify(&file_stem(file));
+    let id = slug_id(&file_stem(file), file)?;
     Some(mk_collection(
         id,
         "geojson",
@@ -270,7 +270,7 @@ fn mk_geojson(file: &Path) -> Option<CollectionConfig> {
 
 fn mk_csv(file: &Path) -> Option<CollectionConfig> {
     let path = path_str(file)?;
-    let id = slugify(&file_stem(file));
+    let id = slug_id(&file_stem(file), file)?;
     Some(mk_collection(
         id,
         "csv",
@@ -358,6 +358,25 @@ fn path_str(path: &Path) -> Option<String> {
             );
             None
         }
+    }
+}
+
+/// Slugify `name` into a collection id, or `None` (with a WARN naming the
+/// source path) when it has no URL-safe characters to form an id from — e.g. a
+/// directory named `---` or a file like `.gitkeep`. Returning `None` keeps the
+/// module's skip-rather-than-fail contract instead of letting an `id = ""`
+/// surface as a generic "empty id" `validate()` error.
+fn slug_id(name: &str, source: &Path) -> Option<String> {
+    let id = slugify(name);
+    if id.is_empty() {
+        tracing::warn!(
+            "--auto-collections: skipping {} — its name has no URL-safe characters \
+             for a collection id",
+            source.display()
+        );
+        None
+    } else {
+        Some(id)
     }
 }
 
@@ -556,6 +575,47 @@ mod tests {
             cfgs.is_empty(),
             "phase-2 formats must be skipped: {:?}",
             ids(&cfgs)
+        );
+    }
+
+    #[test]
+    fn name_with_no_url_safe_chars_is_skipped() {
+        let root = TempDir::new().unwrap();
+        // A directory whose name slugifies to "" must be skipped, not yield an
+        // empty-id collection that fails validate() with a generic error.
+        let weird = root.path().join("---");
+        fs::create_dir(&weird).unwrap();
+        touch(&weird, "run.sqd");
+
+        let cfgs = scan_roots(&[root.path().to_str().unwrap().to_string()]);
+        assert!(cfgs.is_empty(), "{:?}", ids(&cfgs));
+    }
+
+    #[test]
+    fn duplicate_ids_rejected_by_validate() {
+        use ds_core::config::ServerConfig;
+        let root = TempDir::new().unwrap();
+        let r = root.path();
+        // Two subdirs that slugify to the same id ("radar-fmi").
+        for name in ["radar-fmi", "radar_fmi"] {
+            let d = r.join(name);
+            fs::create_dir(&d).unwrap();
+            touch(&d, "run.sqd");
+        }
+        let cfgs = scan_roots(&[r.to_str().unwrap().to_string()]);
+        assert_eq!(
+            cfgs.iter().map(|c| c.id.as_str()).collect::<Vec<_>>(),
+            vec!["radar-fmi", "radar-fmi"],
+            "both names must collapse to the same slug",
+        );
+
+        // The merged set goes through the same validate() as TOML collections,
+        // which rejects duplicate ids — the path that also covers config + auto.
+        let mut config = ServerConfig::default_for_auto();
+        config.collections = cfgs;
+        assert!(
+            config.validate().is_err(),
+            "duplicate collection ids must fail validate()",
         );
     }
 }

--- a/crates/server/src/auto.rs
+++ b/crates/server/src/auto.rs
@@ -83,7 +83,7 @@ fn classify_dir(dir: &Path, id_hint: &str) -> Vec<CollectionConfig> {
             None => vec![],
         };
     }
-    let files: Vec<std::path::PathBuf> = match std::fs::read_dir(dir) {
+    let mut files: Vec<std::path::PathBuf> = match std::fs::read_dir(dir) {
         Ok(rd) => rd
             .filter_map(|e| e.ok().map(|e| e.path()))
             .filter(|p| p.is_file())
@@ -93,6 +93,10 @@ fn classify_dir(dir: &Path, id_hint: &str) -> Vec<CollectionConfig> {
             return vec![];
         }
     };
+    // `read_dir` order is OS/filesystem-dependent; sort so the per-file
+    // single-file branch emits collections deterministically (matching the
+    // sort `scan_one_root` already does for subdirs/loose files).
+    files.sort();
     classify_files(&files, dir, id_hint)
 }
 
@@ -187,7 +191,9 @@ fn classify_files(
         return single;
     }
 
-    tracing::info!(
+    // A directory the user explicitly pointed at that yielded nothing deserves
+    // visible feedback (warn shows at the default level; info would be silent).
+    tracing::warn!(
         "--auto-collections: no recognized data files in {}; skipping",
         dir.display()
     );
@@ -210,7 +216,7 @@ fn mk_zarr(dir: &Path) -> Option<CollectionConfig> {
         Some(ZarrConfig::auto_local(path)),
         None,
         None,
-        &dir.display().to_string(),
+        &file_name(dir),
     ))
 }
 
@@ -224,7 +230,7 @@ fn mk_querydata(dir: &Path, id_hint: &str) -> Option<CollectionConfig> {
         None,
         None,
         Some(QueryDataConfig::auto_default()),
-        &dir.display().to_string(),
+        &file_name(dir),
     ))
 }
 
@@ -249,7 +255,7 @@ fn mk_grib(
             index_format.map(|s| s.to_string()),
         )),
         None,
-        &dir.display().to_string(),
+        &file_name(dir),
     ))
 }
 
@@ -264,7 +270,7 @@ fn mk_geojson(file: &Path) -> Option<CollectionConfig> {
         None,
         None,
         None,
-        &file.display().to_string(),
+        &file_name(file),
     ))
 }
 
@@ -279,7 +285,7 @@ fn mk_csv(file: &Path) -> Option<CollectionConfig> {
         None,
         None,
         None,
-        &file.display().to_string(),
+        &file_name(file),
     ))
 }
 
@@ -616,6 +622,25 @@ mod tests {
         assert!(
             config.validate().is_err(),
             "duplicate collection ids must fail validate()",
+        );
+    }
+
+    #[test]
+    fn config_plus_auto_duplicate_id_rejected() {
+        use ds_core::config::ServerConfig;
+        let root = TempDir::new().unwrap();
+        touch(root.path(), "weather.csv");
+        let auto = scan_roots(&[root.path().to_str().unwrap().to_string()]);
+        assert_eq!(auto.len(), 1, "{:?}", ids(&auto));
+
+        // A pre-existing (config-file) collection with the same id as an
+        // auto-discovered one is rejected by the shared validate().
+        let mut config = ServerConfig::default_for_auto();
+        config.collections.push(auto[0].clone());
+        config.collections.extend(auto);
+        assert!(
+            config.validate().is_err(),
+            "config + auto duplicate id must fail validate()",
         );
     }
 }

--- a/crates/server/src/auto.rs
+++ b/crates/server/src/auto.rs
@@ -365,13 +365,15 @@ fn mk_collection(
 
 // ---- helpers ---------------------------------------------------------------
 
-/// A directory is a Zarr store if its name ends in `.zarr` or it holds Zarr
-/// group/array metadata (`zarr.json` for V3, `.zgroup`/`.zarray` for V2).
+/// A directory is a Zarr store **root** if its name ends in `.zarr` or it holds
+/// store-root metadata: `zarr.json` (V3 root) or `.zgroup` (V2 group root). We
+/// deliberately do **not** match `.zarray` — that marks a V2 *array* node (a leaf
+/// inside a store, or a chunk subdirectory), not a store the engine can open as a
+/// root group; matching it would hand the engine an array dir that fails at load.
 fn dir_is_zarr_store(dir: &Path) -> bool {
     file_name(dir).to_ascii_lowercase().ends_with(".zarr")
         || dir.join("zarr.json").exists()
         || dir.join(".zgroup").exists()
-        || dir.join(".zarray").exists()
 }
 
 fn has_ext(path: &Path, ext: &str) -> bool {
@@ -686,6 +688,23 @@ mod tests {
         assert_eq!(cfgs.len(), 1, "{:?}", ids(&cfgs));
         assert_eq!(cfgs[0].engine_type, "zarr");
         assert!(cfgs[0].zarr.is_some());
+    }
+
+    #[test]
+    fn bare_zarray_dir_is_not_a_store() {
+        // `.zarray` marks a V2 array node (a leaf inside a store / a chunk dir),
+        // not a store root — it must NOT be handed to the engine as a store.
+        let root = TempDir::new().unwrap();
+        let arr = root.path().join("some-array");
+        fs::create_dir(&arr).unwrap();
+        touch(&arr, ".zarray");
+
+        let cfgs = scan_roots(&[root.path().to_str().unwrap().to_string()]);
+        assert!(
+            !cfgs.iter().any(|c| c.engine_type == "zarr"),
+            "a bare .zarray dir must not be detected as a zarr store: {:?}",
+            ids(&cfgs)
+        );
     }
 
     #[test]

--- a/crates/server/src/auto.rs
+++ b/crates/server/src/auto.rs
@@ -128,6 +128,10 @@ fn classify_files(
     let has_grib_data = files
         .iter()
         .any(|f| has_ext(f, "grib2") || has_ext(f, "grb2"));
+    // Co-located single-file formats that a directory-native winner displaces.
+    let has_leaf = files
+        .iter()
+        .any(|f| has_ext(f, "geojson") || has_ext(f, "csv"));
 
     // 1. QueryData — a directory of .sqd (time + params read from the file).
     if files.iter().any(|f| has_ext(f, "sqd")) {
@@ -137,6 +141,9 @@ fn classify_files(
                  ignoring the GRIB files",
                 dir.display()
             );
+        }
+        if has_leaf {
+            warn_ignored_leaf(dir, "querydata");
         }
         return mk_querydata(dir, id_hint).into_iter().collect();
     }
@@ -168,9 +175,28 @@ fn classify_files(
             None
         };
         return match index {
-            Some((index_suffix, fmt)) => mk_grib(dir, id_hint, index_suffix, data_suffix, fmt)
-                .into_iter()
-                .collect(),
+            // The engine pairs index <-> data by basename (X.index <-> X.grib2),
+            // so the chosen suffixes must actually share a basename. A directory
+            // mixing suffixes (e.g. a.grib2 + b.grb2 + b.idx) picks .grib2 + .idx,
+            // which never pair — skip with a clear warning rather than load a
+            // silently-empty collection.
+            Some((index_suffix, fmt)) => {
+                if index_pairs_with_data(files, index_suffix, data_suffix) {
+                    if has_leaf {
+                        warn_ignored_leaf(dir, "grib");
+                    }
+                    mk_grib(dir, id_hint, index_suffix, data_suffix, fmt)
+                        .into_iter()
+                        .collect()
+                } else {
+                    tracing::warn!(
+                        "--auto-collections: {} GRIB {data_suffix} data and {index_suffix} \
+                         sidecars share no common basename (mixed/mismatched files) — skipping",
+                        dir.display()
+                    );
+                    vec![]
+                }
+            }
             None => {
                 tracing::warn!(
                     "--auto-collections: {} has GRIB2 data but no .index/.idx sidecars — \
@@ -244,9 +270,15 @@ fn classify_files(
 
 fn mk_zarr(dir: &Path) -> Option<CollectionConfig> {
     let path = path_str(dir)?;
-    // Strip a trailing ".zarr" from the store directory name for the id.
+    // Strip a trailing ".zarr" from the store directory name for the id —
+    // case-insensitively, to match `dir_is_zarr_store`'s detection (else a dir
+    // named `Era5.Zarr` is detected as a store but keeps `.zarr` in its id).
     let raw = file_name(dir);
-    let stem = raw.strip_suffix(".zarr").unwrap_or(&raw);
+    let stem = if raw.to_ascii_lowercase().ends_with(".zarr") {
+        &raw[..raw.len() - ".zarr".len()]
+    } else {
+        &raw
+    };
     let id = slug_id(stem, dir)?;
     Some(mk_collection(
         id,
@@ -374,6 +406,36 @@ fn dir_is_zarr_store(dir: &Path) -> bool {
     file_name(dir).to_ascii_lowercase().ends_with(".zarr")
         || dir.join("zarr.json").exists()
         || dir.join(".zgroup").exists()
+}
+
+/// True if at least one `<base><index_suffix>` file has a sibling
+/// `<base><data_suffix>` file — i.e. the chosen index/data suffixes actually pair
+/// by basename, the way the GRIB engine matches them (X.index <-> X.grib2).
+fn index_pairs_with_data(
+    files: &[std::path::PathBuf],
+    index_suffix: &str,
+    data_suffix: &str,
+) -> bool {
+    let data_bases: std::collections::HashSet<&str> = files
+        .iter()
+        .filter_map(|f| f.file_name().and_then(|n| n.to_str()))
+        .filter_map(|n| n.strip_suffix(data_suffix))
+        .collect();
+    files
+        .iter()
+        .filter_map(|f| f.file_name().and_then(|n| n.to_str()))
+        .filter_map(|n| n.strip_suffix(index_suffix))
+        .any(|base| data_bases.contains(base))
+}
+
+/// Warn that co-located `.geojson`/`.csv` files were ignored because a
+/// directory-native engine claimed the directory (first-match-wins).
+fn warn_ignored_leaf(dir: &Path, winner: &str) {
+    tracing::warn!(
+        "--auto-collections: {} has co-located .geojson/.csv files — ignored \
+         ({winner} took the directory)",
+        dir.display()
+    );
 }
 
 fn has_ext(path: &Path, ext: &str) -> bool {
@@ -552,6 +614,56 @@ mod tests {
         assert_eq!(g.index_suffix.as_deref(), Some(".idx"));
         assert_eq!(g.data_suffix.as_deref(), Some(".grib2"));
         assert!(g.data_path.is_some());
+    }
+
+    #[test]
+    fn grib_with_mismatched_suffixes_is_skipped() {
+        // a.grib2 has no index; b uses .grb2 + .idx. The chosen suffixes
+        // (.grib2 + .idx) never share a basename, so don't load an empty grib.
+        let root = TempDir::new().unwrap();
+        let d = root.path().join("mix");
+        fs::create_dir(&d).unwrap();
+        touch(&d, "a.grib2");
+        touch(&d, "b.grb2");
+        touch(&d, "b.idx");
+
+        let cfgs = scan_roots(&[root.path().to_str().unwrap().to_string()]);
+        assert!(
+            !cfgs.iter().any(|c| c.engine_type == "grib"),
+            "mismatched grib suffixes must skip, not load empty: {:?}",
+            ids(&cfgs)
+        );
+    }
+
+    #[test]
+    fn grib_wins_over_colocated_csv() {
+        // A directory-native winner (grib) claims the dir; a stray .csv is
+        // dropped (warned), not turned into its own collection.
+        let root = TempDir::new().unwrap();
+        let d = root.path().join("ec");
+        fs::create_dir(&d).unwrap();
+        touch(&d, "run.grib2");
+        touch(&d, "run.index");
+        touch(&d, "stray.csv");
+
+        let cfgs = scan_roots(&[root.path().to_str().unwrap().to_string()]);
+        let got = ids(&cfgs);
+        assert!(got.contains(&("ec".into(), "grib".into())), "{got:?}");
+        assert!(!got.iter().any(|(_, e)| e == "csv"), "{got:?}");
+    }
+
+    #[test]
+    fn zarr_suffix_stripped_case_insensitively() {
+        // `Era5.Zarr` is detected as a store (case-insensitive) and its id must
+        // drop the suffix the same way → "era5", not "era5-zarr".
+        let root = TempDir::new().unwrap();
+        let store = root.path().join("Era5.Zarr");
+        fs::create_dir(&store).unwrap();
+        touch(&store, ".zgroup");
+
+        let cfgs = scan_roots(&[root.path().to_str().unwrap().to_string()]);
+        let z = cfgs.iter().find(|c| c.engine_type == "zarr").unwrap();
+        assert_eq!(z.id, "era5", "id was {:?}", z.id);
     }
 
     #[test]

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -192,18 +192,15 @@ fn parse_cli_args() -> CliArgs {
             s if s.starts_with("--config=") => {
                 config = Some(s["--config=".len()..].to_string());
             }
-            "--auto-collections" | "--auto" => {
+            "--auto-collections" => {
                 let Some(value) = args.next() else {
-                    eprintln!("error: {arg} requires a directory");
+                    eprintln!("error: --auto-collections requires a directory");
                     std::process::exit(2);
                 };
                 auto_collections.push(value);
             }
             s if s.starts_with("--auto-collections=") => {
                 auto_collections.push(s["--auto-collections=".len()..].to_string());
-            }
-            s if s.starts_with("--auto=") => {
-                auto_collections.push(s["--auto=".len()..].to_string());
             }
             other => {
                 eprintln!("error: unknown argument '{other}' (try --help)");

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -1,4 +1,5 @@
 mod admin;
+mod auto;
 mod preview;
 mod watcher;
 
@@ -100,6 +101,11 @@ struct CliArgs {
     /// is a hard error (unlike the default path, which falls back to built-in
     /// defaults when absent).
     config: Option<String>,
+    /// Directories to auto-discover collections from (`--auto-collections`,
+    /// repeatable). Each is scanned and turned into synthesized collections
+    /// (#411); the results are merged with any config-file collections and
+    /// validated together.
+    auto_collections: Vec<String>,
 }
 
 /// Very small hand-rolled argv parser — the server only has a handful of
@@ -116,6 +122,7 @@ fn parse_cli_args() -> CliArgs {
     let mut host: Option<String> = None;
     let mut port: Option<u16> = None;
     let mut config: Option<String> = None;
+    let mut auto_collections: Vec<String> = Vec::new();
     let mut args = std::env::args().skip(1);
     while let Some(arg) = args.next() {
         match arg.as_str() {
@@ -128,6 +135,8 @@ fn parse_cli_args() -> CliArgs {
                        --host <HOST>                 Bind host (overrides [server].host)\n  \
                        --port <PORT>                 Bind port (overrides [server].port)\n  \
                        --config <PATH>               Config file path (overrides CONFIG_PATH)\n  \
+                       --auto-collections <DIR>      Auto-discover collections from a directory\n                                \
+                                 (repeatable; zarr/grib/querydata/csv/geojson)\n  \
                        -h, --help                    Show this help\n\
                      \n\
                      With no config file and no --port, the server binds localhost\n  \
@@ -183,6 +192,19 @@ fn parse_cli_args() -> CliArgs {
             s if s.starts_with("--config=") => {
                 config = Some(s["--config=".len()..].to_string());
             }
+            "--auto-collections" | "--auto" => {
+                let Some(value) = args.next() else {
+                    eprintln!("error: {arg} requires a directory");
+                    std::process::exit(2);
+                };
+                auto_collections.push(value);
+            }
+            s if s.starts_with("--auto-collections=") => {
+                auto_collections.push(s["--auto-collections=".len()..].to_string());
+            }
+            s if s.starts_with("--auto=") => {
+                auto_collections.push(s["--auto=".len()..].to_string());
+            }
             other => {
                 eprintln!("error: unknown argument '{other}' (try --help)");
                 std::process::exit(2);
@@ -194,6 +216,7 @@ fn parse_cli_args() -> CliArgs {
         host,
         port,
         config,
+        auto_collections,
     }
 }
 
@@ -276,12 +299,17 @@ async fn main() {
         std::process::exit(1);
     } else {
         // No config file at the default path and none requested: boot from
-        // built-in defaults (localhost + auto-selected port, no collections).
-        // This is the base for pointing the server at a directory with no
-        // config.toml (auto-collections, #411).
+        // built-in defaults (localhost + auto-selected port). Collections come
+        // from --auto-collections, if given (#411); otherwise the server starts
+        // empty.
+        let source = if cli.auto_collections.is_empty() {
+            "no collections"
+        } else {
+            "collections from --auto-collections"
+        };
         tracing::warn!(
             "No config file at '{config_path}'; starting with built-in defaults \
-             (localhost, auto-selected port, no collections)."
+             (localhost, auto-selected port, {source})."
         );
         (
             ds_core::config::ServerConfig::default_for_auto(),
@@ -290,6 +318,24 @@ async fn main() {
     };
     for warning in &config_warnings {
         tracing::warn!("{warning}");
+    }
+
+    // Auto-discover collections from any --auto-collections directories (#411)
+    // and merge them with the config-file collections. The merged set goes
+    // through the same validate() as TOML collections (so duplicate ids across
+    // config + auto, or auto + auto, are rejected uniformly).
+    if !cli.auto_collections.is_empty() {
+        let discovered = auto::scan_roots(&cli.auto_collections);
+        info!(
+            "--auto-collections: discovered {} collection(s) across {} director(ies)",
+            discovered.len(),
+            cli.auto_collections.len()
+        );
+        config.collections.extend(discovered);
+        if let Err(e) = config.validate() {
+            tracing::error!("Auto-discovered collections failed validation: {e}");
+            std::process::exit(1);
+        }
     }
 
     // Apply --collections filter if provided. Unknown IDs are a hard error —


### PR DESCRIPTION
Implements **#411 phase 1**. Builds on the no-config boot + auto-port from #412 (merged).

## What

Point the server at a directory tree and it **synthesizes collections from the data files on disk** — no `config.toml`. Combined with #412, `server --auto-collections ./data` serves OGC endpoints on localhost + an auto-selected port with zero config.

```bash
server --auto-collections ./data --port 9000   # or no --port -> localhost, first free port >= 8000
```

### Mapping (`server/src/auto.rs`)

Per the decisions on #411: **per-subdirectory + loose files**. Each immediate subdirectory of a root becomes a collection; loose files in the root are grouped under the root name. Detection per directory (first match wins):

| On disk | Becomes | APIs |
|---|---|---|
| `zarr.json`/`.zgroup`/`.zarray`, or a `*.zarr` dir name | `zarr` | EDR, WMS, Maps, Tiles |
| `*.sqd` | `querydata` | EDR, WMS, Maps, Tiles |
| `*.grib2`/`*.grb2` **with** `*.index`/`*.idx` | `grib` | EDR, WMS, Maps, Tiles (`index_format` inferred: `.idx`→wgrib2, `.index`→ecmwf-json) |
| `*.grib2` **without** index sidecars | _skipped + WARN_ | the engine never builds indexes |
| `*.tif`/`*.h5` | _skipped_ | **phase 2** (filename-template inference + COMP/PVOL probe) |
| `*.geojson` | `geojson` (per file) | Features, Tiles (MVT) |
| `*.csv` | `csv` (per file) | EDR, Features |

Each collection enables **all APIs relevant to its type** (mirroring the `engine_type → supported_apis` allowlist), so an auto-discovered raster/grid collection **renders and shows a parameter selector in `/preview`** out of the box. WMS/Maps/Tiles load with no `[wms]` block — the render path falls back to a default colormap. The colormap *range* is generic (viridis `0..1`), so weather data in physical units renders but with poor colour contrast until a per-collection `[wms]` `min`/`max` (or auto-scaling, #320).

Synthesized configs are merged into `config.collections` and run through the **same `ServerConfig::validate()`** as TOML (duplicate ids rejected uniformly). Engine-config defaults come from new `{QueryData,Grib,Zarr}Config::auto_*` constructors in `ds-core` that reuse the serde default fns (DRY). ids slugified to URL-safe `[a-z0-9-]` (aligns with #305, empty-slug names skipped with a WARN); titles humanized. The root may itself be a Zarr store; symlinks are followed (same trust model as `collections_dir`). Resolved once at startup (reload doesn't re-scan auto roots in v1).

### Scope (self-describing first, per #411)

Phase 1 = the directory-native / single-file engines (zarr, grib, querydata, csv, geojson). **GeoTIFF + ODIM** (filename-timestamped) are detected and **deferred to phase 2** (template inference + ODIM COMP/PVOL probe).

## Tests

11 classifier unit tests (per-format subdirs incl. an `apis` assertion, grib index-format inference, grib-without-index skip, loose per-file, empty/unknown dirs, phase-2 deferral, slugify/humanize, empty-slug skip, root-is-zarr-store, auto+auto and config+auto duplicate-id rejection). `cargo test -p server -p ds-core` green; fmt + clippy `--tests` clean.

**Verified end-to-end** against real fixtures, no config.toml:
- a tree of `zarr-era5-t2m` / `meps` (sqd) / `ecmwf` + `grib-local` (grib) / `weather.csv` / `regions.geojson` / `radar-fmi-pvol` (h5) → boots `127.0.0.1:8000` (auto-port), **6/6 collections loaded**; ODIM PVOL dir deferred; era5 EDR position returns real values (`[278.75, …]K`); ecmwf grib decoded real params; regions geojson served 19 features.
- `testdata/ecmwf-kenya` (the reported case): collection gains `edr/wms/maps/tiles`, `/preview` manifest exposes `parameters` (`2t/msl/rr1h`) + `tiles.raster`, and tiles/WMS render `HTTP 200 image/png` — so the preview parameter selector appears with no SPA change.

## Docs

`README.md` (Command-Line Options + Auto-collections section with the detection/APIs table) and `CLAUDE.md` (Server CLI flags) updated.

## Follow-ups

- **#414** — `/preview` should show parameter selection for collections a user *deliberately* restricts to `apis=["edr"]` (pre-existing preview gap; manifest + SPA).
- On #411: phase 2 (GeoTIFF/ODIM template inference), phase 3 (WMS colormap auto-assign; re-scan auto roots on reload + watcher), and the two carried-over nits from #412 (try-and-handle config load; auto-port count wording).
- #320 — default colormap range / auto-scale (improves auto raster rendering).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
