### PR TITLE
feat(ds-render): shared vector polygon → raster fill primitive (#397)

### DIFF
--- a/crates/core/src/geo.rs
+++ b/crates/core/src/geo.rs
@@ -1,5 +1,8 @@
 use std::f64::consts::PI;
 
+use crate::feature::Geometry;
+use crate::map_engine::OutputCrs;
+
 /// WGS84 ellipsoid parameters
 const WGS84_A: f64 = 6_378_137.0; // semi-major axis (meters)
 const WGS84_F: f64 = 1.0 / 298.257223563; // flattening
@@ -1270,6 +1273,93 @@ fn rotlatlon_inverse(
     (lon_norm, lat.to_degrees())
 }
 
+// ---------------------------------------------------------------------------
+// Vector geometry → output pixel space (for ds-render's polygon fill, #397)
+// ---------------------------------------------------------------------------
+
+/// A single polygon projected into output **pixel** space: an exterior ring
+/// plus interior rings (holes), each a list of `[x, y]` pixel coordinates.
+/// Feeds directly into `ds_render::rasterize::fill_polygon`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PixelPolygon {
+    /// Exterior ring, pixel coordinates.
+    pub exterior: Vec<[f64; 2]>,
+    /// Interior rings (holes), pixel coordinates.
+    pub holes: Vec<Vec<[f64; 2]>>,
+}
+
+/// A [`Geometry`] projected into output pixel space for one render request —
+/// the bridge between [`OutputCrs`] projection (here, in `ds-core`) and the
+/// pure scanline fill (`ds_render::rasterize::fill_polygon`), keeping CRS math
+/// in one place and the fill math in another.
+///
+/// **Pixel convention** — top-left origin: `x` increases east (`x = 0` at the
+/// west/left edge, `x = width` at the east/right edge), `y` increases south
+/// (`y = 0` at the north/top edge, `y = height` at the bottom). A vertex
+/// off-tile keeps its projected pixel value (the fill clips to the tile) and a
+/// vertex outside a projection's valid domain can be non-finite (the
+/// `Projected` forward may not converge) — `fill_polygon` skips edges with a
+/// non-finite endpoint, so vertex topology is preserved as-is here. Non-polygon
+/// geometries (`Point`, `Null`) yield no polygons.
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct PixelGeometry {
+    /// One entry per polygon (a `Polygon` yields one; a `MultiPolygon`, one
+    /// per member).
+    pub polygons: Vec<PixelPolygon>,
+}
+
+/// Project a [`Geometry`]'s polygon rings into output **pixel** space for a
+/// render request, so they can be filled by `ds_render::rasterize::fill_polygon`.
+///
+/// Only the polygonal parts contribute: `Polygon` → one [`PixelPolygon`],
+/// `MultiPolygon` → one per member, `Point`/`Null` → none. Each ring vertex
+/// `[lon, lat]` (WGS84 degrees) is mapped through [`OutputCrs::world_to_fraction`]
+/// (projecting **vertices only**, never per output pixel — #203) and scaled by
+/// `width`/`height`.
+///
+/// `bbox` is the request's WGS84 bounding box `[west, south, east, north]` (used
+/// by the `Wgs84`/`WebMercator` variants; the `Projected` variant carries its
+/// own projected extents and ignores it). See [`PixelGeometry`] for the pixel
+/// coordinate convention and out-of-domain handling.
+///
+/// **Antimeridian (v1 limitation):** vertices are projected independently with
+/// no ±180° seam handling, so a polygon ring that crosses the antimeridian — or
+/// a request bbox spanning it — is not split and will render incorrectly (a
+/// ring vertex at +179° and one at −179° map to opposite edges of the tile,
+/// filling the wrong span between them). Callers must pre-split such polygons.
+/// Antimeridian splitting is a deferred follow-up (#397); small alert/SIGMET
+/// polygons away from ±180° are unaffected.
+pub fn geometry_to_pixels(
+    geom: &Geometry,
+    bbox: [f64; 4],
+    width: u32,
+    height: u32,
+    output_crs: &OutputCrs,
+) -> PixelGeometry {
+    let (w, h) = (width as f64, height as f64);
+    let project_ring = |ring: &[[f64; 2]]| -> Vec<[f64; 2]> {
+        ring.iter()
+            .map(|&[lon, lat]| {
+                let (fx, fy) = output_crs.world_to_fraction(bbox, lon, lat);
+                [fx * w, fy * h]
+            })
+            .collect()
+    };
+    let project_polygon = |exterior: &[[f64; 2]], holes: &[Vec<[f64; 2]>]| PixelPolygon {
+        exterior: project_ring(exterior),
+        holes: holes.iter().map(|ring| project_ring(ring)).collect(),
+    };
+    let polygons = match geom {
+        Geometry::Polygon { exterior, holes } => vec![project_polygon(exterior, holes)],
+        Geometry::MultiPolygon { polygons } => polygons
+            .iter()
+            .map(|(exterior, holes)| project_polygon(exterior, holes))
+            .collect(),
+        Geometry::Point { .. } | Geometry::Null => Vec::new(),
+    };
+    PixelGeometry { polygons }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1947,5 +2037,136 @@ mod tests {
         assert!(x.abs() < 1e-6, "x={x}");
         assert!((y - (WGS84_A + 100.0)).abs() < 1e-3, "y={y}");
         assert!(z.abs() < 1e-6, "z={z}");
+    }
+
+    // -- geometry_to_pixels (#397) -----------------------------------------
+
+    fn approx(a: [f64; 2], b: [f64; 2], eps: f64) -> bool {
+        (a[0] - b[0]).abs() < eps && (a[1] - b[1]).abs() < eps
+    }
+
+    #[test]
+    fn geometry_to_pixels_wgs84_pins_corners_and_centre() {
+        // bbox [west, south, east, north] = [0, 0, 10, 10], 100×100 px.
+        // Linear lon/lat → pixel: NW corner → (0,0), SE corner → (100,100),
+        // centre → (50,50). y is top-down (north at y=0).
+        let bbox = [0.0, 0.0, 10.0, 10.0];
+        let geom = Geometry::Polygon {
+            exterior: vec![
+                [0.0, 10.0],  // NW
+                [10.0, 10.0], // NE
+                [10.0, 0.0],  // SE
+                [0.0, 0.0],   // SW
+                [5.0, 5.0],   // centre
+            ],
+            holes: vec![],
+        };
+        let px = geometry_to_pixels(&geom, bbox, 100, 100, &OutputCrs::Wgs84);
+        assert_eq!(px.polygons.len(), 1);
+        let ring = &px.polygons[0].exterior;
+        assert!(approx(ring[0], [0.0, 0.0], 1e-9), "NW {:?}", ring[0]);
+        assert!(approx(ring[1], [100.0, 0.0], 1e-9), "NE {:?}", ring[1]);
+        assert!(approx(ring[2], [100.0, 100.0], 1e-9), "SE {:?}", ring[2]);
+        assert!(approx(ring[3], [0.0, 100.0], 1e-9), "SW {:?}", ring[3]);
+        assert!(approx(ring[4], [50.0, 50.0], 1e-9), "centre {:?}", ring[4]);
+    }
+
+    #[test]
+    fn geometry_to_pixels_web_mercator_bows_y() {
+        // Same bbox; x stays linear in lon, but y follows Mercator: northern
+        // latitudes occupy more Mercator-Y space, so the geographic lat=5°
+        // midpoint is pushed *below* the geometric middle (pixel y > 50).
+        let bbox = [0.0, 0.0, 10.0, 10.0];
+        let geom = Geometry::Polygon {
+            exterior: vec![[0.0, 10.0], [10.0, 0.0], [5.0, 5.0]],
+            holes: vec![],
+        };
+        let px = geometry_to_pixels(&geom, bbox, 100, 100, &OutputCrs::WebMercator);
+        let ring = &px.polygons[0].exterior;
+        // Corners pin exactly (the bbox edges are fixed points of the mapping).
+        assert!(approx(ring[0], [0.0, 0.0], 1e-9), "NW {:?}", ring[0]);
+        assert!(approx(ring[1], [100.0, 100.0], 1e-9), "SE {:?}", ring[1]);
+        // Centre: pin y against an independently-computed Mercator fraction.
+        let merc = |lat: f64| {
+            6_378_137.0_f64 * ((std::f64::consts::FRAC_PI_4 + lat.to_radians() / 2.0).tan()).ln()
+        };
+        let (my_n, my_s, my_m) = (merc(10.0), merc(0.0), merc(5.0));
+        let expected_y = (my_n - my_m) / (my_n - my_s) * 100.0;
+        assert!(expected_y > 50.0, "Mercator midpoint below centre");
+        assert!(
+            (ring[2][0] - 50.0).abs() < 1e-9 && (ring[2][1] - expected_y).abs() < 1e-6,
+            "centre {:?} vs expected y {expected_y}",
+            ring[2]
+        );
+    }
+
+    #[test]
+    fn geometry_to_pixels_projected_epsg3067() {
+        // EPSG:3067 (TM35FIN). Output bbox in projected metres straddling the
+        // central meridian (27°E ↔ easting 500 000). A polygon vertex on the
+        // central meridian must land at fx = 0.5 — an independent pin that the
+        // projection is actually applied (not the metres treated as degrees).
+        let crs = projected_output_crs("EPSG:3067").unwrap();
+        let bbox_proj = [400_000.0, 6_600_000.0, 600_000.0, 6_900_000.0];
+        let out = OutputCrs::Projected {
+            crs: crs.clone(),
+            bbox: bbox_proj,
+        };
+        let geom = Geometry::Polygon {
+            exterior: vec![[27.0, 62.0], [28.0, 62.0], [27.0, 61.0]],
+            holes: vec![],
+        };
+        // The WGS84 `bbox` arg is ignored by the Projected variant.
+        let px = geometry_to_pixels(&geom, [0.0; 4], 200, 300, &out);
+        let ring = &px.polygons[0].exterior;
+        // Vertex 0 is on λ0=27° → easting exactly 500 000 → fx=0.5 → x=100.
+        assert!((ring[0][0] - 100.0).abs() < 1e-3, "λ0 x {:?}", ring[0]);
+        // Cross-check the full mapping against forward() + the fraction math.
+        for (i, &[lon, lat]) in geom_exterior(&geom).iter().enumerate() {
+            let (e, n) = crs.forward(lon, lat);
+            let fx = (e - bbox_proj[0]) / (bbox_proj[2] - bbox_proj[0]);
+            let fy = (bbox_proj[3] - n) / (bbox_proj[3] - bbox_proj[1]);
+            assert!(
+                approx(ring[i], [fx * 200.0, fy * 300.0], 1e-6),
+                "vertex {i} {:?}",
+                ring[i]
+            );
+        }
+    }
+
+    #[test]
+    fn geometry_to_pixels_multipolygon_and_holes() {
+        let bbox = [0.0, 0.0, 10.0, 10.0];
+        let geom = Geometry::MultiPolygon {
+            polygons: vec![
+                (
+                    vec![[0.0, 10.0], [2.0, 10.0], [0.0, 8.0]],
+                    vec![vec![[0.5, 9.5], [1.0, 9.5], [0.5, 9.0]]],
+                ),
+                (vec![[8.0, 2.0], [10.0, 2.0], [8.0, 0.0]], vec![]),
+            ],
+        };
+        let px = geometry_to_pixels(&geom, bbox, 100, 100, &OutputCrs::Wgs84);
+        assert_eq!(px.polygons.len(), 2);
+        assert_eq!(px.polygons[0].holes.len(), 1);
+        // First hole vertex [0.5, 9.5] → (5, 5).
+        assert!(approx(px.polygons[0].holes[0][0], [5.0, 5.0], 1e-9));
+        assert!(px.polygons[1].holes.is_empty());
+    }
+
+    #[test]
+    fn geometry_to_pixels_point_and_null_yield_nothing() {
+        let bbox = [0.0, 0.0, 10.0, 10.0];
+        for geom in [Geometry::Point { x: 5.0, y: 5.0 }, Geometry::Null] {
+            let px = geometry_to_pixels(&geom, bbox, 100, 100, &OutputCrs::Wgs84);
+            assert!(px.polygons.is_empty());
+        }
+    }
+
+    fn geom_exterior(geom: &Geometry) -> &[[f64; 2]] {
+        match geom {
+            Geometry::Polygon { exterior, .. } => exterior,
+            _ => panic!("not a polygon"),
+        }
     }
 }

--- a/crates/core/src/geo.rs
+++ b/crates/core/src/geo.rs
@@ -1317,10 +1317,12 @@ pub struct PixelGeometry {
 /// (projecting **vertices only**, never per output pixel — #203) and scaled by
 /// `width`/`height`.
 ///
-/// `bbox` is the request's WGS84 bounding box `[west, south, east, north]` (used
-/// by the `Wgs84`/`WebMercator` variants; the `Projected` variant carries its
-/// own projected extents and ignores it). See [`PixelGeometry`] for the pixel
-/// coordinate convention and out-of-domain handling.
+/// `wgs84_bbox` is the request's WGS84 bounding box `[west, south, east, north]`
+/// (used by the `Wgs84`/`WebMercator` variants; the `Projected` variant carries
+/// its own projected extents and ignores it — the name matches the downstream
+/// [`OutputCrs::world_to_fraction`] parameter and flags the WGS84-only
+/// semantics at the call site). See [`PixelGeometry`] for the pixel coordinate
+/// convention and out-of-domain handling.
 ///
 /// **Antimeridian (v1 limitation):** vertices are projected independently with
 /// no ±180° seam handling, so a polygon ring that crosses the antimeridian — or
@@ -1331,7 +1333,7 @@ pub struct PixelGeometry {
 /// polygons away from ±180° are unaffected.
 pub fn geometry_to_pixels(
     geom: &Geometry,
-    bbox: [f64; 4],
+    wgs84_bbox: [f64; 4],
     width: u32,
     height: u32,
     output_crs: &OutputCrs,
@@ -1340,7 +1342,7 @@ pub fn geometry_to_pixels(
     let project_ring = |ring: &[[f64; 2]]| -> Vec<[f64; 2]> {
         ring.iter()
             .map(|&[lon, lat]| {
-                let (fx, fy) = output_crs.world_to_fraction(bbox, lon, lat);
+                let (fx, fy) = output_crs.world_to_fraction(wgs84_bbox, lon, lat);
                 [fx * w, fy * h]
             })
             .collect()

--- a/crates/render/src/lib.rs
+++ b/crates/render/src/lib.rs
@@ -5,6 +5,7 @@ mod encode;
 pub(crate) mod font;
 pub mod metatile;
 pub mod plot;
+pub mod rasterize;
 
 pub use colormap::{
     parse_hex_color, BuiltinColormap, ColorMap, ColorStop, IntegerLutColorMap, LinearColorMap,
@@ -13,6 +14,7 @@ pub use colormap::{
 pub use encode::{encode_jpeg, encode_png, encode_webp};
 pub use metatile::{render_metatiled, MetaTile, MetaTileStats, TileKeyPrefix, TilePixelCache};
 pub use plot::{render_chart, render_heatmap, Heatmap, Panel, Series};
+pub use rasterize::{fill_polygon, Combine};
 
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;

--- a/crates/render/src/rasterize.rs
+++ b/crates/render/src/rasterize.rs
@@ -69,10 +69,12 @@ pub fn fill_polygon(
     combine: Combine,
 ) {
     // Precondition: fill values are finite (severity/category codes). A
-    // non-finite `value` would make `Combine::Max` order-dependent — an empty
-    // slot stores `Some(NaN)` while a populated slot drops it via `f64::max` —
-    // breaking the documented draw-order independence. Assert in debug builds
-    // to catch misuse rather than silently violating the contract.
+    // non-finite `value` would corrupt the first fill: `None => value` writes
+    // `Some(NaN)` into the slot, and Rust's f64::max maxNum semantics mean
+    // subsequent fills (`existing.max(value)`) keep `existing` — so a pixel
+    // covered only by a NaN alert stays `Some(NaN)` and colorizes incorrectly.
+    // Assert in debug builds to catch misuse rather than silently violating the
+    // contract.
     debug_assert!(value.is_finite(), "fill_polygon value must be finite");
 
     let (w, h) = (width as usize, height as usize);
@@ -122,7 +124,7 @@ pub fn fill_polygon(
         while i + 1 < crossings.len() {
             let (span_start, span_end) = (crossings[i], crossings[i + 1]);
             // Pixels whose centre (x + 0.5) lies in [span_start, span_end).
-            let x_start = (span_start - 0.5).ceil().max(0.0) as usize;
+            let x_start = ((span_start - 0.5).ceil().max(0.0) as usize).min(w);
             let x_end = ((span_end - 0.5).ceil().max(0.0) as usize).min(w);
             for x in x_start..x_end {
                 paint(&mut out[row + x], value, combine);
@@ -454,8 +456,9 @@ mod tests {
         let mut out = vec![None; 100];
         let ring = vec![[2.0, 2.0], [f64::NAN, 4.0], [8.0, 8.0], [2.0, 8.0]];
         fill_polygon(&mut out, 10, 10, &ring, &[], 1.0, Combine::Replace);
-        // No panic; the result is well-defined (whatever the finite edges give).
-        // The key contract is robustness, not a specific shape.
+        // No panic; one valid edge remains but produces only one crossing per
+        // scanline (odd count), so the guard fires and zero pixels are filled.
+        // The key contract is robustness against NaN vertices, not a specific shape.
         let _ = filled(&out);
     }
 }

--- a/crates/render/src/rasterize.rs
+++ b/crates/render/src/rasterize.rs
@@ -1,0 +1,454 @@
+//! Pure 2-D scanline polygon fill — the framework-free rasterizer shared by
+//! every vector map layer (alert/hazard *areas*: CAP #396, GeoJSON Maps #398,
+//! IWXXM #399). Built once here so scan-conversion (winding, holes, tile-edge
+//! clipping) is implemented and tested in one place rather than re-derived per
+//! engine.
+//!
+//! Inputs are **pixel-space** rings: the engine projects geometry *vertices*
+//! via [`ds_core::geo::geometry_to_pixels`] (never per output pixel — #203);
+//! this module knows nothing about CRS or projection. It fills polygons into a
+//! `RasterTile`-shaped `Vec<Option<f64>>` *before* colorization, so the existing
+//! colormap pipeline styles the result like any other raster layer (the value
+//! is a severity code, category id, … that a `LutColorMap`/`IntegerLutColorMap`
+//! turns into colour).
+//!
+//! The fill uses the **even-odd** rule over the combined edge set of the
+//! exterior ring plus its holes, so a hole punches out the interior regardless
+//! of its winding direction — robust against inconsistently-wound source data.
+//! Pixels are sampled at their centre (`x + 0.5`, `y + 0.5`); edges are hard
+//! (no anti-aliasing — alert zones are categorical). Spans are clipped to the
+//! tile, so a polygon partly off-tile fills only its visible part.
+
+/// How a fill value combines with whatever a pixel already holds — the
+/// overlap policy when multiple features (or rings) cover the same pixel.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Combine {
+    /// Overwrite the existing value (last writer wins).
+    Replace,
+    /// Keep the larger of the existing and new value. Overlapping alerts
+    /// resolve to the highest severity **deterministically, regardless of the
+    /// order features are filled** — CAP's policy.
+    Max,
+    /// Only fill nodata pixels; keep an already-set value (first writer wins).
+    First,
+}
+
+/// One edge of a polygon ring in pixel space. Horizontal and non-finite edges
+/// are filtered out before this is constructed, so `y0 != y1` and all fields
+/// are finite — the scanline crossing math never divides by zero.
+struct Edge {
+    x0: f64,
+    y0: f64,
+    x1: f64,
+    y1: f64,
+}
+
+/// Fill a polygon (one exterior ring + interior-ring holes), given in
+/// **pixel** coordinates, into a row-major `width × height` value buffer.
+///
+/// - `out` — the target raster's `values`; must be exactly `width * height`
+///   long (a mismatch is a no-op, never a panic).
+/// - `exterior` / `holes` — pixel-space rings (`[x, y]`). Rings need not be
+///   explicitly closed (the last→first edge is added implicitly); a ring with
+///   fewer than 3 vertices contributes nothing. Vertices may lie outside the
+///   tile (the fill clips) and edges touching a non-finite vertex are skipped.
+/// - `value` — the value written into each covered pixel (severity, category,
+///   …), later colorized.
+/// - `combine` — the [`Combine`] overlap policy for pixels already set.
+///
+/// Uses even-odd scanline conversion: holes are just additional rings in the
+/// edge set, so they punch out the interior for any winding. Degenerate
+/// (zero-area / collinear) rings fill nothing.
+pub fn fill_polygon(
+    out: &mut [Option<f64>],
+    width: u32,
+    height: u32,
+    exterior: &[[f64; 2]],
+    holes: &[Vec<[f64; 2]>],
+    value: f64,
+    combine: Combine,
+) {
+    let (w, h) = (width as usize, height as usize);
+    if w == 0 || h == 0 || out.len() != w.saturating_mul(h) {
+        return;
+    }
+
+    // Collect every ring's edges into one set (even-odd treats them uniformly).
+    let mut edges: Vec<Edge> = Vec::new();
+    push_ring_edges(exterior, &mut edges);
+    for hole in holes {
+        push_ring_edges(hole, &mut edges);
+    }
+    if edges.is_empty() {
+        return;
+    }
+
+    // Bound the scanline sweep to the polygon's vertical extent ∩ the tile.
+    let (mut y_min, mut y_max) = (f64::INFINITY, f64::NEG_INFINITY);
+    for e in &edges {
+        y_min = y_min.min(e.y0.min(e.y1));
+        y_max = y_max.max(e.y0.max(e.y1));
+    }
+    let y_start = y_min.floor().clamp(0.0, h as f64) as usize;
+    let y_end = y_max.ceil().clamp(0.0, h as f64) as usize;
+
+    let mut crossings: Vec<f64> = Vec::new();
+    for y in y_start..y_end {
+        let yc = y as f64 + 0.5;
+        crossings.clear();
+        for e in &edges {
+            // Half-open crossing test: each shared vertex is counted for
+            // exactly one of its two edges, so no double counts at vertices.
+            if (e.y0 <= yc) != (e.y1 <= yc) {
+                let t = (yc - e.y0) / (e.y1 - e.y0);
+                crossings.push(e.x0 + t * (e.x1 - e.x0));
+            }
+        }
+        if crossings.len() < 2 {
+            continue;
+        }
+        crossings.sort_by(f64::total_cmp);
+
+        // Even-odd: fill the span between each consecutive crossing pair.
+        let row = y * w;
+        let mut i = 0;
+        while i + 1 < crossings.len() {
+            let (span_start, span_end) = (crossings[i], crossings[i + 1]);
+            // Pixels whose centre (x + 0.5) lies in [span_start, span_end).
+            let x_start = (span_start - 0.5).ceil().max(0.0) as usize;
+            let x_end = ((span_end - 0.5).ceil().max(0.0) as usize).min(w);
+            for x in x_start..x_end {
+                paint(&mut out[row + x], value, combine);
+            }
+            i += 2;
+        }
+    }
+}
+
+/// Append the (non-horizontal, finite) edges of a closed ring to `edges`.
+/// Consecutive vertices form edges and the ring is closed implicitly
+/// (`last → first`); rings with < 3 vertices add nothing.
+fn push_ring_edges(ring: &[[f64; 2]], edges: &mut Vec<Edge>) {
+    let n = ring.len();
+    if n < 3 {
+        return;
+    }
+    for i in 0..n {
+        let a = ring[i];
+        let b = ring[(i + 1) % n];
+        if !(a[0].is_finite() && a[1].is_finite() && b[0].is_finite() && b[1].is_finite()) {
+            continue;
+        }
+        // Horizontal edges contribute no scanline crossing.
+        if a[1] == b[1] {
+            continue;
+        }
+        edges.push(Edge {
+            x0: a[0],
+            y0: a[1],
+            x1: b[0],
+            y1: b[1],
+        });
+    }
+}
+
+/// Apply the overlap policy to a single pixel slot.
+#[inline]
+fn paint(slot: &mut Option<f64>, value: f64, combine: Combine) {
+    match combine {
+        Combine::Replace => *slot = Some(value),
+        Combine::First => {
+            if slot.is_none() {
+                *slot = Some(value);
+            }
+        }
+        Combine::Max => {
+            *slot = Some(match *slot {
+                Some(existing) => existing.max(value),
+                None => value,
+            });
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Count the set (non-nodata) pixels.
+    fn filled(out: &[Option<f64>]) -> usize {
+        out.iter().filter(|v| v.is_some()).count()
+    }
+
+    fn at(out: &[Option<f64>], w: u32, x: u32, y: u32) -> Option<f64> {
+        out[(y * w + x) as usize]
+    }
+
+    fn square(x0: f64, y0: f64, x1: f64, y1: f64) -> Vec<[f64; 2]> {
+        vec![[x0, y0], [x1, y0], [x1, y1], [x0, y1]]
+    }
+
+    #[test]
+    fn fills_convex_square() {
+        let mut out = vec![None; 100];
+        // Square spanning integer pixel edges 2..8 → 6×6 = 36 pixels filled.
+        fill_polygon(
+            &mut out,
+            10,
+            10,
+            &square(2.0, 2.0, 8.0, 8.0),
+            &[],
+            1.0,
+            Combine::Replace,
+        );
+        assert_eq!(filled(&out), 36);
+        assert_eq!(at(&out, 10, 5, 5), Some(1.0));
+        assert_eq!(at(&out, 10, 2, 2), Some(1.0)); // inclusive corner pixel
+        assert_eq!(at(&out, 10, 0, 0), None);
+        assert_eq!(at(&out, 10, 8, 8), None); // exclusive far edge
+    }
+
+    #[test]
+    fn fills_concave_polygon() {
+        // An L-shape: bottom bar x∈[1,5] y∈[1,3] + left bar x∈[1,3] y∈[1,5].
+        let mut out = vec![None; 64];
+        let l = vec![
+            [1.0, 1.0],
+            [5.0, 1.0],
+            [5.0, 3.0],
+            [3.0, 3.0],
+            [3.0, 5.0],
+            [1.0, 5.0],
+        ];
+        fill_polygon(&mut out, 8, 8, &l, &[], 1.0, Combine::Replace);
+        assert_eq!(at(&out, 8, 2, 2), Some(1.0)); // bottom bar
+        assert_eq!(at(&out, 8, 2, 4), Some(1.0)); // left bar
+        assert_eq!(at(&out, 8, 4, 4), None); // the notch (concavity) is empty
+    }
+
+    #[test]
+    fn punches_hole() {
+        // 10×10 outer square with a 3..7 hole.
+        let mut out = vec![None; 100];
+        fill_polygon(
+            &mut out,
+            10,
+            10,
+            &square(0.0, 0.0, 10.0, 10.0),
+            &[square(3.0, 3.0, 7.0, 7.0)],
+            1.0,
+            Combine::Replace,
+        );
+        assert_eq!(at(&out, 10, 5, 5), None); // inside the hole
+        assert_eq!(at(&out, 10, 1, 1), Some(1.0)); // outside the hole, inside outer
+        assert_eq!(at(&out, 10, 8, 8), Some(1.0));
+        // Outer 100 minus the 4×4 hole = 84.
+        assert_eq!(filled(&out), 84);
+    }
+
+    #[test]
+    fn hole_winding_does_not_matter() {
+        // Same hole wound the opposite way still punches out (even-odd rule).
+        let mut cw = vec![None; 100];
+        let mut ccw = vec![None; 100];
+        let hole_cw = vec![[3.0, 3.0], [7.0, 3.0], [7.0, 7.0], [3.0, 7.0]];
+        let hole_ccw = vec![[3.0, 3.0], [3.0, 7.0], [7.0, 7.0], [7.0, 3.0]];
+        fill_polygon(
+            &mut cw,
+            10,
+            10,
+            &square(0.0, 0.0, 10.0, 10.0),
+            &[hole_cw],
+            1.0,
+            Combine::Replace,
+        );
+        fill_polygon(
+            &mut ccw,
+            10,
+            10,
+            &square(0.0, 0.0, 10.0, 10.0),
+            &[hole_ccw],
+            1.0,
+            Combine::Replace,
+        );
+        assert_eq!(cw, ccw);
+        assert_eq!(filled(&cw), 84);
+    }
+
+    #[test]
+    fn clips_at_every_tile_edge() {
+        // A polygon larger than the tile on all four sides fills every pixel.
+        let mut out = vec![None; 100];
+        fill_polygon(
+            &mut out,
+            10,
+            10,
+            &square(-5.0, -5.0, 15.0, 15.0),
+            &[],
+            1.0,
+            Combine::Replace,
+        );
+        assert_eq!(filled(&out), 100);
+
+        // Each edge individually: a polygon poking across just one edge fills
+        // only its visible span, never panics, never touches the far side.
+        // Off the LEFT edge: x∈[-5,4] visible as 0..4.
+        let mut left = vec![None; 100];
+        fill_polygon(
+            &mut left,
+            10,
+            10,
+            &square(-5.0, 2.0, 4.0, 8.0),
+            &[],
+            1.0,
+            Combine::Replace,
+        );
+        assert_eq!(at(&left, 10, 0, 5), Some(1.0));
+        assert_eq!(at(&left, 10, 3, 5), Some(1.0));
+        assert_eq!(at(&left, 10, 5, 5), None);
+
+        // Off the RIGHT edge: x∈[6,15] visible as 6..10.
+        let mut right = vec![None; 100];
+        fill_polygon(
+            &mut right,
+            10,
+            10,
+            &square(6.0, 2.0, 15.0, 8.0),
+            &[],
+            1.0,
+            Combine::Replace,
+        );
+        assert_eq!(at(&right, 10, 9, 5), Some(1.0));
+        assert_eq!(at(&right, 10, 6, 5), Some(1.0));
+        assert_eq!(at(&right, 10, 4, 5), None);
+
+        // Off the TOP edge: y∈[-5,4] visible as 0..4.
+        let mut top = vec![None; 100];
+        fill_polygon(
+            &mut top,
+            10,
+            10,
+            &square(2.0, -5.0, 8.0, 4.0),
+            &[],
+            1.0,
+            Combine::Replace,
+        );
+        assert_eq!(at(&top, 10, 5, 0), Some(1.0));
+        assert_eq!(at(&top, 10, 5, 3), Some(1.0));
+        assert_eq!(at(&top, 10, 5, 5), None);
+
+        // Off the BOTTOM edge: y∈[6,15] visible as 6..10.
+        let mut bottom = vec![None; 100];
+        fill_polygon(
+            &mut bottom,
+            10,
+            10,
+            &square(2.0, 6.0, 8.0, 15.0),
+            &[],
+            1.0,
+            Combine::Replace,
+        );
+        assert_eq!(at(&bottom, 10, 5, 9), Some(1.0));
+        assert_eq!(at(&bottom, 10, 5, 6), Some(1.0));
+        assert_eq!(at(&bottom, 10, 5, 4), None);
+    }
+
+    #[test]
+    fn degenerate_rings_fill_nothing() {
+        // Collinear exterior (zero area).
+        let mut collinear = vec![None; 100];
+        fill_polygon(
+            &mut collinear,
+            10,
+            10,
+            &[[0.0, 0.0], [5.0, 0.0], [10.0, 0.0]],
+            &[],
+            1.0,
+            Combine::Replace,
+        );
+        assert_eq!(filled(&collinear), 0);
+
+        // Fewer than 3 vertices.
+        let mut two = vec![None; 100];
+        fill_polygon(
+            &mut two,
+            10,
+            10,
+            &[[1.0, 1.0], [8.0, 8.0]],
+            &[],
+            1.0,
+            Combine::Replace,
+        );
+        assert_eq!(filled(&two), 0);
+
+        // Empty ring.
+        let mut empty = vec![None; 100];
+        fill_polygon(&mut empty, 10, 10, &[], &[], 1.0, Combine::Replace);
+        assert_eq!(filled(&empty), 0);
+    }
+
+    #[test]
+    fn combine_max_is_order_independent() {
+        // Three overlapping fills of the whole tile with values 1, 3, 2 in any
+        // order resolve to the max (3) under Combine::Max.
+        let orders: [[f64; 3]; 2] = [[1.0, 3.0, 2.0], [2.0, 1.0, 3.0]];
+        for vals in orders {
+            let mut out = vec![None; 100];
+            for v in vals {
+                fill_polygon(
+                    &mut out,
+                    10,
+                    10,
+                    &square(0.0, 0.0, 10.0, 10.0),
+                    &[],
+                    v,
+                    Combine::Max,
+                );
+            }
+            assert_eq!(at(&out, 10, 5, 5), Some(3.0), "order {vals:?}");
+        }
+    }
+
+    #[test]
+    fn combine_replace_and_first() {
+        let sq = square(0.0, 0.0, 10.0, 10.0);
+        // Replace → last writer wins.
+        let mut replace = vec![None; 100];
+        fill_polygon(&mut replace, 10, 10, &sq, &[], 1.0, Combine::Replace);
+        fill_polygon(&mut replace, 10, 10, &sq, &[], 9.0, Combine::Replace);
+        assert_eq!(at(&replace, 10, 5, 5), Some(9.0));
+
+        // First → first writer wins (only nodata is filled).
+        let mut first = vec![None; 100];
+        fill_polygon(&mut first, 10, 10, &sq, &[], 1.0, Combine::First);
+        fill_polygon(&mut first, 10, 10, &sq, &[], 9.0, Combine::First);
+        assert_eq!(at(&first, 10, 5, 5), Some(1.0));
+    }
+
+    #[test]
+    fn mismatched_buffer_is_noop() {
+        let mut out = vec![None; 50]; // not 10*10
+        fill_polygon(
+            &mut out,
+            10,
+            10,
+            &square(0.0, 0.0, 10.0, 10.0),
+            &[],
+            1.0,
+            Combine::Replace,
+        );
+        assert_eq!(filled(&out), 0);
+    }
+
+    #[test]
+    fn non_finite_vertices_are_skipped() {
+        // A vertex outside a projection's domain (NaN) must not panic or
+        // corrupt the fill; the touching edges are dropped.
+        let mut out = vec![None; 100];
+        let ring = vec![[2.0, 2.0], [f64::NAN, 4.0], [8.0, 8.0], [2.0, 8.0]];
+        fill_polygon(&mut out, 10, 10, &ring, &[], 1.0, Combine::Replace);
+        // No panic; the result is well-defined (whatever the finite edges give).
+        // The key contract is robustness, not a specific shape.
+        let _ = filled(&out);
+    }
+}

--- a/crates/render/src/rasterize.rs
+++ b/crates/render/src/rasterize.rs
@@ -68,6 +68,13 @@ pub fn fill_polygon(
     value: f64,
     combine: Combine,
 ) {
+    // Precondition: fill values are finite (severity/category codes). A
+    // non-finite `value` would make `Combine::Max` order-dependent — an empty
+    // slot stores `Some(NaN)` while a populated slot drops it via `f64::max` —
+    // breaking the documented draw-order independence. Assert in debug builds
+    // to catch misuse rather than silently violating the contract.
+    debug_assert!(value.is_finite(), "fill_polygon value must be finite");
+
     let (w, h) = (width as usize, height as usize);
     if w == 0 || h == 0 || out.len() != w.saturating_mul(h) {
         return;


### PR DESCRIPTION
Implements #397 — a **shared vector polygon → raster fill primitive in `ds-render`** so any vector source (alert/hazard areas) can be rendered as a colored WMS/Maps/Tiles layer, not just exposed as Features. Built once, reusable, rather than re-deriving scan-conversion in each engine. Foundation/dependency for CAP (#396), GeoJSON Maps (#398), and IWXXM (#399).

## What's in this PR

Clean split that keeps the framework-free invariants (`ds-render` = `ds-core` + `png`; CRS math stays in `ds-core::geo`):

**1. Projection — `ds_core::geo::geometry_to_pixels` (vertices only)**
- Projects a `Geometry`'s polygon rings into output **pixel** space via `OutputCrs::world_to_fraction` — projecting *vertices*, never per output pixel (per #203).
- Returns `PixelGeometry { polygons: Vec<PixelPolygon { exterior, holes }> }` — `Polygon` → one, `MultiPolygon` → one per member, `Point`/`Null` → none.

**2. Fill — `ds_render::rasterize::fill_polygon` (pure 2-D scanline)**
- Even-odd scanline conversion over the combined exterior + hole edge set, so holes punch out **regardless of winding** (robust to inconsistently-wound source data).
- Spans clip to `[0,width) × [0,height)` — polygons partly off-tile fill only their visible span (load-bearing for tiled WMS/Maps).
- `Combine::{Replace, Max, First}` overlap policy. `Combine::Max` resolves overlapping alerts to the highest severity **deterministically, regardless of draw order** (CAP's policy).
- No `ds-render` colorization changes: it fills a `Vec<Option<f64>>` *before* colorize, so the existing `LutColorMap`/`IntegerLutColorMap` pipeline styles the result.

## Acceptance criteria

- [x] `fill_polygon` unit tests: convex, concave, holes (+ winding-independence), per-tile-edge clipping, degenerate/collinear rings, `Combine::Max` overlap (order-independent), buffer-mismatch no-op, non-finite vertices.
- [x] `geometry_to_pixels` tests for `Wgs84`, `WebMercator`, and a `Projected` (EPSG:3067) output, pinned against expected pixel coords (central-meridian `fx=0.5` is an independent pin).
- [x] Antimeridian-crossing polygon behavior documented as a v1 limitation.
- [ ] **#396 (CAP) adoption** — intentionally **out of scope** here; CAP is not yet implemented. This PR is the dependency it will adopt.

## Out of scope / follow-ups (per the issue)

Edge densification for large projected polygons, antimeridian splitting, line/point styling, anti-aliased edges.

## Testing

- `cargo test -p ds-core` (5 new `geometry_to_pixels` tests) — green
- `cargo test -p ds-render` (10 new `rasterize` tests) — green
- `cargo fmt` + `cargo clippy -p ds-core -p ds-render --all-targets` — clean
- `cargo check --workspace` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)