### PR TITLE
perf(server): reload preserves the warm render caches instead of rebuilding them (closes #421)

### DIFF
--- a/crates/server/src/admin.rs
+++ b/crates/server/src/admin.rs
@@ -661,12 +661,26 @@ pub struct LoadResult {
     pub postgis_engines: Vec<Arc<engine_postgis::PostgisEngine>>,
 }
 
+/// Render caches carried across a reload so a config reload **preserves** the
+/// warm cache instead of rebuilding it empty. Rebuilding on every reload dumps
+/// a fully-warmed meta-tile cache (multiple GB) and forces a cold re-warm — and
+/// a spurious `collections_dir` watcher event could trigger that repeatedly,
+/// tanking render latency. `Default` (all `None`, used at startup) builds fresh;
+/// [`do_reload`] passes the live caches to reuse.
+#[derive(Default)]
+pub struct ReusableCaches {
+    pub rendered: Option<Arc<ds_render::RenderedCache>>,
+    pub tile: Option<Arc<ds_render::TilePixelCache>>,
+    pub vector: Option<Arc<ds_mvt::VectorTileCache>>,
+}
+
 pub fn load_collections(
     collections: &[CollectionConfig],
     style_bundles: &[StyleBundle],
     base_url: &str,
     trust_proxy_headers: bool,
     metatile_cache_mb: u64,
+    reuse: ReusableCaches,
 ) -> LoadResult {
     let bundle_index: HashMap<&str, &StyleBundle> =
         style_bundles.iter().map(|b| (b.id.as_str(), b)).collect();
@@ -1966,12 +1980,31 @@ pub fn load_collections(
         .max(8);
     tracing::info!("Render concurrency: {render_concurrency} (2× available CPUs, min 8)");
     let render_semaphore = Arc::new(tokio::sync::Semaphore::new(render_concurrency));
-    let rendered_cache = Arc::new(ds_render::RenderedCache::new(rendered_cache_mb));
-    let tile_cache = Arc::new(ds_render::TilePixelCache::new(metatile_cache_mb));
+    // Reuse the live render caches across a reload when their configured byte
+    // size is unchanged, so a reload preserves the warm cache instead of
+    // dumping GBs of meta-tiles and forcing a cold re-warm (see
+    // [`ReusableCaches`]). A size change (or startup, where `reuse` is empty)
+    // builds fresh. Stale entries survive harmlessly: a removed collection's
+    // layer 404s before its cached tiles can be served (they then age out via
+    // LRU), and a changed colormap re-colors as new timesteps render (the cache
+    // key carries `time`); a hard guarantee for an in-place colormap swap still
+    // needs a restart.
+    let mb = |m: u64| m.saturating_mul(1024 * 1024);
+    let rendered_cache = match reuse.rendered {
+        Some(c) if c.capacity() == mb(rendered_cache_mb) => c,
+        _ => Arc::new(ds_render::RenderedCache::new(rendered_cache_mb)),
+    };
+    let tile_cache = match reuse.tile {
+        Some(c) if c.capacity() == mb(metatile_cache_mb) => c,
+        _ => Arc::new(ds_render::TilePixelCache::new(metatile_cache_mb)),
+    };
     // Vector-tile (MVT) cache is independent of the raster cache because the
-    // workloads differ (1–50 KB vs 30–200 KB per tile). 128 MB matches the
-    // raster default; a config knob lands when an operator asks for it.
-    let vector_tile_cache = Arc::new(ds_mvt::VectorTileCache::new(128));
+    // workloads differ (1–50 KB vs 30–200 KB per tile). Fixed 128 MB; reused
+    // across reloads on the same terms.
+    let vector_tile_cache = match reuse.vector {
+        Some(c) if c.capacity_bytes() == mb(128) => c,
+        _ => Arc::new(ds_mvt::VectorTileCache::new(128)),
+    };
 
     // Set initial render semaphore total gauge
     RENDER_SEMAPHORE_TOTAL.set(render_concurrency as i64);
@@ -2514,12 +2547,25 @@ pub(crate) fn do_reload(state: &AdminState) -> Result<ReloadOutcome, ReloadError
     // reload would freeze the live registry with dead loops and no new ones
     // spawned (the guard returns before the spawn block).
 
+    // Carry the live render caches into the reload so it preserves the warm
+    // cache instead of rebuilding it empty — a spurious `collections_dir`
+    // watcher event must not dump a multi-GB meta-tile cache. `load_collections`
+    // reuses each one iff its configured size is unchanged.
+    let reuse = {
+        let wms = state.wms.load();
+        ReusableCaches {
+            rendered: Some(wms.rendered_cache.clone()),
+            tile: Some(wms.tile_cache.clone()),
+            vector: Some(state.tiles.load().vector_tile_cache.clone()),
+        }
+    };
     let mut result = load_collections(
         &config.collections,
         &config.style_bundles,
         &base_url,
         config.server.trust_proxy_headers,
         config.server.metatile_cache_mb,
+        reuse,
     );
 
     // Reload protection counts *fully working* (`Ready`) collections, not
@@ -3386,6 +3432,76 @@ mod tests {
     use ds_core::config::{CollectionConfig, StyleBundle};
     use std::collections::HashMap;
     use std::sync::Arc;
+
+    // --- reload preserves the warm render caches (ReusableCaches) ---
+
+    #[test]
+    fn reload_reuses_render_caches_when_size_unchanged() {
+        // Startup-equivalent: fresh caches (empty collections is fine — the
+        // render caches are built unconditionally).
+        let first = super::load_collections(
+            &[],
+            &[],
+            "http://x",
+            false,
+            64,
+            super::ReusableCaches::default(),
+        );
+        let tile0 = first.wms_state.tile_cache.clone();
+        let rendered0 = first.wms_state.rendered_cache.clone();
+        let vector0 = first.tiles_state.vector_tile_cache.clone();
+
+        // Reload with the SAME meta-tile size → every cache is reused (same
+        // `Arc`), so a warm cache survives a reload instead of being dumped.
+        let second = super::load_collections(
+            &[],
+            &[],
+            "http://x",
+            false,
+            64,
+            super::ReusableCaches {
+                rendered: Some(rendered0.clone()),
+                tile: Some(tile0.clone()),
+                vector: Some(vector0.clone()),
+            },
+        );
+        assert!(
+            Arc::ptr_eq(&tile0, &second.wms_state.tile_cache),
+            "tile cache reused"
+        );
+        assert!(
+            Arc::ptr_eq(&rendered0, &second.wms_state.rendered_cache),
+            "rendered cache reused"
+        );
+        assert!(
+            Arc::ptr_eq(&vector0, &second.tiles_state.vector_tile_cache),
+            "vector cache reused"
+        );
+
+        // Reload with a CHANGED meta-tile size → the tile cache is rebuilt (a
+        // differently-sized cache can't be reused); the unchanged rendered/
+        // vector caches are still reused.
+        let third = super::load_collections(
+            &[],
+            &[],
+            "http://x",
+            false,
+            128,
+            super::ReusableCaches {
+                rendered: Some(rendered0.clone()),
+                tile: Some(tile0.clone()),
+                vector: Some(vector0.clone()),
+            },
+        );
+        assert!(
+            !Arc::ptr_eq(&tile0, &third.wms_state.tile_cache),
+            "tile cache rebuilt on size change"
+        );
+        assert!(
+            Arc::ptr_eq(&rendered0, &third.wms_state.rendered_cache),
+            "rendered cache unchanged → reused"
+        );
+    }
 
     // --- maybe_wrap_integer_lut (#207) ---
 

--- a/crates/server/src/admin.rs
+++ b/crates/server/src/admin.rs
@@ -1999,11 +1999,14 @@ pub fn load_collections(
         _ => Arc::new(ds_render::TilePixelCache::new(metatile_cache_mb)),
     };
     // Vector-tile (MVT) cache is independent of the raster cache because the
-    // workloads differ (1–50 KB vs 30–200 KB per tile). Fixed 128 MB; reused
-    // across reloads on the same terms.
+    // workloads differ (1–50 KB vs 30–200 KB per tile). Fixed size, kept in a
+    // single constant so the build and the reuse-capacity check can't drift (a
+    // mismatch would silently always rebuild). Reused across reloads on the same
+    // terms as the raster caches.
+    const VECTOR_TILE_CACHE_MB: u64 = 128;
     let vector_tile_cache = match reuse.vector {
-        Some(c) if c.capacity_bytes() == mb(128) => c,
-        _ => Arc::new(ds_mvt::VectorTileCache::new(128)),
+        Some(c) if c.capacity_bytes() == mb(VECTOR_TILE_CACHE_MB) => c,
+        _ => Arc::new(ds_mvt::VectorTileCache::new(VECTOR_TILE_CACHE_MB)),
     };
 
     // Set initial render semaphore total gauge
@@ -3500,6 +3503,10 @@ mod tests {
         assert!(
             Arc::ptr_eq(&rendered0, &third.wms_state.rendered_cache),
             "rendered cache unchanged → reused"
+        );
+        assert!(
+            Arc::ptr_eq(&vector0, &third.tiles_state.vector_tile_cache),
+            "vector cache unchanged → reused"
         );
     }
 

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -428,6 +428,8 @@ async fn main() {
         &base_url,
         config.server.trust_proxy_headers,
         config.server.metatile_cache_mb,
+        // Startup builds the render caches fresh; reloads reuse them.
+        admin::ReusableCaches::default(),
     );
 
     let loaded = result

--- a/crates/server/src/watcher.rs
+++ b/crates/server/src/watcher.rs
@@ -144,7 +144,7 @@ mod tests {
 
     // -- End-to-end: a collections.d add/remove auto-reloads the registry -----
 
-    use crate::admin::{load_collections, CollectionStatus, ServerState};
+    use crate::admin::{load_collections, CollectionStatus, ReusableCaches, ServerState};
     use arc_swap::ArcSwap;
     use ds_core::config::ServerConfig;
     use std::fs;
@@ -159,6 +159,7 @@ mod tests {
             &config.server.base_url(),
             config.server.trust_proxy_headers,
             config.server.metatile_cache_mb,
+            ReusableCaches::default(),
         );
         Arc::new(ServerState {
             edr: Arc::new(ArcSwap::from_pointee(result.edr_state)),


### PR DESCRIPTION
## What
A collections reload — `POST /admin/collections/reload` **or** the `collections_dir` watcher — rebuilt `RenderedCache` + `TilePixelCache` + the MVT cache from scratch in `load_collections`, **dumping the fully-warmed meta-tile cache** (multiple GB) and forcing a cold re-warm.

This threads the live caches into `load_collections` via a `ReusableCaches` struct and **reuses** each one when its configured byte capacity is unchanged (a size change or startup builds fresh).

## Why
The meta-tile cache is what makes full-viewport WMS `GetMap` fast (the exact-bbox `RenderedCache` gets ~3% on arbitrary viewports; the meta-tile cache carries ~80%). Dumping it on every reload spikes render latency until it re-warms — very visible for high-res browser clients.

**Live incident:** a spurious `collections_dir` watcher event (an `ATTRIB`/access inotify event with no content change, from a periodic file reader) triggered a reload every ~2.5 min, resetting the meta-tile cache to 0 each time → permanently cold cache → slow browser WMS. This fix makes the cache survive any reload (spurious or legitimate), so it can't be dumped that way.

## Correctness — stale entries survive harmlessly
- A **removed collection's** layer 404s before its cached tiles can be served (then they age out via LRU).
- A **changed colormap** re-colors as new timesteps render (the cache key carries `time`); a hard guarantee for an *in-place* colormap swap on an existing timestep still needs a restart. Documented in code.
- A **cache-size change** (`metatile_cache_mb`) rebuilds fresh (a differently-sized cache can't be reused).

## Testing
New `reload_reuses_render_caches_when_size_unchanged`: a same-size reload returns the **same** cache `Arc` (`Arc::ptr_eq`) for rendered/tile/vector; a size change rebuilds the tile cache while reusing the unchanged ones. Full `cargo test -p server` (73 + 10) green, including all watcher/reload tests; `cargo clippy -p server --all-targets -- -D warnings` clean; `cargo fmt` clean.

## Follow-up (separate)
Have the watcher skip the reload entirely when watched-file content is unchanged (fingerprint), so spurious events don't churn engines/poll-loops either — noted on #421.

Closes #421.

🤖 Generated with [Claude Code](https://claude.com/claude-code)