### PR TITLE
ci: bump actions/checkout to v6 in claude workflows

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # Full history so the action can diff the PR against the base branch.
           fetch-depth: 0

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -34,7 +34,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 


### PR DESCRIPTION
`claude.yml` and `claude-code-review.yml` pinned `actions/checkout@v4` (Node 20 — deprecated on GitHub-hosted runners, forced to Node 24 since 2026-06-02 and removed 2026-09-16). `ci.yml`/`release.yml` are already on v6. Two-line bump, no other changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T22YrnSuwKW6mFebJBHaBt