### PR TITLE
fix(server): collections_dir watcher ignores read events — stops self-reload loop (#424)

### DIFF
--- a/crates/server/src/watcher.rs
+++ b/crates/server/src/watcher.rs
@@ -15,6 +15,7 @@
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
+use notify::event::{AccessKind, AccessMode, EventKind, ModifyKind};
 use notify::{RecursiveMode, Watcher};
 use tracing::{info, warn};
 
@@ -36,7 +37,13 @@ pub fn spawn_collections_watcher(
 
     let mut watcher =
         notify::recommended_watcher(move |res: notify::Result<notify::Event>| match res {
-            Ok(event) if is_toml_event(&event) => {
+            // A reload must fire only on a real content/structural change — NOT
+            // on a read. `do_reload` re-opens every `.toml` to parse it, and
+            // notify's inotify mask always includes `IN_OPEN`, so reacting to
+            // read-access would let a reload's own file reads re-trigger the
+            // next reload — an infinite self-sustaining loop (see
+            // [`is_read_only_event`]).
+            Ok(event) if is_toml_event(&event) && !is_read_only_event(&event.kind) => {
                 // Ignore send errors — a closed receiver just means the task ended.
                 let _ = tx.send(());
             }
@@ -114,10 +121,36 @@ fn is_toml_event(event: &notify::Event) -> bool {
     })
 }
 
+/// Whether an event is a *read* (or pure-metadata touch) that must NOT trigger a
+/// reload.
+///
+/// `do_reload` re-opens and reads every collection `.toml` to re-parse the
+/// config. `notify`'s inotify backend registers `IN_OPEN` in its watch mask
+/// **unconditionally** (notify 8.x, `inotify.rs` `add_single_watch`), surfacing
+/// it as [`EventKind::Access`]`(`[`AccessKind::Open`]`)`. Because the event
+/// filter keys on the file *path* alone, reacting to that open made a reload's
+/// own reads emit events that re-triggered the next reload — an infinite,
+/// self-sustaining loop. It was invisible in `stat` (reads don't change
+/// timestamps) and only fully provable on the production *read-only*
+/// `collections_dir` mount, where `IN_OPEN` is the **only** event that can fire.
+///
+/// We therefore drop read-type accesses (`Open`/`Read`/read-`Close`) and
+/// metadata-only touches (atime/chmod/chown), while keeping every genuine
+/// change: create, remove, rename, data writes, and `IN_CLOSE_WRITE`
+/// (`Access(Close(Write))`) — which `do_reload`'s read-only opens never produce.
+fn is_read_only_event(kind: &EventKind) -> bool {
+    matches!(
+        kind,
+        EventKind::Access(AccessKind::Open(_))
+            | EventKind::Access(AccessKind::Read)
+            | EventKind::Access(AccessKind::Close(AccessMode::Read))
+            | EventKind::Modify(ModifyKind::Metadata(_))
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use notify::event::{EventKind, ModifyKind};
     use notify::Event;
 
     fn event_for(path: &str) -> Event {
@@ -140,6 +173,50 @@ mod tests {
     fn non_toml_changes_ignored() {
         assert!(!is_toml_event(&event_for("/c.d/README.md")));
         assert!(!is_toml_event(&event_for("/c.d/notes.txt")));
+    }
+
+    #[test]
+    fn read_only_events_are_dropped() {
+        // The bug: notify's inotify mask always includes IN_OPEN, surfaced as
+        // Access(Open). do_reload re-opens every .toml, so reacting to these
+        // would self-trigger an infinite reload loop.
+        assert!(is_read_only_event(&EventKind::Access(AccessKind::Open(
+            AccessMode::Any
+        ))));
+        assert!(is_read_only_event(&EventKind::Access(AccessKind::Open(
+            AccessMode::Read
+        ))));
+        assert!(is_read_only_event(&EventKind::Access(AccessKind::Read)));
+        assert!(is_read_only_event(&EventKind::Access(AccessKind::Close(
+            AccessMode::Read
+        ))));
+        // atime/chmod/chown touches don't change config content.
+        assert!(is_read_only_event(&EventKind::Modify(
+            ModifyKind::Metadata(notify::event::MetadataKind::Any)
+        )));
+    }
+
+    #[test]
+    fn real_changes_are_kept() {
+        use notify::event::{CreateKind, DataChange, RemoveKind, RenameMode};
+        // Create / remove / rename / data write / IN_CLOSE_WRITE all survive.
+        assert!(!is_read_only_event(&EventKind::Create(CreateKind::File)));
+        assert!(!is_read_only_event(&EventKind::Remove(RemoveKind::File)));
+        assert!(!is_read_only_event(&EventKind::Modify(ModifyKind::Name(
+            RenameMode::Any
+        ))));
+        assert!(!is_read_only_event(&EventKind::Modify(ModifyKind::Data(
+            DataChange::Any
+        ))));
+        assert!(!is_read_only_event(&EventKind::Modify(ModifyKind::Any)));
+        // IN_CLOSE_WRITE — a real write closed; do_reload's read-only opens
+        // never produce this, so keeping it is loop-safe.
+        assert!(!is_read_only_event(&EventKind::Access(AccessKind::Close(
+            AccessMode::Write
+        ))));
+        // Catch-alls stay permissive so a real change is never missed.
+        assert!(!is_read_only_event(&EventKind::Any));
+        assert!(!is_read_only_event(&EventKind::Other));
     }
 
     // -- End-to-end: a collections.d add/remove auto-reloads the registry -----

--- a/crates/server/src/watcher.rs
+++ b/crates/server/src/watcher.rs
@@ -186,6 +186,13 @@ mod tests {
         assert!(is_read_only_event(&EventKind::Access(AccessKind::Open(
             AccessMode::Read
         ))));
+        // Open(Write) must ALSO be dropped — the `Open(_)` wildcard is
+        // deliberate: a write-mode open is not evidence the data was committed
+        // (the real signals are Close(Write)/Modify(Data)), so reloading on it
+        // would be premature. Narrowing to `Open(Any | Read)` would regress this.
+        assert!(is_read_only_event(&EventKind::Access(AccessKind::Open(
+            AccessMode::Write
+        ))));
         assert!(is_read_only_event(&EventKind::Access(AccessKind::Read)));
         assert!(is_read_only_event(&EventKind::Access(AccessKind::Close(
             AccessMode::Read


### PR DESCRIPTION
Fixes #424 — a production incident where the `collections_dir` auto-reload watcher reloaded continuously (every ~2.5 min on prod), keeping the render caches permanently cold and high-res browser WMS slow.

## Root cause (triple-confirmed, with verbatim source)

The watcher reacted to **its own reload reading the config files**:

1. **`notify` 8.2.0 registers `IN_OPEN` in its inotify watch mask unconditionally** — `notify-8.2.0/src/inotify.rs` `add_single_watch()`: `ATTRIB | CREATE | OPEN | DELETE | CLOSE_WRITE | MODIFY | MOVED_FROM | MOVED_TO`. `IN_OPEN` → `EventKind::Access(AccessKind::Open)`.
2. **`is_toml_event` filtered on the file path only**, never `event.kind`.
3. **`do_reload` → `ServerConfig::from_file` re-opens and reads every `collections.d/*.toml`** (`read_to_string`).
4. Each open emits `IN_OPEN` → `Access(Open)` with a `.toml` path → the filter forwards it → another reload → more opens → **infinite self-sustaining loop**.

Invisible to `stat` (reads dont change timestamps); only fully provable on the prod **read-only** `collections_dir` mount, where `IN_OPEN` is the *only* inotify event physically possible — yet the watcher still fired every cycle.

The loop is **latent**: a fresh boot reads the configs *before* the watcher is spawned (`main.rs:425` load vs `main.rs:602` spawn), so it stays quiet until one real reload (a collection edit, a deploy, or an external reader of the dir) arms it — then it self-sustains. That matches the field timeline (watcher enabled for days, loop began when the new radar collections were added).

Confirmed: nothing in the codebase writes to `collections_dir` (all file-mutating calls are test/example-only), so it is not a write side-effect.

## Fix

The notify callback now forwards only **real content/structural changes**:

```rust
Ok(event) if is_toml_event(&event) && !is_read_only_event(&event.kind) => { ... }
```

`is_read_only_event` drops `Access(Open/Read/Close(Read))` and `Modify(Metadata)` (reads + atime/chmod touches) and keeps create/remove/rename, data writes, and `IN_CLOSE_WRITE` (`Access(Close(Write))`) — which `do_reload`s read-only opens never produce, so keeping it is loop-safe. Real edits always emit a kept kind (in-place save → `Modify(Data)`; atomic save/rename → `Create`/`Modify(Name)`/`MovedTo`; rm/add → `Remove`/`Create`), so auto-reload still works. This also immunises the watcher against any external periodic reader of the directory (the originally-suspected #421 kick).

## Tests

`read_only_events_are_dropped` (Open/Read/Close(Read)/Metadata → dropped) and `real_changes_are_kept` (Create/Remove/Modify(Data/Name/Any)/CLOSE_WRITE/Any/Other → kept); existing path-filter tests unchanged. fmt + clippy clean.

## Note on deploy
The deployed `af6bcc1` also lacks #422 (reload-preserves-cache, merged but not deployed), which is why each loop iteration dumped the warm cache. Deploying current main + this fix gets both: #424 stops the loop, #422 keeps any future reload cache-safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)