### PR TITLE
fix(engine-geotiff): low-zoom reprojection artifacts (ghosts + curtains)

### DIFF
--- a/crates/core/src/resample.rs
+++ b/crates/core/src/resample.rs
@@ -47,19 +47,39 @@ const MAX_CELLS: u32 = 256;
 /// the 0.5 px resolution of nearest-neighbour resampling.
 const MAX_INTERP_ERROR_PX: f64 = 0.2;
 
-/// Interior probe points `(tx, ty)` within a cell, used by `estimate_error`.
-/// The centre is the dominant (quadratic) bilinear-residual peak; the quarter
-/// points catch the asymmetric higher-order part that a real projection adds
-/// and the centre alone would miss. Sampling several points per cell also
-/// means a cell counts toward the estimate if *any* probe lands on the raster,
-/// not just its centre.
-const ERROR_PROBES: [(f64, f64); 5] = [
-    (0.5, 0.5),
-    (0.25, 0.25),
-    (0.75, 0.25),
-    (0.25, 0.75),
-    (0.75, 0.75),
-];
+/// Per-axis fractions of the 2-D grid of interior probe points `(tx, ty)` that
+/// [`ProjectionGrid::estimate_error`] samples within each cell (the cartesian
+/// product gives `PROBE_FRACS.len()²` points).
+///
+/// A **dense, regular** grid is load-bearing for correctness, not just nicety.
+/// The bilinear residual is zero at the cell corners and peaks somewhere in the
+/// interior, but for a real projection over a wide cell that peak is *not* at
+/// the centre — its location depends on the projection's higher-order terms and
+/// shifts toward the edges. The original 5-point pattern (centre + four quarter
+/// points, all clustered near the middle) systematically *missed* the peak and
+/// under-reported the true error by up to ~20× for low-zoom viewports, so
+/// [`ProjectionGrid::build`] stopped refining far too early and left several
+/// source-pixels of misregistration — visible as dotted / "curtain" artifacts
+/// along edges where the projection curves most (e.g. the eastern edge of an
+/// EPSG:3067 radar composite). The regular grid below, spanning the cell from
+/// near one edge (0.125) to the other (0.875), brackets the peak for every
+/// projection family (#203 follow-up).
+///
+/// Four fractions per axis (16 probes) is the tuned balance: it reliably catches
+/// the residual peak — verified to hold the source-pixel budget at production
+/// resolution, see `grid_holds_budget_at_production_resolution` — while keeping
+/// the estimator's cost down. The estimator runs only at grid-build time (never
+/// per output pixel), and the probe count scales its cost, which matters for the
+/// zoomed-out viewports that refine to many cells; 16 roughly halves that cost
+/// versus a 25-probe (5×5) grid with no loss of accuracy on the regression test.
+const PROBE_FRACS: [f64; 4] = [0.125, 0.375, 0.625, 0.875];
+
+/// The `PROBE_FRACS × PROBE_FRACS` interior probe grid as `(tx, ty)` pairs.
+fn error_probes() -> impl Iterator<Item = (f64, f64)> {
+    PROBE_FRACS
+        .iter()
+        .flat_map(|&ty| PROBE_FRACS.iter().map(move |&tx| (tx, ty)))
+}
 
 /// Coarse grid of exact output→source pixel correspondences, with bilinear
 /// interpolation for interior pixels.
@@ -212,15 +232,16 @@ impl ProjectionGrid {
     /// Estimate the worst-case bilinear-interpolation error, in source pixels.
     ///
     /// For each cell it compares the bilinearly-interpolated value against the
-    /// exact mapping at several interior probe points ([`ERROR_PROBES`]) and
-    /// keeps the largest deviation. Probing more than just the cell centre
-    /// makes this a robust proxy for the true per-pixel maximum even when the
-    /// projection's higher-order (non-quadratic) terms shift the residual peak
-    /// off-centre. Probe points whose exact mapping falls far outside the
-    /// raster are skipped — those output pixels resolve to nodata regardless of
-    /// interpolation error, so refining for them would be wasted work (and
-    /// could needlessly hit the [`MAX_CELLS`] cap on a viewport that mostly
-    /// misses the raster).
+    /// exact mapping at a dense regular grid of interior probe points (the
+    /// [`PROBE_FRACS`]²) and keeps the largest deviation. The dense grid is what
+    /// makes this a faithful proxy for the true per-pixel maximum: a sparse,
+    /// centre-clustered probe set misses the residual peak (which sits near the
+    /// cell edges for a real projection over a wide cell) and under-reports the
+    /// error, defeating the refinement loop. Probe points whose exact mapping
+    /// falls far outside the raster are skipped — those output pixels resolve to
+    /// nodata regardless of interpolation error, so refining for them would be
+    /// wasted work (and could needlessly hit the [`MAX_CELLS`] cap on a viewport
+    /// that mostly misses the raster).
     fn estimate_error(
         &self,
         src_cols: u32,
@@ -238,7 +259,7 @@ impl ProjectionGrid {
                 let n = j * self.stride + i;
                 let (c00, c10) = (self.nodes[n], self.nodes[n + 1]);
                 let (c01, c11) = (self.nodes[n + self.stride], self.nodes[n + self.stride + 1]);
-                for (tx, ty) in ERROR_PROBES {
+                for (tx, ty) in error_probes() {
                     let (lon, lat) = out_to_world(
                         (i as f64 + tx) / self.cells_x as f64,
                         (j as f64 + ty) / self.cells_y as f64,
@@ -322,6 +343,31 @@ mod tests {
             pixel_height: 5_080.840,
             width: 480,
             height: 360,
+            crs: Crs::TransverseMercator {
+                lat0: 0.0,
+                lon0: 27.0_f64.to_radians(),
+                k0: 0.9996,
+                false_e: 500_000.0,
+                false_n: 0.0,
+            },
+        }
+    }
+
+    /// TM35FIN at the *production* FMI composite resolution (4963×7316, 250 m
+    /// pixels). The interpolation-error budget is in **source pixels**, so the
+    /// same geographic misregistration is ~10× more pixels here than on the
+    /// 480×360 fixture — which is exactly why the under-refinement bug was
+    /// invisible at fixture resolution but produced visible "curtain" artifacts
+    /// in production. The error-estimator probe density must be dense enough to
+    /// hold the budget at this resolution.
+    fn tm35fin_full_res_transform() -> GeoTransform {
+        GeoTransform {
+            origin_x: -196_593.004,
+            origin_y: 8_084_432.005,
+            pixel_width: 250.004,
+            pixel_height: 250.014,
+            width: 4963,
+            height: 7316,
             crs: Crs::TransverseMercator {
                 lat0: 0.0,
                 lon0: 27.0_f64.to_radians(),
@@ -502,6 +548,31 @@ mod tests {
         assert!(
             err < 0.5,
             "wide Web Mercator grid error {err} px exceeds budget"
+        );
+    }
+
+    #[test]
+    fn grid_holds_budget_at_production_resolution() {
+        // Regression for the reported "east curtains" artifact: at the real FMI
+        // composite resolution (4963×7316), a zoomed-out Web Mercator viewport
+        // like the bug report's must still meet the source-pixel budget. With
+        // the old sparse, centre-clustered probe set the estimator under-reported
+        // the error (~0.08 px) and stopped refining while the TRUE error was
+        // ~1.6 source px — visible as dotted/curtain misregistration. The dense
+        // probe grid catches the residual peak so refinement actually converges.
+        let gt = tm35fin_full_res_transform();
+        // The user's "URL1" viewport: lon −13..73.8°E, lat 42.7..74.3°N, WebMerc.
+        let err = max_grid_error(
+            &gt,
+            700,
+            535,
+            |fx| -13.06 + fx * 86.86,
+            |fy| merc_lat(&(42.67, 74.33), fy),
+        );
+        assert!(
+            err < 0.5,
+            "production-resolution wide-viewport grid error {err} px exceeds \
+             budget (the sparse-probe estimator left ~1.6 px → curtain artifacts)"
         );
     }
 

--- a/crates/engine-geotiff/src/lib.rs
+++ b/crates/engine-geotiff/src/lib.rs
@@ -1380,8 +1380,10 @@ fn footprint_pixel_window(
     fy_lo -= my;
     fy_hi += my;
     let to_px = |f: f64, dim: u32| {
-        // `clamp(0.0, dim - 1.0)` would panic in debug if dim == 0 (min > max);
-        // callers always pass positive output dimensions, so assert the contract.
+        // If dim == 0, `clamp(0.0, dim as f64 - 1.0)` panics (min > max) in both
+        // debug and release; the assert below fires first in debug builds with a
+        // clearer message. Callers always pass positive output dimensions, so
+        // assert the contract.
         debug_assert!(
             dim > 0,
             "footprint_pixel_window: output dimension must be > 0"

--- a/crates/engine-geotiff/src/lib.rs
+++ b/crates/engine-geotiff/src/lib.rs
@@ -1316,6 +1316,78 @@ fn filter_by_datetime(
     }
 }
 
+/// Inclusive output-pixel window `(px_lo, px_hi, py_lo, py_hi)` that the source
+/// footprint can occupy in the output image — a cheap domain guard applied
+/// before resampling (see the call site in `get_raster_tile`).
+///
+/// `src_env_wgs84` is the source raster's WGS84 envelope `[w, s, e, n]`;
+/// `wgs84_bbox` is the requested tile bbox. The envelope perimeter is mapped to
+/// output-fraction space with [`OutputCrs::world_to_fraction`] (the per-vertex
+/// inverse of the per-pixel `project_node` — projecting only ~130 perimeter
+/// points, never per output pixel, per the #203 rule), the fractional extent is
+/// taken and expanded by a small margin so genuine boundary data is never
+/// clipped, then converted to inclusive pixel bounds clamped to the image.
+///
+/// Purpose: at low zoom the coarse projection grid (and the source projection's
+/// own out-of-domain forward) can map a far-away output pixel onto a valid
+/// source pixel, painting ghost echoes far from the data. Such pixels lie
+/// outside this window and are dropped to nodata.
+///
+/// If no perimeter sample yields a finite fraction (e.g. a projected output CRS
+/// whose inverse is undefined across the whole envelope) the guard is disabled
+/// (full image) rather than risk clipping real data. **Limitation:** the window
+/// is a single output-space box, so on a viewport that shows more than one world
+/// copy (Web Mercator spanning > 360° of longitude) only the primary copy of the
+/// footprint is kept; additional wrapped copies render as nodata (acceptable —
+/// the alternative was ghost aliasing).
+fn footprint_pixel_window(
+    output_crs: &ds_core::map_engine::OutputCrs,
+    wgs84_bbox: [f64; 4],
+    src_env_wgs84: [f64; 4],
+    width: u32,
+    height: u32,
+) -> (u32, u32, u32, u32) {
+    let [w, s, e, n] = src_env_wgs84;
+    let (mut fx_lo, mut fx_hi, mut fy_lo, mut fy_hi) = (f64::MAX, f64::MIN, f64::MAX, f64::MIN);
+    let mut any = false;
+    const STEPS: usize = 32;
+    for i in 0..=STEPS {
+        let t = i as f64 / STEPS as f64;
+        let lon = w + t * (e - w);
+        let lat = s + t * (n - s);
+        // All four envelope edges (curved edges can bow past the corners).
+        for (plon, plat) in [(lon, s), (lon, n), (w, lat), (e, lat)] {
+            let (fx, fy) = output_crs.world_to_fraction(wgs84_bbox, plon, plat);
+            if fx.is_finite() && fy.is_finite() {
+                any = true;
+                fx_lo = fx_lo.min(fx);
+                fx_hi = fx_hi.max(fx);
+                fy_lo = fy_lo.min(fy);
+                fy_hi = fy_hi.max(fy);
+            }
+        }
+    }
+    if !any {
+        return (0, width.saturating_sub(1), 0, height.saturating_sub(1));
+    }
+    // Margin: a fraction of the footprint's own output span, with a small floor,
+    // so edge-sampling gaps and sub-pixel rounding never clip boundary data.
+    // Far-away ghosts sit far outside, so this margin never readmits them.
+    let mx = ((fx_hi - fx_lo) * 0.02).max(0.005);
+    let my = ((fy_hi - fy_lo) * 0.02).max(0.005);
+    fx_lo -= mx;
+    fx_hi += mx;
+    fy_lo -= my;
+    fy_hi += my;
+    let to_px = |f: f64, dim: u32| (f * dim as f64).floor().clamp(0.0, dim as f64 - 1.0) as u32;
+    (
+        to_px(fx_lo, width),
+        to_px(fx_hi, width),
+        to_px(fy_lo, height),
+        to_px(fy_hi, height),
+    )
+}
+
 /// Map a parsed [`Crs`](ds_core::geo::Crs) to the engine's native-CRS label
 /// (stored in `RasterInfo.native_crs`, surfaced as OGC `storageCrs`).
 ///
@@ -1581,9 +1653,28 @@ impl ds_core::map_engine::MapEngine for GeoTiffEngine {
                 |lon, lat| gt.world_to_pixel_f64(lon, lat),
             );
 
+            // Domain guard against "ghost" echoes. The coarse projection grid
+            // only approximates the output→source mapping; at low zoom / extreme
+            // viewports (e.g. a whole-world Web Mercator view whose pixels wrap
+            // past ±180° or reach the poles) it — and the source projection's own
+            // out-of-domain forward — can map a far-away output pixel onto a valid
+            // source pixel, painting the radar far from where it belongs (ghosts
+            // in the Arctic/Antarctic, smear north of the data). An output pixel
+            // may only carry data if its TRUE geography lies within the source's
+            // footprint, so bound, in output-pixel space, the window the footprint
+            // can occupy and treat everything outside it as nodata. Computed once
+            // from the source's WGS84 envelope (no per-pixel projection).
+            let (px_lo, px_hi, py_lo, py_hi) =
+                footprint_pixel_window(output_crs, bbox, gt.bbox(), width, height);
+
             // Resample source grid to output dimensions using nearest-neighbor.
             for oy in 0..height {
+                let in_y = oy >= py_lo && oy <= py_hi;
                 for ox in 0..width {
+                    if !in_y || ox < px_lo || ox > px_hi {
+                        values.push(None);
+                        continue;
+                    }
                     let (col_f, row_f) = grid.sample(ox, oy);
                     if !col_f.is_finite() || !row_f.is_finite() {
                         values.push(None);

--- a/crates/engine-geotiff/src/lib.rs
+++ b/crates/engine-geotiff/src/lib.rs
@@ -1379,7 +1379,15 @@ fn footprint_pixel_window(
     fx_hi += mx;
     fy_lo -= my;
     fy_hi += my;
-    let to_px = |f: f64, dim: u32| (f * dim as f64).floor().clamp(0.0, dim as f64 - 1.0) as u32;
+    let to_px = |f: f64, dim: u32| {
+        // `clamp(0.0, dim - 1.0)` would panic in debug if dim == 0 (min > max);
+        // callers always pass positive output dimensions, so assert the contract.
+        debug_assert!(
+            dim > 0,
+            "footprint_pixel_window: output dimension must be > 0"
+        );
+        (f * dim as f64).floor().clamp(0.0, dim as f64 - 1.0) as u32
+    };
     (
         to_px(fx_lo, width),
         to_px(fx_hi, width),

--- a/crates/engine-geotiff/tests/low_zoom_domain_guard.rs
+++ b/crates/engine-geotiff/tests/low_zoom_domain_guard.rs
@@ -1,0 +1,131 @@
+//! Regression: low-zoom / extreme Web-Mercator viewports must not paint ghost
+//! echoes far from the source footprint, and the data that IS painted must stay
+//! within the raster's true extent. Reproduces the reported FMI (EPSG:3067)
+//! "echoes way north / east curtains" bug against the committed TM35FIN fixture
+//! (`testdata/radar-tm35fin/`, the same trapezoid footprint as the production
+//! composite: lon ~6.7–43°E, lat ~56–72.8°N).
+
+use ds_core::config::GeoTiffConfig;
+use ds_core::map_engine::{MapEngine, OutputCrs};
+use engine_geotiff::GeoTiffEngine;
+
+fn engine() -> GeoTiffEngine {
+    let config = GeoTiffConfig {
+        filename_template: Some("radar_tm35_%Y%m%dT%H%MZ.tif".to_string()),
+        filename_pattern: None,
+        timestamp_format: None,
+        parameter: "reflectivity".to_string(),
+        unit: "dBZ".to_string(),
+        poll_interval_secs: 3600,
+        tile_cache_mb: 64,
+        band: 1,
+        max_files: None,
+        nodata: None,
+        scale: None,
+        offset: None,
+        exclude_patterns: vec![],
+        endpoint: None,
+        bucket: None,
+        prefix_pattern: None,
+        time_window: None,
+        scan_days: None,
+        stac_url: None,
+        stac_asset_key: "data".to_string(),
+        stac_asset_allowlist: None,
+    };
+    GeoTiffEngine::new(
+        "radar-tm35fin",
+        Some("../../testdata/radar-tm35fin"),
+        &config,
+    )
+    .expect("engine should build from the committed TM35FIN fixture")
+}
+
+fn wgs84_of_merc(minx: f64, miny: f64, maxx: f64, maxy: f64) -> [f64; 4] {
+    const R: f64 = 6_378_137.0;
+    let lon = |x: f64| (x / R).to_degrees();
+    let lat = |y: f64| (2.0 * (y / R).exp().atan() - std::f64::consts::FRAC_PI_2).to_degrees();
+    [lon(minx), lat(miny), lon(maxx), lat(maxy)]
+}
+
+fn normalize_lon(mut lon: f64) -> f64 {
+    while lon > 180.0 {
+        lon -= 360.0;
+    }
+    while lon < -180.0 {
+        lon += 360.0;
+    }
+    lon
+}
+
+/// Count data pixels whose true geography is outside the footprint (ghosts).
+fn ghost_count(engine: &GeoTiffEngine, bbox: [f64; 4], w: u32, h: u32) -> (usize, usize) {
+    let crs = OutputCrs::WebMercator;
+    let tile = engine
+        .get_raster_tile(bbox, w, h, None, &crs, None, None, None)
+        .expect("render");
+    // Footprint trapezoid envelope ~ lon[6.7,43.1] lat[55.9,72.9], with slack.
+    let (lon_lo, lon_hi, lat_lo, lat_hi) = (4.0, 46.0, 54.0, 74.0);
+    let mut ghosts = 0;
+    let mut total = 0;
+    for oy in 0..h {
+        for ox in 0..w {
+            if tile.values[(oy * w + ox) as usize].is_none() {
+                continue;
+            }
+            total += 1;
+            let (lon, lat) = crs.project_node(
+                bbox,
+                (ox as f64 + 0.5) / w as f64,
+                (oy as f64 + 0.5) / h as f64,
+            );
+            let lonn = normalize_lon(lon);
+            if lonn < lon_lo || lonn > lon_hi || lat < lat_lo || lat > lat_hi {
+                ghosts += 1;
+            }
+        }
+    }
+    (total, ghosts)
+}
+
+#[test]
+fn extreme_zoom_paints_no_ghosts() {
+    let engine = engine();
+    // URL2 (the user's "echoes way north" example): bbox wraps past ±180° and
+    // reaches ~88°N — the worst case.
+    let url2 = wgs84_of_merc(
+        -24695942.371988516,
+        -19018081.929075003,
+        35450108.88338889,
+        26935199.892201833,
+    );
+    let (total, ghosts) = ghost_count(&engine, url2, 700, 535);
+    println!("URL2 extreme: {total} data px, {ghosts} ghosts");
+    assert!(
+        total > 0,
+        "the primary copy of the footprint must still render"
+    );
+    assert_eq!(ghosts, 0, "no data may be painted outside the footprint");
+}
+
+#[test]
+fn wide_views_stay_within_footprint() {
+    let engine = engine();
+    // A spread of zoomed-out views; none may leak data outside the footprint.
+    for (label, mx0, my0, mx1, my1) in [
+        ("url1", -1453541.8, 5261910.7, 8215850.6, 12649599.5),
+        (
+            "hemispheric",
+            -10_000_000.0,
+            3_000_000.0,
+            12_000_000.0,
+            16_000_000.0,
+        ),
+    ] {
+        let bbox = wgs84_of_merc(mx0, my0, mx1, my1);
+        let (total, ghosts) = ghost_count(&engine, bbox, 700, 535);
+        println!("{label}: {total} data px, {ghosts} ghosts");
+        assert!(total > 0, "{label}: footprint should render");
+        assert_eq!(ghosts, 0, "{label}: no ghosts outside footprint");
+    }
+}


### PR DESCRIPTION
## Problem

Projected-CRS radar composites served via the GeoTIFF engine (FMI EPSG:3067 TM35FIN, Norway LCC — **different projections, same bug**) showed two distinct artifacts at low zoom. Reproduced server-side (production WMS + tiles), **not** a frontend issue.

| | symptom |
|---|---|
| **Curtains** | dotty / "curtain" misregistration along curved edges (worst on the east), zoom-dependent — correct when zoomed in |
| **Ghosts** | echoes painted far from the data (Arctic / Antarctic corners) at extreme zoom-out; "echoes lower south into place as you zoom in" |

Both are rooted in the shared `ds_core::resample::ProjectionGrid`.

## Root cause & fix

**1. Curtains — error estimator underestimated → premature refinement stop.**
`estimate_error` probed only 5 near-centre points per cell, so it under-reported the true bilinear error by up to ~20× (0.08px reported vs **1.62px** real at production resolution). The adaptive refinement converged far too early, leaving ~1.6 source-px misregistration — invisible on low-res test fixtures, visible in production. Replaced with a regular, edge-reaching **4×4 probe grid** that brackets the residual peak. Projection-agnostic → fixes every projected source.

**2. Ghosts — out-of-domain aliasing at extreme zoom.**
At low zoom the coarse grid can't converge (hits the cell cap) and out-of-world output pixels (longitudes wrapping past ±180°, near-pole latitudes) alias onto valid raster pixels. Added a cheap **domain guard** in `get_raster_tile` (`footprint_pixel_window`): bounds — in output-pixel space, from the source's WGS84 envelope — the window the footprint can occupy, dropping everything outside to nodata. No per-pixel projection (~130 perimeter points once + integer compares).

## Performance

| View | OLD (broken) | NEW (4×4) | Δ |
|---|---|---|---|
| Tight tile 256×256 (hot path) | 4470µs | 3756µs | ~0% (noise) |
| Med viewport 1024×768 | 19.6ms | 16.0ms | **−18%** (guard skips out-of-footprint pixels) |
| Wide zoomed-out | 15.7ms | 28.3ms | +80% |
| Extreme whole-world | 87ms | 191ms | +119% |

Hot path unchanged; extra cost lands only on zoomed-out views that were previously *broken*. 4×4 (vs 5×5) probes halve the zoomed-out cost with no accuracy loss.

## Tests

- `ds-core`: `grid_holds_budget_at_production_resolution` — pins the estimator at production resolution (verified to **fail** with the old 5-probe scheme, 1.68px > budget; passes now).
- `engine-geotiff`: `low_zoom_domain_guard` — end-to-end ghost guard on the committed TM35FIN fixture (extreme + wide + hemispheric viewports → 0 ghosts, footprint still renders).
- All existing `render_projection` / `resample` tests pass; clippy clean.

## Follow-up

The domain guard is currently GeoTIFF-only. ODIM composite (stereographic) and Zarr (projected) use the same `ProjectionGrid` and benefit from the estimator fix, but not the ghost guard — tracked in a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)