### PR TITLE
feat(collections): FMI radar reflectivity composite (local COG)

### DIFF
--- a/collections.d/radar-fi-composite-dbzh-local-cog.toml
+++ b/collections.d/radar-fi-composite-dbzh-local-cog.toml
@@ -1,0 +1,25 @@
+id = "radar-fi-composite-dbzh-local-cog"
+title = "FMI — radar reflectivity composite (local, COG)"
+description = "Finnish radar reflectivity (DBZH) composite from FMI open data. EPSG:3067 (ETRS89 / TM35FIN) Cloud-Optimized GeoTIFF, from local sample files."
+data_path = "testdata/fmi-radar"
+engine_type = "geotiff"
+apis = ["edr", "wms", "maps", "tiles"]
+keywords = ["radar", "reflectivity", "composite", "precipitation", "Finland", "FMI"]
+
+[geotiff]
+# FMI composites are 5-minute, always SS=00 (literal "00" in the name).
+filename_template = "%Y%m%d%H%M00_fmi_radar_composite_dbz.tif"
+parameter = "reflectivity"
+unit = "dBZ"
+# Raw Byte 1..254 → dBZ via value = raw*0.5 - 32 (raw 255 = nodata). The file
+# carries no GDAL scale/offset tags, so they are applied here.
+nodata = 255
+scale = 0.5
+offset = -32
+poll_interval_secs = 30
+
+[wms]
+style_bundle = "radar_multi"
+
+[license]
+title = "CC-BY-4.0"


### PR DESCRIPTION
## Summary

Adds the **missing** FMI radar composite config: `radar-fi-composite-dbzh-local-cog`. Every other country ships a `-local-` variant (DE/DK/EU/NO), but FMI only had the S3 one (`radar-fi-composite-dbzh-s3-cog`).

Points at the committed `testdata/fmi-radar/` fixture (EPSG:3067 / TM35FIN COG), mirroring the production `fmi_radar_composite_dbz` product:
- raw `Byte` → dBZ via `scale=0.5`, `offset=-32`, `nodata=255` (the file has no embedded GDAL scale/offset tags);
- `filename_template = "%Y%m%d%H%M00_fmi_radar_composite_dbz.tif"` (FMI 5-min composites, SS always 00);
- `radar_multi` style bundle; `apis = [edr, wms, maps, tiles]`.

## Smoke test (end-to-end, real fixture)

Booted scoped (`--collections radar-fi-composite-dbzh-local-cog`):
- loads 1 file, extent `2026-04-06 06:40Z`, status `ready`, wired to EDR/WMS/Maps/Tiles;
- WMS GetMap (EPSG:3857 over Finland) → valid **PNG8**, echoes correctly placed over Finland;
- EDR position `POINT(25 61)` → `reflectivity = 13.0` dBZ (sensible — confirms scale/offset is applied, not a raw byte);
- collection JSON: `storageCrs = EPSG:3067`, keywords + CC-BY-4.0 license present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)