### PR TITLE
fix(wms): GetLegendGraphic accepts singular STYLE alias (#165)

### DIFF
--- a/crates/api-wms/src/handlers.rs
+++ b/crates/api-wms/src/handlers.rs
@@ -571,10 +571,7 @@ pub async fn wms_handler(
                 .or(query.layer.as_deref())
                 .ok_or(WmsError::missing_parameter("LAYER"))?;
 
-            // Accept singular STYLE as well as plural STYLES — GetLegendGraphic's
-            // SLD parameter is `STYLE`, and GetMap already honours both. Without
-            // this a client sending only STYLE=… silently gets the default
-            // legend instead of the one it asked for (#165).
+            // Also accept singular STYLE= — SLD standard for GetLegendGraphic (#165).
             let style_name = query
                 .styles
                 .as_deref()

--- a/crates/api-wms/src/handlers.rs
+++ b/crates/api-wms/src/handlers.rs
@@ -571,7 +571,15 @@ pub async fn wms_handler(
                 .or(query.layer.as_deref())
                 .ok_or(WmsError::missing_parameter("LAYER"))?;
 
-            let style_name = query.styles.as_deref().unwrap_or("default");
+            // Accept singular STYLE as well as plural STYLES — GetLegendGraphic's
+            // SLD parameter is `STYLE`, and GetMap already honours both. Without
+            // this a client sending only STYLE=… silently gets the default
+            // legend instead of the one it asked for (#165).
+            let style_name = query
+                .styles
+                .as_deref()
+                .or(query.style.as_deref())
+                .unwrap_or("default");
             let style_name = if style_name.is_empty() {
                 "default"
             } else {

--- a/crates/api-wms/tests/integration.rs
+++ b/crates/api-wms/tests/integration.rs
@@ -1864,6 +1864,40 @@ async fn legend_graphic_reflects_selected_style() {
     );
 }
 
+/// `GetLegendGraphic` honours the singular `STYLE` alias, not just plural
+/// `STYLES` (#165). A client sending only `STYLE=radar_fmi` must get that
+/// style's legend, identical to `STYLES=radar_fmi` — not the default.
+#[tokio::test]
+async fn legend_graphic_accepts_singular_style_alias() {
+    let app = build_empty_router();
+    let fetch = |query: &str| {
+        let uri = format!(
+            "/?SERVICE=WMS&REQUEST=GetLegendGraphic&VERSION=1.3.0\
+             &LAYER=empty&FORMAT=image/png&{query}"
+        );
+        let app = app.clone();
+        async move {
+            let resp = app
+                .oneshot(Request::builder().uri(uri).body(Body::empty()).unwrap())
+                .await
+                .unwrap();
+            assert_eq!(resp.status(), StatusCode::OK);
+            resp.into_body().collect().await.unwrap().to_bytes()
+        }
+    };
+    let singular = fetch("STYLE=radar_fmi").await;
+    let plural = fetch("STYLES=radar_fmi").await;
+    let default = fetch("STYLES=default").await;
+    assert_eq!(
+        singular, plural,
+        "STYLE=… must resolve the same style as STYLES=…"
+    );
+    assert_ne!(
+        singular, default,
+        "STYLE=radar_fmi must not fall through to the default legend"
+    );
+}
+
 /// A client may still request an explicit (smaller) legend size; the handler
 /// honours it and the renderer degrades to a bare swatch when too narrow for
 /// labels. Asserts the requested dimensions round-trip.


### PR DESCRIPTION
Closes #165.

## Bug

`GetMap` accepts both `STYLE` and `STYLES`, but `GetLegendGraphic` only read the
plural `STYLES`. A client sending `STYLE=my-style` (the SLD-standard singular
parameter for a legend) silently received the `default` legend instead of the
requested one — no error, just wrong output. `LAYER`/`LAYERS` was already
handled symmetrically; the `STYLE` alias was the odd one out.

## Fix

Mirror the existing LAYER/LAYERS pattern — fall back to `query.style` when
`query.styles` is absent:

```rust
let style_name = query
    .styles
    .as_deref()
    .or(query.style.as_deref())
    .unwrap_or("default");
```

`WmsQuery` already parses both (`#[serde(alias = "STYLE")]`), so this is purely
the handler honouring the field GetMap already uses.

## Test

`legend_graphic_accepts_singular_style_alias` (api-wms integration): `STYLE=radar_fmi`
returns bytes identical to `STYLES=radar_fmi` and distinct from the default legend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)