### PR TITLE
perf(render,api): shared empty-tile cache (#171) + uniform-region assembly fast path (#416)

### DIFF
--- a/crates/api-maps/src/handlers.rs
+++ b/crates/api-maps/src/handlers.rs
@@ -1184,11 +1184,10 @@ async fn render_map(
             (cached, "MISS", content_type)
         }
         Ok(None) => {
-            // Empty tile: transparent PNG, never cached.
-            let rgba = vec![0u8; (width * height * 4) as usize];
-            let png = ds_render::encode_png(&rgba, width, height)
+            // Empty tile: a transparent PNG, encoded once per (w,h) and shared
+            // across WMS/Maps/Tiles (#171). Not inserted into the rendered cache.
+            let cached = ds_render::empty_tile(width, height)
                 .map_err(|e| MapsError::Internal(format!("Failed to encode empty tile: {e}")))?;
-            let cached = ds_render::CachedRendered::new(bytes::Bytes::from(png));
             (cached, "EMPTY", "image/png")
         }
         Err(e) => {

--- a/crates/api-tiles/src/handlers.rs
+++ b/crates/api-tiles/src/handlers.rs
@@ -22,26 +22,19 @@ use crate::error::TilesError;
 use crate::params::{self, TileQueryParams};
 use crate::tilematrixset::{self, SUPPORTED_TILE_MATRIX_SETS};
 
-/// Pre-generated 256x256 fully transparent PNG for empty (all-nodata) tiles.
-/// Avoids running the colorization + encoding pipeline when a tile has no data.
-static EMPTY_TILE_PNG: LazyLock<bytes::Bytes> = LazyLock::new(|| {
-    let size = params::TILE_SIZE;
-    let rgba = vec![0u8; (size * size * 4) as usize];
-    bytes::Bytes::from(
-        ds_render::encode_png(&rgba, size, size).expect("encoding empty tile PNG must not fail"),
-    )
+/// Pre-generated 256×256 fully transparent `CachedRendered` for empty
+/// (all-nodata) tiles — the bytes and their FNV-1a ETag are computed once per
+/// process instead of on every empty-tile response, and the colorization +
+/// encoding pipeline is skipped when a tile has no data.
+///
+/// Sourced from the shared [`ds_render::empty_tile`] cache, which WMS and Maps
+/// now use too (#171) — so all three raster APIs share one mechanism rather than
+/// each rolling their own. Tiles is always 256×256, so a process-once `LazyLock`
+/// keeps cloning per request essentially free (`Bytes` is `Arc`-backed).
+static EMPTY_TILE_CACHED: LazyLock<ds_render::CachedRendered> = LazyLock::new(|| {
+    ds_render::empty_tile(params::TILE_SIZE, params::TILE_SIZE)
+        .expect("encoding empty tile PNG must not fail")
 });
-
-/// Companion to [`EMPTY_TILE_PNG`]: the same bytes wrapped in
-/// `CachedRendered`, so the FNV-1a hash that produces the empty-tile
-/// ETag is computed **once per process** instead of on every empty-tile
-/// response. Both fields are `Clone`-cheap (`Bytes` is `Arc`-backed,
-/// `String` is a 20-byte allocation done once), so cloning per request
-/// is essentially free. `api-maps` and `api-wms` cannot use this trick
-/// — they allocate fresh empty bytes per request to match the requested
-/// dimensions — but Tiles is always 256×256.
-static EMPTY_TILE_CACHED: LazyLock<ds_render::CachedRendered> =
-    LazyLock::new(|| ds_render::CachedRendered::new(EMPTY_TILE_PNG.clone()));
 
 /// Shared state for the OGC API Tiles service.
 #[derive(Clone)]

--- a/crates/api-wms/src/handlers.rs
+++ b/crates/api-wms/src/handlers.rs
@@ -510,13 +510,14 @@ pub async fn wms_handler(
                     (cached, "MISS", content_type)
                 }
                 Ok(None) => {
-                    // Empty tile: transparent PNG, never cached.
-                    let rgba = vec![0u8; (params.width * params.height * 4) as usize];
-                    let png =
-                        ds_render::encode_png(&rgba, params.width, params.height).map_err(|e| {
+                    // Empty tile: a transparent PNG, encoded once per (w,h) and
+                    // shared across WMS/Maps/Tiles (#171). Not inserted into the
+                    // rendered cache — the shared empty-tile cache already serves
+                    // the deterministic empty response.
+                    let cached =
+                        ds_render::empty_tile(params.width, params.height).map_err(|e| {
                             WmsError::Internal(format!("Failed to encode empty tile: {e}"))
                         })?;
-                    let cached = ds_render::CachedRendered::new(bytes::Bytes::from(png));
                     (cached, "EMPTY", "image/png")
                 }
                 Err(e) => {

--- a/crates/render/src/lib.rs
+++ b/crates/render/src/lib.rs
@@ -265,6 +265,40 @@ impl CachedRendered {
     }
 }
 
+/// Max distinct `(width, height)` transparent tiles retained (see
+/// [`empty_tile`]). 64 covers any realistic mix of client viewport sizes;
+/// beyond that the LRU recycles.
+const EMPTY_TILE_CACHE_ITEMS: usize = 64;
+
+/// Process-global cache of transparent (all-nodata) PNGs keyed by output
+/// dimensions, as ready-to-serve [`CachedRendered`] entries (bytes + their
+/// stable FNV-1a ETag).
+///
+/// WMS / Maps `GetMap` take an all-nodata fast path on off-coverage viewports;
+/// the encoded transparent PNG and its ETag are identical for a given
+/// `(width, height)`, so encoding once per distinct size and cloning the
+/// `Arc`-backed bytes is far cheaper than re-allocating `width·height·4` zero
+/// bytes and re-encoding + re-hashing on every empty response (#171). The Tiles
+/// service (always 256×256) sources its single global from here too, so all
+/// three raster APIs share one mechanism. Bounded by item count so a
+/// `?WIDTH=…&HEIGHT=…` fan-out can't pin unbounded memory — an abuser just
+/// cycles the LRU; a real client uses a handful of viewport sizes.
+static EMPTY_TILE_CACHE: std::sync::LazyLock<Cache<(u32, u32), CachedRendered>> =
+    std::sync::LazyLock::new(|| Cache::new(EMPTY_TILE_CACHE_ITEMS));
+
+/// A fully-transparent `width`×`height` PNG as a ready-to-serve
+/// [`CachedRendered`], encoded once per distinct size and cloned thereafter
+/// (#171). Use this for the all-nodata fast path instead of allocating and
+/// encoding a fresh transparent image on every empty response.
+pub fn empty_tile(width: u32, height: u32) -> Result<CachedRendered, DataServerError> {
+    EMPTY_TILE_CACHE.get_or_insert_with(&(width, height), || {
+        let rgba = vec![0u8; width as usize * height as usize * 4];
+        Ok(CachedRendered::new(Bytes::from(encode_png(
+            &rgba, width, height,
+        )?)))
+    })
+}
+
 /// Weight function: count the byte size of each cached rendered image.
 #[derive(Clone)]
 struct RenderedWeighter;
@@ -429,6 +463,24 @@ pub(crate) fn colorize(tile: &RasterTile, colormap: &dyn ColorMap) -> Vec<u8> {
 mod tests {
     use super::*;
     use ds_core::map_engine::RasterTile;
+
+    #[test]
+    fn empty_tile_is_deterministic_and_memoized() {
+        let a = empty_tile(64, 48).expect("encode empty tile");
+        let b = empty_tile(64, 48).expect("encode empty tile");
+        // Same dimensions → identical bytes + ETag (the second call is a cache
+        // hit), so browsers can revalidate empty responses across requests.
+        assert_eq!(a.etag(), b.etag(), "same (w,h) must yield a stable ETag");
+        assert_eq!(
+            a.bytes(),
+            b.bytes(),
+            "same (w,h) must yield identical bytes"
+        );
+        // Different dimensions → different content (and a different ETag).
+        let c = empty_tile(100, 100).expect("encode empty tile");
+        assert_ne!(a.etag(), c.etag(), "different (w,h) must differ");
+        assert!(!a.bytes().is_empty(), "an empty tile is still a real PNG");
+    }
 
     #[test]
     fn test_render_tile_png_produces_valid_png() {

--- a/crates/render/src/metatile.rs
+++ b/crates/render/src/metatile.rs
@@ -504,10 +504,27 @@ fn sample_bilinear(tiles: &Mosaic, gx: f64, gy: f64) -> [u8; 4] {
     let dy = fy - y0;
     let (x0, y0) = (x0 as i64, y0 as i64);
 
-    let c00 = premul(global_pixel(tiles, x0, y0));
-    let c10 = premul(global_pixel(tiles, x0 + 1, y0));
-    let c01 = premul(global_pixel(tiles, x0, y0 + 1));
-    let c11 = premul(global_pixel(tiles, x0 + 1, y0 + 1));
+    let p00 = global_pixel(tiles, x0, y0);
+    let p10 = global_pixel(tiles, x0 + 1, y0);
+    let p01 = global_pixel(tiles, x0, y0 + 1);
+    let p11 = global_pixel(tiles, x0 + 1, y0 + 1);
+
+    // Uniform-region fast path (#416): bilinear interpolation of four identical
+    // texels IS that texel — exactly, not an approximation — so skip the
+    // premultiply / blend / unpremultiply (including the per-pixel alpha
+    // reciprocal divide) when all four are equal. Antialiased edges have
+    // differing corners and fall through to the full path, so this can't soften
+    // them. Radar composites are mostly transparent ([0,0,0,0] over clear air /
+    // ocean) with large flat regions, so this fires on the majority of output
+    // pixels.
+    if p00 == p10 && p00 == p01 && p00 == p11 {
+        return p00;
+    }
+
+    let c00 = premul(p00);
+    let c10 = premul(p10);
+    let c01 = premul(p01);
+    let c11 = premul(p11);
 
     let mut acc = [0.0f64; 4];
     for i in 0..4 {
@@ -547,6 +564,45 @@ fn unpremul(c: [f64; 4]) -> [u8; 4] {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn sample_bilinear_uniform_region_is_exact() {
+        // One opaque tile filled with a single non-trivial colour.
+        let fill = |colour: [u8; 4]| {
+            let mut tile = vec![0u8; TILE_PX as usize * TILE_PX as usize * 4];
+            for px in tile.chunks_exact_mut(4) {
+                px.copy_from_slice(&colour);
+            }
+            Mosaic {
+                col0: 0,
+                row0: 0,
+                ncols: 1,
+                nrows: 1,
+                tiles: vec![Some(Arc::from(tile.into_boxed_slice()))],
+            }
+        };
+        // Interior fractional sample (all four texels inside the uniform tile)
+        // returns the EXACT colour — the #416 fast path must match what the full
+        // premul/blend/unpremul path recovers, with no rounding drift.
+        let opaque = [37u8, 211, 99, 255];
+        assert_eq!(sample_bilinear(&fill(opaque), 100.3, 50.7), opaque);
+        // A semi-transparent uniform colour also round-trips exactly (the case
+        // the alpha-reciprocal unpremultiply would otherwise have to recover).
+        let translucent = [37u8, 211, 99, 128];
+        assert_eq!(
+            sample_bilinear(&fill(translucent), 100.3, 50.7),
+            translucent
+        );
+        // Fully-transparent region (the common radar case) → [0, 0, 0, 0].
+        let empty = Mosaic {
+            col0: 0,
+            row0: 0,
+            ncols: 1,
+            nrows: 1,
+            tiles: vec![None],
+        };
+        assert_eq!(sample_bilinear(&empty, 100.3, 50.7), [0, 0, 0, 0]);
+    }
 
     #[test]
     fn standard_zoom_resolutions_snap_exactly() {


### PR DESCRIPTION
Two render-exit-path efficiency fixes from the local-h5 ODIM WMS hot-path audit, bundled (both touch the `render_metatiled`/empty-tile output path).

## #171 — shared empty-tile PNG cache
WMS and Maps re-allocated `width·height·4` zero bytes and **re-encoded + re-hashed** a transparent PNG on **every** all-nodata response (panning over off-coverage or hitting an empty timestep repeats it per frame — ~8 MB alloc + encode at 1900×1100). 

New `ds_render::empty_tile(w, h)` → a process-global, dimension-keyed, count-bounded cache returning a ready-to-serve `CachedRendered` (bytes + stable ETag), encoded once per distinct size and cloned thereafter. WMS, Maps, **and Tiles** now all source their empty response from it (Tiles keeps its 256×256 `LazyLock`, which delegates to the shared cache) — one mechanism instead of three. Bounded so a `?WIDTH=…&HEIGHT=…` fan-out can't pin unbounded memory.

## #416 — uniform-region assembly fast path
`render_metatiled`'s assemble loop runs a full premultiplied bilinear blend + a per-pixel **alpha-reciprocal unpremultiply divide** on every output pixel of every GetMap — the irreducible per-frame floor, run even when all meta-tiles are cache hits (the arbitrary outer viewport is never itself cached).

Exact fast path in `sample_bilinear`: when the four texels are identical, **bilinear of equal values IS that value** — mathematically exact, so it can't soften antialiased edges (those have differing corners and take the full path). Radar composites are mostly transparent (`[0,0,0,0]`) with large flat regions, so it fires on the majority of pixels and skips the divide for them.

## Testing
- `empty_tile_is_deterministic_and_memoized` — same `(w,h)` → identical bytes + ETag (cache hit); different `(w,h)` differ.
- `sample_bilinear_uniform_region_is_exact` — opaque, translucent (the alpha-reciprocal case), and fully-transparent uniform regions return the exact texel.
- `cargo test -p ds-render` (79 pass) + `cargo clippy -p ds-render -p api-wms -p api-maps -p api-tiles --all-targets -- -D warnings` clean + `cargo fmt` clean.

Closes #171. Closes #416.

🤖 Generated with [Claude Code](https://claude.com/claude-code)