### PR TITLE
feat(render): generalize low-zoom footprint domain guard into ds-core (#449)

### DIFF
--- a/crates/core/src/map_engine.rs
+++ b/crates/core/src/map_engine.rs
@@ -132,7 +132,10 @@ impl OutputCrs {
     /// domain guard for projected-raster resampling.
     ///
     /// `src_env_wgs84` is the source raster's WGS84 envelope `[w, s, e, n]`;
-    /// `wgs84_bbox` is the requested tile bbox. The envelope perimeter is mapped
+    /// `wgs84_bbox` is the requested tile bbox (for `Wgs84`/`WebMercator` output;
+    /// it is **ignored for `Projected` output**, whose extents are embedded in the
+    /// `Projected { crs, bbox }` variant — same as [`Self::world_to_fraction`]).
+    /// The envelope perimeter is mapped
     /// to output-fraction space with [`Self::world_to_fraction`] (the per-vertex
     /// inverse of the per-pixel [`Self::project_node`] — only ~130 perimeter
     /// points, never per output pixel, per the #203 rule), the fractional extent
@@ -444,6 +447,37 @@ mod tests {
         );
         // The footprint centre (lon 25.5, lat ~64.5) must fall inside the window.
         let (cfx, cfy) = crs.world_to_fraction(view, 25.5, 64.5);
+        let (cx, cy) = ((cfx * w as f64) as u32, (cfy * h as f64) as u32);
+        assert!(
+            (px_lo..=px_hi).contains(&cx) && (py_lo..=py_hi).contains(&cy),
+            "footprint centre must be inside the window"
+        );
+    }
+
+    #[test]
+    fn footprint_window_bounds_source_for_projected_output() {
+        // ODIM COMP serves EPSG:3067 national-grid requests via `Projected`
+        // output (a different `world_to_fraction` path — `crs.forward` against the
+        // embedded projected bbox). A view wider than the source footprint must
+        // yield a sub-window, and the footprint centre must fall inside it.
+        let crs = projected_output_crs("EPSG:3067").unwrap();
+        // Request rectangle in EPSG:3067 metres, deliberately wider than Finland.
+        let (e0, n0) = crs.forward(5.0, 53.0);
+        let (e1, n1) = crs.forward(45.0, 74.0);
+        let out = OutputCrs::Projected {
+            crs,
+            bbox: [e0.min(e1), n0.min(n1), e0.max(e1), n0.max(n1)],
+        };
+        let (w, h) = (800u32, 800u32);
+        // `wgs84_bbox` is ignored for `Projected`; pass the footprint either way.
+        let (px_lo, px_hi, py_lo, py_hi) =
+            out.footprint_pixel_window(FINLAND_WGS84, FINLAND_WGS84, w, h);
+        assert!(px_lo < px_hi && py_lo < py_hi, "window must be non-empty");
+        assert!(
+            px_lo > 0 || px_hi < w - 1 || py_lo > 0 || py_hi < h - 1,
+            "a view wider than the footprint must not span the full image"
+        );
+        let (cfx, cfy) = out.world_to_fraction(FINLAND_WGS84, 25.5, 64.5);
         let (cx, cy) = ((cfx * w as f64) as u32, (cfy * h as f64) as u32);
         assert!(
             (px_lo..=px_hi).contains(&cx) && (py_lo..=py_hi).contains(&cy),

--- a/crates/core/src/map_engine.rs
+++ b/crates/core/src/map_engine.rs
@@ -126,6 +126,89 @@ impl OutputCrs {
             }
         }
     }
+
+    /// Inclusive output-pixel window `(px_lo, px_hi, py_lo, py_hi)` that a source
+    /// raster's footprint can occupy in a `width`×`height` output image — a cheap
+    /// domain guard for projected-raster resampling.
+    ///
+    /// `src_env_wgs84` is the source raster's WGS84 envelope `[w, s, e, n]`;
+    /// `wgs84_bbox` is the requested tile bbox. The envelope perimeter is mapped
+    /// to output-fraction space with [`Self::world_to_fraction`] (the per-vertex
+    /// inverse of the per-pixel [`Self::project_node`] — only ~130 perimeter
+    /// points, never per output pixel, per the #203 rule), the fractional extent
+    /// is taken and expanded by a small margin so genuine boundary data is never
+    /// clipped, then converted to inclusive pixel bounds clamped to the image.
+    ///
+    /// Purpose: at low zoom the coarse [`crate::resample::ProjectionGrid`] (and
+    /// the source projection's own out-of-domain forward) can map a far-away
+    /// output pixel onto a valid source pixel, painting "ghost" data far from
+    /// the real coverage (e.g. radar echoes in the Arctic on a whole-world Web
+    /// Mercator view that wraps past ±180°). Pixels outside this window are
+    /// dropped to nodata. Shared by every projected raster engine (#449).
+    ///
+    /// If no perimeter sample yields a finite fraction (e.g. a projected output
+    /// CRS whose inverse is undefined across the whole envelope) the guard is
+    /// disabled (full image) rather than risk clipping real data. **Limitation:**
+    /// a single output-space box, so on a viewport showing more than one world
+    /// copy (Web Mercator spanning > 360° of longitude) only the primary copy of
+    /// the footprint is kept; wrapped copies render as nodata (acceptable — the
+    /// alternative was ghost aliasing).
+    pub fn footprint_pixel_window(
+        &self,
+        wgs84_bbox: [f64; 4],
+        src_env_wgs84: [f64; 4],
+        width: u32,
+        height: u32,
+    ) -> (u32, u32, u32, u32) {
+        let [w, s, e, n] = src_env_wgs84;
+        let (mut fx_lo, mut fx_hi, mut fy_lo, mut fy_hi) = (f64::MAX, f64::MIN, f64::MAX, f64::MIN);
+        let mut any = false;
+        const STEPS: usize = 32;
+        for i in 0..=STEPS {
+            let t = i as f64 / STEPS as f64;
+            let lon = w + t * (e - w);
+            let lat = s + t * (n - s);
+            // All four envelope edges (curved edges can bow past the corners).
+            for (plon, plat) in [(lon, s), (lon, n), (w, lat), (e, lat)] {
+                let (fx, fy) = self.world_to_fraction(wgs84_bbox, plon, plat);
+                if fx.is_finite() && fy.is_finite() {
+                    any = true;
+                    fx_lo = fx_lo.min(fx);
+                    fx_hi = fx_hi.max(fx);
+                    fy_lo = fy_lo.min(fy);
+                    fy_hi = fy_hi.max(fy);
+                }
+            }
+        }
+        if !any {
+            return (0, width.saturating_sub(1), 0, height.saturating_sub(1));
+        }
+        // Margin: a fraction of the footprint's own output span, with a small
+        // floor, so edge-sampling gaps and sub-pixel rounding never clip boundary
+        // data. Far-away ghosts sit far outside, so the margin never readmits them.
+        let mx = ((fx_hi - fx_lo) * 0.02).max(0.005);
+        let my = ((fy_hi - fy_lo) * 0.02).max(0.005);
+        fx_lo -= mx;
+        fx_hi += mx;
+        fy_lo -= my;
+        fy_hi += my;
+        let to_px = |f: f64, dim: u32| {
+            // If dim == 0, `clamp(0.0, dim as f64 - 1.0)` panics (min > max) in
+            // both debug and release; the assert below fires first in debug with
+            // a clearer message. Callers always pass positive output dimensions.
+            debug_assert!(
+                dim > 0,
+                "footprint_pixel_window: output dimension must be > 0"
+            );
+            (f * dim as f64).floor().clamp(0.0, dim as f64 - 1.0) as u32
+        };
+        (
+            to_px(fx_lo, width),
+            to_px(fx_hi, width),
+            to_px(fy_lo, height),
+            to_px(fy_hi, height),
+        )
+    }
 }
 
 /// A raster tile that can be colorized and served as a map image.
@@ -323,5 +406,45 @@ mod tests {
             let (gx, _) = out.world_to_fraction(FINLAND_WGS84, 5.0, 64.0);
             assert!(gx < 0.0, "west of the tile must map to fx < 0, got {gx}");
         }
+    }
+
+    #[test]
+    fn footprint_window_bounds_a_small_source_in_a_wide_view() {
+        // A whole-world-ish Web Mercator view; the Finland footprint occupies
+        // only a narrow band, so the guard window must be a small sub-rectangle
+        // — NOT the full image (that's what kills ghost echoes outside it).
+        let crs = OutputCrs::WebMercator;
+        let view = [-160.0, -60.0, 160.0, 80.0]; // wide [w,s,e,n]
+        let (w, h) = (1000u32, 1000u32);
+        let (px_lo, px_hi, py_lo, py_hi) = crs.footprint_pixel_window(view, FINLAND_WGS84, w, h);
+        assert!(px_lo < px_hi && py_lo < py_hi, "window must be non-empty");
+        // Finland (lon 19..32 of a -160..160 span) sits left-of-centre and is
+        // narrow; the window must exclude the far edges where ghosts appear.
+        assert!(
+            px_lo > 0 && px_hi < w - 1,
+            "x window must not span the image"
+        );
+        assert!(
+            py_lo > 0 && py_hi < h - 1,
+            "y window must not span the image"
+        );
+        // The footprint centre (lon 25.5, lat ~64.5) must fall inside the window.
+        let (cfx, cfy) = crs.world_to_fraction(view, 25.5, 64.5);
+        let (cx, cy) = ((cfx * w as f64) as u32, (cfy * h as f64) as u32);
+        assert!(
+            (px_lo..=px_hi).contains(&cx) && (py_lo..=py_hi).contains(&cy),
+            "footprint centre must be inside the window"
+        );
+    }
+
+    #[test]
+    fn footprint_window_is_permissive_when_view_is_inside_the_source() {
+        // Zoomed INTO the data (view ⊂ footprint): the window must cover the
+        // whole image so nothing legitimate is clipped.
+        let crs = OutputCrs::WebMercator;
+        let tight = [24.0, 63.0, 26.0, 65.0]; // well inside FINLAND_WGS84
+        let (w, h) = (256u32, 256u32);
+        let (px_lo, px_hi, py_lo, py_hi) = crs.footprint_pixel_window(tight, FINLAND_WGS84, w, h);
+        assert_eq!((px_lo, px_hi, py_lo, py_hi), (0, w - 1, 0, h - 1));
     }
 }

--- a/crates/core/src/map_engine.rs
+++ b/crates/core/src/map_engine.rs
@@ -148,11 +148,25 @@ impl OutputCrs {
     ///
     /// If no perimeter sample yields a finite fraction (e.g. a projected output
     /// CRS whose inverse is undefined across the whole envelope) the guard is
-    /// disabled (full image) rather than risk clipping real data. **Limitation:**
-    /// a single output-space box, so on a viewport showing more than one world
-    /// copy (Web Mercator spanning > 360° of longitude) only the primary copy of
-    /// the footprint is kept; wrapped copies render as nodata (acceptable — the
-    /// alternative was ghost aliasing).
+    /// disabled (full image) rather than risk clipping real data.
+    ///
+    /// **Requires `src_env_wgs84` to be a true WGS84 `[w, s, e, n]` envelope** —
+    /// it is fed to [`Self::world_to_fraction`] as lon/lat. A native-CRS extent
+    /// (projected metres) would produce a nonsense window and silently disable
+    /// the guard; engines must reproject to WGS84 before calling.
+    ///
+    /// **Limitations:**
+    /// - A single output-space box, so on a viewport showing more than one world
+    ///   copy (Web Mercator spanning > 360° of longitude) only the primary copy
+    ///   of the footprint is kept; wrapped copies render as nodata (acceptable —
+    ///   the alternative was ghost aliasing).
+    /// - The perimeter walk assumes `w <= e` (and `s <= n`). An
+    ///   **antimeridian-crossing** envelope (`w > e`, e.g. `w=170, e=-170`) steps
+    ///   backwards through the interior instead of wrapping over ±180°, yielding
+    ///   an over-wide window that effectively disables the guard for that source.
+    ///   No current data type crosses the antimeridian (European/national
+    ///   composites, regional rasters, geographic Zarr grids); revisit if one is
+    ///   added.
     pub fn footprint_pixel_window(
         &self,
         wgs84_bbox: [f64; 4],

--- a/crates/engine-geotiff/src/lib.rs
+++ b/crates/engine-geotiff/src/lib.rs
@@ -1316,88 +1316,6 @@ fn filter_by_datetime(
     }
 }
 
-/// Inclusive output-pixel window `(px_lo, px_hi, py_lo, py_hi)` that the source
-/// footprint can occupy in the output image — a cheap domain guard applied
-/// before resampling (see the call site in `get_raster_tile`).
-///
-/// `src_env_wgs84` is the source raster's WGS84 envelope `[w, s, e, n]`;
-/// `wgs84_bbox` is the requested tile bbox. The envelope perimeter is mapped to
-/// output-fraction space with [`OutputCrs::world_to_fraction`] (the per-vertex
-/// inverse of the per-pixel `project_node` — projecting only ~130 perimeter
-/// points, never per output pixel, per the #203 rule), the fractional extent is
-/// taken and expanded by a small margin so genuine boundary data is never
-/// clipped, then converted to inclusive pixel bounds clamped to the image.
-///
-/// Purpose: at low zoom the coarse projection grid (and the source projection's
-/// own out-of-domain forward) can map a far-away output pixel onto a valid
-/// source pixel, painting ghost echoes far from the data. Such pixels lie
-/// outside this window and are dropped to nodata.
-///
-/// If no perimeter sample yields a finite fraction (e.g. a projected output CRS
-/// whose inverse is undefined across the whole envelope) the guard is disabled
-/// (full image) rather than risk clipping real data. **Limitation:** the window
-/// is a single output-space box, so on a viewport that shows more than one world
-/// copy (Web Mercator spanning > 360° of longitude) only the primary copy of the
-/// footprint is kept; additional wrapped copies render as nodata (acceptable —
-/// the alternative was ghost aliasing).
-fn footprint_pixel_window(
-    output_crs: &ds_core::map_engine::OutputCrs,
-    wgs84_bbox: [f64; 4],
-    src_env_wgs84: [f64; 4],
-    width: u32,
-    height: u32,
-) -> (u32, u32, u32, u32) {
-    let [w, s, e, n] = src_env_wgs84;
-    let (mut fx_lo, mut fx_hi, mut fy_lo, mut fy_hi) = (f64::MAX, f64::MIN, f64::MAX, f64::MIN);
-    let mut any = false;
-    const STEPS: usize = 32;
-    for i in 0..=STEPS {
-        let t = i as f64 / STEPS as f64;
-        let lon = w + t * (e - w);
-        let lat = s + t * (n - s);
-        // All four envelope edges (curved edges can bow past the corners).
-        for (plon, plat) in [(lon, s), (lon, n), (w, lat), (e, lat)] {
-            let (fx, fy) = output_crs.world_to_fraction(wgs84_bbox, plon, plat);
-            if fx.is_finite() && fy.is_finite() {
-                any = true;
-                fx_lo = fx_lo.min(fx);
-                fx_hi = fx_hi.max(fx);
-                fy_lo = fy_lo.min(fy);
-                fy_hi = fy_hi.max(fy);
-            }
-        }
-    }
-    if !any {
-        return (0, width.saturating_sub(1), 0, height.saturating_sub(1));
-    }
-    // Margin: a fraction of the footprint's own output span, with a small floor,
-    // so edge-sampling gaps and sub-pixel rounding never clip boundary data.
-    // Far-away ghosts sit far outside, so this margin never readmits them.
-    let mx = ((fx_hi - fx_lo) * 0.02).max(0.005);
-    let my = ((fy_hi - fy_lo) * 0.02).max(0.005);
-    fx_lo -= mx;
-    fx_hi += mx;
-    fy_lo -= my;
-    fy_hi += my;
-    let to_px = |f: f64, dim: u32| {
-        // If dim == 0, `clamp(0.0, dim as f64 - 1.0)` panics (min > max) in both
-        // debug and release; the assert below fires first in debug builds with a
-        // clearer message. Callers always pass positive output dimensions, so
-        // assert the contract.
-        debug_assert!(
-            dim > 0,
-            "footprint_pixel_window: output dimension must be > 0"
-        );
-        (f * dim as f64).floor().clamp(0.0, dim as f64 - 1.0) as u32
-    };
-    (
-        to_px(fx_lo, width),
-        to_px(fx_hi, width),
-        to_px(fy_lo, height),
-        to_px(fy_hi, height),
-    )
-}
-
 /// Map a parsed [`Crs`](ds_core::geo::Crs) to the engine's native-CRS label
 /// (stored in `RasterInfo.native_crs`, surfaced as OGC `storageCrs`).
 ///
@@ -1675,7 +1593,7 @@ impl ds_core::map_engine::MapEngine for GeoTiffEngine {
             // can occupy and treat everything outside it as nodata. Computed once
             // from the source's WGS84 envelope (no per-pixel projection).
             let (px_lo, px_hi, py_lo, py_hi) =
-                footprint_pixel_window(output_crs, bbox, gt.bbox(), width, height);
+                output_crs.footprint_pixel_window(bbox, gt.bbox(), width, height);
 
             // Resample source grid to output dimensions using nearest-neighbor.
             for oy in 0..height {

--- a/crates/engine-odim/src/engine.rs
+++ b/crates/engine-odim/src/engine.rs
@@ -1214,13 +1214,26 @@ impl MapEngine for OdimEngine {
             world_to_src_px,
         );
 
+        // Domain guard against "ghost" echoes: at low zoom / extreme viewports
+        // the coarse grid (and the projection's out-of-domain forward) can map a
+        // far-away output pixel onto a valid source pixel, painting the composite
+        // far from its coverage. Bound the output window to the source footprint
+        // (WGS84 `seed_spatial_extent`); everything outside is nodata (#449).
+        let (px_lo, px_hi, py_lo, py_hi) =
+            output_crs.footprint_pixel_window(bbox, self.seed_spatial_extent, width, height);
+
         // Resample source grid to output dimensions using nearest-neighbour.
         // The grid interpolates only the output→source coordinate map; the data
         // values are still sampled nearest-neighbour (radar dBZ must not be
         // blended across nodata/undetect edges).
         let mut values = Vec::with_capacity((width * height) as usize);
         for oy in 0..height {
+            let in_y = oy >= py_lo && oy <= py_hi;
             for ox in 0..width {
+                if !in_y || ox < px_lo || ox > px_hi {
+                    values.push(None);
+                    continue;
+                }
                 let (col_f, row_f) = grid.sample(ox, oy);
                 if !col_f.is_finite() || !row_f.is_finite() {
                     values.push(None);

--- a/crates/engine-zarr/src/lib.rs
+++ b/crates/engine-zarr/src/lib.rs
@@ -401,8 +401,26 @@ impl MapEngine for ZarrEngine {
                     |fx, fy| output_crs.project_node(bbox, fx, fy),
                     |lon, lat| window.frac_px(lon, lat),
                 );
+                // Domain guard (#449): bound the output to the source footprint
+                // so the coarse grid can't map a far-away output pixel onto valid
+                // source data. For today's geographic Zarr grids the `frac_px`
+                // map is affine/monotonic and can't alias far points back onto the
+                // grid (out-of-range → nodata already), so this is belt-and-
+                // suspenders; it becomes load-bearing for projected source grids
+                // (Phase 4 STAC per-item-CRS, e.g. HRRR/Lambert), whose forward
+                // aliases like the TM/stereographic raster engines do.
+                let (px_lo, px_hi, py_lo, py_hi) = cat
+                    .raster_info
+                    .spatial_extent
+                    .map(|env| output_crs.footprint_pixel_window(bbox, env, width, height))
+                    .unwrap_or((0, width.saturating_sub(1), 0, height.saturating_sub(1)));
                 for oy in 0..height {
+                    let in_y = oy >= py_lo && oy <= py_hi;
                     for ox in 0..width {
+                        if !in_y || ox < px_lo || ox > px_hi {
+                            values.push(None);
+                            continue;
+                        }
                         let (col_f, row_f) = grid.sample(ox, oy);
                         values.push(window.bilinear_at(col_f, row_f));
                     }

--- a/crates/engine-zarr/src/lib.rs
+++ b/crates/engine-zarr/src/lib.rs
@@ -409,6 +409,13 @@ impl MapEngine for ZarrEngine {
                 // suspenders; it becomes load-bearing for projected source grids
                 // (Phase 4 STAC per-item-CRS, e.g. HRRR/Lambert), whose forward
                 // aliases like the TM/stereographic raster engines do.
+                //
+                // `footprint_pixel_window` REQUIRES `spatial_extent` to be a WGS84
+                // [w,s,e,n] envelope (it feeds it to `world_to_fraction` as
+                // lon/lat). That holds today — the catalog builds `extent` from the
+                // lon/lat CF coordinate arrays. Phase 4 projected sources must keep
+                // this invariant (reproject the native extent to WGS84 before
+                // storing it) or this guard would compute a nonsense window.
                 let (px_lo, px_hi, py_lo, py_hi) = cat
                     .raster_info
                     .spatial_extent


### PR DESCRIPTION
Closes #449.

## Summary

#448 added a per-engine "ghost guard" to `engine-geotiff`: at low zoom the coarse `ProjectionGrid` (and a projection's out-of-domain forward) can map a far-away output pixel onto valid source data, painting echoes far from the real coverage. This lifts that guard into `ds-core` so every projected raster engine shares it.

## Changes

- **ds-core**: `OutputCrs::footprint_pixel_window(wgs84_bbox, src_env_wgs84, w, h)` — bounds the output-pixel window the source footprint can occupy, mapping the envelope perimeter to output-fraction space via `world_to_fraction` (per-vertex, never per pixel — #203). Moved verbatim from engine-geotiff, now unit-tested (`footprint_window_bounds_a_small_source_in_a_wide_view`, `footprint_window_is_permissive_when_view_is_inside_the_source`).
- **engine-geotiff**: use the shared method; drop the local copy.
- **engine-odim (COMP)**: adopt it — the stereographic source aliases like TM, so this is a *real* fix for whole-world Web Mercator views.
- **engine-zarr (projected path)**: adopt it. Today's geographic Zarr grids use an affine/monotonic `frac_px` map that can't alias (out-of-range → nodata already), so it's belt-and-suspenders now; it becomes **load-bearing for Phase 4 projected source grids** (STAC per-item-CRS, e.g. HRRR/Lambert).

## Not changed: ODIM PVOL

Its exact `bin_f >= nbins` coverage-disk check plus great-circle ENU mapping already reject far/wrapped points (no truncated-series aliasing), so the bbox guard would be redundant. Noted in the issue.

## Notes

- Independent of the meta-tile ±85° displacement fix (separate PR #452).
- Existing `engine-geotiff` `low_zoom_domain_guard` integration test still passes against the shared method.

🤖 Generated with [Claude Code](https://claude.com/claude-code)