### PR TITLE
fix(docker): force workspace recompile after cargo-chef cook (stale-binary bug)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,6 +69,20 @@ RUN cargo chef cook --release --locked --recipe-path recipe.json -p server \
 # Now copy the actual workspace source and build. Only the changed
 # workspace member's crate needs to recompile; deps are already linked.
 COPY . .
+# Force the workspace crates to recompile against the REAL source.
+#
+# `cargo chef cook` (above) compiled every workspace crate as an empty stub.
+# `COPY . .` then lays down the real sources, but BuildKit preserves their
+# build-context mtime (the git-checkout time). When the `cook` layer is rebuilt
+# (any Cargo.lock change busts its cache), its stub artifacts in `target/` end
+# up with a *newer* mtime than these just-copied real sources — so cargo's
+# mtime-based fingerprint decides the workspace crates are "up to date" and
+# links the stale stub objects, silently shipping a binary that lags the
+# source. (Observed in prod: an engine fix was present in the image's source
+# but absent from its compiled binary.) `touch`ing the sources to "now"
+# guarantees a real recompile of the workspace crates while still reusing
+# cook's (untouched) dependency artifacts.
+RUN find crates -type f -exec touch {} +
 RUN cargo build --release --locked -p server \
         ${CARGO_FEATURES:+--features "$CARGO_FEATURES"}
 


### PR DESCRIPTION
## Summary

The Docker image can ship a **compiled binary that lags its own source** — a silent, serious build bug.

The builder uses `cargo-chef`: `cook` compiles every workspace crate as an empty **stub**, then `COPY . .` lays down the real sources and `cargo build` is meant to recompile them. But BuildKit preserves the copied files' **build-context (git-checkout) mtime**, and when the `cook` layer is rebuilt (any `Cargo.lock` change busts its cache), its stub artifacts in `target/` get a **newer** mtime than the copied sources. Cargo's mtime-based fingerprint then decides `ds-core`/`engine-geotiff`/etc. are "up to date" and **links the stale stub objects** instead of recompiling.

## How it was found

The #448 GeoTIFF low-zoom reprojection fix was confirmed **present in the deployed image's source** (revision label `1ec84f4`, which contains the fix) but **absent from its binary**: production still rendered the pre-fix output (Finland radar displaced ~10° north). Rendering the *exact same commit* locally produced the correct output, and rendering directly from the running container (bypassing the proxy) reproduced the stale output — isolating it to the binary inside the image, i.e. the build.

This affects **any** workspace-source change whenever the cook cache is rebuilt, not just #448.

## Fix

`touch` the workspace sources after `COPY . .` so they always post-date cook's stub artifacts, forcing a real recompile of the workspace crates while still reusing cook's (untouched) dependency artifacts:

```dockerfile
COPY . .
RUN find crates -type f -exec touch {} +
RUN cargo build --release --locked -p server ...
```

## Verification / rollout

- `Docker Build (PR)` CI confirms it still builds.
- After merge, the post-merge `:main` build produces a fresh binary (the new `touch` layer busts everything after it, so `cargo build` reruns with current-mtime source). Then redeploy `ghcr.io/mrauhala/meteocore:main` with `docker compose pull && docker compose up -d --force-recreate`.
- Verify: the FMI composite at a wide/extreme zoom should render over Finland (lat ~58–71°N), not displaced north.

🤖 Generated with [Claude Code](https://claude.com/claude-code)