### PR TITLE
feat(server,ds-core): reverse-proxy base URL detection (trust_proxy_headers) (#12)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -765,7 +765,13 @@ are client-controllable; even when enabled, host values are sanitised
 (whitespace/slashes/`@`/non-ASCII rejected), the scheme is restricted to
 `http`/`https`, and only the first value of a comma list is used — a malformed
 header falls through to the next source rather than producing a spoofed URL.
-Enable it only when a trusted proxy sets/overwrites these headers.
+Enable it only when a trusted proxy sets/overwrites these headers. **Ensure the
+proxy strips or overwrites `Forwarded`/`X-Forwarded-*` on untrusted client
+requests, and that clients cannot reach the backend directly** — otherwise a
+client bypassing the proxy could spoof these headers and control the emitted
+self-links (an open-redirect risk for downstream consumers of those links). The
+`Forwarded` parser uses the **last** element specifically because a client can
+pre-inject the first one (RFC 7239 §4 append semantics).
 
 ### Collection Keywords & License
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -676,7 +676,8 @@ tracked in #125. **The crate is phased; Phases 1-3 ship today.**
 [server]
 host = "0.0.0.0"
 port = 8000
-# base_url = "https://api.example.com"  # optional, for absolute links behind a proxy
+# base_url = "https://api.example.com"  # optional, static fallback for absolute links behind a proxy
+# trust_proxy_headers = true            # optional, derive per-request link base from proxy headers (default false)
 # collections_dir = "collections.d"     # optional, directory of per-collection .toml files
 # watch_collections_dir = true          # optional, auto-reload on collections_dir changes (default false)
 # watch_debounce_ms = 500               # optional, coalesce-window for the watcher (default 500)
@@ -739,6 +740,31 @@ time_window = "PT12H"
 ```
 
 See config struct definitions in each engine crate and `ds-core/src/config.rs` for all fields.
+
+### Reverse-proxy base URL (`trust_proxy_headers`, #12)
+
+Absolute self-links (landing pages, `collections`, GeoJSON `links`, WMS
+`GetCapabilities` OnlineResource/legend URLs, 3D Tiles docs, …) are built from a
+base URL. By default that base is resolved **once at startup** —
+`BASE_URL` env > `[server] base_url` > `http://{host}:{port}` — and is wrong when
+the server sits behind a reverse proxy (`http://0.0.0.0:8000/edr/...`).
+
+With `[server] trust_proxy_headers = true`, the base URL is instead resolved
+**per request** from the standard forwarding headers, with this precedence:
+
+1. RFC 7239 `Forwarded` (`proto=`/`host=` of the first element),
+2. `X-Forwarded-Proto` + `X-Forwarded-Host` (+ optional `X-Forwarded-Port`),
+3. the static fallback above.
+
+The pure resolver is `ds_core::proxy::resolve_base_url` (framework-free — the
+axum handlers pass header values in via a closure, so ds-core keeps its no-HTTP
+rule); each API handler calls it through a small per-crate `request_base_url`
+helper. **Security:** the flag is `false` by default because forwarding headers
+are client-controllable; even when enabled, host values are sanitised
+(whitespace/slashes/`@`/non-ASCII rejected), the scheme is restricted to
+`http`/`https`, and only the first value of a comma list is used — a malformed
+header falls through to the next source rather than producing a spoofed URL.
+Enable it only when a trusted proxy sets/overwrites these headers.
 
 ### Collection Keywords & License
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -752,7 +752,8 @@ the server sits behind a reverse proxy (`http://0.0.0.0:8000/edr/...`).
 With `[server] trust_proxy_headers = true`, the base URL is instead resolved
 **per request** from the standard forwarding headers, with this precedence:
 
-1. RFC 7239 `Forwarded` (`proto=`/`host=` of the first element),
+1. RFC 7239 `Forwarded` (`proto=`/`host=` of the **last** element — the closest
+   trusted proxy; the first element is the client-injectable oldest hop),
 2. `X-Forwarded-Proto` + `X-Forwarded-Host` (+ optional `X-Forwarded-Port`),
 3. the static fallback above.
 

--- a/config.toml
+++ b/config.toml
@@ -2,6 +2,9 @@
 host = "127.0.0.1"
 port = 8000
 collections_dir = "collections.d"
+# Derive each request's absolute link base from reverse-proxy headers
+# (Forwarded / X-Forwarded-*). Default false; enable only behind a trusted proxy.
+# trust_proxy_headers = true
 
 # Shared WMS style bundles. Collections reference these by id from their
 # [wms] style_bundle field to avoid duplicating the same default + extras

--- a/crates/api-3dtiles/src/handlers.rs
+++ b/crates/api-3dtiles/src/handlers.rs
@@ -265,11 +265,22 @@ pub struct TilesState3d {
     pub colormap: Arc<dyn ColorMap>,
     /// Bounds concurrent sampling/encoding, shared with the raster render path.
     pub render_semaphore: Arc<tokio::sync::Semaphore>,
-    /// Public base URL for absolute links.
+    /// Static fallback base URL for absolute links. Used as-is unless
+    /// `trust_proxy_headers` resolves a per-request value.
     pub base_url: String,
+    /// Honour reverse-proxy forwarding headers when generating self-links (#12).
+    pub trust_proxy_headers: bool,
 }
 
 pub type AppState = Arc<ArcSwap<TilesState3d>>;
+
+/// Resolve the absolute base URL for the current request, honouring reverse-proxy
+/// forwarding headers when `trust_proxy_headers` is enabled (#12).
+fn request_base_url(state: &TilesState3d, headers: &HeaderMap) -> String {
+    ds_core::proxy::resolve_base_url(&state.base_url, state.trust_proxy_headers, |name| {
+        headers.get(name).and_then(|v| v.to_str().ok())
+    })
+}
 
 /// Look up a collection's volume engine + config, 404 if absent.
 fn lookup<'a>(
@@ -1172,9 +1183,12 @@ pub async fn get_voxel_content(
 // ---------------------------------------------------------------------------
 
 /// `GET /` — API landing document.
-pub async fn landing_page(State(state): State<AppState>) -> Json<serde_json::Value> {
+pub async fn landing_page(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+) -> Json<serde_json::Value> {
     let state = state.load_full();
-    let base = &state.base_url;
+    let base = &request_base_url(&state, &headers);
     Json(json!({
         "title": "MeteoCore — 3D Tiles",
         "description": "Volumetric weather data as OGC 3D Tiles (radar polar volumes)",
@@ -1187,9 +1201,12 @@ pub async fn landing_page(State(state): State<AppState>) -> Json<serde_json::Val
 }
 
 /// `GET /collections` — list 3D-Tiles-capable collections.
-pub async fn collections(State(state): State<AppState>) -> Json<serde_json::Value> {
+pub async fn collections(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+) -> Json<serde_json::Value> {
     let state = state.load_full();
-    let base = &state.base_url;
+    let base = &request_base_url(&state, &headers);
     let mut ids: Vec<&String> = state.volume_engines.keys().collect();
     ids.sort();
     let items: Vec<_> = ids
@@ -1203,11 +1220,16 @@ pub async fn collections(State(state): State<AppState>) -> Json<serde_json::Valu
 pub async fn collection(
     Path(id): Path<String>,
     State(state): State<AppState>,
+    headers: HeaderMap,
 ) -> Result<Json<serde_json::Value>, Tiles3dError> {
     let state = state.load_full();
     // 404 if not a volume collection.
     lookup(&state, &id)?;
-    Ok(Json(collection_doc(&state, &id, &state.base_url)))
+    Ok(Json(collection_doc(
+        &state,
+        &id,
+        &request_base_url(&state, &headers),
+    )))
 }
 
 fn collection_doc(state: &TilesState3d, id: &str, base: &str) -> serde_json::Value {

--- a/crates/api-3dtiles/tests/integration.rs
+++ b/crates/api-3dtiles/tests/integration.rs
@@ -230,6 +230,7 @@ fn router() -> axum::Router {
         )),
         render_semaphore: Arc::new(tokio::sync::Semaphore::new(4)),
         base_url: String::new(),
+        trust_proxy_headers: false,
     }));
     api_3dtiles::router(state)
 }
@@ -492,6 +493,7 @@ async fn voxels_not_advertised_without_coverage() {
         )),
         render_semaphore: Arc::new(tokio::sync::Semaphore::new(4)),
         base_url: String::new(),
+        trust_proxy_headers: false,
     }));
     let app = api_3dtiles::router(state);
     let send = |uri: &str| {
@@ -550,6 +552,7 @@ async fn isosurface_on_unsupported_collection_is_400() {
         )),
         render_semaphore: Arc::new(tokio::sync::Semaphore::new(4)),
         base_url: String::new(),
+        trust_proxy_headers: false,
     }));
     let app = api_3dtiles::router(state);
 
@@ -1001,6 +1004,7 @@ fn router_with(id: &str, engine: Arc<dyn VolumeEngine>) -> axum::Router {
         )),
         render_semaphore: Arc::new(tokio::sync::Semaphore::new(4)),
         base_url: String::new(),
+        trust_proxy_headers: false,
     }));
     api_3dtiles::router(state)
 }

--- a/crates/api-edr/src/handlers.rs
+++ b/crates/api-edr/src/handlers.rs
@@ -103,11 +103,22 @@ fn with_vary(mut resp: Response) -> Response {
 pub struct EdrState {
     pub engines: HashMap<String, Arc<dyn EdrEngine>>,
     pub collections: HashMap<String, CollectionConfig>,
-    /// Base URL for generating absolute links (e.g. "https://api.example.com").
+    /// Static fallback base URL for absolute links (e.g. "https://api.example.com").
+    /// Used as-is unless `trust_proxy_headers` resolves a per-request value.
     pub base_url: String,
+    /// Honour reverse-proxy forwarding headers when generating self-links (#12).
+    pub trust_proxy_headers: bool,
 }
 
 pub type AppState = Arc<ArcSwap<EdrState>>;
+
+/// Resolve the absolute base URL for the current request, honouring reverse-proxy
+/// forwarding headers when `trust_proxy_headers` is enabled (#12).
+fn request_base_url(state: &EdrState, headers: &HeaderMap) -> String {
+    ds_core::proxy::resolve_base_url(&state.base_url, state.trust_proxy_headers, |name| {
+        headers.get(name).and_then(|v| v.to_str().ok())
+    })
+}
 
 #[allow(clippy::type_complexity)]
 fn lookup_collection<'a>(
@@ -205,7 +216,7 @@ pub async fn landing_page(
     use ds_core::html::{LinkView, Wanted};
     let wanted = negotiate(fp.f.as_deref(), &headers)?;
     let state = state.load_full();
-    let base = &state.base_url;
+    let base = &request_base_url(&state, &headers);
     let title = "MeteoCore - EDR";
     let description = "Metocean Data Server — OGC API EDR";
     // (href, rel, type, title) — one source for both representations.
@@ -747,9 +758,9 @@ pub async fn api_definition(State(state): State<AppState>) -> impl IntoResponse 
     Json(openapi)
 }
 
-pub async fn api_docs(State(state): State<AppState>) -> impl IntoResponse {
+pub async fn api_docs(State(state): State<AppState>, headers: HeaderMap) -> impl IntoResponse {
     let state = state.load_full();
-    let spec_url = format!("{}/edr/api", state.base_url);
+    let spec_url = format!("{}/edr/api", request_base_url(&state, &headers));
     axum::response::Html(ds_core::openapi::swagger_ui_html(
         "MeteoCore - EDR API",
         &spec_url,
@@ -764,7 +775,7 @@ pub async fn conformance(
     use ds_core::html::{LinkView, Wanted};
     let wanted = negotiate(fp.f.as_deref(), &headers)?;
     let state = state.load_full();
-    let base = &state.base_url;
+    let base = &request_base_url(&state, &headers);
     let classes = [
         "http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/core",
         "http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/landing-page",
@@ -812,7 +823,7 @@ pub async fn collections(
     let wanted = negotiate(sp.f.as_deref(), &headers)?;
     let params = sp.parse().map_err(|e| bad_request_msg(&e.to_string()))?;
     let state = state.load_full();
-    let base = &state.base_url;
+    let base = &request_base_url(&state, &headers);
 
     // (id, title, description, bbox, time, metadata, keywords, license) per
     // collection. Tuple element types are inferred, so no extra chrono import is
@@ -949,7 +960,7 @@ pub async fn collection(
     let wanted = negotiate(fp.f.as_deref(), &headers)?;
     let state = state.load_full();
     let (engine, config) = lookup_collection(&state, &id)?;
-    let base = &state.base_url;
+    let base = &request_base_url(&state, &headers);
     Ok(with_vary(match wanted {
         Wanted::Json => Json(build_collection_metadata(
             engine.as_ref(),
@@ -989,10 +1000,11 @@ pub async fn collection(
 pub async fn instances(
     Path(id): Path<String>,
     State(state): State<AppState>,
+    headers: HeaderMap,
 ) -> Result<impl IntoResponse, (StatusCode, Json<serde_json::Value>)> {
     let state = state.load_full();
     let (engine, config) = lookup_collection(&state, &id)?;
-    let base = &state.base_url;
+    let base = &request_base_url(&state, &headers);
     // A non-forecast collection (no instances) returns 200 with an empty
     // `instances` list rather than 404. This is the standard REST list
     // convention and matches `/collections` (empty ⇒ 200 `{"collections":[]}`),
@@ -1028,10 +1040,11 @@ pub async fn instances(
 pub async fn instance(
     Path((id, instance_id)): Path<(String, String)>,
     State(state): State<AppState>,
+    headers: HeaderMap,
 ) -> Result<impl IntoResponse, (StatusCode, Json<serde_json::Value>)> {
     let state = state.load_full();
     let (engine, config) = lookup_collection(&state, &id)?;
-    let base = &state.base_url;
+    let base = &request_base_url(&state, &headers);
     // A collection with no instances has no instance sub-resources at all, so
     // any id (parseable or not) is 404 — consistent with the query path's
     // `resolve_instance` guard, rather than 400 on an unparseable id.
@@ -1075,6 +1088,7 @@ pub async fn instance(
 pub async fn locations(
     Path(id): Path<String>,
     State(state): State<AppState>,
+    headers: HeaderMap,
 ) -> Result<impl IntoResponse, (StatusCode, Json<serde_json::Value>)> {
     let state = state.load_full();
     let (engine, _config) = lookup_collection(&state, &id)?;
@@ -1093,7 +1107,7 @@ pub async fn locations(
         collection_id: &id,
         parameter_names: &params,
         temporal_extent: temporal,
-        base_url: &state.base_url,
+        base_url: &request_base_url(&state, &headers),
     };
     let body = serde_json::to_string(&locations_to_geojson(&locs, &ctx)).unwrap();
     Ok(([(header::CONTENT_TYPE, "application/geo+json")], body))

--- a/crates/api-edr/tests/instances_tests.rs
+++ b/crates/api-edr/tests/instances_tests.rs
@@ -231,6 +231,7 @@ fn state() -> api_edr::handlers::AppState {
         engines,
         collections,
         base_url: String::new(),
+        trust_proxy_headers: false,
     }))
 }
 

--- a/crates/api-edr/tests/ogc_edr_api_tests.rs
+++ b/crates/api-edr/tests/ogc_edr_api_tests.rs
@@ -209,6 +209,7 @@ fn make_edr_state(engine: Arc<dyn EdrEngine>) -> Arc<ArcSwap<EdrState>> {
         engines,
         collections,
         base_url: String::new(),
+        trust_proxy_headers: false,
     }))
 }
 
@@ -225,6 +226,95 @@ async fn get(uri: &str) -> (StatusCode, Value) {
     let body = resp.into_body().collect().await.unwrap().to_bytes();
     let json: Value = serde_json::from_slice(&body).unwrap();
     (status, json)
+}
+
+// ---------------------------------------------------------------------------
+// Reverse-proxy base-URL resolution (#12)
+// ---------------------------------------------------------------------------
+
+mod proxy_headers {
+    use super::*;
+
+    /// Build a router whose state has an explicit fallback base URL and a
+    /// configurable `trust_proxy_headers` flag.
+    fn router_with(base_url: &str, trust_proxy_headers: bool) -> axum::Router {
+        let engine: Arc<dyn EdrEngine> = Arc::new(MockEngine);
+        let state = make_edr_state(engine);
+        let cur = state.load();
+        state.store(Arc::new(EdrState {
+            engines: cur.engines.clone(),
+            collections: cur.collections.clone(),
+            base_url: base_url.to_string(),
+            trust_proxy_headers,
+        }));
+        api_edr::router(state)
+    }
+
+    /// Fetch the landing page's `self` link href with the given forwarding headers.
+    async fn self_href(app: axum::Router, headers: &[(&str, &str)]) -> String {
+        let mut req = Request::builder().uri("/");
+        for (k, v) in headers {
+            req = req.header(*k, *v);
+        }
+        let resp = app.oneshot(req.body(Body::empty()).unwrap()).await.unwrap();
+        let body = resp.into_body().collect().await.unwrap().to_bytes();
+        let json: Value = serde_json::from_slice(&body).unwrap();
+        json["links"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|l| l["rel"] == "self")
+            .expect("landing page has a self link")["href"]
+            .as_str()
+            .unwrap()
+            .to_string()
+    }
+
+    #[tokio::test]
+    async fn x_forwarded_headers_rewrite_links_when_trusted() {
+        let href = self_href(
+            router_with("http://127.0.0.1:8000", true),
+            &[
+                ("x-forwarded-host", "api.example.com"),
+                ("x-forwarded-proto", "https"),
+            ],
+        )
+        .await;
+        assert_eq!(href, "https://api.example.com/edr/");
+    }
+
+    #[tokio::test]
+    async fn forwarded_header_rewrites_links_when_trusted() {
+        let href = self_href(
+            router_with("http://127.0.0.1:8000", true),
+            &[(
+                "forwarded",
+                "for=192.0.2.1;host=proxy.example.com;proto=https",
+            )],
+        )
+        .await;
+        assert_eq!(href, "https://proxy.example.com/edr/");
+    }
+
+    #[tokio::test]
+    async fn headers_ignored_when_not_trusted() {
+        // The default: a client cannot spoof the base URL.
+        let href = self_href(
+            router_with("http://127.0.0.1:8000", false),
+            &[
+                ("x-forwarded-host", "evil.example.com"),
+                ("x-forwarded-proto", "https"),
+            ],
+        )
+        .await;
+        assert_eq!(href, "http://127.0.0.1:8000/edr/");
+    }
+
+    #[tokio::test]
+    async fn falls_back_without_headers() {
+        let href = self_href(router_with("http://127.0.0.1:8000", true), &[]).await;
+        assert_eq!(href, "http://127.0.0.1:8000/edr/");
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1393,6 +1483,7 @@ mod metadata_extras {
             engines,
             collections,
             base_url: String::new(),
+            trust_proxy_headers: false,
         }))
     }
 

--- a/crates/api-edr/tests/performance_tests.rs
+++ b/crates/api-edr/tests/performance_tests.rs
@@ -182,6 +182,7 @@ fn make_edr_state(engine: Arc<dyn EdrEngine>) -> Arc<ArcSwap<EdrState>> {
         engines,
         collections,
         base_url: String::new(),
+        trust_proxy_headers: false,
     }))
 }
 

--- a/crates/api-edr/tests/png_plot_tests.rs
+++ b/crates/api-edr/tests/png_plot_tests.rs
@@ -176,6 +176,7 @@ fn router_with(engine: Arc<dyn EdrEngine>) -> axum::Router {
         engines,
         collections,
         base_url: String::new(),
+        trust_proxy_headers: false,
     })))
 }
 

--- a/crates/api-edr/tests/security_tests.rs
+++ b/crates/api-edr/tests/security_tests.rs
@@ -122,6 +122,7 @@ fn make_edr_state(engine: Arc<dyn EdrEngine>) -> Arc<ArcSwap<EdrState>> {
         engines,
         collections,
         base_url: String::new(),
+        trust_proxy_headers: false,
     }))
 }
 

--- a/crates/api-edr/tests/spec_compliance_tests.rs
+++ b/crates/api-edr/tests/spec_compliance_tests.rs
@@ -137,6 +137,7 @@ fn make_edr_state(engine: Arc<dyn EdrEngine>) -> Arc<ArcSwap<EdrState>> {
         engines,
         collections,
         base_url: String::new(),
+        trust_proxy_headers: false,
     }))
 }
 

--- a/crates/api-features/src/handlers.rs
+++ b/crates/api-features/src/handlers.rs
@@ -21,11 +21,22 @@ use crate::response::{feature_page_to_geojson, feature_to_geojson};
 pub struct FeaturesState {
     pub engines: HashMap<String, Arc<dyn FeatureEngine>>,
     pub collections: HashMap<String, CollectionConfig>,
-    /// Base URL for generating absolute links (e.g. "https://api.example.com").
+    /// Static fallback base URL for absolute links (e.g. "https://api.example.com").
+    /// Used as-is unless `trust_proxy_headers` resolves a per-request value.
     pub base_url: String,
+    /// Honour reverse-proxy forwarding headers when generating self-links (#12).
+    pub trust_proxy_headers: bool,
 }
 
 pub type AppState = Arc<ArcSwap<FeaturesState>>;
+
+/// Resolve the absolute base URL for the current request, honouring reverse-proxy
+/// forwarding headers when `trust_proxy_headers` is enabled (#12).
+fn request_base_url(state: &FeaturesState, headers: &HeaderMap) -> String {
+    ds_core::proxy::resolve_base_url(&state.base_url, state.trust_proxy_headers, |name| {
+        headers.get(name).and_then(|v| v.to_str().ok())
+    })
+}
 
 /// Custom response type for GeoJSON with correct Content-Type.
 pub struct GeoJsonResponse(pub serde_json::Value);
@@ -96,7 +107,7 @@ pub async fn landing_page(
     use ds_core::html::{LinkView, Wanted};
     let wanted = negotiate(fp.f.as_deref(), &headers)?;
     let state = state.load_full();
-    let base = &state.base_url;
+    let base = &request_base_url(&state, &headers);
     let title = "MeteoCore - Features";
     let description = "Metocean Data Server — OGC API Features";
     // (href, rel, type, title) — one source for both representations.
@@ -166,7 +177,7 @@ pub async fn conformance(
     use ds_core::html::{LinkView, Wanted};
     let wanted = negotiate(fp.f.as_deref(), &headers)?;
     let state = state.load_full();
-    let base = &state.base_url;
+    let base = &request_base_url(&state, &headers);
     let classes = [
         // OGC API – Common – Part 1: Core and Part 2: Geospatial Data. The
         // Features landing page, /conformance, /api, and
@@ -454,9 +465,9 @@ pub async fn api_definition(State(state): State<AppState>) -> impl IntoResponse 
     Json(openapi)
 }
 
-pub async fn api_docs(State(state): State<AppState>) -> impl IntoResponse {
+pub async fn api_docs(State(state): State<AppState>, headers: HeaderMap) -> impl IntoResponse {
     let state = state.load_full();
-    let spec_url = format!("{}/features/api", state.base_url);
+    let spec_url = format!("{}/features/api", request_base_url(&state, &headers));
     axum::response::Html(ds_core::openapi::swagger_ui_html(
         "MeteoCore - Features API",
         &spec_url,
@@ -474,7 +485,7 @@ pub async fn collections(
     let wanted = negotiate(sp.f.as_deref(), &headers)?;
     let params = sp.parse().map_err(|e| bad_request_msg(&e.to_string()))?;
     let state = state.load_full();
-    let base = &state.base_url;
+    let base = &request_base_url(&state, &headers);
 
     // (id, title, description, bbox, metadata, keywords, license) per
     // collection. Features carry no temporal extent today (`time: None`), so per
@@ -613,7 +624,7 @@ pub async fn collection(
     let wanted = negotiate(fp.f.as_deref(), &headers)?;
     let state = state.load_full();
     let (engine, config) = lookup_collection(&state, &id)?;
-    let base = &state.base_url;
+    let base = &request_base_url(&state, &headers);
     Ok(with_vary(match wanted {
         Wanted::Json => {
             Json(build_collection_metadata(engine.as_ref(), config, base)).into_response()
@@ -648,6 +659,7 @@ pub async fn items(
     Path(id): Path<String>,
     Query(params): Query<ItemsQueryParams>,
     State(state): State<AppState>,
+    headers: HeaderMap,
 ) -> Result<impl IntoResponse, (StatusCode, Json<serde_json::Value>)> {
     let state = state.load_full();
     let (engine, _config) = lookup_collection(&state, &id)?;
@@ -700,13 +712,14 @@ pub async fn items(
         limit,
         offset,
         &timestamp,
-        &state.base_url,
+        &request_base_url(&state, &headers),
     )))
 }
 
 pub async fn item(
     Path((id, feature_id)): Path<(String, String)>,
     State(state): State<AppState>,
+    headers: HeaderMap,
 ) -> Result<impl IntoResponse, (StatusCode, Json<serde_json::Value>)> {
     let state = state.load_full();
     let (engine, _config) = lookup_collection(&state, &id)?;
@@ -725,7 +738,7 @@ pub async fn item(
     Ok(GeoJsonResponse(feature_to_geojson(
         &feature,
         &id,
-        &state.base_url,
+        &request_base_url(&state, &headers),
     )))
 }
 

--- a/crates/api-features/tests/ogc_features_api_tests.rs
+++ b/crates/api-features/tests/ogc_features_api_tests.rs
@@ -157,6 +157,7 @@ fn build_router() -> axum::Router {
         engines,
         collections,
         base_url: String::new(),
+        trust_proxy_headers: false,
     }));
     api_features::router(state)
 }
@@ -452,6 +453,7 @@ mod vector_tile_discovery {
             engines,
             collections,
             base_url: String::new(),
+            trust_proxy_headers: false,
         }));
         api_features::router(state)
     }
@@ -918,6 +920,7 @@ mod metadata_extras {
             engines,
             collections,
             base_url: String::new(),
+            trust_proxy_headers: false,
         }));
         api_features::router(state)
     }

--- a/crates/api-maps/src/handlers.rs
+++ b/crates/api-maps/src/handlers.rs
@@ -24,10 +24,22 @@ pub struct MapsState {
     pub styles: HashMap<String, HashMap<String, StyleInfo>>,
     pub render_semaphore: Arc<tokio::sync::Semaphore>,
     pub rendered_cache: Arc<RenderedCache>,
+    /// Static fallback base URL for absolute links. Used as-is unless
+    /// `trust_proxy_headers` resolves a per-request value.
     pub base_url: String,
+    /// Honour reverse-proxy forwarding headers when generating self-links (#12).
+    pub trust_proxy_headers: bool,
 }
 
 pub type AppState = Arc<ArcSwap<MapsState>>;
+
+/// Resolve the absolute base URL for the current request, honouring reverse-proxy
+/// forwarding headers when `trust_proxy_headers` is enabled (#12).
+fn request_base_url(state: &MapsState, headers: &HeaderMap) -> String {
+    ds_core::proxy::resolve_base_url(&state.base_url, state.trust_proxy_headers, |name| {
+        headers.get(name).and_then(|v| v.to_str().ok())
+    })
+}
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -238,7 +250,7 @@ pub async fn landing_page(
     use ds_core::html::{LinkView, Wanted};
     let wanted = negotiate(fp.f.as_deref(), &headers)?;
     let state = state.load_full();
-    let base = &state.base_url;
+    let base = &request_base_url(&state, &headers);
     let title = "MeteoCore - Maps";
     let description = "Metocean Data Server — OGC API Maps";
     // (href, rel, type, title) — one source for both representations.
@@ -633,9 +645,9 @@ pub async fn api_definition(State(state): State<AppState>) -> impl IntoResponse 
 }
 
 /// GET /maps/api/docs — Swagger UI
-pub async fn api_docs(State(state): State<AppState>) -> impl IntoResponse {
+pub async fn api_docs(State(state): State<AppState>, headers: HeaderMap) -> impl IntoResponse {
     let state = state.load_full();
-    let spec_url = format!("{}/maps/api", state.base_url);
+    let spec_url = format!("{}/maps/api", request_base_url(&state, &headers));
     axum::response::Html(ds_core::openapi::swagger_ui_html(
         "MeteoCore - Maps API",
         &spec_url,
@@ -651,7 +663,7 @@ pub async fn conformance(
     use ds_core::html::{LinkView, Wanted};
     let wanted = negotiate(fp.f.as_deref(), &headers)?;
     let state = state.load_full();
-    let base = &state.base_url;
+    let base = &request_base_url(&state, &headers);
     let classes = [
         // OGC API - Common - Part 1: Core (landing page, /conformance,
         // /api) and Part 2: Geospatial Data (/collections + /collections/
@@ -716,7 +728,7 @@ pub async fn collections(
         .parse()
         .map_err(|e| MapsError::BadRequest(e.to_string()))?;
     let state = state.load_full();
-    let base = &state.base_url;
+    let base = &request_base_url(&state, &headers);
 
     // (id, title, description, bbox, time, metadata, keywords, license) per
     // collection; tuple element types are inferred (no extra chrono import).
@@ -857,7 +869,7 @@ pub async fn collection(
     let wanted = negotiate(fp.f.as_deref(), &headers)?;
     let state = state.load_full();
     let (engine, config) = lookup_engine(&state, &id)?;
-    let base = &state.base_url;
+    let base = &request_base_url(&state, &headers);
     Ok(with_vary(match wanted {
         Wanted::Json => {
             let info = engine.raster_info();
@@ -894,10 +906,11 @@ pub async fn collection(
 pub async fn styles(
     Path(id): Path<String>,
     State(state): State<AppState>,
+    headers: HeaderMap,
 ) -> Result<impl IntoResponse, MapsError> {
     let state = state.load_full();
     let (_engine, config) = lookup_engine(&state, &id)?;
-    let base = &state.base_url;
+    let base = &request_base_url(&state, &headers);
 
     let mut style_list = Vec::new();
     if let Some(layer_styles) = state.styles.get(&id) {

--- a/crates/api-maps/tests/integration.rs
+++ b/crates/api-maps/tests/integration.rs
@@ -167,6 +167,7 @@ fn build_router_with_engine(engine: Arc<dyn MapEngine>) -> axum::Router {
         render_semaphore: Arc::new(tokio::sync::Semaphore::new(4)),
         rendered_cache: Arc::new(RenderedCache::new(16)),
         base_url: String::new(),
+        trust_proxy_headers: false,
     }));
     api_maps::router(state)
 }
@@ -241,6 +242,7 @@ fn build_router_with_apis(apis: Vec<String>) -> axum::Router {
         render_semaphore: Arc::new(tokio::sync::Semaphore::new(4)),
         rendered_cache: Arc::new(RenderedCache::new(16)),
         base_url: String::new(),
+        trust_proxy_headers: false,
     }));
     api_maps::router(state)
 }
@@ -312,6 +314,7 @@ async fn fetch_collection_json(engine: Arc<dyn MapEngine>, id: &str, apis: Vec<S
         render_semaphore: Arc::new(tokio::sync::Semaphore::new(4)),
         rendered_cache: Arc::new(RenderedCache::new(16)),
         base_url: String::new(),
+        trust_proxy_headers: false,
     }));
     let (_, json) = get_on(api_maps::router(state), &format!("/collections/{id}")).await;
     json
@@ -357,6 +360,7 @@ fn router_with(
         render_semaphore: Arc::new(tokio::sync::Semaphore::new(4)),
         rendered_cache: Arc::new(RenderedCache::new(16)),
         base_url: String::new(),
+        trust_proxy_headers: false,
     }));
     api_maps::router(state)
 }
@@ -1290,6 +1294,7 @@ fn build_empty_router() -> axum::Router {
         render_semaphore: Arc::new(tokio::sync::Semaphore::new(4)),
         rendered_cache: Arc::new(RenderedCache::new(16)),
         base_url: String::new(),
+        trust_proxy_headers: false,
     }));
     api_maps::router(state)
 }
@@ -1406,6 +1411,7 @@ fn build_multi_param_router() -> axum::Router {
         render_semaphore: Arc::new(tokio::sync::Semaphore::new(4)),
         rendered_cache: Arc::new(RenderedCache::new(16)),
         base_url: String::new(),
+        trust_proxy_headers: false,
     }));
     api_maps::router(state)
 }
@@ -1829,6 +1835,7 @@ mod searchable {
             render_semaphore: Arc::new(tokio::sync::Semaphore::new(4)),
             rendered_cache: Arc::new(RenderedCache::new(16)),
             base_url: String::new(),
+            trust_proxy_headers: false,
         }));
         api_maps::router(state)
     }

--- a/crates/api-tiles/src/handlers.rs
+++ b/crates/api-tiles/src/handlers.rs
@@ -57,10 +57,22 @@ pub struct TilesState {
     pub render_semaphore: Arc<tokio::sync::Semaphore>,
     pub rendered_cache: Arc<RenderedCache>,
     pub vector_tile_cache: Arc<VectorTileCache>,
+    /// Static fallback base URL for absolute links. Used as-is unless
+    /// `trust_proxy_headers` resolves a per-request value.
     pub base_url: String,
+    /// Honour reverse-proxy forwarding headers when generating self-links (#12).
+    pub trust_proxy_headers: bool,
 }
 
 pub type AppState = Arc<ArcSwap<TilesState>>;
+
+/// Resolve the absolute base URL for the current request, honouring reverse-proxy
+/// forwarding headers when `trust_proxy_headers` is enabled (#12).
+fn request_base_url(state: &TilesState, headers: &HeaderMap) -> String {
+    ds_core::proxy::resolve_base_url(&state.base_url, state.trust_proxy_headers, |name| {
+        headers.get(name).and_then(|v| v.to_str().ok())
+    })
+}
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -294,7 +306,7 @@ pub async fn landing_page(
     use ds_core::html::{LinkView, Wanted};
     let wanted = negotiate(fp.f.as_deref(), &headers)?;
     let state = state.load_full();
-    let base = &state.base_url;
+    let base = &request_base_url(&state, &headers);
     let title = "MeteoCore - Tiles";
     let description = "Metocean Data Server \u{2014} OGC API Tiles";
     // (href, rel, type, title) — one source for both representations.
@@ -621,9 +633,9 @@ pub async fn api_definition(State(state): State<AppState>) -> impl IntoResponse 
 }
 
 /// GET /tiles/api/docs — Swagger UI
-pub async fn api_docs(State(state): State<AppState>) -> impl IntoResponse {
+pub async fn api_docs(State(state): State<AppState>, headers: HeaderMap) -> impl IntoResponse {
     let state = state.load_full();
-    let spec_url = format!("{}/tiles/api", state.base_url);
+    let spec_url = format!("{}/tiles/api", request_base_url(&state, &headers));
     axum::response::Html(ds_core::openapi::swagger_ui_html(
         "MeteoCore - Tiles API",
         &spec_url,
@@ -639,7 +651,7 @@ pub async fn conformance(
     use ds_core::html::{LinkView, Wanted};
     let wanted = negotiate(fp.f.as_deref(), &headers)?;
     let state = state.load_full();
-    let base = &state.base_url;
+    let base = &request_base_url(&state, &headers);
     let classes = [
         // OGC API - Common - Part 1: Core (landing page, /conformance,
         // /api) and Part 2: Geospatial Data (/collections + /collections/
@@ -682,9 +694,12 @@ pub async fn conformance(
 }
 
 /// GET /tiles/tileMatrixSets — List supported tile matrix sets
-pub async fn tile_matrix_sets(State(state): State<AppState>) -> impl IntoResponse {
+pub async fn tile_matrix_sets(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+) -> impl IntoResponse {
     let state = state.load_full();
-    let base = &state.base_url;
+    let base = &request_base_url(&state, &headers);
     let sets: Vec<serde_json::Value> = SUPPORTED_TILE_MATRIX_SETS
         .iter()
         .filter_map(|id| {
@@ -739,7 +754,7 @@ pub async fn collections(
         .parse()
         .map_err(|e| TilesError::BadRequest(e.to_string()))?;
     let state = state.load_full();
-    let base = &state.base_url;
+    let base = &request_base_url(&state, &headers);
 
     // Surface every tile-enabled collection, regardless of which engine backs
     // it — a vector-only collection that lives in `feature_collections` would
@@ -904,7 +919,7 @@ pub async fn collection(
             "Collection '{id}' has no tile source"
         )));
     }
-    let base = &state.base_url;
+    let base = &request_base_url(&state, &headers);
     Ok(with_vary(match wanted {
         Wanted::Json => {
             let styles = state.styles.get(&id);
@@ -947,6 +962,7 @@ pub async fn collection(
 pub async fn collection_tilesets(
     Path(id): Path<String>,
     State(state): State<AppState>,
+    headers: HeaderMap,
 ) -> Result<impl IntoResponse, TilesError> {
     let state = state.load_full();
     let raster_info = state.map_engines.get(&id).map(|e| e.raster_info());
@@ -966,7 +982,7 @@ pub async fn collection_tilesets(
             "Collection '{id}' has no tile source"
         )));
     }
-    let base = &state.base_url;
+    let base = &request_base_url(&state, &headers);
 
     let max_zoom = params::DEFAULT_MAX_ZOOM;
     let spatial_extent = raster_info

--- a/crates/api-tiles/tests/integration.rs
+++ b/crates/api-tiles/tests/integration.rs
@@ -184,6 +184,7 @@ fn build_router() -> axum::Router {
         rendered_cache: Arc::new(RenderedCache::new(16)),
         vector_tile_cache: Arc::new(VectorTileCache::new(16)),
         base_url: String::new(),
+        trust_proxy_headers: false,
     }));
     api_tiles::router(state)
 }
@@ -244,6 +245,7 @@ fn build_router_with_engine(engine: Arc<dyn MapEngine>) -> axum::Router {
         rendered_cache: Arc::new(RenderedCache::new(16)),
         vector_tile_cache: Arc::new(VectorTileCache::new(16)),
         base_url: String::new(),
+        trust_proxy_headers: false,
     }));
     api_tiles::router(state)
 }
@@ -1064,6 +1066,7 @@ fn build_empty_router() -> axum::Router {
         rendered_cache: Arc::new(RenderedCache::new(16)),
         vector_tile_cache: Arc::new(VectorTileCache::new(16)),
         base_url: String::new(),
+        trust_proxy_headers: false,
     }));
     api_tiles::router(state)
 }
@@ -1183,6 +1186,7 @@ fn build_multi_param_router() -> axum::Router {
         rendered_cache: Arc::new(RenderedCache::new(16)),
         vector_tile_cache: Arc::new(VectorTileCache::new(16)),
         base_url: String::new(),
+        trust_proxy_headers: false,
     }));
     api_tiles::router(state)
 }
@@ -1381,6 +1385,7 @@ mod mvt {
             rendered_cache: Arc::new(RenderedCache::new(16)),
             vector_tile_cache: Arc::new(VectorTileCache::new(16)),
             base_url: String::new(),
+            trust_proxy_headers: false,
         }));
         api_tiles::router(state)
     }
@@ -1467,6 +1472,7 @@ mod mvt {
             rendered_cache: Arc::new(RenderedCache::new(16)),
             vector_tile_cache: Arc::new(VectorTileCache::new(16)),
             base_url: String::new(),
+            trust_proxy_headers: false,
         }));
         api_tiles::router(state)
     }
@@ -1778,6 +1784,7 @@ mod temporal_grid_jitter {
             rendered_cache: Arc::new(RenderedCache::new(16)),
             vector_tile_cache: Arc::new(VectorTileCache::new(16)),
             base_url: String::new(),
+            trust_proxy_headers: false,
         }));
         let app = api_tiles::router(state);
         let req = Request::builder()
@@ -1947,6 +1954,7 @@ mod metadata_extras {
             rendered_cache: Arc::new(RenderedCache::new(16)),
             vector_tile_cache: Arc::new(VectorTileCache::new(16)),
             base_url: String::new(),
+            trust_proxy_headers: false,
         }));
         api_tiles::router(state)
     }

--- a/crates/api-wms/src/handlers.rs
+++ b/crates/api-wms/src/handlers.rs
@@ -45,10 +45,22 @@ pub struct WmsState {
     pub rendered_cache: Arc<RenderedCache>,
     /// Decoded-RGBA meta-tile cache for the Web Mercator GetMap path (#202).
     pub tile_cache: Arc<ds_render::TilePixelCache>,
+    /// Static fallback base URL for absolute links. Used as-is unless
+    /// `trust_proxy_headers` resolves a per-request value.
     pub base_url: String,
+    /// Honour reverse-proxy forwarding headers when generating self-links (#12).
+    pub trust_proxy_headers: bool,
 }
 
 pub type AppState = Arc<ArcSwap<WmsState>>;
+
+/// Resolve the absolute base URL for the current request, honouring reverse-proxy
+/// forwarding headers when `trust_proxy_headers` is enabled (#12).
+fn request_base_url(state: &WmsState, headers: &HeaderMap) -> String {
+    ds_core::proxy::resolve_base_url(&state.base_url, state.trust_proxy_headers, |name| {
+        headers.get(name).and_then(|v| v.to_str().ok())
+    })
+}
 
 /// Render a semi-transparent red error tile to make failed areas visible.
 fn render_error_tile(width: u32, height: u32) -> Result<Vec<u8>, WmsError> {
@@ -87,7 +99,7 @@ pub async fn wms_handler(
                 &state.engines,
                 &state.collections,
                 &state.styles,
-                &state.base_url,
+                &request_base_url(&state, &headers),
             );
             Ok((
                 [

--- a/crates/api-wms/tests/integration.rs
+++ b/crates/api-wms/tests/integration.rs
@@ -123,6 +123,7 @@ fn build_empty_router() -> axum::Router {
         rendered_cache: Arc::new(RenderedCache::new(16)),
         tile_cache: Arc::new(ds_render::TilePixelCache::new(16)),
         base_url: String::new(),
+        trust_proxy_headers: false,
     }));
     api_wms::router(state)
 }
@@ -278,6 +279,7 @@ fn build_failing_router() -> axum::Router {
         rendered_cache: Arc::new(RenderedCache::new(16)),
         tile_cache: Arc::new(ds_render::TilePixelCache::new(16)),
         base_url: String::new(),
+        trust_proxy_headers: false,
     }));
     api_wms::router(state)
 }
@@ -424,6 +426,7 @@ fn build_populated_router() -> axum::Router {
         rendered_cache: Arc::new(RenderedCache::new(16)),
         tile_cache: Arc::new(ds_render::TilePixelCache::new(16)),
         base_url: String::new(),
+        trust_proxy_headers: false,
     }));
     api_wms::router(state)
 }
@@ -788,6 +791,7 @@ fn build_counting_router(
         rendered_cache: Arc::new(RenderedCache::new(16)),
         tile_cache: tile_cache.clone(),
         base_url: String::new(),
+        trust_proxy_headers: false,
     }));
     (api_wms::router(state), tile_cache, calls)
 }
@@ -1258,6 +1262,7 @@ fn build_forecast_router() -> (axum::Router, RunRecorder) {
         rendered_cache: Arc::new(RenderedCache::new(16)),
         tile_cache: Arc::new(ds_render::TilePixelCache::new(16)),
         base_url: String::new(),
+        trust_proxy_headers: false,
     }));
     (api_wms::router(state), calls)
 }
@@ -1694,6 +1699,7 @@ fn build_advancing_router() -> AdvancingFixture {
         rendered_cache: Arc::new(RenderedCache::new(16)),
         tile_cache: Arc::new(ds_render::TilePixelCache::new(16)),
         base_url: String::new(),
+        trust_proxy_headers: false,
     }));
     (api_wms::router(state), times, calls)
 }

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -45,6 +45,14 @@ pub struct ServerSettings {
     /// window coalesce into a single reload. Default: 500.
     #[serde(default = "default_watch_debounce_ms")]
     pub watch_debounce_ms: u64,
+    /// Trust reverse-proxy forwarding headers (`Forwarded`, `X-Forwarded-Proto`,
+    /// `X-Forwarded-Host`, `X-Forwarded-Port`) to derive each request's
+    /// absolute self-link base URL (#12). Default `false`. Enable ONLY when the
+    /// server sits behind a trusted proxy that sets/overwrites these headers —
+    /// otherwise a client could spoof them. When `false`, links use the static
+    /// base URL (`BASE_URL` env > `[server] base_url` > `http://{host}:{port}`).
+    #[serde(default)]
+    pub trust_proxy_headers: bool,
 }
 
 impl ServerSettings {
@@ -80,6 +88,7 @@ impl ServerConfig {
                 metatile_cache_mb: default_metatile_cache_mb(),
                 watch_collections_dir: false,
                 watch_debounce_ms: default_watch_debounce_ms(),
+                trust_proxy_headers: false,
             },
             collections: Vec::new(),
             style_bundles: Vec::new(),

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -13,6 +13,7 @@ pub mod map_engine;
 pub mod model;
 pub mod ogc_extent;
 pub mod openapi;
+pub mod proxy;
 pub mod raster_paint;
 pub mod resample;
 pub mod vertical;

--- a/crates/core/src/proxy.rs
+++ b/crates/core/src/proxy.rs
@@ -26,7 +26,8 @@
 /// slash.
 ///
 /// Precedence when `trust` is `true`:
-///   1. RFC 7239 `Forwarded` — `proto=` / `host=` of the **first** element.
+///   1. RFC 7239 `Forwarded` — `proto=` / `host=` of the **last** element (the
+///      closest trusted proxy; see [`from_forwarded`] for why not the first).
 ///   2. `X-Forwarded-Proto` + `X-Forwarded-Host` (+ optional `X-Forwarded-Port`).
 ///   3. `fallback` — the startup-resolved base (`BASE_URL` env > `[server]
 ///      base_url` > `http://{host}:{port}`).
@@ -60,15 +61,22 @@ pub fn resolve_base_url<'h>(
     fallback.to_string()
 }
 
-/// Parse an RFC 7239 `Forwarded` header, using the first forwarded element.
+/// Parse an RFC 7239 `Forwarded` header, using the **last** forwarded element.
 /// The `host` directive already includes any port, so it is used verbatim.
+///
+/// RFC 7239 §4 requires each proxy to *append* its entry to a comma-separated
+/// list, so the **first** element is the oldest hop — which a client can
+/// pre-inject (`Forwarded: host=evil.example.com;proto=https`) before the
+/// trusted proxy appends its own entry. The last element is the one written by
+/// the closest upstream proxy (the trusted one), so it is the only safe choice.
+/// (`X-Forwarded-*` differs: proxies conventionally *overwrite* those, so the
+/// trust model — "enable only when a trusted proxy sets/overwrites these" — makes
+/// the single value authoritative there.)
 fn from_forwarded(value: Option<&str>, fallback: &str) -> Option<String> {
-    // Multiple proxies append elements separated by commas; use the first
-    // (closest to the client) hop.
-    let first = first_value(value?);
+    let last = value?.split(',').next_back().unwrap_or_default().trim();
     let mut host: Option<&str> = None;
     let mut proto: Option<&str> = None;
-    for pair in first.split(';') {
+    for pair in last.split(';') {
         let Some((k, v)) = pair.split_once('=') else {
             continue;
         };
@@ -364,16 +372,20 @@ mod tests {
     }
 
     #[test]
-    fn forwarded_first_element_only() {
+    fn forwarded_uses_last_element_not_client_injected_first() {
+        // RFC 7239 §4: proxies *append*, so the first element is the oldest hop
+        // (a client can pre-inject it); the trusted proxy's entry is last. The
+        // client-supplied `evil.example.com` must be ignored in favour of the
+        // trusted proxy's `trusted.example.com`.
         let url = resolve_base_url(
             "http://127.0.0.1:8000",
             true,
             hdrs(&[(
                 "forwarded",
-                "host=first.example.com;proto=https, host=second.example.com;proto=http",
+                "host=evil.example.com;proto=https, host=trusted.example.com;proto=https",
             )]),
         );
-        assert_eq!(url, "https://first.example.com");
+        assert_eq!(url, "https://trusted.example.com");
     }
 
     #[test]

--- a/crates/core/src/proxy.rs
+++ b/crates/core/src/proxy.rs
@@ -166,9 +166,32 @@ fn sanitize_host(host: &str) -> Option<&str> {
     if !safe {
         return None;
     }
-    // A bare leading/trailing colon (`:8080`, `example.com:`) is malformed.
-    if host.starts_with(':') || host.ends_with(':') {
-        return None;
+    // Beyond the byte allowlist, validate the authority *structure* so a
+    // malformed header can never yield a broken URL (the module invariant).
+    if host.starts_with('[') {
+        // IPv6 literal: exactly one bracket pair, non-empty contents, and only
+        // an optional `:port` after the closing bracket.
+        if host.matches('[').count() != 1 || host.matches(']').count() != 1 {
+            return None;
+        }
+        let close = host.find(']')?;
+        if close == 1 {
+            return None; // empty `[]`
+        }
+        match &host[close + 1..] {
+            "" => {}
+            rest => validate_port(rest.strip_prefix(':')?).map(|_| ())?,
+        }
+    } else {
+        // Non-bracketed: no stray brackets, and a bare IPv6 (more than one
+        // colon) MUST be bracketed — reject it rather than emit `https://::1`.
+        if host.contains('[') || host.contains(']') || host.matches(':').count() > 1 {
+            return None;
+        }
+        // A bare leading/trailing colon (`:8080`, `example.com:`) is malformed.
+        if host.starts_with(':') || host.ends_with(':') {
+            return None;
+        }
     }
     Some(host)
 }
@@ -412,6 +435,69 @@ mod tests {
             ]),
         );
         assert_eq!(url, "https://[2001:db8::1]:8443");
+    }
+
+    #[test]
+    fn ipv6_literal_host_with_separate_port() {
+        // Bracketed IPv6 with no embedded port + a separate X-Forwarded-Port:
+        // the port is appended after the closing bracket.
+        let url = resolve_base_url(
+            "http://127.0.0.1:8000",
+            true,
+            hdrs(&[
+                ("x-forwarded-host", "[2001:db8::1]"),
+                ("x-forwarded-proto", "https"),
+                ("x-forwarded-port", "8443"),
+            ]),
+        );
+        assert_eq!(url, "https://[2001:db8::1]:8443");
+    }
+
+    #[test]
+    fn bare_unbracketed_ipv6_rejected() {
+        // A literal IPv6 in a URL authority MUST be bracketed; an unbracketed or
+        // malformed one must not yield a broken URL — it falls back.
+        for bad in ["2001:db8::1", "::1", "[2001:db8::1", "2001:db8::1]", "[]"] {
+            let url = resolve_base_url(
+                "http://127.0.0.1:8000",
+                true,
+                hdrs(&[("x-forwarded-host", bad), ("x-forwarded-proto", "https")]),
+            );
+            assert_eq!(
+                url, "http://127.0.0.1:8000",
+                "host {bad:?} should be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn bare_colon_edges_rejected() {
+        for bad in [":8080", "example.com:"] {
+            let url = resolve_base_url(
+                "http://127.0.0.1:8000",
+                true,
+                hdrs(&[("x-forwarded-host", bad), ("x-forwarded-proto", "https")]),
+            );
+            assert_eq!(
+                url, "http://127.0.0.1:8000",
+                "host {bad:?} should be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn http_default_port_not_appended_and_fallback_scheme() {
+        // Covers the http/80 default-port arm and scheme_of's http branch
+        // (no proto + http fallback).
+        let url = resolve_base_url(
+            "http://internal:8000",
+            true,
+            hdrs(&[
+                ("x-forwarded-host", "api.example.com"),
+                ("x-forwarded-port", "80"),
+            ]),
+        );
+        assert_eq!(url, "http://api.example.com");
     }
 
     #[test]

--- a/crates/core/src/proxy.rs
+++ b/crates/core/src/proxy.rs
@@ -1,0 +1,440 @@
+//! Reverse-proxy-aware base-URL resolution (issue #12).
+//!
+//! When the server sits behind a reverse proxy, the address it bound to is not
+//! the address clients use, so absolute self-links generated from the static
+//! configured base URL are wrong (`http://0.0.0.0:8000/edr/...`). With
+//! `[server] trust_proxy_headers = true` each request's self-links are instead
+//! derived from the standard proxy forwarding headers.
+//!
+//! This module is **framework-free**: the HTTP layer passes header values in
+//! through a closure, so ds-core never depends on `axum`/`http` (see the
+//! "ds-core has no framework dependencies" rule). The axum handlers call
+//! [`resolve_base_url`] with `|name| headers.get(name).and_then(|v|
+//! v.to_str().ok())`.
+//!
+//! # Security
+//!
+//! Forwarding headers are client-controllable, so resolution is **off by
+//! default** and only honoured when the operator opts in (the proxy is trusted
+//! to set/overwrite these headers). Even then, host values are sanitised
+//! (whitespace, slashes, `@`, non-ASCII and other authority-breaking characters
+//! are rejected) and the scheme is restricted to `http`/`https`. A malformed or
+//! suspicious header never produces a broken or attacker-chosen URL: resolution
+//! simply falls through to the next source, ultimately the static fallback.
+
+/// Resolve the effective base URL for a single request, without a trailing
+/// slash.
+///
+/// Precedence when `trust` is `true`:
+///   1. RFC 7239 `Forwarded` — `proto=` / `host=` of the **first** element.
+///   2. `X-Forwarded-Proto` + `X-Forwarded-Host` (+ optional `X-Forwarded-Port`).
+///   3. `fallback` — the startup-resolved base (`BASE_URL` env > `[server]
+///      base_url` > `http://{host}:{port}`).
+///
+/// When `trust` is `false` (the default) `fallback` is returned unchanged, so
+/// there is no behaviour change without the flag.
+///
+/// `header` returns the raw value of a header by its lowercase name (or `None`
+/// when absent). For headers that may legitimately carry a comma-separated list
+/// of proxy hops, only the **first** value is used.
+pub fn resolve_base_url<'h>(
+    fallback: &str,
+    trust: bool,
+    header: impl Fn(&str) -> Option<&'h str>,
+) -> String {
+    let fallback = fallback.trim_end_matches('/');
+    if !trust {
+        return fallback.to_string();
+    }
+    if let Some(url) = from_forwarded(header("forwarded"), fallback) {
+        return url;
+    }
+    if let Some(url) = from_x_forwarded(
+        header("x-forwarded-proto"),
+        header("x-forwarded-host"),
+        header("x-forwarded-port"),
+        fallback,
+    ) {
+        return url;
+    }
+    fallback.to_string()
+}
+
+/// Parse an RFC 7239 `Forwarded` header, using the first forwarded element.
+/// The `host` directive already includes any port, so it is used verbatim.
+fn from_forwarded(value: Option<&str>, fallback: &str) -> Option<String> {
+    // Multiple proxies append elements separated by commas; use the first
+    // (closest to the client) hop.
+    let first = first_value(value?);
+    let mut host: Option<&str> = None;
+    let mut proto: Option<&str> = None;
+    for pair in first.split(';') {
+        let Some((k, v)) = pair.split_once('=') else {
+            continue;
+        };
+        let k = k.trim();
+        let v = unquote(v.trim());
+        if host.is_none() && k.eq_ignore_ascii_case("host") {
+            host = Some(v);
+        } else if proto.is_none() && k.eq_ignore_ascii_case("proto") {
+            proto = Some(v);
+        }
+    }
+    let host = sanitize_host(host?)?;
+    let scheme = proto
+        .and_then(validate_scheme)
+        .unwrap_or_else(|| scheme_of(fallback));
+    Some(format!("{scheme}://{host}"))
+}
+
+/// Build a base URL from the `X-Forwarded-*` family. Returns `None` when there
+/// is no usable host so the caller falls through to the next source.
+fn from_x_forwarded(
+    proto: Option<&str>,
+    host: Option<&str>,
+    port: Option<&str>,
+    fallback: &str,
+) -> Option<String> {
+    let host = sanitize_host(first_value(host?))?;
+    let scheme = proto
+        .map(first_value)
+        .and_then(validate_scheme)
+        .unwrap_or_else(|| scheme_of(fallback));
+
+    // `X-Forwarded-Host` may already carry the port. Otherwise append a valid,
+    // non-default `X-Forwarded-Port`.
+    let authority = if host_has_port(host) {
+        host.to_string()
+    } else if let Some(p) = port.map(first_value).and_then(validate_port) {
+        if is_default_port(&scheme, p) {
+            host.to_string()
+        } else {
+            format!("{host}:{p}")
+        }
+    } else {
+        host.to_string()
+    };
+    Some(format!("{scheme}://{authority}"))
+}
+
+/// First value of a (possibly) comma-separated header list, trimmed.
+fn first_value(s: &str) -> &str {
+    s.split(',').next().unwrap_or(s).trim()
+}
+
+/// Strip a single pair of surrounding double quotes (RFC 7239 quoted-string).
+fn unquote(s: &str) -> &str {
+    s.strip_prefix('"')
+        .and_then(|s| s.strip_suffix('"'))
+        .unwrap_or(s)
+}
+
+/// Validate and lower-case a forwarded scheme. Only `http`/`https` are allowed.
+fn validate_scheme(s: &str) -> Option<String> {
+    let s = s.trim();
+    if s.eq_ignore_ascii_case("http") {
+        Some("http".to_string())
+    } else if s.eq_ignore_ascii_case("https") {
+        Some("https".to_string())
+    } else {
+        None
+    }
+}
+
+/// Scheme of the static fallback URL, used when a forwarded host carries no
+/// (valid) proto.
+fn scheme_of(url: &str) -> String {
+    if url.starts_with("https://") {
+        "https".to_string()
+    } else {
+        "http".to_string()
+    }
+}
+
+/// Reject host values that contain whitespace, slashes, or any character that
+/// could break out of the authority component / inject another URL part
+/// (`@`, `?`, `#`, `%`, control bytes, non-ASCII, …). Returns the trimmed host
+/// when it is composed solely of safe host/IPv6-literal/port characters.
+fn sanitize_host(host: &str) -> Option<&str> {
+    let host = host.trim();
+    if host.is_empty() {
+        return None;
+    }
+    let safe = host
+        .bytes()
+        .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'.' | b'-' | b'_' | b':' | b'[' | b']'));
+    if !safe {
+        return None;
+    }
+    // A bare leading/trailing colon (`:8080`, `example.com:`) is malformed.
+    if host.starts_with(':') || host.ends_with(':') {
+        return None;
+    }
+    Some(host)
+}
+
+/// Whether a sanitised host already carries an explicit port.
+fn host_has_port(host: &str) -> bool {
+    if let Some(rest) = host.strip_prefix('[') {
+        // IPv6 literal: a port follows the closing bracket as `]:port`.
+        matches!(rest.split_once(']'), Some((_, after)) if after.starts_with(':'))
+    } else {
+        // host:port — a single colon. Multiple colons in a non-bracketed host
+        // would be a bare IPv6 address (invalid in a URL authority); treat it
+        // as "no appendable port" and leave the (already sanitised) host as-is.
+        host.matches(':').count() == 1
+    }
+}
+
+/// Parse a port, rejecting `0` and out-of-range values.
+fn validate_port(p: &str) -> Option<u16> {
+    p.trim().parse::<u16>().ok().filter(|&n| n != 0)
+}
+
+fn is_default_port(scheme: &str, port: u16) -> bool {
+    matches!((scheme, port), ("http", 80) | ("https", 443))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a closure mimicking the axum `HeaderMap` lookup from a static map.
+    fn hdrs<'p>(
+        pairs: &'p [(&'static str, &'static str)],
+    ) -> impl Fn(&str) -> Option<&'static str> + 'p {
+        move |name: &str| {
+            pairs
+                .iter()
+                .find(|(k, _)| k.eq_ignore_ascii_case(name))
+                .map(|(_, v)| *v)
+        }
+    }
+
+    #[test]
+    fn trust_disabled_returns_fallback_even_with_headers() {
+        let url = resolve_base_url(
+            "http://127.0.0.1:8000",
+            false,
+            hdrs(&[
+                ("x-forwarded-host", "api.example.com"),
+                ("x-forwarded-proto", "https"),
+            ]),
+        );
+        assert_eq!(url, "http://127.0.0.1:8000");
+    }
+
+    #[test]
+    fn fallback_trailing_slash_trimmed() {
+        let url = resolve_base_url("http://127.0.0.1:8000/", true, hdrs(&[]));
+        assert_eq!(url, "http://127.0.0.1:8000");
+    }
+
+    #[test]
+    fn no_headers_falls_back() {
+        let url = resolve_base_url("http://127.0.0.1:8000", true, hdrs(&[]));
+        assert_eq!(url, "http://127.0.0.1:8000");
+    }
+
+    #[test]
+    fn x_forwarded_host_and_proto() {
+        let url = resolve_base_url(
+            "http://127.0.0.1:8000",
+            true,
+            hdrs(&[
+                ("x-forwarded-host", "api.example.com"),
+                ("x-forwarded-proto", "https"),
+            ]),
+        );
+        assert_eq!(url, "https://api.example.com");
+    }
+
+    #[test]
+    fn x_forwarded_proto_missing_uses_fallback_scheme() {
+        let url = resolve_base_url(
+            "https://internal:8000",
+            true,
+            hdrs(&[("x-forwarded-host", "api.example.com")]),
+        );
+        assert_eq!(url, "https://api.example.com");
+    }
+
+    #[test]
+    fn x_forwarded_port_appended_when_non_default() {
+        let url = resolve_base_url(
+            "http://127.0.0.1:8000",
+            true,
+            hdrs(&[
+                ("x-forwarded-host", "api.example.com"),
+                ("x-forwarded-proto", "https"),
+                ("x-forwarded-port", "8443"),
+            ]),
+        );
+        assert_eq!(url, "https://api.example.com:8443");
+    }
+
+    #[test]
+    fn x_forwarded_default_port_not_appended() {
+        let url = resolve_base_url(
+            "http://127.0.0.1:8000",
+            true,
+            hdrs(&[
+                ("x-forwarded-host", "api.example.com"),
+                ("x-forwarded-proto", "https"),
+                ("x-forwarded-port", "443"),
+            ]),
+        );
+        assert_eq!(url, "https://api.example.com");
+    }
+
+    #[test]
+    fn x_forwarded_host_with_explicit_port_ignores_forwarded_port() {
+        let url = resolve_base_url(
+            "http://127.0.0.1:8000",
+            true,
+            hdrs(&[
+                ("x-forwarded-host", "api.example.com:9000"),
+                ("x-forwarded-proto", "https"),
+                ("x-forwarded-port", "8443"),
+            ]),
+        );
+        assert_eq!(url, "https://api.example.com:9000");
+    }
+
+    #[test]
+    fn first_value_of_comma_list_used() {
+        let url = resolve_base_url(
+            "http://127.0.0.1:8000",
+            true,
+            hdrs(&[
+                ("x-forwarded-host", "api.example.com, evil.example.org"),
+                ("x-forwarded-proto", "https, http"),
+            ]),
+        );
+        assert_eq!(url, "https://api.example.com");
+    }
+
+    #[test]
+    fn forwarded_header_takes_precedence() {
+        let url = resolve_base_url(
+            "http://127.0.0.1:8000",
+            true,
+            hdrs(&[
+                (
+                    "forwarded",
+                    "for=192.0.2.60;proto=https;host=fwd.example.com",
+                ),
+                ("x-forwarded-host", "xfwd.example.com"),
+            ]),
+        );
+        assert_eq!(url, "https://fwd.example.com");
+    }
+
+    #[test]
+    fn forwarded_quoted_host_with_port() {
+        let url = resolve_base_url(
+            "http://127.0.0.1:8000",
+            true,
+            hdrs(&[("forwarded", "host=\"api.example.com:8443\";proto=https")]),
+        );
+        assert_eq!(url, "https://api.example.com:8443");
+    }
+
+    #[test]
+    fn forwarded_first_element_only() {
+        let url = resolve_base_url(
+            "http://127.0.0.1:8000",
+            true,
+            hdrs(&[(
+                "forwarded",
+                "host=first.example.com;proto=https, host=second.example.com;proto=http",
+            )]),
+        );
+        assert_eq!(url, "https://first.example.com");
+    }
+
+    #[test]
+    fn malformed_host_rejected_falls_through() {
+        // X-Forwarded-Host with a slash is rejected; nothing else usable -> fallback.
+        let url = resolve_base_url(
+            "http://127.0.0.1:8000",
+            true,
+            hdrs(&[
+                ("x-forwarded-host", "evil.com/path"),
+                ("x-forwarded-proto", "https"),
+            ]),
+        );
+        assert_eq!(url, "http://127.0.0.1:8000");
+    }
+
+    #[test]
+    fn host_with_whitespace_or_at_rejected() {
+        for bad in [
+            "bad host.com",
+            "user@evil.com",
+            "ho st",
+            "exa\tmple.com",
+            "naïve.com",
+        ] {
+            let url = resolve_base_url(
+                "http://127.0.0.1:8000",
+                true,
+                hdrs(&[("x-forwarded-host", bad), ("x-forwarded-proto", "https")]),
+            );
+            assert_eq!(
+                url, "http://127.0.0.1:8000",
+                "host {bad:?} should be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn invalid_proto_falls_back_to_fallback_scheme() {
+        let url = resolve_base_url(
+            "https://internal:8000",
+            true,
+            hdrs(&[
+                ("x-forwarded-host", "api.example.com"),
+                ("x-forwarded-proto", "ftp"),
+            ]),
+        );
+        assert_eq!(url, "https://api.example.com");
+    }
+
+    #[test]
+    fn ipv6_literal_host() {
+        let url = resolve_base_url(
+            "http://127.0.0.1:8000",
+            true,
+            hdrs(&[
+                ("x-forwarded-host", "[2001:db8::1]:8443"),
+                ("x-forwarded-proto", "https"),
+            ]),
+        );
+        assert_eq!(url, "https://[2001:db8::1]:8443");
+    }
+
+    #[test]
+    fn invalid_port_ignored() {
+        let url = resolve_base_url(
+            "http://127.0.0.1:8000",
+            true,
+            hdrs(&[
+                ("x-forwarded-host", "api.example.com"),
+                ("x-forwarded-proto", "https"),
+                ("x-forwarded-port", "not-a-port"),
+            ]),
+        );
+        assert_eq!(url, "https://api.example.com");
+    }
+
+    #[test]
+    fn forwarded_without_proto_uses_fallback_scheme() {
+        let url = resolve_base_url(
+            "https://internal:8000",
+            true,
+            hdrs(&[("forwarded", "host=api.example.com")]),
+        );
+        assert_eq!(url, "https://api.example.com");
+    }
+}

--- a/crates/server/src/admin.rs
+++ b/crates/server/src/admin.rs
@@ -619,6 +619,7 @@ pub fn load_collections(
     collections: &[CollectionConfig],
     style_bundles: &[StyleBundle],
     base_url: &str,
+    trust_proxy_headers: bool,
     metatile_cache_mb: u64,
 ) -> LoadResult {
     let bundle_index: HashMap<&str, &StyleBundle> =
@@ -1934,11 +1935,13 @@ pub fn load_collections(
             engines: edr_engines,
             collections: edr_collections,
             base_url: base_url.to_string(),
+            trust_proxy_headers,
         },
         features_state: FeaturesState {
             engines: feature_engines,
             collections: feature_collections,
             base_url: base_url.to_string(),
+            trust_proxy_headers,
         },
         wms_state: WmsState {
             engines: map_engines,
@@ -1948,6 +1951,7 @@ pub fn load_collections(
             rendered_cache: rendered_cache.clone(),
             tile_cache,
             base_url: base_url.to_string(),
+            trust_proxy_headers,
         },
         maps_state: MapsState {
             engines: maps_engines,
@@ -1956,6 +1960,7 @@ pub fn load_collections(
             render_semaphore: render_semaphore.clone(),
             rendered_cache: rendered_cache.clone(),
             base_url: base_url.to_string(),
+            trust_proxy_headers,
         },
         tiles_state: TilesState {
             map_engines: tiles_engines,
@@ -1967,6 +1972,7 @@ pub fn load_collections(
             rendered_cache: rendered_cache.clone(),
             vector_tile_cache: vector_tile_cache.clone(),
             base_url: base_url.to_string(),
+            trust_proxy_headers,
         },
         tiles_3d_state: api_3dtiles::TilesState3d {
             volume_engines,
@@ -1977,6 +1983,7 @@ pub fn load_collections(
             colormap: api_3dtiles::default_point_colormap(),
             render_semaphore: render_semaphore.clone(),
             base_url: base_url.to_string(),
+            trust_proxy_headers,
         },
         health,
         geotiff_engines,
@@ -2465,6 +2472,7 @@ pub(crate) fn do_reload(state: &AdminState) -> Result<ReloadOutcome, ReloadError
         &config.collections,
         &config.style_bundles,
         &base_url,
+        config.server.trust_proxy_headers,
         config.server.metatile_cache_mb,
     );
 

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -426,6 +426,7 @@ async fn main() {
         &config.collections,
         &config.style_bundles,
         &base_url,
+        config.server.trust_proxy_headers,
         config.server.metatile_cache_mb,
     );
 
@@ -605,7 +606,12 @@ async fn main() {
 
     // Public routes get permissive CORS (OGC APIs, health, metrics)
     let public = Router::new()
-        .route("/", get(move || root_landing_page(root_state)))
+        .route(
+            "/",
+            get(move |headers: axum::http::HeaderMap| {
+                root_landing_page(root_state.clone(), headers)
+            }),
+        )
         .nest("/edr", api_edr::router(edr_swap.clone()))
         .nest("/features", api_features::router(features_swap.clone()))
         .nest("/wms", api_wms::router(wms_swap.clone()))
@@ -749,9 +755,13 @@ async fn shutdown_signal() {
     }
 }
 
-async fn root_landing_page(state: AdminState) -> impl IntoResponse {
+async fn root_landing_page(state: AdminState, headers: axum::http::HeaderMap) -> impl IntoResponse {
     let edr_state = state.edr.load_full();
-    let base = &edr_state.base_url;
+    let base = &ds_core::proxy::resolve_base_url(
+        &edr_state.base_url,
+        edr_state.trust_proxy_headers,
+        |name| headers.get(name).and_then(|v| v.to_str().ok()),
+    );
     Json(json!({
         "title": "MeteoCore",
         "description": "Metocean Data Server implementing OGC API - EDR, OGC API - Features, OGC API - Maps, OGC API - Tiles, and OGC WMS 1.3.0",

--- a/crates/server/src/preview.rs
+++ b/crates/server/src/preview.rs
@@ -229,9 +229,17 @@ impl ManifestParams {
 pub async fn manifest_handler(
     State(state): State<AdminState>,
     Query(params): Query<ManifestParams>,
+    headers: axum::http::HeaderMap,
 ) -> impl IntoResponse {
     let (offset, limit) = params.resolved();
-    let manifest = build_manifest(&state, offset, limit);
+    // Resolve the link base per request so the emitted tile-URL templates honour
+    // reverse-proxy forwarding headers (#12), matching the OGC API handlers.
+    let tiles = state.tiles.load_full();
+    let base_url =
+        ds_core::proxy::resolve_base_url(&tiles.base_url, tiles.trust_proxy_headers, |name| {
+            headers.get(name).and_then(|v| v.to_str().ok())
+        });
+    let manifest = build_manifest_with_base(&state, &base_url, offset, limit);
 
     // Size guard — log only, never reject; pagination defaults already prevent
     // pathological responses, and the soft warn lets operators see drift early.
@@ -289,21 +297,35 @@ pub async fn manifest_handler(
 /// once all five `ArcSwap`s settle. This is an accepted trade-off of
 /// the per-API `ArcSwap` pattern — wrapping all five in a single outer
 /// `ArcSwap` would fix it but is out of scope for this PR.
+#[cfg(test)]
 pub(crate) fn build_manifest(state: &AdminState, offset: usize, limit: usize) -> Value {
+    // Tests and any non-HTTP caller get the static startup base URL. The HTTP
+    // handler uses `build_manifest_with_base` with a per-request,
+    // reverse-proxy-aware base so tile URL templates are correct behind a proxy
+    // (#12).
+    //
+    // All five `*State.base_url` fields are initialised from the same
+    // `config.server.base_url()` at load time, so `tiles.base_url` is correct;
+    // sourcing it from `tiles` makes the dependency explicit (this builds tile
+    // URL templates), and keeps a tile-only deployment correct if per-API
+    // base-URL overrides ever land.
+    let base_url = state.tiles.load_full().base_url.clone();
+    build_manifest_with_base(state, &base_url, offset, limit)
+}
+
+/// As [`build_manifest`], but with an explicit, already-resolved link base URL
+/// — the per-request, reverse-proxy-aware value computed by `manifest_handler`.
+pub(crate) fn build_manifest_with_base(
+    state: &AdminState,
+    base_url: &str,
+    offset: usize,
+    limit: usize,
+) -> Value {
     let edr = state.edr.load_full();
     let features = state.features.load_full();
     let maps = state.maps.load_full();
     let tiles = state.tiles.load_full();
     let wms = state.wms.load_full();
-
-    // All five `*State.base_url` fields are initialised from the same
-    // `config.server.base_url()` at load time, so any of them is correct
-    // in practice. Sourcing from `tiles.base_url` makes the dependency
-    // explicit: this function builds tile URL templates, so it reads
-    // base_url from the state that owns those URLs. A tile-only
-    // deployment with no EDR collections would now stay correct if
-    // per-API base-URL overrides ever land.
-    let base_url = tiles.base_url.clone();
 
     // Build the canonical id ordering: union of all *State.collections keys,
     // sorted lexicographically. Stable across reloads when configs are stable.
@@ -321,7 +343,7 @@ pub(crate) fn build_manifest(state: &AdminState, offset: usize, limit: usize) ->
 
     let entries: Vec<Value> = returned
         .into_iter()
-        .map(|id| build_entry(id, &base_url, &edr, &features, &maps, &tiles, &wms))
+        .map(|id| build_entry(id, base_url, &edr, &features, &maps, &tiles, &wms))
         .collect();
 
     let next = if offset + returned_count < total {
@@ -1171,6 +1193,62 @@ mod tests {
         );
         assert!(vector_url.contains("f=mvt"));
         assert!(stations["tiles"].get("raster").is_none());
+    }
+
+    #[tokio::test]
+    async fn manifest_handler_honours_proxy_headers() {
+        use axum::extract::{Query, State};
+        // Regression guard (#12): the preview manifest's tile URL templates must
+        // follow reverse-proxy forwarding headers when trust_proxy_headers is on
+        // — this is the /preview/manifest.json endpoint that was initially missed.
+        let mut tiles = empty_tiles();
+        tiles.base_url = "http://127.0.0.1:8000".into();
+        tiles.trust_proxy_headers = true;
+        let raster: Arc<dyn MapEngine> = Arc::new(RasterMock {
+            spatial_extent: Some([-180.0, -85.0, 180.0, 85.0]),
+            times: vec![],
+            parameter: "reflectivity".into(),
+            unit: "dBZ".into(),
+            parameters: vec![],
+        });
+        tiles.map_engines.insert("radar".into(), raster);
+        tiles
+            .collections
+            .insert("radar".into(), config("radar", &["tiles"]));
+
+        let state = make_state(
+            empty_edr(),
+            empty_features(),
+            empty_maps(),
+            tiles,
+            empty_wms(),
+        );
+
+        let mut req_headers = axum::http::HeaderMap::new();
+        req_headers.insert(
+            "x-forwarded-host",
+            axum::http::HeaderValue::from_static("radar.example.com"),
+        );
+        req_headers.insert(
+            "x-forwarded-proto",
+            axum::http::HeaderValue::from_static("https"),
+        );
+
+        let resp = manifest_handler(State(state), Query(ManifestParams::default()), req_headers)
+            .await
+            .into_response();
+        let body = axum::body::to_bytes(resp.into_body(), 1024 * 1024)
+            .await
+            .unwrap();
+        let m: Value = serde_json::from_slice(&body).unwrap();
+
+        let url = m["collections"][0]["tiles"]["raster"]["url_template"]
+            .as_str()
+            .unwrap();
+        assert!(
+            url.starts_with("https://radar.example.com/tiles/collections/radar/tiles/"),
+            "manifest tile URL must use the proxy host, got: {url}"
+        );
     }
 
     #[test]
@@ -2241,9 +2319,13 @@ mod tests {
             empty_tiles(),
             empty_wms(),
         );
-        let resp = manifest_handler(State(state), Query(ManifestParams::default()))
-            .await
-            .into_response();
+        let resp = manifest_handler(
+            State(state),
+            Query(ManifestParams::default()),
+            axum::http::HeaderMap::new(),
+        )
+        .await
+        .into_response();
         assert_eq!(
             resp.headers().get(header::CACHE_CONTROL).unwrap(),
             "no-store"

--- a/crates/server/src/preview.rs
+++ b/crates/server/src/preview.rs
@@ -888,6 +888,7 @@ mod tests {
             engines: HashMap::new(),
             collections: HashMap::new(),
             base_url: String::new(),
+            trust_proxy_headers: false,
         }
     }
 
@@ -896,6 +897,7 @@ mod tests {
             engines: HashMap::new(),
             collections: HashMap::new(),
             base_url: String::new(),
+            trust_proxy_headers: false,
         }
     }
 
@@ -908,6 +910,7 @@ mod tests {
             rendered_cache: Arc::new(ds_render::RenderedCache::new(1)),
             tile_cache: Arc::new(ds_render::TilePixelCache::new(1)),
             base_url: String::new(),
+            trust_proxy_headers: false,
         }
     }
 
@@ -919,6 +922,7 @@ mod tests {
             render_semaphore: Arc::new(tokio::sync::Semaphore::new(1)),
             rendered_cache: Arc::new(ds_render::RenderedCache::new(1)),
             base_url: String::new(),
+            trust_proxy_headers: false,
         }
     }
 
@@ -933,6 +937,7 @@ mod tests {
             rendered_cache: Arc::new(ds_render::RenderedCache::new(1)),
             vector_tile_cache: Arc::new(ds_mvt::VectorTileCache::new(1)),
             base_url: String::new(),
+            trust_proxy_headers: false,
         }
     }
 
@@ -955,6 +960,7 @@ mod tests {
                 colormap: api_3dtiles::default_point_colormap(),
                 render_semaphore: Arc::new(tokio::sync::Semaphore::new(1)),
                 base_url: String::new(),
+                trust_proxy_headers: false,
             })),
             config_path: String::new(),
             health: RwLock::new(Vec::new()),

--- a/crates/server/src/watcher.rs
+++ b/crates/server/src/watcher.rs
@@ -157,6 +157,7 @@ mod tests {
             &config.collections,
             &config.style_bundles,
             &config.server.base_url(),
+            config.server.trust_proxy_headers,
             config.server.metatile_cache_mb,
         );
         Arc::new(ServerState {

--- a/crates/server/tests/middleware.rs
+++ b/crates/server/tests/middleware.rs
@@ -127,6 +127,7 @@ fn build_wms_router() -> axum::Router {
         rendered_cache: Arc::new(RenderedCache::new(16)),
         tile_cache: Arc::new(ds_render::TilePixelCache::new(16)),
         base_url: String::new(),
+        trust_proxy_headers: false,
     }));
     api_wms::router(state)
 }
@@ -326,6 +327,7 @@ mod load_shedding {
             rendered_cache: Arc::new(RenderedCache::new(16)),
             tile_cache: Arc::new(ds_render::TilePixelCache::new(16)),
             base_url: String::new(),
+            trust_proxy_headers: false,
         }));
         let app = api_wms::router(state);
 


### PR DESCRIPTION
Closes #12.

## What

Absolute self-links across every API (EDR/Features/Maps/Tiles/WMS/3D Tiles landing pages, collection docs, GeoJSON `links`, WMS `GetCapabilities` OnlineResource + legend URLs, the server root page) were built from a base URL resolved **once at startup** (`BASE_URL` env > `[server] base_url` > `http://{host}:{port}`). Behind a reverse proxy that base is wrong (`http://0.0.0.0:8000/edr/...`), which previously required a hardcoded `BASE_URL`.

This adds opt-in **per-request** base-URL resolution from standard proxy forwarding headers.

## How

- New `ds_core::proxy::resolve_base_url(fallback, trust, header_fn)` — the pure resolver. Precedence:
  1. RFC 7239 `Forwarded` (`proto=`/`host=` of the first element)
  2. `X-Forwarded-Proto` + `X-Forwarded-Host` (+ optional `X-Forwarded-Port`)
  3. the static startup fallback
  It is **framework-free**: the axum handlers pass header values in via a closure, so `ds-core` keeps its no-HTTP-deps rule.
- New `[server] trust_proxy_headers` config flag (`#[serde(default)]` → **false**), threaded through `load_collections` into all six API state structs.
- Each API handler that builds self-links resolves the base per request through a tiny per-crate `request_base_url(state, headers)` helper (most handlers already had a `HeaderMap` for `?f=` negotiation; the rest gained one). The server root page resolves inline.

Per-request (not startup) resolution is required: forwarding headers only exist at request time, and one backend behind a proxy can serve multiple external hostnames.

## Security

- **Off by default** — forwarding headers are client-controllable, so resolution only happens when the operator opts in (the proxy is trusted to set/overwrite them).
- When enabled: host values are **sanitised** (whitespace, `/`, `\`, `@`, `%`, control bytes, non-ASCII rejected), scheme restricted to `http`/`https`, and only the **first** value of a comma list is used. A malformed/suspicious header falls through to the next source rather than producing a spoofed URL.
- **No behaviour change without the flag** — `trust=false` returns the static fallback unchanged.

## Tests

- 18 unit tests in `ds-core` for `resolve_base_url` (X-Forwarded, Forwarded incl. quoted host + multi-element, port handling, IPv6 literal, host/proto/port validation + rejection, precedence, trust-off).
- 4 api-edr integration tests: X-Forwarded rewrite, Forwarded rewrite, spoofing-ignored-when-untrusted, fallback-without-headers.
- `cargo fmt`, `cargo clippy --workspace --all-targets -D warnings`, and `cargo test --workspace` all green.

## Docs

`trust_proxy_headers` documented in CLAUDE.md (Config Format + a dedicated note) and `config.toml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)