### PR TITLE
chore(claude): committed project hooks — branch/fmt commit guard + per-crate edit checks

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "sh scripts/hooks/pre-commit-guard.sh",
+            "command": "cd \"${CLAUDE_PROJECT_DIR:-.}\" && sh scripts/hooks/pre-commit-guard.sh",
             "timeout": 120,
             "statusMessage": "Pre-commit guard: branch + cargo fmt"
           }
@@ -19,7 +19,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 scripts/hooks/post-edit-checks.py",
+            "command": "cd \"${CLAUDE_PROJECT_DIR:-.}\" && python3 scripts/hooks/post-edit-checks.py",
             "timeout": 60,
             "statusMessage": "Post-edit checks: SQL safety / CovJSON reminder"
           }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,30 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh scripts/hooks/pre-commit-guard.sh",
+            "timeout": 120,
+            "statusMessage": "Pre-commit guard: branch + cargo fmt"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 scripts/hooks/post-edit-checks.py",
+            "timeout": 60,
+            "statusMessage": "Post-edit checks: SQL safety / CovJSON reminder"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@ __pycache__/
 # Docker builder; should never be committed (.dockerignore also excludes
 # it so a stray local copy doesn't override the planner's fresh output).
 recipe.json
+
+# Personal Claude Code overrides — .claude/settings.json is committed
+# (team hooks), but the .local variant is per-machine and must never be.
+.claude/settings.local.json

--- a/scripts/hooks/post-edit-checks.py
+++ b/scripts/hooks/post-edit-checks.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Claude Code PostToolUse hook (matcher: Edit|Write).
+
+Per-file guards that run right after an edit lands, instead of waiting
+for CI:
+
+- An edit under crates/engine-postgis/ re-runs scripts/check_sql_safety.sh
+  (the CI SQL-injection tripwire); a failure is fed back to the model as a
+  blocking reason so it fixes the pattern immediately.
+- An edit to crates/api-edr/src/response.rs injects a reminder that all
+  CoverageJSON output must validate against the OGC schema
+  (`cargo test -p api-edr`, CLAUDE.md Critical Rule 12).
+
+Wired up in .claude/settings.json. Exits 0 with no output when nothing
+applies.
+"""
+
+import json
+import subprocess
+import sys
+
+
+def main() -> None:
+    try:
+        data = json.load(sys.stdin)
+    except Exception:
+        return
+
+    tool_input = data.get("tool_input") or {}
+    tool_response = data.get("tool_response") or {}
+    path = tool_input.get("file_path") or tool_response.get("filePath") or ""
+
+    if "crates/engine-postgis/" in path and path.endswith(".rs"):
+        result = subprocess.run(
+            ["sh", "scripts/check_sql_safety.sh"],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            output = (result.stdout + result.stderr)[-2000:]
+            print(
+                json.dumps(
+                    {
+                        "decision": "block",
+                        "reason": (
+                            "scripts/check_sql_safety.sh failed after this "
+                            "edit - fix the flagged SQL pattern before "
+                            "continuing:\n" + output
+                        ),
+                    }
+                )
+            )
+        return
+
+    if path.endswith("crates/api-edr/src/response.rs"):
+        print(
+            json.dumps(
+                {
+                    "hookSpecificOutput": {
+                        "hookEventName": "PostToolUse",
+                        "additionalContext": (
+                            "response.rs (CoverageJSON output) was modified. "
+                            "All CoverageJSON must validate against the OGC "
+                            "schema - run `cargo test -p api-edr` before "
+                            "finishing (CLAUDE.md Critical Rule 12)."
+                        ),
+                    }
+                }
+            )
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/hooks/post-edit-checks.py
+++ b/scripts/hooks/post-edit-checks.py
@@ -36,7 +36,7 @@ def main() -> None:
             capture_output=True,
             text=True,
         )
-        if result.returncode != 0:
+        if result.returncode == 1:
             output = (result.stdout + result.stderr)[-2000:]
             print(
                 json.dumps(
@@ -47,6 +47,21 @@ def main() -> None:
                             "edit - fix the flagged SQL pattern before "
                             "continuing:\n" + output
                         ),
+                    }
+                )
+            )
+        elif result.returncode != 0:
+            # Exit 2 = the script couldn't find its target directory (wrong
+            # cwd / moved tree) - a hook-config problem, not a violation.
+            # Warn without blocking.
+            print(
+                json.dumps(
+                    {
+                        "systemMessage": (
+                            "post-edit-checks: check_sql_safety.sh exited "
+                            f"{result.returncode} (config problem, not a "
+                            "violation) - run it manually from the repo root."
+                        )
                     }
                 )
             )

--- a/scripts/hooks/pre-commit-guard.sh
+++ b/scripts/hooks/pre-commit-guard.sh
@@ -19,11 +19,16 @@ input=$(cat)
 
 # Detect an actual `git commit` INVOCATION, not the substring: `git` must sit
 # at a command position (start of line, or after ;, &, |, (, backtick, or a
-# newline), followed only by flag-like tokens before the `commit` subcommand
-# (optionally quoted). This avoids denying e.g. `git log --grep="git commit"`
-# while still catching `git add x && git commit`, `git  commit`, and
-# `git "commit"`. A variable-built command can still evade this — it is a
-# guardrail against habitual mistakes, not a security boundary.
+# newline), optionally preceded by NAME=value env assignments, followed only
+# by flag tokens (each may take one non-flag argument: -C <dir>, -c k=v)
+# before the `commit` subcommand (optionally quoted). Heredoc bodies are
+# stripped first so a data line reading "git commit" (e.g. writing an example
+# script) is not treated as an invocation. This avoids denying
+# `git log --grep="git commit"` and heredoc data while still catching
+# `git add x && git commit`, `git  commit`, `git "commit"`,
+# `git -C /tmp commit`, `git -c user.email=x commit`, and `V=1 git commit`.
+# A variable-built command can still evade this — it is a guardrail against
+# habitual mistakes, not a security boundary.
 is_commit=$(printf '%s' "$input" | python3 -c '
 import json, re, sys
 try:
@@ -31,7 +36,20 @@ try:
 except Exception:
     sys.exit(0)
 cmd = (data.get("tool_input") or {}).get("command", "")
-pat = re.compile(r"(?:^|[;&|(`\n])\s*git\s+(?:-\S+\s+)*[\"\x27]?commit\b")
+# Strip heredoc bodies (<<EOF … EOF, <<-EOF, quoted delimiters).
+cmd = re.sub(
+    r"<<-?\s*([\"\x27]?)(\w+)\1.*?\n\s*\2\s*(?=\n|$)",
+    "<<HEREDOC_STRIPPED",
+    cmd,
+    flags=re.S,
+)
+pat = re.compile(
+    r"(?:^|[;&|(`\n])\s*"                    # command position
+    r"(?:[A-Za-z_][A-Za-z0-9_]*=\S*\s+)*"    # env-var prefixes
+    r"git\s+"
+    r"(?:-\S+(?:\s+[^-\s]\S*)?\s+)*"         # flags, each w/ optional argument
+    r"[\"\x27]?commit\b"
+)
 print("commit" if pat.search(cmd) else "")
 ' 2>/dev/null) || exit 0
 

--- a/scripts/hooks/pre-commit-guard.sh
+++ b/scripts/hooks/pre-commit-guard.sh
@@ -26,9 +26,13 @@ input=$(cat)
 # script) is not treated as an invocation. This avoids denying
 # `git log --grep="git commit"` and heredoc data while still catching
 # `git add x && git commit`, `git  commit`, `git "commit"`,
-# `git -C /tmp commit`, `git -c user.email=x commit`, and `V=1 git commit`.
-# A variable-built command can still evade this — it is a guardrail against
-# habitual mistakes, not a security boundary.
+# `git -C /tmp commit`, `git -c user.email=x commit`, `V=1 git commit`,
+# `command git commit`, and `\git commit`. The trailing (?!-) keeps the
+# unrelated plumbing subcommands `git commit-tree` / `git commit-graph` out.
+# Known undetected-by-design forms (a guardrail against habitual mistakes,
+# not a security boundary): interpreter-wrapped commits (`sh -c "git commit"`
+# — the string is data to this shell), absolute paths (`/usr/bin/git commit`),
+# and variable-built commands.
 is_commit=$(printf '%s' "$input" | python3 -c '
 import json, re, sys
 try:
@@ -46,9 +50,9 @@ cmd = re.sub(
 pat = re.compile(
     r"(?:^|[;&|(`\n])\s*"                    # command position
     r"(?:[A-Za-z_][A-Za-z0-9_]*=\S*\s+)*"    # env-var prefixes
-    r"git\s+"
+    r"(?:command\s+)?\\?git\s+"              # also `command git`, `\git`
     r"(?:-\S+(?:\s+[^-\s]\S*)?\s+)*"         # flags, each w/ optional argument
-    r"[\"\x27]?commit\b"
+    r"[\"\x27]?commit\b(?!-)"                # not commit-tree / commit-graph
 )
 print("commit" if pat.search(cmd) else "")
 ' 2>/dev/null) || exit 0

--- a/scripts/hooks/pre-commit-guard.sh
+++ b/scripts/hooks/pre-commit-guard.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+# Claude Code PreToolUse hook (matcher: Bash). Guards `git commit`:
+#
+#   1. Blocks committing directly on `main` (CLAUDE.md Critical Rule 1 —
+#      always branch + PR).
+#   2. Blocks committing with formatting drift (Critical Rule 2 — CI runs
+#      `cargo fmt -- --check` and would reject the push anyway; failing
+#      here saves the round-trip).
+#
+# Reads the tool-call JSON on stdin; exits silently (allow) for anything
+# that is not a `git commit`. Emits a PreToolUse permissionDecision JSON
+# to deny, so the reason is fed back to the model.
+#
+# Wired up in .claude/settings.json. POSIX sh; python3 for JSON parsing.
+
+set -u
+
+input=$(cat)
+
+cmd=$(printf '%s' "$input" | python3 -c '
+import json, sys
+try:
+    data = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+print((data.get("tool_input") or {}).get("command", ""))
+' 2>/dev/null) || exit 0
+
+case "$cmd" in
+*"git commit"*) ;;
+*) exit 0 ;;
+esac
+
+deny() {
+    printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"%s"}}\n' "$1"
+    exit 0
+}
+
+branch=$(git branch --show-current 2>/dev/null || true)
+if [ "$branch" = "main" ]; then
+    deny "Blocked: committing directly to main violates CLAUDE.md Critical Rule 1 - create a branch first (git checkout -b <branch>) and open a PR."
+fi
+
+if ! cargo fmt --check >/dev/null 2>&1; then
+    deny "Blocked: cargo fmt --check failed - run cargo fmt before committing (CLAUDE.md Critical Rule 2; CI rejects formatting drift)."
+fi
+
+exit 0

--- a/scripts/hooks/pre-commit-guard.sh
+++ b/scripts/hooks/pre-commit-guard.sh
@@ -17,19 +17,25 @@ set -u
 
 input=$(cat)
 
-cmd=$(printf '%s' "$input" | python3 -c '
-import json, sys
+# Detect an actual `git commit` INVOCATION, not the substring: `git` must sit
+# at a command position (start of line, or after ;, &, |, (, backtick, or a
+# newline), followed only by flag-like tokens before the `commit` subcommand
+# (optionally quoted). This avoids denying e.g. `git log --grep="git commit"`
+# while still catching `git add x && git commit`, `git  commit`, and
+# `git "commit"`. A variable-built command can still evade this — it is a
+# guardrail against habitual mistakes, not a security boundary.
+is_commit=$(printf '%s' "$input" | python3 -c '
+import json, re, sys
 try:
     data = json.load(sys.stdin)
 except Exception:
     sys.exit(0)
-print((data.get("tool_input") or {}).get("command", ""))
+cmd = (data.get("tool_input") or {}).get("command", "")
+pat = re.compile(r"(?:^|[;&|(`\n])\s*git\s+(?:-\S+\s+)*[\"\x27]?commit\b")
+print("commit" if pat.search(cmd) else "")
 ' 2>/dev/null) || exit 0
 
-case "$cmd" in
-*"git commit"*) ;;
-*) exit 0 ;;
-esac
+[ "$is_commit" = "commit" ] || exit 0
 
 deny() {
     printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"%s"}}\n' "$1"


### PR DESCRIPTION
## Summary

First committed `.claude/settings.json` for the repo (project scope; `settings.local.json` remains personal/ignored). Turns three CLAUDE.md prose rules into machine-enforced hooks:

| Hook | Event | Behavior |
|---|---|---|
| `scripts/hooks/pre-commit-guard.sh` | PreToolUse (Bash) | Denies `git commit` on `main`; denies commit when `cargo fmt --check` fails — reason fed back to the model, saving the CI round-trip |
| `scripts/hooks/post-edit-checks.py` | PostToolUse (Edit\|Write) | Re-runs `scripts/check_sql_safety.sh` after any `engine-postgis` `.rs` edit (blocks on failure); injects the `cargo test -p api-edr` CoverageJSON reminder after `api-edr/src/response.rs` edits |

Non-matching tool calls exit silently (~30 ms python3 spawn worst case).

## Verification

Pipe-tested with the exact stdin JSON the harness sends, all 8 paths: non-commit pass-through, commit on feature branch (allow), commit on main (deny JSON), postgis edit on clean tree (silent), postgis edit with a planted `format!("SELECT …")` violation (block JSON, then cleaned up + tripwire re-verified clean), response.rs edit (additionalContext), plus `jq -e` schema validation of settings.json.

Note for reviewers: hooks activate on session start (or `/hooks` reload) — an already-running session won't pick them up mid-flight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T22YrnSuwKW6mFebJBHaBt