### PR TITLE
fix(engine-odim): honor time_window for local sources + unbounded-retention WARN (#465)

### DIFF
--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -698,9 +698,13 @@ pub struct OdimConfig {
     /// `http(s)://` `data_path` (COMP) it is appended under the URL path.
     pub prefix_pattern: Option<String>,
     /// ISO 8601 duration bounding which timesteps to keep, relative to
-    /// now (e.g. `-PT12H` for the last 12 hours). Drives both prefix
-    /// date expansion and timestamp filtering for S3/HTTP sources. When
-    /// unset, the scan falls back to a fixed recent-days window.
+    /// now (e.g. `-PT12H` for the last 12 hours). For S3/HTTP sources it
+    /// drives both prefix date expansion and timestamp filtering; for a
+    /// local `data_path` (COMP and PVOL) it bounds which files are
+    /// retained from the directory on every scan (#465 — previously
+    /// silently ignored for local sources). When unset, a remote scan
+    /// falls back to a fixed recent-days window and a local scan keeps
+    /// everything (bound retention with `max_files` or this field).
     pub time_window: Option<String>,
     /// Discovery mode for an `http(s)://` `data_path` source (COMP only;
     /// ignored for local and S3 sources):

--- a/crates/engine-odim/src/catalog.rs
+++ b/crates/engine-odim/src/catalog.rs
@@ -177,9 +177,12 @@ impl FilenameMatcher {
 }
 
 /// Walk a local directory, match each filename against `matcher`,
-/// and return the matched files sorted by timestamp ascending. Caps
-/// the returned vec at `max_files` from the end (most recent) when
-/// set; useful when the source directory holds years of history.
+/// and return the matched files sorted by timestamp ascending.
+/// `time_filter`, when set, drops entries whose timestamp falls outside
+/// the inclusive `(start, end)` range — the local analogue of
+/// [`scan_remote`]'s window filter (#465). `max_files` then caps the
+/// result at the most recent N; useful when the source directory holds
+/// years of history.
 ///
 /// Non-recursive — only files directly in `dir`. Directories,
 /// symlinks to directories, and files whose names don't match the
@@ -187,6 +190,7 @@ impl FilenameMatcher {
 pub fn scan_local_directory(
     dir: &Path,
     matcher: &FilenameMatcher,
+    time_filter: Option<(DateTime<Utc>, DateTime<Utc>)>,
     max_files: Option<usize>,
 ) -> Result<Vec<CatalogEntry>, CatalogError> {
     let read = std::fs::read_dir(dir).map_err(|e| CatalogError::ReadDir {
@@ -216,6 +220,9 @@ pub fn scan_local_directory(
                 location: Location::Local(path),
             });
         }
+    }
+    if let Some((start, end)) = time_filter {
+        entries.retain(|e| e.time >= start && e.time <= end);
     }
     entries.sort_by_key(|e| e.time);
     if let Some(cap) = max_files {
@@ -565,7 +572,7 @@ mod tests {
             std::fs::write(dir.path().join(name), b"").unwrap();
         }
         let m = FilenameMatcher::from_template("%Y%m%dT%H%M_radar_fi.h5").unwrap();
-        let entries = scan_local_directory(dir.path(), &m, None).unwrap();
+        let entries = scan_local_directory(dir.path(), &m, None, None).unwrap();
         assert_eq!(entries.len(), 3, "README.md must be skipped");
         let times: Vec<_> = entries.iter().map(|e| e.time.to_rfc3339()).collect();
         assert_eq!(
@@ -575,6 +582,30 @@ mod tests {
                 "2025-07-14T15:00:00+00:00",
                 "2025-07-14T15:30:00+00:00",
             ]
+        );
+    }
+
+    /// `time_filter` drops entries outside the inclusive window (before
+    /// the `max_files` cap) — a local source with `time_window` retains
+    /// only the recent tail even when the directory holds more history
+    /// (#465; previously the window was silently ignored for local
+    /// sources).
+    #[test]
+    fn scan_local_directory_applies_time_filter() {
+        let dir = tempfile::tempdir().unwrap();
+        for hour in 0..5 {
+            let name = format!("20250714T{hour:02}00_radar_fi.h5");
+            std::fs::write(dir.path().join(&name), b"").unwrap();
+        }
+        let m = FilenameMatcher::from_template("%Y%m%dT%H%M_radar_fi.h5").unwrap();
+        let start: DateTime<Utc> = "2025-07-14T02:00:00Z".parse().unwrap();
+        let end: DateTime<Utc> = "2025-07-14T03:00:00Z".parse().unwrap();
+        let entries = scan_local_directory(dir.path(), &m, Some((start, end)), None).unwrap();
+        let times: Vec<_> = entries.iter().map(|e| e.time.to_rfc3339()).collect();
+        assert_eq!(
+            times,
+            ["2025-07-14T02:00:00+00:00", "2025-07-14T03:00:00+00:00"],
+            "window is inclusive on both ends; entries outside are dropped"
         );
     }
 
@@ -589,7 +620,7 @@ mod tests {
             std::fs::write(dir.path().join(&name), b"").unwrap();
         }
         let m = FilenameMatcher::from_template("%Y%m%dT%H%M_radar_fi.h5").unwrap();
-        let entries = scan_local_directory(dir.path(), &m, Some(2)).unwrap();
+        let entries = scan_local_directory(dir.path(), &m, None, Some(2)).unwrap();
         assert_eq!(entries.len(), 2);
         let names: Vec<_> = entries
             .iter()

--- a/crates/engine-odim/src/engine.rs
+++ b/crates/engine-odim/src/engine.rs
@@ -129,7 +129,13 @@ pub fn composite_cache_metrics() -> (u64, u64, u64, u64) {
 #[derive(Clone)]
 enum Source {
     /// A local filesystem directory, scanned with `read_dir`.
-    Local { data_dir: PathBuf },
+    /// `time_window`, when set, bounds which timesteps are retained
+    /// (relative to now at each scan) — the local analogue of the remote
+    /// arm's timestamp filter (#465).
+    Local {
+        data_dir: PathBuf,
+        time_window: Option<TimeWindow>,
+    },
     /// An S3 or HTTP(S) object store. `prefix_pattern` may carry
     /// strftime codes (e.g. `%Y/%m/%d/OPERA/COMP/`); it is expanded
     /// per UTC date on every scan so the listing stays current across
@@ -207,7 +213,18 @@ fn scan_source(
     known: &[CatalogEntry],
 ) -> Result<Vec<CatalogEntry>, EngineError> {
     match source {
-        Source::Local { data_dir } => Ok(scan_local_directory(data_dir, matcher, max_files)?),
+        Source::Local {
+            data_dir,
+            time_window,
+        } => {
+            let time_filter = time_window.as_ref().map(|tw| tw.to_range(Utc::now()));
+            Ok(scan_local_directory(
+                data_dir,
+                matcher,
+                time_filter,
+                max_files,
+            )?)
+        }
         Source::Remote {
             store,
             prefix_pattern,
@@ -483,8 +500,9 @@ pub enum EngineError {
     MissingPrefixPattern,
     #[error(
         "no ODIM files found at `{location}` matching the configured filename \
-         pattern — verify the source exists and the template matches the \
-         producer's layout"
+         pattern (and `time_window`, if set) — verify the source exists, the \
+         template matches the producer's layout, and the window covers the \
+         available timesteps"
     )]
     NoFiles { location: String },
     #[error("ODIM source error: {0}")]
@@ -549,15 +567,24 @@ impl OdimEngine {
         let matcher = build_matcher(config)?;
         let source = build_source(collection_id, data_path, config)?;
 
-        // `time_window` only constrains a *remote* (S3/HTTP) source's
-        // prefix expansion + timestamp filtering. A local `data_path`
-        // source ignores it — warn so a misplaced setting doesn't
-        // silently do nothing. (An `http(s)://` `data_path` resolves to
-        // `Source::Remote`, so it is correctly exempt.)
-        if config.time_window.is_some() && matches!(source, Source::Local { .. }) {
+        // An unbounded local source catalogs every matching file in the
+        // directory forever (well, for as long as whatever writes the
+        // directory retains them) — warn so the operator makes retention
+        // an explicit choice (#465). Remote sources are already bounded
+        // by the scanned date prefixes (`DEFAULT_SCAN_DAYS`).
+        if config.max_files.is_none()
+            && matches!(
+                source,
+                Source::Local {
+                    time_window: None,
+                    ..
+                }
+            )
+        {
             tracing::warn!(
-                "[{collection_id}] `time_window` is set but has no effect on a \
-                 local `data_path` ODIM source — it only applies to S3/HTTP sources"
+                "[{collection_id}] local ODIM source has neither `max_files` nor \
+                 `time_window` — every matching file in the directory is cataloged; \
+                 set one to bound retention"
             );
         }
 
@@ -1099,8 +1126,13 @@ fn build_source(
                     }
                 }
             } else {
+                let time_window = match &config.time_window {
+                    Some(s) => Some(TimeWindow::parse(s)?),
+                    None => None,
+                };
                 Ok(Source::Local {
                     data_dir: PathBuf::from(data_path),
+                    time_window,
                 })
             }
         }
@@ -1156,7 +1188,7 @@ fn combine_http_prefix(base_path: &str, prefix_pattern: Option<&str>) -> String 
 /// exactly which store to check.
 fn source_label(source: &Source) -> String {
     match source {
-        Source::Local { data_dir } => data_dir.display().to_string(),
+        Source::Local { data_dir, .. } => data_dir.display().to_string(),
         Source::Remote {
             origin,
             prefix_pattern,

--- a/crates/engine-odim/src/volume_engine.rs
+++ b/crates/engine-odim/src/volume_engine.rs
@@ -826,14 +826,22 @@ fn scan_source(
             data_dir,
             time_window,
         } => {
-            let pending = enumerate_local(collection_id, data_dir)?;
-            // `source` is local here, so `build_catalog` skips the (remote-only)
-            // pixel pre-warm regardless of `prewarm_sweeps`.
-            let mut by_site = build_catalog(collection_id, pending, source, cache, prewarm_sweeps);
             // `time_window` bounds which volumes are retained from the
             // directory — the local analogue of the remote filter below
             // (#465; previously it was silently ignored for local).
             let time_filter = time_window.as_ref().map(|tw| tw.to_range(Utc::now()));
+            let mut pending = enumerate_local(collection_id, data_dir)?;
+            // Drop out-of-window files by FILENAME timestamp *before*
+            // parsing (mirrors the remote arm's pre-filter): the post-parse
+            // filter alone would HDF5-parse every out-of-window file on
+            // every poll only to trim it — and `derive_catalog` then evicts
+            // its parse-cache entry, so it would be re-parsed forever. A
+            // file whose name carries no parseable timestamp falls through
+            // to the post-parse volume-time filter.
+            pending.retain(|p| within_window_by_name(&p.id, time_filter));
+            // `source` is local here, so `build_catalog` skips the (remote-only)
+            // pixel pre-warm regardless of `prewarm_sweeps`.
+            let mut by_site = build_catalog(collection_id, pending, source, cache, prewarm_sweeps);
             retain_within(&mut by_site, time_filter);
             Ok(derive_catalog(by_site, cache, max_files))
         }
@@ -863,6 +871,20 @@ fn retain_within(by_site: &mut HashMap<String, Vec<VolumeEntry>>, filter: Option
         for list in by_site.values_mut() {
             list.retain(|e| e.volume.time >= start && e.volume.time <= end);
         }
+    }
+}
+
+/// Pre-parse window test on a file's NAME: `false` only when the filename
+/// carries a parseable timestamp that falls outside the inclusive range.
+/// No filter, or no parseable timestamp, keeps the file — the post-parse
+/// [`retain_within`] (which sees the volume's internal time) is the
+/// authority; this only exists so out-of-window files are never opened
+/// and HDF5-parsed in the first place (the same cost the remote arm's
+/// candidate pre-filter avoids).
+fn within_window_by_name(id: &str, filter: Option<TimeRange>) -> bool {
+    match (filter, parse_key_timestamp(id)) {
+        (Some((start, end)), Some(ts)) => ts >= start && ts <= end,
+        _ => true,
     }
 }
 
@@ -6196,6 +6218,39 @@ mod tests {
             [t("2026-07-05T06:00:00Z")],
             "volumes outside the window are dropped"
         );
+    }
+
+    /// The pre-parse filename filter (review finding on #471): a file whose
+    /// NAME timestamps outside the window is dropped before it is ever
+    /// opened/parsed — otherwise out-of-window local files would be
+    /// HDF5-parsed and parse-cache-evicted on EVERY poll. Unparseable names
+    /// and no-filter pass through (the post-parse filter is the authority).
+    #[test]
+    fn within_window_by_name_drops_only_parseable_out_of_window() {
+        let t = |s: &str| s.parse::<DateTime<Utc>>().unwrap();
+        let window = Some((t("2026-07-05T05:00:00Z"), t("2026-07-05T07:00:00Z")));
+
+        assert!(within_window_by_name(
+            "/data/202607050600_fivih_PVOL.h5",
+            window
+        ));
+        assert!(!within_window_by_name(
+            "/data/202607050400_fivih_PVOL.h5",
+            window
+        ));
+        // Inclusive bounds — a file exactly at the window edge is kept.
+        assert!(within_window_by_name(
+            "/data/202607050500_fivih_PVOL.h5",
+            window
+        ));
+        // No parseable timestamp in the name → keep (post-parse filter
+        // decides by the volume's internal time).
+        assert!(within_window_by_name("/data/no-timestamp.h5", window));
+        // No filter → keep everything.
+        assert!(within_window_by_name(
+            "/data/202607050400_fivih_PVOL.h5",
+            None
+        ));
     }
 
     /// A site whose latest volume has no usable lowest sweep is kept in

--- a/crates/engine-odim/src/volume_engine.rs
+++ b/crates/engine-odim/src/volume_engine.rs
@@ -416,7 +416,13 @@ pub(crate) fn ground_height_to_slant(
 #[derive(Clone)]
 pub(crate) enum Source {
     /// A local filesystem directory, scanned with `read_dir`.
-    Local { data_dir: PathBuf },
+    /// `time_window`, when set, bounds which volumes are retained
+    /// (relative to now at each scan) — the local analogue of the
+    /// remote arm's timestamp filter (#465).
+    Local {
+        data_dir: PathBuf,
+        time_window: Option<TimeWindow>,
+    },
     /// An S3/HTTP object store. `prefix_pattern` may carry strftime
     /// codes (e.g. `%Y/%m/%d/fivih/`); it is expanded per UTC date on
     /// every scan so the listing stays current across day boundaries.
@@ -485,8 +491,13 @@ fn build_source(
         }
         (None, None) => {
             let data_path = data_path.ok_or(EngineError::NoSource)?;
+            let time_window = match &config.time_window {
+                Some(s) => Some(TimeWindow::parse(s)?),
+                None => None,
+            };
             Ok(Source::Local {
                 data_dir: PathBuf::from(data_path),
+                time_window,
             })
         }
         _ => Err(EngineError::IncompleteS3Config),
@@ -497,7 +508,7 @@ fn build_source(
 /// messages.
 fn source_label(source: &Source) -> String {
     match source {
-        Source::Local { data_dir } => data_dir.display().to_string(),
+        Source::Local { data_dir, .. } => data_dir.display().to_string(),
         Source::Remote {
             endpoint,
             bucket,
@@ -811,11 +822,19 @@ fn scan_source(
         // bootstrap bound only matters for remote (S3/HTTP) sources where
         // each file is a multi-MB network fetch, so local always scans in
         // full regardless of `depth`.
-        Source::Local { data_dir } => {
+        Source::Local {
+            data_dir,
+            time_window,
+        } => {
             let pending = enumerate_local(collection_id, data_dir)?;
             // `source` is local here, so `build_catalog` skips the (remote-only)
             // pixel pre-warm regardless of `prewarm_sweeps`.
-            let by_site = build_catalog(collection_id, pending, source, cache, prewarm_sweeps);
+            let mut by_site = build_catalog(collection_id, pending, source, cache, prewarm_sweeps);
+            // `time_window` bounds which volumes are retained from the
+            // directory — the local analogue of the remote filter below
+            // (#465; previously it was silently ignored for local).
+            let time_filter = time_window.as_ref().map(|tw| tw.to_range(Utc::now()));
+            retain_within(&mut by_site, time_filter);
             Ok(derive_catalog(by_site, cache, max_files))
         }
         Source::Remote {
@@ -830,12 +849,19 @@ fn scan_source(
             // A `time_window` also bounds the timestamps kept: the
             // object listing can include volumes just outside the
             // window (the prefix is a whole UTC day).
-            if let Some((start, end)) = time_filter {
-                for list in by_site.values_mut() {
-                    list.retain(|e| e.volume.time >= start && e.volume.time <= end);
-                }
-            }
+            retain_within(&mut by_site, time_filter);
             Ok(derive_catalog(by_site, cache, max_files))
+        }
+    }
+}
+
+/// Drop volumes whose nominal time falls outside the inclusive
+/// `(start, end)` range. `None` keeps everything. Shared by the local
+/// and remote scan arms so both apply the same `time_window` semantics.
+fn retain_within(by_site: &mut HashMap<String, Vec<VolumeEntry>>, filter: Option<TimeRange>) {
+    if let Some((start, end)) = filter {
+        for list in by_site.values_mut() {
+            list.retain(|e| e.volume.time >= start && e.volume.time <= end);
         }
     }
 }
@@ -1616,17 +1642,29 @@ impl PolarVolumeEngine {
         data_path: Option<&str>,
         config: &ds_core::config::OdimConfig,
     ) -> Result<Self, EngineError> {
-        // `time_window` only constrains S3 prefix expansion + timestamp
-        // filtering. A local `data_path` source ignores it — warn so a
-        // misplaced setting doesn't silently do nothing.
-        if config.time_window.is_some() && config.endpoint.is_none() {
+        let source = Arc::new(build_source(collection_id, data_path, config)?);
+
+        // An unbounded local source catalogs every `.h5` the directory
+        // holds (~288 volumes/site/day at 5-min cadence) and advertises
+        // every timestep in WMS TIME / EDR extents / 3D Tiles `times` —
+        // warn so the operator makes retention an explicit choice (#465).
+        // Remote sources are already bounded by the scanned date prefixes
+        // (`DEFAULT_SCAN_DAYS`).
+        if config.max_files.is_none()
+            && matches!(
+                *source,
+                Source::Local {
+                    time_window: None,
+                    ..
+                }
+            )
+        {
             tracing::warn!(
-                "[{collection_id}] `time_window` is set but has no effect on a \
-                 local `data_path` PVOL source — it only applies to S3 sources"
+                "[{collection_id}] local PVOL source has neither `max_files` nor \
+                 `time_window` — every `.h5` in the directory is cataloged \
+                 (~288 volumes/site/day at 5-min cadence); set one to bound retention"
             );
         }
-
-        let source = Arc::new(build_source(collection_id, data_path, config)?);
 
         let parse_cache = Arc::new(Mutex::new(HashMap::new()));
         // Bootstrap scan: parse only the most-recent slots so a whole-network
@@ -1642,8 +1680,17 @@ impl PolarVolumeEngine {
             config.prewarm_sweeps,
         )?;
         if catalog.by_site.is_empty() {
+            // With a `time_window`, an empty catalog can also mean every file
+            // present was older than the window — say so, or an operator
+            // pointing a bounded source at a stale directory chases a
+            // "missing files" ghost.
+            let window_hint = if config.time_window.is_some() {
+                " (or none within the configured `time_window`)"
+            } else {
+                ""
+            };
             tracing::warn!(
-                "[{collection_id}] no PVOL `.h5` files found at `{}` yet — \
+                "[{collection_id}] no PVOL `.h5` files found at `{}`{window_hint} yet — \
                  the catalog will populate on the next poll",
                 source_label(&source)
             );
@@ -4853,6 +4900,7 @@ mod tests {
     fn pixel_cache_id_local_is_bare_path() {
         let local = Source::Local {
             data_dir: PathBuf::from("/x"),
+            time_window: None,
         };
         // A local id is already an absolute path — used verbatim.
         assert_eq!(
@@ -4901,6 +4949,7 @@ mod tests {
     /// because tests pre-seed the cache (see [`seed_synthetic`]).
     static TEST_SOURCE: std::sync::LazyLock<Source> = std::sync::LazyLock::new(|| Source::Local {
         data_dir: PathBuf::from("/nonexistent-test-pvol"),
+        time_window: None,
     });
 
     /// A `Pixels` context over the dummy source — pairs with [`seed_synthetic`].
@@ -5606,7 +5655,7 @@ mod tests {
     fn build_source_selects_local_when_no_s3_fields() {
         let config = empty_config();
         match build_source("c", Some("/some/dir"), &config).unwrap() {
-            Source::Local { data_dir } => assert_eq!(data_dir, PathBuf::from("/some/dir")),
+            Source::Local { data_dir, .. } => assert_eq!(data_dir, PathBuf::from("/some/dir")),
             Source::Remote { .. } => panic!("expected a Local source"),
         }
     }
@@ -5991,6 +6040,7 @@ mod tests {
             catalog: Arc::new(ArcSwap::from_pointee(catalog)),
             source: Arc::new(Source::Local {
                 data_dir: PathBuf::from("/nonexistent-test-pvol"),
+                time_window: None,
             }),
             nod: nod.to_string(),
             collection_id: format!("test-{nod}"),
@@ -6118,6 +6168,36 @@ mod tests {
         ));
     }
 
+    /// The shared `time_window` filter: drops volumes outside the
+    /// inclusive range, keeps everything on `None`. The local scan arm now
+    /// applies it too (#465 — previously local silently ignored
+    /// `time_window`).
+    #[test]
+    fn retain_within_filters_by_volume_time() {
+        let t = |s: &str| s.parse::<DateTime<Utc>>().unwrap();
+        let mut old = synthetic_volume(25.0, 60.0);
+        old.time = t("2026-07-05T00:00:00Z");
+        let mut recent = synthetic_volume(25.0, 60.0);
+        recent.time = t("2026-07-05T06:00:00Z");
+        let mut by_site: HashMap<String, Vec<VolumeEntry>> = HashMap::new();
+        by_site.insert("fivih".into(), vec![entry(old, "a"), entry(recent, "b")]);
+
+        let mut unfiltered = by_site.clone();
+        retain_within(&mut unfiltered, None);
+        assert_eq!(unfiltered["fivih"].len(), 2, "None keeps everything");
+
+        retain_within(
+            &mut by_site,
+            Some((t("2026-07-05T05:00:00Z"), t("2026-07-05T07:00:00Z"))),
+        );
+        let kept: Vec<_> = by_site["fivih"].iter().map(|e| e.volume.time).collect();
+        assert_eq!(
+            kept,
+            [t("2026-07-05T06:00:00Z")],
+            "volumes outside the window are dropped"
+        );
+    }
+
     /// A site whose latest volume has no usable lowest sweep is kept in
     /// `by_site` but excluded from `by_site_meta` — so `sites()` (which the
     /// loader enumerates) never registers a parameter-less, broken
@@ -6153,6 +6233,7 @@ mod tests {
             catalog: Arc::new(ArcSwap::from_pointee(catalog)),
             source: Arc::new(Source::Local {
                 data_dir: PathBuf::from("/nonexistent-test-pvol"),
+                time_window: None,
             }),
             nod: "good".into(),
             collection_id: "test".into(),
@@ -6482,6 +6563,7 @@ mod tests {
             collection_id: collection_id.to_string(),
             source: Arc::new(Source::Local {
                 data_dir: PathBuf::from("/nonexistent-test-pvol"),
+                time_window: None,
             }),
             max_files: None,
             catalog: Arc::new(ArcSwap::from_pointee(catalog)),


### PR DESCRIPTION
## Summary

Closes #465. `time_window` was an S3/HTTP-only feature: a local `data_path` odim / odim-volume collection setting it got a startup warning ("has no effect") and silently cataloged the entire directory. Prod PVOL configs set `time_window = "-PT2H"` in good faith — this makes the setting do what it says.

### Changes

- **PVOL** (`volume_engine.rs`): `Source::Local` now carries the parsed `TimeWindow`; every scan filters cataloged volumes by nominal time through a `retain_within` helper shared with the remote arm (identical inclusive-range semantics). Volumes aging out of the window drop from the catalog on the next poll, which also prunes the parse cache and shrinks WMS TIME lists / EDR temporal extents / 3D Tiles `times` manifests to the window.
- **COMP** (`catalog.rs` / `engine.rs`): `scan_local_directory` gains a `time_filter` parameter (applied before the `max_files` cap) — the local analogue of `scan_remote`'s filter; the COMP local source carries and resolves the window the same way.
- **The "no effect" warnings are replaced by an unbounded-retention WARN**: a local source with neither `max_files` nor `time_window` now logs that every matching file is cataloged (~288 volumes/site/day at 5-min cadence for PVOL), per #465.
- Empty-catalog bootstrap warning and the COMP `NoFiles` error now mention the window, so a bounded source over a stale directory doesn't read as "missing files".
- `OdimConfig.time_window` doc updated to the new semantics.

### Notes

- The #465 memory-attribution correction is on the issue: catalogs are metadata-only since #289, so the win here is API-surface hygiene (bounded TIME lists, explicit retention choice) more than RAM.
- A site whose volumes ALL fall outside the window disappears from the catalog snapshot (same as remote behavior); its per-site collection stops serving until data returns.

### Verification

- Unit: `retain_within` (None keeps all, window drops outside, inclusive bounds) + `scan_local_directory_applies_time_filter` (filename-timestamp filtering, inclusive window) — plus the two pre-existing scan tests updated for the new parameter.
- End-to-end (13 real fivih volumes from 2026-07-03 in a local dir): no bounds → WARN + 13 volumes cataloged; `time_window="-P7D"` → 13 volumes, no WARN; `"-PT2H"` → 0 volumes, per-site WMS layer absent, window-aware bootstrap message.
- `cargo fmt` clean, `clippy --workspace --all-targets` zero warnings, all 179 engine-odim tests green.

After merge, the prod PVOL configs' existing `time_window = "-PT2H"` starts working as intended with no config change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)