### PR TITLE
fix: geo/XML safety tripwire in CI + three leftover Web Mercator copies (#482)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,9 @@ jobs:
     - name: SQL safety check (engine-postgis)
       run: bash scripts/check_sql_safety.sh
 
+    - name: Geo/XML safety check (web-mercator + WMS XML invariants)
+      run: bash scripts/check_geo_safety.sh
+
     - name: Clippy
       run: cargo clippy --all-targets -- -D warnings
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,10 +44,14 @@ Violating these has caused production incidents. Never break them.
    committing.** CI rejects both formatting drift and clippy warnings.
 3. **Never build XML with `format!()` or string concatenation** — XML
    injection risk. All XML output uses `quick-xml::Writer` (api-wms).
+   `scripts/check_geo_safety.sh` enforces this in CI.
 4. **Never re-implement EPSG:3857 ↔ WGS84 math.** Use `ds_core::web_mercator`
    (`lon_to_x` / `x_to_lon` / `lat_to_y` / `y_to_lat`, `EARTH_RADIUS`,
    `LAT_LIMIT_DEG`). Four hand-rolled copies once drifted and displaced data
    ~10° at low zoom (#452, fixed by consolidation in #454).
+   `scripts/check_geo_safety.sh` enforces this in CI (magic constants have
+   named homes too: `web_mercator::{EARTH_RADIUS, LAT_LIMIT_DEG}`,
+   `geo::WGS84_A`).
    - Never clamp latitude when converting a viewport/bbox — zoomed-out
      requests legitimately reach past ±85°, and the client maps the returned
      image over the full requested extent.

--- a/crates/api-tiles/src/tilematrixset.rs
+++ b/crates/api-tiles/src/tilematrixset.rs
@@ -230,10 +230,13 @@ fn web_mercator_extent_to_tile_range(
     let min_col = ((west + 180.0) / 360.0 * n).floor() as u64;
     let max_col = ((east + 180.0) / 360.0 * n - 1e-10).floor() as u64;
 
-    // Latitude → row (Mercator, row 0 = north)
+    // Latitude → row (Mercator, row 0 = north), via the shared forward
+    // transform — the inverse mirror of `web_mercator_tile_bbox` above (#452).
+    // This is tile-INDEX selection, so out-of-range latitudes clamp to the
+    // grid via the max/min below.
     let lat_to_row = |lat: f64| -> u64 {
-        let lat_rad = lat.to_radians();
-        let y = (1.0 - (lat_rad.tan() + 1.0 / lat_rad.cos()).ln() / PI) / 2.0;
+        let y_m = ds_core::web_mercator::lat_to_y(lat);
+        let y = (1.0 - y_m / (PI * ds_core::web_mercator::EARTH_RADIUS)) / 2.0;
         (y * n).floor().max(0.0) as u64
     };
 

--- a/crates/api-tiles/src/tilematrixset.rs
+++ b/crates/api-tiles/src/tilematrixset.rs
@@ -40,9 +40,9 @@ pub const SUPPORTED_TILE_MATRIX_SETS: &[&str] = &["WebMercatorQuad", "WorldCRS84
 /// Standard pixel size for scale denominator calculation: 0.28mm = 0.00028m
 const PIXEL_SIZE_M: f64 = 0.00028;
 /// Earth equatorial circumference in meters (WGS84 semi-major axis * 2 * pi)
-const EARTH_CIRCUMFERENCE: f64 = 2.0 * PI * 6_378_137.0;
+const EARTH_CIRCUMFERENCE: f64 = 2.0 * PI * ds_core::web_mercator::EARTH_RADIUS;
 /// Half the earth circumference (Web Mercator extent in each direction)
-const HALF_CIRCUMFERENCE: f64 = PI * 6_378_137.0;
+const HALF_CIRCUMFERENCE: f64 = PI * ds_core::web_mercator::EARTH_RADIUS;
 
 pub static WEB_MERCATOR_QUAD: TileMatrixSetDef = TileMatrixSetDef {
     id: "WebMercatorQuad",

--- a/crates/core/src/geo.rs
+++ b/crates/core/src/geo.rs
@@ -3,8 +3,10 @@ use std::f64::consts::PI;
 use crate::feature::Geometry;
 use crate::map_engine::OutputCrs;
 
-/// WGS84 ellipsoid parameters
-const WGS84_A: f64 = 6_378_137.0; // semi-major axis (meters)
+/// WGS84 semi-major axis in metres. Public so engines never hardcode the
+/// radius themselves (`scripts/check_geo_safety.sh` flags the literal);
+/// numerically equal to `web_mercator::EARTH_RADIUS` (the 3857 sphere).
+pub const WGS84_A: f64 = 6_378_137.0;
 const WGS84_F: f64 = 1.0 / 298.257223563; // flattening
 const WGS84_E2: f64 = 2.0 * WGS84_F - WGS84_F * WGS84_F; // eccentricity squared
 

--- a/crates/ds-mvt/src/encode.rs
+++ b/crates/ds-mvt/src/encode.rs
@@ -439,9 +439,9 @@ fn signed_area(ring: &[(f64, f64)]) -> f64 {
 // Projection: WGS84 lon/lat → tile-local pixels (0..extent, 0..extent)
 // ---------------------------------------------------------------------------
 
-const EARTH_RADIUS_M: f64 = 6_378_137.0;
-/// Maximum |lat| representable in Web Mercator before y_m → ±∞.
-const WEB_MERCATOR_MAX_LAT: f64 = 85.051_128_779_806_59;
+// Tile-grid pole cutoff — geometry is pinned to the grid edge, the one
+// place clamping to the limit is allowed (see `ds_core::web_mercator`).
+use ds_core::web_mercator::LAT_LIMIT_DEG as WEB_MERCATOR_MAX_LAT;
 
 struct Projector {
     tms: TmsKind,
@@ -504,12 +504,12 @@ impl Projector {
 }
 
 fn lon_to_merc_x(lon: f64) -> f64 {
-    lon.to_radians() * EARTH_RADIUS_M
+    ds_core::web_mercator::lon_to_x(lon)
 }
 
 fn lat_to_merc_y(lat: f64) -> f64 {
     let clamped = lat.clamp(-WEB_MERCATOR_MAX_LAT, WEB_MERCATOR_MAX_LAT);
-    clamped.to_radians().tan().asinh() * EARTH_RADIUS_M
+    ds_core::web_mercator::lat_to_y(clamped)
 }
 
 /// Hash of a property allowlist for use as a component of vector-tile cache

--- a/crates/engine-geotiff/tests/low_zoom_domain_guard.rs
+++ b/crates/engine-geotiff/tests/low_zoom_domain_guard.rs
@@ -42,10 +42,13 @@ fn engine() -> GeoTiffEngine {
 }
 
 fn wgs84_of_merc(minx: f64, miny: f64, maxx: f64, maxy: f64) -> [f64; 4] {
-    const R: f64 = 6_378_137.0;
-    let lon = |x: f64| (x / R).to_degrees();
-    let lat = |y: f64| (2.0 * (y / R).exp().atan() - std::f64::consts::FRAC_PI_2).to_degrees();
-    [lon(minx), lat(miny), lon(maxx), lat(maxy)]
+    use ds_core::web_mercator::{x_to_lon, y_to_lat};
+    [
+        x_to_lon(minx),
+        y_to_lat(miny),
+        x_to_lon(maxx),
+        y_to_lat(maxy),
+    ]
 }
 
 fn normalize_lon(mut lon: f64) -> f64 {

--- a/crates/engine-odim/src/proj.rs
+++ b/crates/engine-odim/src/proj.rs
@@ -127,8 +127,8 @@ fn parse_k0(params: &HashMap<String, String>) -> Result<Option<f64>, ParseError>
     }
 }
 
-/// WGS84 semi-major axis in metres (matches `ds_core::geo::WGS84_A`).
-const WGS84_A: f64 = 6_378_137.0;
+// WGS84 semi-major axis in metres (the shared ds-core constant).
+use ds_core::geo::WGS84_A;
 /// Tolerance for accepting `+R=` as WGS84-compatible. The producer
 /// is reaffirming the WGS84 sphere within ~1 metre.
 const WGS84_A_TOLERANCE: f64 = 1.0;
@@ -544,7 +544,7 @@ mod tests {
     /// alarm.
     #[test]
     fn sphere_radius_matching_wgs84_a_is_accepted() {
-        let crs = parse("+proj=stere +lat_0=56 +lon_0=10.5666 +k=1 +R=6378137").unwrap();
+        let crs = parse("+proj=stere +lat_0=56 +lon_0=10.5666 +k=1 +R=6378137").unwrap(); // nogeocheck — PROJ-string fixture, the value under test
         assert!(matches!(crs, Crs::Stereographic { .. }));
     }
 

--- a/crates/render/src/metatile.rs
+++ b/crates/render/src/metatile.rs
@@ -625,7 +625,7 @@ mod tests {
         }
         // Grid corners.
         assert!((lon_to_x(-180.0) + ORIGIN).abs() < 1e-3);
-        assert!((lat_to_y(85.0511287798066) - ORIGIN).abs() < 1.0);
+        assert!((lat_to_y(ds_core::web_mercator::LAT_LIMIT_DEG) - ORIGIN).abs() < 1.0);
     }
 
     /// A solid colormap so every in-extent pixel is opaque red; lets us assert

--- a/scripts/check_geo_safety.sh
+++ b/scripts/check_geo_safety.sh
@@ -1,0 +1,95 @@
+#!/bin/sh
+# check_geo_safety.sh — guard rail for two workspace-wide invariants.
+#
+# 1. EPSG:3857 ↔ WGS84 math lives ONLY in `ds_core::web_mercator`.
+#    Four hand-rolled copies once drifted and displaced rendered data
+#    ~10° at low zoom (#452); the consolidation was #454, and two more
+#    leftover copies were found later (#482). This script fails CI when
+#    it finds the forward transform (ln∘tan / asinh∘tan), the inverse
+#    (atan∘sinh / atan∘exp), or the Web Mercator magic constants
+#    (20037508…, 85.0511…) anywhere outside crates/core.
+#
+# 2. api-wms builds all XML through quick-xml::Writer, never format!()
+#    or string concatenation (XML injection risk).
+#
+# Wire into CI next to check_sql_safety.sh:
+#   - name: Geo/XML safety guard
+#     run: bash scripts/check_geo_safety.sh
+#
+# A definitely-legitimate line can opt out with a trailing `// nogeocheck`
+# comment — use sparingly and say why.
+#
+# Exits 0 when clean, 1 when suspicious patterns are found, 2 when the
+# source tree is missing. POSIX sh; BSD-compatible grep (runs on macOS).
+
+set -eu
+
+if [ ! -d "crates" ]; then
+    echo "check_geo_safety: crates/ not found (run from the repo root)" >&2
+    exit 2
+fi
+
+found=0
+
+# All engine/api/render source, excluding crates/core (where web_mercator
+# and geo legitimately implement the math).
+GEO_DIRS=$(find crates -maxdepth 1 -mindepth 1 -type d ! -name core)
+
+# Drop comment-only lines and explicit opt-outs from grep -rn output
+# (file:line:content — filter on the content portion).
+strip_noise() {
+    grep -vE ':[0-9]+:[[:space:]]*//' | grep -v '// nogeocheck'
+}
+
+# --- 1a. Forward Web Mercator: ln(tan φ + sec φ) or asinh(tan φ) ----------
+# shellcheck disable=SC2086
+if grep -rnE '(tan\(.*\.ln\(\)|\.ln\(\).*tan\(|tan\(\)[[:space:]]*\.asinh\(|asinh\(.*tan)' \
+    $GEO_DIRS --include='*.rs' | strip_noise
+then
+    echo >&2
+    echo "check_geo_safety: hand-rolled forward Web Mercator transform." >&2
+    echo "  Use ds_core::web_mercator::lat_to_y / lon_to_x instead (#452)." >&2
+    found=1
+fi
+
+# --- 1b. Inverse Web Mercator: atan(sinh y) or atan(exp y) ----------------
+# shellcheck disable=SC2086
+if grep -rnE 'atan\(.*sinh\(|sinh\(.*atan\(|atan\(.*exp\(|exp\(.*atan\(' \
+    $GEO_DIRS --include='*.rs' | strip_noise
+then
+    echo >&2
+    echo "check_geo_safety: hand-rolled inverse Web Mercator transform." >&2
+    echo "  Use ds_core::web_mercator::y_to_lat / x_to_lon instead (#452)." >&2
+    found=1
+fi
+
+# --- 1c. Web Mercator magic constants -------------------------------------
+# 20037508… (π·R, the world half-width) and 85.0511… (the tile-grid pole
+# cutoff). Both have named homes: web_mercator::{EARTH_RADIUS, LAT_LIMIT_DEG}.
+# shellcheck disable=SC2086
+if grep -rnE '20037508|85\.0511' $GEO_DIRS --include='*.rs' | strip_noise
+then
+    echo >&2
+    echo "check_geo_safety: Web Mercator magic constant outside crates/core." >&2
+    echo "  Use ds_core::web_mercator::{EARTH_RADIUS, LAT_LIMIT_DEG} (#454)." >&2
+    found=1
+fi
+
+# --- 2. XML assembled with format!() in api-wms ----------------------------
+# All XML output goes through quick-xml::Writer for escaping. A format!()
+# whose template opens an XML tag is the injection vector.
+if grep -rnE 'format!\([[:space:]]*"[^"]*<[A-Za-z/]' \
+    crates/api-wms/src --include='*.rs' | strip_noise
+then
+    echo >&2
+    echo "check_geo_safety: format!() assembling XML in api-wms." >&2
+    echo "  All XML must go through quick-xml::Writer (injection risk)." >&2
+    found=1
+fi
+
+if [ "$found" -ne 0 ]; then
+    exit 1
+fi
+
+echo "check_geo_safety: clean"
+exit 0

--- a/scripts/check_geo_safety.sh
+++ b/scripts/check_geo_safety.sh
@@ -63,28 +63,55 @@ then
     found=1
 fi
 
-# --- 1c. Web Mercator magic constants -------------------------------------
-# 20037508… (π·R, the world half-width) and 85.0511… (the tile-grid pole
-# cutoff). Both have named homes: web_mercator::{EARTH_RADIUS, LAT_LIMIT_DEG}.
+# --- 1c. Web Mercator / WGS84 magic constants ------------------------------
+# 20037508… (π·R, the world half-width), 85.0511… (the tile-grid pole
+# cutoff), and the sphere radius 6378137 itself. Rust's underscore-grouped
+# literals (85.051_128_…, 6_378_137.0) would defeat a plain grep, so
+# underscores are stripped before matching (line numbers preserved).
+# Named homes: web_mercator::{EARTH_RADIUS, LAT_LIMIT_DEG}, geo::WGS84_A.
 # shellcheck disable=SC2086
-if grep -rnE '20037508|85\.0511' $GEO_DIRS --include='*.rs' | strip_noise
+if find $GEO_DIRS -name '*.rs' -print0 | xargs -0 perl -ne '
+        my $orig = $_;
+        (my $stripped = $_) =~ s/_//g;
+        print "$ARGV:$.:$orig" if $stripped =~ /20037508|85\.0511|(?<![0-9])6378137/;
+        close ARGV if eof;
+    ' | strip_noise
 then
     echo >&2
-    echo "check_geo_safety: Web Mercator magic constant outside crates/core." >&2
-    echo "  Use ds_core::web_mercator::{EARTH_RADIUS, LAT_LIMIT_DEG} (#454)." >&2
+    echo "check_geo_safety: Web Mercator / WGS84 magic constant outside" >&2
+    echo "  crates/core. Use ds_core::web_mercator::{EARTH_RADIUS," >&2
+    echo "  LAT_LIMIT_DEG} or ds_core::geo::WGS84_A (#454)." >&2
     found=1
 fi
 
-# --- 2. XML assembled with format!() in api-wms ----------------------------
-# All XML output goes through quick-xml::Writer for escaping. A format!()
-# whose template opens an XML tag is the injection vector.
-if grep -rnE 'format!\([[:space:]]*"[^"]*<[A-Za-z/]' \
+# --- 2. XML assembled by hand in api-wms -----------------------------------
+# All XML output goes through quick-xml::Writer for escaping. The CLAUDE.md
+# rule bans format!() AND string concatenation; cover the same three vectors
+# check_sql_safety.sh covers for SQL: format!/concat!, `+ "<…"`, and
+# push_str("<…").
+if grep -rnE '(format!|concat!)\([[:space:]]*"[^"]*<[A-Za-z/]|\+[[:space:]]*"[[:space:]]*<[A-Za-z/]|push_str[[:space:]]*\([[:space:]]*"[^"]*<[A-Za-z/]' \
     crates/api-wms/src --include='*.rs' | strip_noise
 then
     echo >&2
-    echo "check_geo_safety: format!() assembling XML in api-wms." >&2
+    echo "check_geo_safety: hand-assembled XML in api-wms." >&2
     echo "  All XML must go through quick-xml::Writer (injection risk)." >&2
     found=1
+fi
+
+# Multi-line format!() opening an XML tag further down the macro body —
+# line-oriented grep misses these; perl in slurp mode (same silent-skip
+# fallback as check_sql_safety.sh when perl is unavailable).
+if command -v perl >/dev/null 2>&1; then
+    if find crates/api-wms/src -name '*.rs' -print0 | \
+        xargs -0 perl -0ne 'if (/(format!|concat!)\s*\(\s*"[^"]*<[A-Za-z\/]/) { print STDERR "$ARGV: multi-line format!/concat! assembling XML\n"; exit 1 }' \
+        2>/dev/null; then
+        : # no matches
+    else
+        echo >&2
+        echo "check_geo_safety: multi-line format!()/concat!() assembling XML" >&2
+        echo "  in api-wms. All XML must go through quick-xml::Writer." >&2
+        found=1
+    fi
 fi
 
 if [ "$found" -ne 0 ]; then


### PR DESCRIPTION
## Summary

CLAUDE.md's two greppable invariants — EPSG:3857 math only in `ds_core::web_mercator` (#452/#454) and api-wms XML only via `quick-xml::Writer` — were enforced by prose alone. This adds `scripts/check_geo_safety.sh` (mirroring `check_sql_safety.sh`: POSIX sh, comment-line filtering, `// nogeocheck` opt-out) and wires it into CI next to the SQL safety step.

**The tripwire found three live copies the #454 consolidation missed**, all algebraically-equivalent-today forms of the same transform, fixed here:

| Site | Form |
|---|---|
| `api-tiles/src/tilematrixset.rs` `lat_to_row` | `ln(tan φ + sec φ)` forward |
| `ds-mvt/src/encode.rs` `lat_to_merc_y` | `asinh(tan φ)` forward (+ local `EARTH_RADIUS_M` / `WEB_MERCATOR_MAX_LAT` consts, now aliases of the shared ones) |
| `engine-geotiff/tests/low_zoom_domain_guard.rs` | `2·atan(eʸ)−π/2` inverse (test helper) |

The ds-mvt clamp stays (tile-grid-edge pinning — the one clamping the shared module's docs allow); a `render/src/metatile.rs` test's truncated `85.0511287798066` literal now uses `LAT_LIMIT_DEG`.

## Testing

- Script self-test: exit 1 on the pre-fix tree (stash), exit 0 after — both verified.
- `cargo test -p api-tiles -p ds-mvt -p ds-render` all pass; `cargo test -p engine-geotiff --test low_zoom_domain_guard` passes.
- fmt + clippy clean on touched crates.

Closes #482

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T22YrnSuwKW6mFebJBHaBt