### PR TITLE
fix(api-edr): 500 instead of request-path panic on registry divergence (#479)

### DIFF
--- a/crates/api-edr/src/handlers.rs
+++ b/crates/api-edr/src/handlers.rs
@@ -131,7 +131,18 @@ fn lookup_collection<'a>(
             Json(json!({ "code": "NotFound", "description": format!("Collection '{id}' not found") })),
         )
     })?;
-    let config = state.collections.get(id).unwrap();
+    // engines and collections are built from the same config in admin.rs, but
+    // a registration divergence must surface as a 500, not a request panic.
+    let config = state.collections.get(id).ok_or_else(|| {
+        tracing::error!(
+            collection = id,
+            "engine registered without a matching collection config"
+        );
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({ "code": "InternalError", "description": "Internal server error" })),
+        )
+    })?;
     Ok((engine, config))
 }
 

--- a/crates/api-edr/src/handlers.rs
+++ b/crates/api-edr/src/handlers.rs
@@ -138,10 +138,7 @@ fn lookup_collection<'a>(
             collection = id,
             "engine registered without a matching collection config"
         );
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(json!({ "code": "InternalError", "description": "Internal server error" })),
-        )
+        server_error()
     })?;
     Ok((engine, config))
 }


### PR DESCRIPTION
## Summary

`lookup_collection` in `crates/api-edr/src/handlers.rs` did `state.collections.get(id).unwrap()` after the `engines` lookup succeeded — a keyset-parity assumption between two maps built in `admin.rs`. If they ever diverge (engine wired without its config), every request for that collection panics on the request path.

Now: `ok_or_else` → `tracing::error!` + generic 500 (per the CLAUDE.md no-internal-details rule).

Found and verified in the 2026-07-06 code-quality audit. The similar-looking `.expect("searchable params is a JSON array")` sites were checked and deliberately left — they act on a locally-built `json!([...])` literal and are infallible by construction.

## Testing

`cargo test -p api-edr` (all pass), fmt + clippy clean.

Closes #479

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T22YrnSuwKW6mFebJBHaBt