### PR TITLE
fix(engine-postgis): surface the real DB error in metadata refresh (#436)

### DIFF
--- a/crates/engine-postgis/src/engine.rs
+++ b/crates/engine-postgis/src/engine.rs
@@ -140,7 +140,21 @@ impl PostgisEngine {
             .cache
             .refresh(&self.config, &self.pool)
             .await
-            .map_err(|e| DataServerError::Engine(format!("metadata refresh failed: {e}")));
+            .map_err(|e| {
+                // Full detail (including the underlying Postgres error) goes to
+                // the log only. The returned error's Display is stored on
+                // CollectionHealth.error at boot (admin.rs) and served verbatim
+                // by the public /health endpoint, so it must stay generic — the
+                // "no internal error details to clients" rule.
+                tracing::warn!(
+                    collection = %self.collection_id,
+                    error = %e,
+                    "postgis: metadata refresh failed"
+                );
+                DataServerError::Engine(
+                    "metadata refresh failed (database error; see server logs)".to_string(),
+                )
+            });
         self.health.record_refresh(result.is_ok(), start.elapsed());
         result
     }

--- a/crates/engine-postgis/src/metadata.rs
+++ b/crates/engine-postgis/src/metadata.rs
@@ -33,8 +33,8 @@ use crate::schema::{LocationSource, ObservationSchema};
 pub enum MetadataError {
     #[error("pool error: {0}")]
     Pool(String),
-    #[error("database error")]
-    Db,
+    #[error("database error: {0}")]
+    Db(String),
     #[error("row decode error: {0}")]
     Decode(String),
 }
@@ -253,12 +253,12 @@ async fn fetch_station_rows(
     let stmt = client
         .prepare_cached(&built.sql)
         .await
-        .map_err(|_| MetadataError::Db)?;
+        .map_err(|e| MetadataError::Db(e.to_string()))?;
     let param_refs = crate::query::params_as_refs(&built.params);
     let rows = client
         .query(&stmt, &param_refs)
         .await
-        .map_err(|_| MetadataError::Db)?;
+        .map_err(|e| MetadataError::Db(e.to_string()))?;
 
     let mut out = Vec::with_capacity(rows.len());
     for row in &rows {
@@ -335,12 +335,12 @@ async fn fetch_observation_rows(
         let stmt = client
             .prepare_cached(&built.sql)
             .await
-            .map_err(|_| MetadataError::Db)?;
+            .map_err(|e| MetadataError::Db(e.to_string()))?;
         let param_refs = crate::query::params_as_refs(&built.params);
         let rows = client
             .query(&stmt, &param_refs)
             .await
-            .map_err(|_| MetadataError::Db)?;
+            .map_err(|e| MetadataError::Db(e.to_string()))?;
 
         for row in &rows {
             let id: String = row
@@ -521,7 +521,7 @@ async fn fetch_temporal_extent(
     let row = client
         .query_one(&sql, &param_refs)
         .await
-        .map_err(|_| MetadataError::Db)?;
+        .map_err(|e| MetadataError::Db(e.to_string()))?;
 
     let lo: Option<DateTime<Utc>> = row
         .try_get("lo")


### PR DESCRIPTION
## Summary

`MetadataError::Db` was a unit variant displaying just `"database error"`; five `map_err(|_| MetadataError::Db)` sites in `metadata.rs` (prepare/query/query_one) discarded the underlying `tokio_postgres::Error`. A failed metadata refresh therefore logged with no cause — the exact detail-swallowing that hid a production misconfiguration (#436).

Two-part fix:

1. `Db(String)` carries the source error text (matching the sibling `Pool(String)`/`Decode(String)` style), so the five sites preserve it.
2. **Detail stays in logs only** (added after review): `refresh_metadata`'s returned `Display` is stored on `CollectionHealth.error` at boot (`admin.rs`) and served verbatim by the public unauthenticated `GET /health`, so `refresh_metadata` now logs the full detail itself (`collection` + underlying error) and returns a generic message — the operator gets the real cause in the server log, `/health` clients get `"metadata refresh failed (database error; see server logs)"`.

## Testing

`cargo test -p engine-postgis`, fmt + clippy clean.

Closes #436

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T22YrnSuwKW6mFebJBHaBt