### PR TITLE
refactor: extract shared byte-bounded LRU cache module (#480)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,7 @@ weather data (radar, NWP models, observations, alerts).
 Crates: `ds-core` (traits + types + shared utilities, directory `crates/core`),
 `ds-storage` (S3/HTTP/local object store, directory `crates/storage`),
 `ds-render` (raster colorization + PNG encoding, directory `crates/render`),
+`ds-cache` (shared byte-bounded LRU cache plumbing),
 `ds-mvt` (Mapbox Vector Tile encoder + LRU tile cache), `ds-3dtiles`
 (OGC 3D Tiles encoder), engines (`engine-csv`, `engine-geojson`,
 `engine-geotiff`, `engine-grib`, `engine-odim`, `engine-querydata`,
@@ -147,6 +148,14 @@ gh issue create --title "..." --label "bug,priority: high" --milestone "v0.2"
 - **`ds-render` has no framework dependencies** (only ds-core and `png`).
   `ds-mvt` and `ds-3dtiles` are likewise framework-free byte encoders,
   mirroring `ds-render`.
+- **Byte-bounded LRU caches go through `ds-cache`** (#480):
+  `ds_cache::ByteBoundedCache` owns the weigher/env-parse/hit-miss-counter/
+  metrics plumbing (including single-flight `get_or_insert_with`); call
+  sites keep their key type, weight fn, `MC_*_CACHE_MB` env var name and
+  defaults. Don't hand-roll a `quick_cache` byte-weighted cache — before
+  extraction the same ~40 lines were copy-pasted 12×. In `server/src/
+  admin.rs`, a global cache's `/metrics` family is one `CacheMetricSet`
+  static + one `update()` call in `metrics_handler`.
 - **API crates depend only on ds-core** (plus ds-render for
   api-wms/api-maps, and api-edr for its `f=png` time-series plots) — never on
   engine crates. API state is a registry of engines keyed by collection ID.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,10 +73,10 @@ dependencies = [
  "bytes",
  "chrono",
  "ds-3dtiles",
+ "ds-cache",
  "ds-core",
  "ds-render",
  "http-body-util",
- "quick_cache",
  "serde",
  "serde_json",
  "tokio",
@@ -1030,6 +1030,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "ds-cache"
+version = "0.1.0"
+dependencies = [
+ "quick_cache",
+]
+
+[[package]]
 name = "ds-core"
 version = "0.1.0"
 dependencies = [
@@ -1045,9 +1052,9 @@ name = "ds-mvt"
 version = "0.1.0"
 dependencies = [
  "bytes",
+ "ds-cache",
  "ds-core",
  "mvt",
- "quick_cache",
  "thiserror 2.0.18",
 ]
 
@@ -1057,6 +1064,7 @@ version = "0.1.0"
 dependencies = [
  "bytes",
  "chrono",
+ "ds-cache",
  "ds-core",
  "jpeg-encoder",
  "png",
@@ -1149,12 +1157,12 @@ dependencies = [
  "bytes",
  "chrono",
  "criterion",
+ "ds-cache",
  "ds-core",
  "ds-storage",
  "flate2",
  "futures",
  "memmap2",
- "quick_cache",
  "rayon",
  "regex",
  "reqwest",
@@ -1173,10 +1181,10 @@ version = "0.1.0"
 dependencies = [
  "arc-swap",
  "chrono",
+ "ds-cache",
  "ds-core",
  "ds-storage",
  "grib",
- "quick_cache",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -1191,6 +1199,7 @@ dependencies = [
  "arc-swap",
  "chrono",
  "ds-3dtiles",
+ "ds-cache",
  "ds-core",
  "ds-render",
  "ds-storage",
@@ -1241,10 +1250,10 @@ dependencies = [
  "arc-swap",
  "bytes",
  "chrono",
+ "ds-cache",
  "ds-core",
  "ds-storage",
  "icechunk",
- "quick_cache",
  "serde",
  "serde_json",
  "tempfile",
@@ -4034,6 +4043,7 @@ dependencies = [
  "arc-swap",
  "axum",
  "chrono",
+ "ds-cache",
  "ds-core",
  "ds-mvt",
  "ds-render",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "crates/engine-zarr",
     "crates/storage",
     "crates/render",
+    "crates/ds-cache",
     "crates/ds-mvt",
     "crates/ds-3dtiles",
     "crates/api-edr",

--- a/crates/api-3dtiles/Cargo.toml
+++ b/crates/api-3dtiles/Cargo.toml
@@ -12,7 +12,7 @@ arc-swap = "1"
 axum = "0.8"
 bytes = "1"
 chrono = { version = "0.4", features = ["serde"] }
-quick_cache = "0.6"
+ds-cache = { path = "../ds-cache" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["sync", "rt"] }

--- a/crates/api-3dtiles/src/cache.rs
+++ b/crates/api-3dtiles/src/cache.rs
@@ -27,11 +27,11 @@
 
 use std::collections::HashMap;
 use std::future::Future;
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, LazyLock, Mutex};
 
 use bytes::Bytes;
 use chrono::{DateTime, Utc};
+use ds_cache::{ByteBoundedCache, CacheMetrics};
 
 use crate::error::Tiles3dError;
 
@@ -93,43 +93,32 @@ pub struct CachedContent {
 }
 
 /// Byte-weights an entry by its encoded payload.
-#[derive(Clone)]
-struct ContentWeighter;
-
-impl quick_cache::Weighter<ContentKey, CachedContent> for ContentWeighter {
-    fn weight(&self, key: &ContentKey, val: &CachedContent) -> u64 {
-        (val.bytes.len() + val.etag.len() + key.collection.len() + key.quantity.len() + 128) as u64
-    }
+fn weigh_content(key: &ContentKey, val: &CachedContent) -> u64 {
+    (val.bytes.len() + val.etag.len() + key.collection.len() + key.quantity.len() + 128) as u64
 }
 
 /// Byte-bounded LRU of encoded content + per-key single-flight gates.
 pub struct ContentCache {
-    cache: quick_cache::sync::Cache<ContentKey, CachedContent, ContentWeighter>,
+    cache: ByteBoundedCache<ContentKey, CachedContent>,
     /// One async mutex per in-flight key. The first requester computes while
     /// holding the gate; coalesced requesters block on it, then find the
     /// cache populated. Entries are removed when their compute finishes, so
     /// the map only ever holds currently-computing keys.
     inflight: Mutex<HashMap<ContentKey, Arc<tokio::sync::Mutex<()>>>>,
-    hits: AtomicU64,
-    misses: AtomicU64,
 }
 
 impl ContentCache {
     fn new(capacity_mb: u64) -> Self {
-        let capacity_bytes = capacity_mb.saturating_mul(1024 * 1024);
-        // Estimate item slots at ~2 MB each; `.max(1)` keeps capacity 0 valid
+        // Estimate item slots at ~2 MB each; capacity 0 disables retention
         // (entries heavier than capacity are simply never admitted — the same
         // "disabled" idiom as the engine's pixel cache).
-        let estimated_items = ((capacity_bytes / (2 * 1024 * 1024)).max(16)) as usize;
         ContentCache {
-            cache: quick_cache::sync::Cache::with_weighter(
-                estimated_items,
-                capacity_bytes.max(1),
-                ContentWeighter,
+            cache: ByteBoundedCache::new(
+                capacity_mb.saturating_mul(ds_cache::MIB),
+                2 * ds_cache::MIB,
+                weigh_content,
             ),
             inflight: Mutex::new(HashMap::new()),
-            hits: AtomicU64::new(0),
-            misses: AtomicU64::new(0),
         }
     }
 
@@ -147,8 +136,11 @@ impl ContentCache {
         F: FnOnce() -> Fut,
         Fut: Future<Output = Result<(Vec<u8>, String), Tiles3dError>>,
     {
-        if let Some(hit) = self.cache.get(&key) {
-            self.hits.fetch_add(1, Ordering::Relaxed);
+        // Untracked lookups + explicit hit/miss recording: a coalesced waiter
+        // that misses the first lookup but hits the re-check under the gate
+        // must count as ONE hit, not a miss + a hit.
+        if let Some(hit) = self.cache.get_untracked(&key) {
+            self.cache.record_hit();
             return Ok(hit);
         }
         let gate = {
@@ -160,12 +152,12 @@ impl ContentCache {
         let _held = gate.lock().await;
         // Re-check under the gate: if a coalesced compute just finished, the
         // bytes are in the cache and this request cost two lookups.
-        if let Some(hit) = self.cache.get(&key) {
-            self.hits.fetch_add(1, Ordering::Relaxed);
+        if let Some(hit) = self.cache.get_untracked(&key) {
+            self.cache.record_hit();
             self.release(&key, &gate);
             return Ok(hit);
         }
-        self.misses.fetch_add(1, Ordering::Relaxed);
+        self.cache.record_miss();
         let result = compute().await;
         let out = match result {
             Ok((bytes, etag)) => {
@@ -192,33 +184,29 @@ impl ContentCache {
         }
     }
 
-    /// Snapshot for `/metrics`: `(hits, misses, resident_bytes, capacity_bytes)`.
-    pub fn metrics(&self) -> (u64, u64, u64, u64) {
-        (
-            self.hits.load(Ordering::Relaxed),
-            self.misses.load(Ordering::Relaxed),
-            self.cache.weight(),
-            self.cache.capacity(),
-        )
+    /// Snapshot for `/metrics`.
+    pub fn metrics(&self) -> CacheMetrics {
+        self.cache.metrics()
     }
 }
 
 /// The process-global content cache, sized once from the environment.
 pub static CONTENT_CACHE: LazyLock<ContentCache> = LazyLock::new(|| {
-    let mb = std::env::var("MC_3DTILES_CONTENT_CACHE_MB")
-        .ok()
-        .and_then(|s| s.trim().parse::<u64>().ok())
-        .unwrap_or(DEFAULT_CONTENT_CACHE_MB);
-    ContentCache::new(mb)
+    ContentCache::new(ds_cache::env_mb(
+        "MC_3DTILES_CONTENT_CACHE_MB",
+        DEFAULT_CONTENT_CACHE_MB,
+    ))
 });
 
 /// Snapshot of the global cache for `/metrics`.
-pub fn content_cache_metrics() -> (u64, u64, u64, u64) {
+pub fn content_cache_metrics() -> CacheMetrics {
     CONTENT_CACHE.metrics()
 }
 
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::{AtomicU64, Ordering};
+
     use super::*;
 
     fn key(n: u64) -> ContentKey {
@@ -250,9 +238,9 @@ mod tests {
             assert_eq!(&*got.etag, "\"abc\"");
         }
         assert_eq!(computes.load(Ordering::Relaxed), 1, "one compute, two hits");
-        let (hits, misses, bytes, _cap) = cache.metrics();
-        assert_eq!((hits, misses), (2, 1));
-        assert!(bytes > 0);
+        let m = cache.metrics();
+        assert_eq!((m.hits, m.misses), (2, 1));
+        assert!(m.bytes > 0);
     }
 
     #[tokio::test]
@@ -268,8 +256,8 @@ mod tests {
                 .unwrap();
             assert_eq!(&got.bytes[..], &[v as u8]);
         }
-        let (hits, misses, _, _) = cache.metrics();
-        assert_eq!((hits, misses), (0, 2));
+        let m = cache.metrics();
+        assert_eq!((m.hits, m.misses), (0, 2));
     }
 
     #[tokio::test]
@@ -328,7 +316,7 @@ mod tests {
                 .unwrap();
             assert_eq!(&got.bytes[..], &[1]);
         }
-        let (hits, misses, _, _) = cache.metrics();
-        assert_eq!((hits, misses), (0, 2), "nothing admitted at capacity 0");
+        let m = cache.metrics();
+        assert_eq!((m.hits, m.misses), (0, 2), "nothing admitted at capacity 0");
     }
 }

--- a/crates/ds-cache/Cargo.toml
+++ b/crates/ds-cache/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "ds-cache"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+quick_cache = "0.6"

--- a/crates/ds-cache/src/lib.rs
+++ b/crates/ds-cache/src/lib.rs
@@ -1,0 +1,341 @@
+//! Shared byte-bounded LRU cache plumbing (#480).
+//!
+//! Every process-global or per-collection cache in the workspace follows the
+//! same shape: a [`quick_cache`] LRU whose eviction budget is **bytes** (a
+//! weigher measures each entry) rather than entry count, sized from an
+//! `MC_*_CACHE_MB` environment variable or a config field, with cumulative
+//! hit/miss counters surfaced to `/metrics`. Before this crate that shape was
+//! copy-pasted twelve times across the engines, render layer, and API crates
+//! (the top duplication finding of the 2026-07 code-quality audit); this
+//! module is the single home for the weigher/env-parse/counter plumbing.
+//! Call sites keep what is genuinely theirs: the key type, the weight
+//! function, the env var name, and the default/entry-size constants.
+//!
+//! Deliberately dependency-light (only `quick_cache` + `std`) so every crate
+//! — including the framework-free `ds-render`/`ds-mvt`/`ds-3dtiles` tier —
+//! can depend on it. Domain types stay out; this is mechanism only.
+
+use std::hash::Hash;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Re-exported so call sites can name the borrowed-key-lookup bound without
+/// depending on `quick_cache` directly.
+pub use quick_cache::Equivalent;
+
+/// One mebibyte, for `*_MB` → bytes conversions.
+pub const MIB: u64 = 1024 * 1024;
+
+/// Parse a cache size (in MB) from the environment: `MC_*_CACHE_MB`-style
+/// variables are trimmed and parsed as `u64`, with unset/unparseable values
+/// falling back to `default_mb`. `0` conventionally disables the cache.
+pub fn env_mb(var: &str, default_mb: u64) -> u64 {
+    std::env::var(var)
+        .ok()
+        .and_then(|s| s.trim().parse::<u64>().ok())
+        .unwrap_or(default_mb)
+}
+
+/// Snapshot of a cache's counters and occupancy for `/metrics`.
+///
+/// `hits`/`misses` are cumulative since construction (the server's metrics
+/// layer delta-tracks them into Prometheus counters); `bytes` is the current
+/// resident weight; `capacity_bytes` is the **configured** budget — `0` for a
+/// disabled cache, even though the underlying store is clamped to a 1-byte
+/// budget internally (see [`ByteBoundedCache::new`]).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CacheMetrics {
+    pub hits: u64,
+    pub misses: u64,
+    pub bytes: u64,
+    pub capacity_bytes: u64,
+}
+
+/// Adapts a plain `fn(&K, &V) -> u64` to `quick_cache`'s `Weighter` trait so
+/// call sites pass a function instead of hand-rolling a unit-struct impl.
+struct WeighFn<K, V> {
+    weigh: fn(&K, &V) -> u64,
+}
+
+// Manual Clone/Copy: a fn pointer is always copyable, but `#[derive]` would
+// add unwanted `K: Clone, V: Clone` bounds.
+impl<K, V> Clone for WeighFn<K, V> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl<K, V> Copy for WeighFn<K, V> {}
+
+impl<K, V> quick_cache::Weighter<K, V> for WeighFn<K, V> {
+    fn weight(&self, key: &K, val: &V) -> u64 {
+        (self.weigh)(key, val)
+    }
+}
+
+/// A thread-safe LRU cache bounded by total **bytes** (per-entry weight from
+/// a caller-supplied function), with cumulative hit/miss counters.
+///
+/// Semantics shared by every call site:
+///
+/// - **Weight includes overhead.** Weight functions should count the payload
+///   plus key strings plus a small fixed allowance for `Arc`/node overhead,
+///   so the configured budget approximates real resident memory.
+/// - **Capacity 0 disables retention.** `quick_cache` has no zero capacity,
+///   so the store is built with a 1-byte budget: every real entry outweighs
+///   it and is never admitted, making each `get` a miss and each `insert` a
+///   no-op. [`Self::capacity_bytes`] still reports the configured `0`.
+/// - **Counting is explicit.** [`Self::get`] and [`Self::get_or_insert_with`]
+///   count hits/misses; [`Self::get_untracked`]/[`Self::contains_key`] don't,
+///   and [`Self::record_hit`]/[`Self::record_miss`] let wrappers with custom
+///   accounting (e.g. a negative-cache check between lookup and miss) keep
+///   the counters truthful.
+pub struct ByteBoundedCache<K: Eq + Hash, V: Clone> {
+    cache: quick_cache::sync::Cache<K, V, WeighFn<K, V>>,
+    capacity_bytes: u64,
+    hits: AtomicU64,
+    misses: AtomicU64,
+}
+
+impl<K: Eq + Hash, V: Clone> ByteBoundedCache<K, V> {
+    /// Build a cache with a budget of `capacity_bytes`. `approx_entry_bytes`
+    /// is only a hash-map sizing hint (expected typical entry weight); the
+    /// eviction budget is always `capacity_bytes`.
+    pub fn new(capacity_bytes: u64, approx_entry_bytes: u64, weigh: fn(&K, &V) -> u64) -> Self {
+        // `max(16)` keeps a small/zero capacity valid (a near-disabled cache
+        // that holds nothing still needs a non-zero item estimate).
+        let estimated_items = (capacity_bytes / approx_entry_bytes.max(1)).max(16) as usize;
+        ByteBoundedCache {
+            cache: quick_cache::sync::Cache::with_weighter(
+                estimated_items,
+                capacity_bytes.max(1),
+                WeighFn { weigh },
+            ),
+            capacity_bytes,
+            hits: AtomicU64::new(0),
+            misses: AtomicU64::new(0),
+        }
+    }
+
+    /// Build a cache sized from the environment: `var` (MB, [`env_mb`]) with
+    /// `default_mb` as the fallback. `0` disables retention.
+    pub fn from_env(
+        var: &str,
+        default_mb: u64,
+        approx_entry_bytes: u64,
+        weigh: fn(&K, &V) -> u64,
+    ) -> Self {
+        Self::new(
+            env_mb(var, default_mb).saturating_mul(MIB),
+            approx_entry_bytes,
+            weigh,
+        )
+    }
+
+    /// Look up `key`, counting a hit or a miss.
+    pub fn get<Q>(&self, key: &Q) -> Option<V>
+    where
+        Q: Hash + Equivalent<K> + ?Sized,
+    {
+        let result = self.cache.get(key);
+        if result.is_some() {
+            self.hits.fetch_add(1, Ordering::Relaxed);
+        } else {
+            self.misses.fetch_add(1, Ordering::Relaxed);
+        }
+        result
+    }
+
+    /// Look up `key` without touching the hit/miss counters (LRU recency is
+    /// still bumped). For wrappers whose accounting doesn't map 1:1 onto
+    /// lookups — pair with [`Self::record_hit`]/[`Self::record_miss`].
+    pub fn get_untracked<Q>(&self, key: &Q) -> Option<V>
+    where
+        Q: Hash + Equivalent<K> + ?Sized,
+    {
+        self.cache.get(key)
+    }
+
+    /// Whether `key` is resident — no recency bump, no counter change.
+    pub fn contains_key<Q>(&self, key: &Q) -> bool
+    where
+        Q: Hash + Equivalent<K> + ?Sized,
+    {
+        self.cache.contains_key(key)
+    }
+
+    /// Insert an entry. At capacity 0 the entry is never admitted (see the
+    /// type-level docs), so this is effectively a no-op there.
+    pub fn insert(&self, key: K, value: V) {
+        self.cache.insert(key, value);
+    }
+
+    /// Fetch `key` from the cache, or run `with` and insert its result.
+    ///
+    /// `quick_cache`'s placeholder guard is the single-flight: concurrent
+    /// callers for the SAME key block on one compute. An error is returned to
+    /// this caller without inserting (no key poisoning); the miss is counted
+    /// *before* the fallible compute so failures still register as misses.
+    pub fn get_or_insert_with<Q, E>(
+        &self,
+        key: &Q,
+        with: impl FnOnce() -> Result<V, E>,
+    ) -> Result<V, E>
+    where
+        Q: Hash + Equivalent<K> + ToOwned<Owned = K> + ?Sized,
+    {
+        let mut computed = false;
+        let value = self.cache.get_or_insert_with(key, || {
+            computed = true;
+            self.misses.fetch_add(1, Ordering::Relaxed);
+            with()
+        })?;
+        if !computed {
+            self.hits.fetch_add(1, Ordering::Relaxed);
+        }
+        Ok(value)
+    }
+
+    /// Count one hit (for wrappers using [`Self::get_untracked`]).
+    pub fn record_hit(&self) {
+        self.hits.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Count one miss (for wrappers using [`Self::get_untracked`]).
+    pub fn record_miss(&self) {
+        self.misses.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Cumulative `(hits, misses)`.
+    pub fn stats(&self) -> (u64, u64) {
+        (
+            self.hits.load(Ordering::Relaxed),
+            self.misses.load(Ordering::Relaxed),
+        )
+    }
+
+    /// Current resident weight (bytes, as measured by the weight function).
+    pub fn weight(&self) -> u64 {
+        self.cache.weight()
+    }
+
+    /// The **configured** capacity in bytes (`0` = disabled), not the
+    /// internal 1-byte clamp.
+    pub fn capacity_bytes(&self) -> u64 {
+        self.capacity_bytes
+    }
+
+    /// Number of resident entries.
+    pub fn len(&self) -> usize {
+        self.cache.len()
+    }
+
+    /// Whether the cache currently holds no entries.
+    pub fn is_empty(&self) -> bool {
+        self.cache.len() == 0
+    }
+
+    /// Snapshot for `/metrics`.
+    pub fn metrics(&self) -> CacheMetrics {
+        let (hits, misses) = self.stats();
+        CacheMetrics {
+            hits,
+            misses,
+            bytes: self.weight(),
+            capacity_bytes: self.capacity_bytes,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // The signature must match `fn(&K, &V)` with `K = String`, `V = Vec<u8>`.
+    #[allow(clippy::ptr_arg)]
+    fn weigh_str(key: &String, val: &Vec<u8>) -> u64 {
+        key.len() as u64 + val.len() as u64 + 64
+    }
+
+    #[test]
+    fn get_counts_hits_and_misses() {
+        let cache = ByteBoundedCache::new(MIB, 1024, weigh_str);
+        assert!(cache.get(&"a".to_string()).is_none());
+        cache.insert("a".to_string(), vec![1, 2, 3]);
+        assert_eq!(cache.get(&"a".to_string()).unwrap(), vec![1, 2, 3]);
+        assert_eq!(cache.stats(), (1, 1));
+    }
+
+    #[test]
+    fn zero_capacity_disables_retention_but_reports_configured_capacity() {
+        let cache = ByteBoundedCache::new(0, 1024, weigh_str);
+        cache.insert("a".to_string(), vec![1]);
+        assert!(cache.get(&"a".to_string()).is_none(), "nothing admitted");
+        assert_eq!(cache.capacity_bytes(), 0);
+        assert_eq!(cache.metrics().capacity_bytes, 0);
+        assert_eq!(cache.stats(), (0, 1));
+    }
+
+    #[test]
+    fn evicts_by_weight() {
+        let cache = ByteBoundedCache::new(500, 100, weigh_str);
+        for i in 0..20 {
+            cache.insert(format!("k{i}"), vec![0u8; 100]);
+        }
+        let found = (0..20)
+            .filter(|i| cache.get_untracked(&format!("k{i}")).is_some())
+            .count();
+        assert!(found < 20, "expected evictions, all {found} survived");
+        assert!(found > 0, "expected some entries to survive");
+    }
+
+    #[test]
+    fn get_or_insert_with_counts_and_coalesces() {
+        let cache = ByteBoundedCache::new(MIB, 1024, weigh_str);
+        let mut computes = 0;
+        for _ in 0..3 {
+            let v = cache
+                .get_or_insert_with(&"k".to_string(), || {
+                    computes += 1;
+                    Ok::<_, ()>(vec![7])
+                })
+                .unwrap();
+            assert_eq!(v, vec![7]);
+        }
+        assert_eq!(computes, 1, "one compute, then cached");
+        assert_eq!(cache.stats(), (2, 1));
+    }
+
+    #[test]
+    fn get_or_insert_with_error_does_not_poison_and_counts_a_miss() {
+        let cache = ByteBoundedCache::new(MIB, 1024, weigh_str);
+        let err = cache.get_or_insert_with(&"k".to_string(), || Err::<Vec<u8>, _>("boom"));
+        assert!(err.is_err());
+        let ok = cache
+            .get_or_insert_with(&"k".to_string(), || Ok::<_, &str>(vec![42]))
+            .unwrap();
+        assert_eq!(ok, vec![42]);
+        assert_eq!(cache.stats(), (0, 2), "both attempts were misses");
+    }
+
+    #[test]
+    fn untracked_and_manual_counting_compose() {
+        let cache = ByteBoundedCache::new(MIB, 1024, weigh_str);
+        cache.insert("a".to_string(), vec![1]);
+        assert!(cache.get_untracked(&"a".to_string()).is_some());
+        assert!(cache.contains_key(&"a".to_string()));
+        assert_eq!(cache.stats(), (0, 0), "untracked lookups don't count");
+        cache.record_hit();
+        cache.record_miss();
+        assert_eq!(cache.stats(), (1, 1));
+    }
+
+    #[test]
+    fn env_mb_parses_and_falls_back() {
+        // Unset → default.
+        assert_eq!(env_mb("DS_CACHE_TEST_UNSET_VAR", 42), 42);
+        // Set/whitespace/garbage via a uniquely-named var per case.
+        std::env::set_var("DS_CACHE_TEST_SET_VAR", " 128 ");
+        assert_eq!(env_mb("DS_CACHE_TEST_SET_VAR", 42), 128);
+        std::env::set_var("DS_CACHE_TEST_BAD_VAR", "lots");
+        assert_eq!(env_mb("DS_CACHE_TEST_BAD_VAR", 42), 42);
+    }
+}

--- a/crates/ds-mvt/Cargo.toml
+++ b/crates/ds-mvt/Cargo.toml
@@ -6,6 +6,6 @@ edition = "2021"
 [dependencies]
 ds-core = { path = "../core" }
 mvt = "0.13"
-quick_cache = "0.6"
+ds-cache = { path = "../ds-cache" }
 bytes = "1"
 thiserror = "2"

--- a/crates/ds-mvt/src/cache.rs
+++ b/crates/ds-mvt/src/cache.rs
@@ -4,11 +4,8 @@
 //! instead of (bbox, width, height, style). Sized by bytes — eviction is driven
 //! by total weight, not entry count.
 
-use std::sync::atomic::{AtomicU64, Ordering};
-
 use bytes::Bytes;
-use quick_cache::sync::Cache;
-use quick_cache::Weighter;
+use ds_cache::ByteBoundedCache;
 
 use crate::encode::TmsKind;
 use crate::hash::{fnv1a_mix, FNV1A_OFFSET};
@@ -75,76 +72,50 @@ impl CachedTile {
     }
 }
 
-#[derive(Clone)]
-struct TileWeighter;
-
-impl Weighter<VectorTileKey, CachedTile> for TileWeighter {
-    fn weight(&self, key: &VectorTileKey, val: &CachedTile) -> u64 {
-        // 64-byte fixed overhead per entry + key string length + payload size
-        // + 18 bytes for the quoted hex64 ETag string.
-        64u64 + key.collection.len() as u64 + val.bytes.len() as u64 + val.etag.len() as u64
-    }
+/// Weight function: 64-byte fixed overhead per entry + key string length +
+/// payload size + 18 bytes for the quoted hex64 ETag string.
+fn weigh_tile(key: &VectorTileKey, val: &CachedTile) -> u64 {
+    64u64 + key.collection.len() as u64 + val.bytes.len() as u64 + val.etag.len() as u64
 }
 
 /// Thread-safe weighted LRU cache for MVT bytes.
 pub struct VectorTileCache {
-    cache: Cache<VectorTileKey, CachedTile, TileWeighter>,
-    capacity_bytes: u64,
-    hits: AtomicU64,
-    misses: AtomicU64,
+    cache: ByteBoundedCache<VectorTileKey, CachedTile>,
 }
 
 impl VectorTileCache {
     /// Build a cache with the given byte budget. A `capacity_mb` of 0 disables
     /// caching entirely (every `get` is a miss, every `insert` is a no-op).
     pub fn new(capacity_mb: u64) -> Self {
-        let capacity_bytes = capacity_mb.saturating_mul(1024 * 1024);
-        // quick_cache requires a non-zero estimated item count even when weighted;
-        // pick a generous number — actual eviction is driven by the weight budget.
-        let estimated_items = ((capacity_bytes / 8192).max(1)) as usize;
-        let cache = Cache::with_weighter(estimated_items, capacity_bytes.max(1), TileWeighter);
+        // ~8 KB per encoded tile for initial hash map sizing; eviction is
+        // driven by the weight budget.
         Self {
-            cache,
-            capacity_bytes,
-            hits: AtomicU64::new(0),
-            misses: AtomicU64::new(0),
+            cache: ByteBoundedCache::new(
+                capacity_mb.saturating_mul(ds_cache::MIB),
+                8192,
+                weigh_tile,
+            ),
         }
     }
 
     pub fn get(&self, key: &VectorTileKey) -> Option<CachedTile> {
-        if self.capacity_bytes == 0 {
-            self.misses.fetch_add(1, Ordering::Relaxed);
-            return None;
-        }
-        match self.cache.get(key) {
-            Some(v) => {
-                self.hits.fetch_add(1, Ordering::Relaxed);
-                Some(v)
-            }
-            None => {
-                self.misses.fetch_add(1, Ordering::Relaxed);
-                None
-            }
-        }
+        self.cache.get(key)
     }
 
     pub fn insert(&self, key: VectorTileKey, val: CachedTile) {
-        if self.capacity_bytes == 0 {
-            return;
-        }
         self.cache.insert(key, val);
     }
 
     pub fn capacity_bytes(&self) -> u64 {
-        self.capacity_bytes
+        self.cache.capacity_bytes()
     }
 
     pub fn hits(&self) -> u64 {
-        self.hits.load(Ordering::Relaxed)
+        self.cache.stats().0
     }
 
     pub fn misses(&self) -> u64 {
-        self.misses.load(Ordering::Relaxed)
+        self.cache.stats().1
     }
 }
 

--- a/crates/engine-geotiff/Cargo.toml
+++ b/crates/engine-geotiff/Cargo.toml
@@ -20,7 +20,7 @@ ds-storage = { path = "../storage" }
 futures = "0.3"
 flate2 = "1"
 weezl = "0.1"
-quick_cache = "0.6"
+ds-cache = { path = "../ds-cache" }
 rayon = "1"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 serde_json = "1"

--- a/crates/engine-geotiff/src/cache.rs
+++ b/crates/engine-geotiff/src/cache.rs
@@ -6,10 +6,10 @@
 //! with negligible CPU overhead on cache hits.
 
 use std::path::Path;
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
 use bytes::Bytes;
+use ds_cache::ByteBoundedCache;
 
 /// Cache key: uniquely identifies a compressed tile across all files and IFD levels.
 /// Uses Arc<str> instead of PathBuf to avoid allocation on every lookup.
@@ -22,44 +22,24 @@ struct TileCacheKey {
     ifd_index: u16,
 }
 
-/// Weight function: count the compressed byte size of each entry.
-#[derive(Clone)]
-struct TileWeighter;
-
-impl quick_cache::Weighter<TileCacheKey, Bytes> for TileWeighter {
-    fn weight(&self, _key: &TileCacheKey, val: &Bytes) -> u64 {
-        // Bytes overhead (~32 bytes) + actual data
-        val.len() as u64 + 32
-    }
+/// Weight function: count the compressed byte size of each entry
+/// (plus ~32 bytes of `Bytes` overhead).
+fn weigh_tile(_key: &TileCacheKey, val: &Bytes) -> u64 {
+    val.len() as u64 + 32
 }
 
-/// Thread-safe tile cache backed by quick_cache (lock-free concurrent LRU).
+/// Thread-safe tile cache backed by the shared byte-bounded LRU (#480).
 pub struct TileCache {
-    inner: quick_cache::sync::Cache<TileCacheKey, Bytes, TileWeighter>,
-    capacity_bytes: u64,
-    hits: AtomicU64,
-    misses: AtomicU64,
+    inner: ByteBoundedCache<TileCacheKey, Bytes>,
 }
 
 impl TileCache {
     /// Create a new tile cache with the given capacity in bytes.
     /// Pass 0 to create a no-op cache that never stores anything.
     pub fn new(max_bytes: u64) -> Self {
-        // Estimate ~100 entries per MB for initial hash map sizing
-        let estimated_items = if max_bytes > 0 {
-            (max_bytes / (16 * 1024)).max(64) as usize
-        } else {
-            0
-        };
+        // ~16 KB per compressed tile for initial hash map sizing.
         TileCache {
-            inner: quick_cache::sync::Cache::with_weighter(
-                estimated_items,
-                max_bytes,
-                TileWeighter,
-            ),
-            capacity_bytes: max_bytes,
-            hits: AtomicU64::new(0),
-            misses: AtomicU64::new(0),
+            inner: ByteBoundedCache::new(max_bytes, 16 * 1024, weigh_tile),
         }
     }
 
@@ -71,13 +51,7 @@ impl TileCache {
             chunk_index,
             ifd_index,
         };
-        let result = self.inner.get(&key);
-        if result.is_some() {
-            self.hits.fetch_add(1, Ordering::Relaxed);
-        } else {
-            self.misses.fetch_add(1, Ordering::Relaxed);
-        }
-        result
+        self.inner.get(&key)
     }
 
     /// Insert compressed tile bytes into the cache.
@@ -93,10 +67,7 @@ impl TileCache {
 
     /// Return (hits, misses) counters for logging.
     pub fn stats(&self) -> (u64, u64) {
-        (
-            self.hits.load(Ordering::Relaxed),
-            self.misses.load(Ordering::Relaxed),
-        )
+        self.inner.stats()
     }
 
     /// Current weight (bytes used) of the cache.
@@ -106,7 +77,7 @@ impl TileCache {
 
     /// Maximum weight (bytes) the cache will hold.
     pub fn capacity(&self) -> u64 {
-        self.capacity_bytes
+        self.inner.capacity_bytes()
     }
 
     /// Number of entries currently in the cache.

--- a/crates/engine-geotiff/src/decoded_cache.rs
+++ b/crates/engine-geotiff/src/decoded_cache.rs
@@ -23,7 +23,6 @@
 //! unable to hold anything, so every read decodes — same convention as the
 //! ODIM caches).
 
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
 use ds_core::error::DataServerError;
@@ -127,13 +126,8 @@ fn byte_len(chunk: &DecodingResult) -> u64 {
 
 /// Byte-weights each cached chunk by its decoded buffer (plus key string and
 /// `Arc`/control overhead). Mirrors the compressed `TileCache` weighter.
-#[derive(Clone)]
-struct ChunkWeighter;
-
-impl quick_cache::Weighter<ChunkKey, Arc<DecodingResult>> for ChunkWeighter {
-    fn weight(&self, key: &ChunkKey, val: &Arc<DecodingResult>) -> u64 {
-        byte_len(val) + key.file.len() as u64 + 64
-    }
+fn weigh_chunk(key: &ChunkKey, val: &Arc<DecodingResult>) -> u64 {
+    byte_len(val) + key.file.len() as u64 + 64
 }
 
 /// Default cache size (MB) when `MC_GEOTIFF_DECODED_CHUNK_CACHE_MB` is unset.
@@ -143,33 +137,21 @@ impl quick_cache::Weighter<ChunkKey, Arc<DecodingResult>> for ChunkWeighter {
 /// (1 MB/tile) still keeps ~500 tiles resident.
 const DEFAULT_DECODED_CHUNK_CACHE_MB: u64 = 512;
 
-type ChunkCache = quick_cache::sync::Cache<ChunkKey, Arc<DecodingResult>, ChunkWeighter>;
+type ChunkCache = ds_cache::ByteBoundedCache<ChunkKey, Arc<DecodingResult>>;
 
 static CACHE: std::sync::LazyLock<ChunkCache> = std::sync::LazyLock::new(|| {
-    let capacity_bytes = std::env::var("MC_GEOTIFF_DECODED_CHUNK_CACHE_MB")
-        .ok()
-        .and_then(|s| s.trim().parse::<u64>().ok())
-        .unwrap_or(DEFAULT_DECODED_CHUNK_CACHE_MB)
-        .saturating_mul(1024 * 1024);
-    // Estimate item slots at one 512×512 Byte tile each; `max(16)` keeps a
-    // small/zero capacity valid (a near-disabled cache holds nothing).
-    let estimated_items = ((capacity_bytes / (256 * 1024)).max(16)) as usize;
-    quick_cache::sync::Cache::with_weighter(estimated_items, capacity_bytes.max(1), ChunkWeighter)
+    // Estimate item slots at one 512×512 Byte tile (256 KB) each.
+    ChunkCache::from_env(
+        "MC_GEOTIFF_DECODED_CHUNK_CACHE_MB",
+        DEFAULT_DECODED_CHUNK_CACHE_MB,
+        256 * 1024,
+        weigh_chunk,
+    )
 });
 
-/// Cumulative `(hits, misses)`, for `/metrics`.
-static HITS: AtomicU64 = AtomicU64::new(0);
-static MISSES: AtomicU64 = AtomicU64::new(0);
-
-/// Snapshot of the process-global decoded-chunk cache for `/metrics`:
-/// `(hits, misses, bytes, capacity_bytes)`.
-pub fn metrics() -> (u64, u64, u64, u64) {
-    (
-        HITS.load(Ordering::Relaxed),
-        MISSES.load(Ordering::Relaxed),
-        CACHE.weight(),
-        CACHE.capacity(),
-    )
+/// Snapshot of the process-global decoded-chunk cache for `/metrics`.
+pub fn metrics() -> ds_cache::CacheMetrics {
+    CACHE.metrics()
 }
 
 /// Fetch the decoded chunk for `(scope, ifd, chunk)` from the cache, or run
@@ -189,16 +171,7 @@ pub(crate) fn get_or_decode(
         ifd_index,
         chunk_index,
     };
-    let mut computed = false;
-    let chunk = CACHE.get_or_insert_with(&key, || {
-        computed = true;
-        MISSES.fetch_add(1, Ordering::Relaxed);
-        decode().map(Arc::new)
-    })?;
-    if !computed {
-        HITS.fetch_add(1, Ordering::Relaxed);
-    }
-    Ok(chunk)
+    CACHE.get_or_insert_with(&key, || decode().map(Arc::new))
 }
 
 #[cfg(test)]

--- a/crates/engine-geotiff/src/reader.rs
+++ b/crates/engine-geotiff/src/reader.rs
@@ -3514,7 +3514,7 @@ mod tests {
         let metadata = TiffMetadata::from_source(&source).expect("parse fixture metadata");
         let n_tiles = (metadata.tiles_across * metadata.tiles_down) as u64;
 
-        let (_, m0, _, _) = crate::decoded_cache::metrics();
+        let m0 = crate::decoded_cache::metrics().misses;
         let first = read_bbox_map(
             &source,
             &metadata,
@@ -3527,7 +3527,11 @@ mod tests {
             0,
         )
         .expect("first full read");
-        let (h1, m1, _, _) = crate::decoded_cache::metrics();
+        let ds_cache::CacheMetrics {
+            hits: h1,
+            misses: m1,
+            ..
+        } = crate::decoded_cache::metrics();
         assert!(
             m1 - m0 >= n_tiles,
             "first read should decode all {n_tiles} covering tiles (misses {m0} → {m1})"
@@ -3545,7 +3549,7 @@ mod tests {
             0,
         )
         .expect("second full read");
-        let (h2, _, _, _) = crate::decoded_cache::metrics();
+        let h2 = crate::decoded_cache::metrics().hits;
         assert!(
             h2 - h1 >= n_tiles,
             "repeat read should be served from the decoded-chunk cache (hits {h1} → {h2})"

--- a/crates/engine-grib/Cargo.toml
+++ b/crates/engine-grib/Cargo.toml
@@ -11,7 +11,7 @@ chrono = { version = "0.4", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 arc-swap = "1"
-quick_cache = "0.6"
+ds-cache = { path = "../ds-cache" }
 tracing = "0.1"
 tokio = { version = "1", features = ["sync"] }
 thiserror = "2"

--- a/crates/engine-grib/src/cache.rs
+++ b/crates/engine-grib/src/cache.rs
@@ -3,9 +3,9 @@
 //! Caches decoded f64 arrays keyed by (grib_url, offset) to avoid
 //! repeated byte-range fetches and GRIB decoding.
 
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
+use ds_cache::ByteBoundedCache;
 use ds_core::map_engine::OutputCrs;
 
 /// Cache key: identifies a specific GRIB message.
@@ -19,13 +19,8 @@ struct GridKey {
 }
 
 /// Weight function: count the byte size of each cached grid.
-#[derive(Clone)]
-struct GridWeighter;
-
-impl quick_cache::Weighter<GridKey, Arc<DecodedGrid>> for GridWeighter {
-    fn weight(&self, _key: &GridKey, val: &Arc<DecodedGrid>) -> u64 {
-        val.size_bytes() as u64
-    }
+fn weigh_grid(_key: &GridKey, val: &Arc<DecodedGrid>) -> u64 {
+    val.size_bytes() as u64
 }
 
 /// A decoded grid with its metadata.
@@ -300,10 +295,7 @@ impl DecodedGrid {
 
 /// LRU cache for decoded grids, weighted by byte size.
 pub struct GridCache {
-    cache: quick_cache::sync::Cache<GridKey, Arc<DecodedGrid>, GridWeighter>,
-    capacity_bytes: u64,
-    hits: AtomicU64,
-    misses: AtomicU64,
+    cache: ByteBoundedCache<GridKey, Arc<DecodedGrid>>,
 }
 
 impl GridCache {
@@ -313,15 +305,13 @@ impl GridCache {
         if size_mb == 0 {
             return None;
         }
-        let max_bytes = size_mb * 1024 * 1024;
         // Estimate: each grid is ~8 MB (1440*721*8 bytes).
-        let estimated_items = (size_mb as usize * 1024 * 1024) / (8 * 1024 * 1024);
-        let items = estimated_items.max(16);
         Some(Self {
-            cache: quick_cache::sync::Cache::with_weighter(items, max_bytes, GridWeighter),
-            capacity_bytes: max_bytes,
-            hits: AtomicU64::new(0),
-            misses: AtomicU64::new(0),
+            cache: ByteBoundedCache::new(
+                size_mb.saturating_mul(ds_cache::MIB),
+                8 * ds_cache::MIB,
+                weigh_grid,
+            ),
         })
     }
 
@@ -331,13 +321,7 @@ impl GridCache {
             url: Arc::from(url),
             offset,
         };
-        let result = self.cache.get(&key);
-        if result.is_some() {
-            self.hits.fetch_add(1, Ordering::Relaxed);
-        } else {
-            self.misses.fetch_add(1, Ordering::Relaxed);
-        }
-        result
+        self.cache.get(&key)
     }
 
     /// Insert a decoded grid into the cache.
@@ -351,10 +335,7 @@ impl GridCache {
 
     /// Return (hits, misses) counters.
     pub fn stats(&self) -> (u64, u64) {
-        (
-            self.hits.load(Ordering::Relaxed),
-            self.misses.load(Ordering::Relaxed),
-        )
+        self.cache.stats()
     }
 
     /// Current weight (bytes used) of the cache.
@@ -364,7 +345,7 @@ impl GridCache {
 
     /// Maximum weight (bytes) the cache will hold.
     pub fn capacity(&self) -> u64 {
-        self.capacity_bytes
+        self.cache.capacity_bytes()
     }
 
     /// Number of entries currently in the cache.

--- a/crates/engine-odim/Cargo.toml
+++ b/crates/engine-odim/Cargo.toml
@@ -11,6 +11,7 @@ ndarray = "0.17"
 chrono = { version = "0.4", features = ["serde"] }
 arc-swap = "1"
 quick_cache = "0.6"
+ds-cache = { path = "../ds-cache" }
 regex = "1"
 tokio = { version = "1", features = ["macros", "rt", "sync", "time"] }
 tracing = "0.1"

--- a/crates/engine-odim/src/cells.rs
+++ b/crates/engine-odim/src/cells.rs
@@ -85,48 +85,23 @@ fn cell_set_weight_bytes(key: &CellSetKey, set: &Arc<CellSet>) -> u64 {
     cells + (std::mem::size_of::<CellSet>() + key.0.len() + key.1.len() + 64) as u64
 }
 
-/// Byte-weights each entry (see [`cell_set_weight_bytes`]).
-#[derive(Clone)]
-struct CellSetWeighter;
-
-impl quick_cache::Weighter<CellSetKey, Arc<CellSet>> for CellSetWeighter {
-    fn weight(&self, key: &CellSetKey, val: &Arc<CellSet>) -> u64 {
-        cell_set_weight_bytes(key, val)
-    }
-}
-
 /// Process-global memo of per-volume segmentations, shared across every PVOL
 /// collection, byte-bounded like `VOXEL_GRID_CACHE`.
-/// `MC_PVOL_CELL_SET_CACHE_MB=0` *effectively* disables it — quick_cache has
-/// no zero capacity, so a 1-byte budget rejects every real entry on insert
-/// (every request re-segments).
-static CELL_SET_CACHE: std::sync::LazyLock<
-    quick_cache::sync::Cache<CellSetKey, Arc<CellSet>, CellSetWeighter>,
-> = std::sync::LazyLock::new(|| {
-    let capacity_bytes = std::env::var("MC_PVOL_CELL_SET_CACHE_MB")
-        .ok()
-        .and_then(|s| s.trim().parse::<u64>().ok())
-        .unwrap_or(DEFAULT_CELL_SET_CACHE_MB)
-        .saturating_mul(1024 * 1024);
-    // Estimate item slots at ~16 KB each; `max(...)` keeps a zero capacity
-    // valid (an effectively-disabled cache that can hold nothing).
-    let estimated_items = ((capacity_bytes / (16 * 1024)).max(4)) as usize;
-    quick_cache::sync::Cache::with_weighter(estimated_items, capacity_bytes.max(1), CellSetWeighter)
-});
+/// `MC_PVOL_CELL_SET_CACHE_MB=0` disables retention (every request
+/// re-segments). Item slots are estimated at ~16 KB each.
+static CELL_SET_CACHE: std::sync::LazyLock<ds_cache::ByteBoundedCache<CellSetKey, Arc<CellSet>>> =
+    std::sync::LazyLock::new(|| {
+        ds_cache::ByteBoundedCache::from_env(
+            "MC_PVOL_CELL_SET_CACHE_MB",
+            DEFAULT_CELL_SET_CACHE_MB,
+            16 * 1024,
+            cell_set_weight_bytes,
+        )
+    });
 
-/// Cumulative `(hits, misses)` of [`CELL_SET_CACHE`], for `/metrics`.
-static CELL_SET_HITS: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
-static CELL_SET_MISSES: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
-
-/// Snapshot of the process-global cell-set cache for `/metrics`:
-/// `(hits, misses, resident_bytes, capacity_bytes)`.
-pub fn cell_set_cache_metrics() -> (u64, u64, u64, u64) {
-    (
-        CELL_SET_HITS.load(std::sync::atomic::Ordering::Relaxed),
-        CELL_SET_MISSES.load(std::sync::atomic::Ordering::Relaxed),
-        CELL_SET_CACHE.weight(),
-        CELL_SET_CACHE.capacity(),
-    )
+/// Snapshot of the process-global cell-set cache for `/metrics`.
+pub fn cell_set_cache_metrics() -> ds_cache::CacheMetrics {
+    CELL_SET_CACHE.metrics()
 }
 
 /// The extraction options as an exact key component: two requests share an
@@ -205,9 +180,7 @@ impl PolarVolumeSiteView {
                 dims,
                 opts_key,
             );
-            let mut computed = false;
             let set = CELL_SET_CACHE.get_or_insert_with(&key, || {
-                computed = true;
                 let (grid, valid) = self.voxel_grid_cached(entry, &quantity, dims, handle)?;
                 let set = if valid == 0 {
                     // No echo anywhere in the volume: a valid empty scan
@@ -223,11 +196,6 @@ impl PolarVolumeSiteView {
                 };
                 Ok::<_, DataServerError>(Arc::new(set))
             })?;
-            if computed {
-                CELL_SET_MISSES.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-            } else {
-                CELL_SET_HITS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-            }
             cell_sets.push((entry.volume.time, set));
         }
         let tracks = track_cells(&cell_sets, &query.tracking);

--- a/crates/engine-odim/src/engine.rs
+++ b/crates/engine-odim/src/engine.rs
@@ -74,13 +74,8 @@ const DEFAULT_COMPOSITE_CACHE_MB: u64 = 2048;
 /// Byte-weights each cached composite by its decoded pixel array (plus the
 /// key string and `Arc`/control overhead). Mirrors the PVOL pixel / voxel-grid
 /// weighters.
-#[derive(Clone)]
-struct CompositeWeighter;
-
-impl quick_cache::Weighter<Arc<str>, Arc<OdimComposite>> for CompositeWeighter {
-    fn weight(&self, key: &Arc<str>, val: &Arc<OdimComposite>) -> u64 {
-        val.size_bytes() as u64 + key.len() as u64 + 64
-    }
+fn weigh_composite(key: &Arc<str>, val: &Arc<OdimComposite>) -> u64 {
+    val.size_bytes() as u64 + key.len() as u64 + 64
 }
 
 /// Process-global byte-bounded LRU of decoded ODIM composites, shared across
@@ -88,41 +83,23 @@ impl quick_cache::Weighter<Arc<str>, Arc<OdimComposite>> for CompositeWeighter {
 /// ([`Location::id`] — a globally-unique local path or S3 object key), which
 /// fully determines the immutable decode, so the key carries no data-version
 /// (same as the PVOL pixel / voxel-grid caches). Sized once from the
-/// environment on first use; `0` disables (`capacity_bytes.max(1)` keeps the
-/// cache valid but unable to retain anything, so every load decodes).
+/// environment on first use; `0` disables retention, so every load decodes.
+/// Item slots are estimated at one OPERA-class (67 MB, f32 — #464) grid each.
 static COMPOSITE_CACHE: std::sync::LazyLock<
-    quick_cache::sync::Cache<Arc<str>, Arc<OdimComposite>, CompositeWeighter>,
+    ds_cache::ByteBoundedCache<Arc<str>, Arc<OdimComposite>>,
 > = std::sync::LazyLock::new(|| {
-    let capacity_bytes = std::env::var("MC_ODIM_COMPOSITE_CACHE_MB")
-        .ok()
-        .and_then(|s| s.trim().parse::<u64>().ok())
-        .unwrap_or(DEFAULT_COMPOSITE_CACHE_MB)
-        .saturating_mul(1024 * 1024);
-    // Estimate item slots at one OPERA-class (67 MB, f32 — #464) grid each;
-    // `max(4)` keeps a small/zero capacity valid (a near-disabled cache holds
-    // nothing).
-    let estimated_items = ((capacity_bytes / (67 * 1024 * 1024)).max(4)) as usize;
-    quick_cache::sync::Cache::with_weighter(
-        estimated_items,
-        capacity_bytes.max(1),
-        CompositeWeighter,
+    ds_cache::ByteBoundedCache::from_env(
+        "MC_ODIM_COMPOSITE_CACHE_MB",
+        DEFAULT_COMPOSITE_CACHE_MB,
+        67 * 1024 * 1024,
+        weigh_composite,
     )
 });
 
-/// Cumulative `(hits, misses)` of [`COMPOSITE_CACHE`], for `/metrics`.
-static COMPOSITE_CACHE_HITS: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
-static COMPOSITE_CACHE_MISSES: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
-
-/// Snapshot of the process-global composite cache for `/metrics`:
-/// `(hits, misses, resident_bytes, capacity_bytes)`. Mirrors
+/// Snapshot of the process-global composite cache for `/metrics`. Mirrors
 /// `volume_engine::voxel_grid_cache_metrics`.
-pub fn composite_cache_metrics() -> (u64, u64, u64, u64) {
-    (
-        COMPOSITE_CACHE_HITS.load(std::sync::atomic::Ordering::Relaxed),
-        COMPOSITE_CACHE_MISSES.load(std::sync::atomic::Ordering::Relaxed),
-        COMPOSITE_CACHE.weight(),
-        COMPOSITE_CACHE.capacity(),
-    )
+pub fn composite_cache_metrics() -> ds_cache::CacheMetrics {
+    COMPOSITE_CACHE.metrics()
 }
 
 /// Where an [`OdimEngine`] reads ODIM files from.
@@ -961,17 +938,12 @@ impl OdimEngine {
         // re-decodes the same 67 MB (f32-stored, #464) OPERA grid many
         // times (#212).
         let key: Arc<str> = Arc::from(location.id().as_str());
-        let mut computed = false;
         // The fallible form returns a fetch/decode error to *this* caller
         // without inserting (the placeholder is dropped), so a transient read
-        // failure does NOT poison the key — the next request retries it. The
-        // miss is counted at the TOP of the closure, before the fallible
-        // fetch/decode, so a failed read still registers as a miss rather than
-        // a silent gap in the metric (the `?` below would otherwise skip the
-        // post-call accounting on error).
+        // failure does NOT poison the key — the next request retries it.
+        // Hit/miss accounting (including counting a failed read as a miss)
+        // lives in the shared cache.
         let composite = COMPOSITE_CACHE.get_or_insert_with(&key, || {
-            computed = true;
-            COMPOSITE_CACHE_MISSES.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
             let bytes = fetch_bytes(location)
                 .map_err(|e| DataServerError::Engine(format!("[{}] {e}", self.collection_id)))?;
             let composite = Arc::new(read_composite(&bytes).map_err(|e| {
@@ -982,12 +954,6 @@ impl OdimEngine {
             })?);
             Ok::<_, DataServerError>(composite)
         })?;
-        // The closure ran (miss, counted inside) iff `computed`; otherwise the
-        // value came from the cache, so count a hit here. Mirrors
-        // `voxel_grid_cached`'s hit/miss accounting.
-        if !computed {
-            COMPOSITE_CACHE_HITS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        }
         Ok(composite)
     }
 }
@@ -1454,7 +1420,7 @@ mod tests {
         let loc_a = Location::Local(path_a);
         let loc_b = Location::Local(path_b);
 
-        let (hits_before, _, _, _) = composite_cache_metrics();
+        let hits_before = composite_cache_metrics().hits;
 
         // A → B → A → B. With a multi-entry LRU both stay resident, so the
         // second load of each key is a hit returning the identical `Arc`.
@@ -1476,7 +1442,8 @@ mod tests {
 
         // Global hit counter only grows, so a `>=` delta is race-free under
         // parallel tests: our own reloads of A and B are at least two hits.
-        let (hits_after, _, bytes, cap) = composite_cache_metrics();
+        let m = composite_cache_metrics();
+        let (hits_after, bytes, cap) = (m.hits, m.bytes, m.capacity_bytes);
         assert!(
             hits_after >= hits_before + 2,
             "expected ≥2 composite-cache hits from the two reloads (before={hits_before}, after={hits_after})"

--- a/crates/engine-odim/src/pixel_cache.rs
+++ b/crates/engine-odim/src/pixel_cache.rs
@@ -9,6 +9,7 @@
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
+use ds_cache::ByteBoundedCache;
 use quick_cache::sync::Cache;
 
 use crate::reader::RawPixels;
@@ -19,14 +20,9 @@ use crate::reader::RawPixels;
 type PixelKey = (Arc<str>, Arc<str>);
 
 /// Byte-weights each entry by its decoded array size (plus key/Arc overhead).
-#[derive(Clone)]
-struct PixelWeighter;
-
-impl quick_cache::Weighter<PixelKey, Arc<RawPixels>> for PixelWeighter {
-    fn weight(&self, key: &PixelKey, val: &Arc<RawPixels>) -> u64 {
-        // Decoded array bytes + the two key strings + Arc/control overhead.
-        val.size_bytes() as u64 + key.0.len() as u64 + key.1.len() as u64 + 64
-    }
+fn weigh_pixels(key: &PixelKey, val: &Arc<RawPixels>) -> u64 {
+    // Decoded array bytes + the two key strings + Arc/control overhead.
+    val.size_bytes() as u64 + key.0.len() as u64 + key.1.len() as u64 + 64
 }
 
 /// Count cap on the negative (known-bad) cache. Bounds the memory a burst of
@@ -36,7 +32,7 @@ const NEGATIVE_CAPACITY_ITEMS: usize = 4096;
 
 /// Thread-safe, byte-bounded LRU of decoded moment arrays.
 pub struct PixelCache {
-    inner: Cache<PixelKey, Arc<RawPixels>, PixelWeighter>,
+    inner: ByteBoundedCache<PixelKey, Arc<RawPixels>>,
     /// Count-bounded LRU of keys whose pixel read/decode failed. A per-cell
     /// sampler loop (e.g. `volume_section`, thousands of cells) would otherwise
     /// re-fetch and re-count a failed moment on every cell, since a failure
@@ -45,9 +41,6 @@ pub struct PixelCache {
     /// Recording the failure here makes the retry a single no-op lookup and
     /// the metric increment happen once.
     negative: Cache<PixelKey, ()>,
-    capacity_bytes: u64,
-    hits: AtomicU64,
-    misses: AtomicU64,
     inserts: AtomicU64,
 }
 
@@ -56,15 +49,14 @@ impl PixelCache {
     /// (or 0) is treated as disabled — `get` always misses and `insert` is a
     /// no-op — so a misconfiguration can't silently hold one giant entry.
     pub fn new(capacity_mb: u64) -> Self {
-        let capacity_bytes = capacity_mb.saturating_mul(1024 * 1024);
         // One FMI moment ≈ 360×500×2 ≈ 360 KB; estimate items at ~256 KB.
-        let estimated_items = ((capacity_bytes / (256 * 1024)).max(16)) as usize;
         PixelCache {
-            inner: Cache::with_weighter(estimated_items, capacity_bytes.max(1), PixelWeighter),
+            inner: ByteBoundedCache::new(
+                capacity_mb.saturating_mul(ds_cache::MIB),
+                256 * 1024,
+                weigh_pixels,
+            ),
             negative: Cache::new(NEGATIVE_CAPACITY_ITEMS),
-            capacity_bytes,
-            hits: AtomicU64::new(0),
-            misses: AtomicU64::new(0),
             inserts: AtomicU64::new(0),
         }
     }
@@ -76,13 +68,13 @@ impl PixelCache {
     /// review r4). Keeping `is_known_bad` *after* this on the loader's hot path
     /// means a good-key access stays a single lookup.
     pub fn get(&self, file_id: &str, dataset_path: &str) -> Option<Arc<RawPixels>> {
-        if self.capacity_bytes == 0 {
+        if self.inner.capacity_bytes() == 0 {
             return None;
         }
         let key: PixelKey = (Arc::from(file_id), Arc::from(dataset_path));
-        let hit = self.inner.get(&key);
+        let hit = self.inner.get_untracked(&key);
         if hit.is_some() {
-            self.hits.fetch_add(1, Ordering::Relaxed);
+            self.inner.record_hit();
         }
         hit
     }
@@ -90,7 +82,7 @@ impl PixelCache {
     /// Count one genuine positive-cache miss — i.e. a key that is neither
     /// cached nor known-bad, so the loader is about to fetch + decode it.
     pub fn record_miss(&self) {
-        self.misses.fetch_add(1, Ordering::Relaxed);
+        self.inner.record_miss();
     }
 
     /// Whether `(file_id, dataset_path)` is already resident — a presence
@@ -100,7 +92,7 @@ impl PixelCache {
     /// later poll) without polluting the hit metric or keeping evicted volumes
     /// artificially warm. Always `false` when disabled (`capacity_mb == 0`).
     pub fn contains(&self, file_id: &str, dataset_path: &str) -> bool {
-        if self.capacity_bytes == 0 {
+        if self.inner.capacity_bytes() == 0 {
             return false;
         }
         let key: PixelKey = (Arc::from(file_id), Arc::from(dataset_path));
@@ -109,7 +101,7 @@ impl PixelCache {
 
     /// Insert a freshly-decoded array. No-op when disabled.
     pub fn insert(&self, file_id: &str, dataset_path: &str, pixels: Arc<RawPixels>) {
-        if self.capacity_bytes == 0 {
+        if self.inner.capacity_bytes() == 0 {
             return;
         }
         let key: PixelKey = (Arc::from(file_id), Arc::from(dataset_path));
@@ -152,15 +144,12 @@ impl PixelCache {
 
     /// Configured byte capacity.
     pub fn capacity(&self) -> u64 {
-        self.capacity_bytes
+        self.inner.capacity_bytes()
     }
 
     /// Cumulative `(hits, misses)`.
     pub fn stats(&self) -> (u64, u64) {
-        (
-            self.hits.load(Ordering::Relaxed),
-            self.misses.load(Ordering::Relaxed),
-        )
+        self.inner.stats()
     }
 
     /// Cumulative inserts (request-time decodes + poll-time pre-warm).

--- a/crates/engine-odim/src/volume_engine.rs
+++ b/crates/engine-odim/src/volume_engine.rs
@@ -94,10 +94,7 @@ const DEFAULT_PIXEL_CACHE_MB: u64 = 1024;
 /// Read the configured lazy-pixel cache size from the environment, or the
 /// default. `0` disables caching (every sample re-reads — diagnostic only).
 fn pixel_cache_mb() -> u64 {
-    std::env::var("MC_PVOL_PIXEL_CACHE_MB")
-        .ok()
-        .and_then(|s| s.trim().parse::<u64>().ok())
-        .unwrap_or(DEFAULT_PIXEL_CACHE_MB)
+    ds_cache::env_mb("MC_PVOL_PIXEL_CACHE_MB", DEFAULT_PIXEL_CACHE_MB)
 }
 
 /// Process-global decoded-pixel LRU, shared by every PVOL collection so a
@@ -120,21 +117,34 @@ pub(crate) fn pixel_cache() -> &'static PixelCache {
 /// `/metrics`) makes the degradation observable (PR #290 review).
 static PIXEL_READ_FAILURES: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
 
-/// Snapshot of the process-global PVOL pixel cache for `/metrics`:
-/// `(hits, misses, inserts, resident_bytes, capacity_bytes, entries,
-/// read_failures)`. `inserts` + `entries` make eviction pressure observable
-/// (#476): evictions ≈ increase(inserts) − delta(entries).
-pub fn pixel_cache_metrics() -> (u64, u64, u64, u64, u64, u64, u64) {
+/// Snapshot of the process-global PVOL pixel cache for `/metrics`.
+/// `inserts` + `entries` make eviction pressure observable (#476):
+/// evictions ≈ increase(inserts) − delta(entries).
+pub struct PixelCacheMetrics {
+    /// Standard hits/misses/bytes/capacity snapshot.
+    pub cache: ds_cache::CacheMetrics,
+    /// Cumulative inserts (request-time decodes + poll-time pre-warm).
+    pub inserts: u64,
+    /// Resident entry count.
+    pub entries: u64,
+    /// Cumulative failed lazy pixel reads (degraded to nodata).
+    pub read_failures: u64,
+}
+
+/// Snapshot of the process-global PVOL pixel cache for `/metrics`.
+pub fn pixel_cache_metrics() -> PixelCacheMetrics {
     let (hits, misses) = PIXEL_CACHE.stats();
-    (
-        hits,
-        misses,
-        PIXEL_CACHE.inserts(),
-        PIXEL_CACHE.weight(),
-        PIXEL_CACHE.capacity(),
-        PIXEL_CACHE.len() as u64,
-        PIXEL_READ_FAILURES.load(std::sync::atomic::Ordering::Relaxed),
-    )
+    PixelCacheMetrics {
+        cache: ds_cache::CacheMetrics {
+            hits,
+            misses,
+            bytes: PIXEL_CACHE.weight(),
+            capacity_bytes: PIXEL_CACHE.capacity(),
+        },
+        inserts: PIXEL_CACHE.inserts(),
+        entries: PIXEL_CACHE.len() as u64,
+        read_failures: PIXEL_READ_FAILURES.load(std::sync::atomic::Ordering::Relaxed),
+    }
 }
 
 /// Default resampled voxel-grid cache size (MB) when
@@ -162,49 +172,28 @@ type VoxelGridKey = (Arc<str>, Arc<str>, [usize; 3]);
 type VoxelGridEntry = (Arc<VoxelGrid>, usize);
 
 /// Byte-weights each entry by its `f32` cell payload (plus key overhead).
-#[derive(Clone)]
-struct VoxelGridWeighter;
-
-impl quick_cache::Weighter<VoxelGridKey, VoxelGridEntry> for VoxelGridWeighter {
-    fn weight(&self, key: &VoxelGridKey, val: &VoxelGridEntry) -> u64 {
-        (val.0.values.len() * 4) as u64 + key.0.len() as u64 + key.1.len() as u64 + 256
-    }
+fn weigh_voxel_grid(key: &VoxelGridKey, val: &VoxelGridEntry) -> u64 {
+    (val.0.values.len() * 4) as u64 + key.0.len() as u64 + key.1.len() as u64 + 256
 }
 
 /// Process-global LRU of resampled cylindrical voxel grids, shared across
 /// every PVOL collection (keys are source-qualified). Sized once from the
-/// environment on first use; `0` disables (every read resamples).
+/// environment on first use; `0` disables (every read resamples). Item
+/// slots are estimated at one `med` (21 MB) grid each.
 static VOXEL_GRID_CACHE: std::sync::LazyLock<
-    quick_cache::sync::Cache<VoxelGridKey, VoxelGridEntry, VoxelGridWeighter>,
+    ds_cache::ByteBoundedCache<VoxelGridKey, VoxelGridEntry>,
 > = std::sync::LazyLock::new(|| {
-    let capacity_bytes = std::env::var("MC_PVOL_VOXEL_GRID_CACHE_MB")
-        .ok()
-        .and_then(|s| s.trim().parse::<u64>().ok())
-        .unwrap_or(DEFAULT_VOXEL_GRID_CACHE_MB)
-        .saturating_mul(1024 * 1024);
-    // Estimate item slots at one `med` grid each; `max(1)` keeps a zero
-    // capacity valid (an effectively-disabled cache that can hold nothing).
-    let estimated_items = ((capacity_bytes / (21 * 1024 * 1024)).max(4)) as usize;
-    quick_cache::sync::Cache::with_weighter(
-        estimated_items,
-        capacity_bytes.max(1),
-        VoxelGridWeighter,
+    ds_cache::ByteBoundedCache::from_env(
+        "MC_PVOL_VOXEL_GRID_CACHE_MB",
+        DEFAULT_VOXEL_GRID_CACHE_MB,
+        21 * 1024 * 1024,
+        weigh_voxel_grid,
     )
 });
 
-/// Cumulative `(hits, misses)` of [`VOXEL_GRID_CACHE`], for `/metrics`.
-static VOXEL_GRID_HITS: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
-static VOXEL_GRID_MISSES: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
-
-/// Snapshot of the process-global voxel-grid cache for `/metrics`:
-/// `(hits, misses, resident_bytes, capacity_bytes)`.
-pub fn voxel_grid_cache_metrics() -> (u64, u64, u64, u64) {
-    (
-        VOXEL_GRID_HITS.load(std::sync::atomic::Ordering::Relaxed),
-        VOXEL_GRID_MISSES.load(std::sync::atomic::Ordering::Relaxed),
-        VOXEL_GRID_CACHE.weight(),
-        VOXEL_GRID_CACHE.capacity(),
-    )
+/// Snapshot of the process-global voxel-grid cache for `/metrics`.
+pub fn voxel_grid_cache_metrics() -> ds_cache::CacheMetrics {
+    VOXEL_GRID_CACHE.metrics()
 }
 
 /// Days of date-partitioned prefixes to scan when an S3 source has no
@@ -4017,9 +4006,7 @@ impl PolarVolumeSiteView {
         // one polar resample (PR #378 review). Blocking the calling thread is
         // acceptable in both caller contexts (a `spawn_blocking` pool thread,
         // or a request worker that would have done the resample itself).
-        let mut computed = false;
         let result = VOXEL_GRID_CACHE.get_or_insert_with(&key, || {
-            computed = true;
             let pix = Pixels {
                 source: &self.source,
                 handle,
@@ -4028,11 +4015,6 @@ impl PolarVolumeSiteView {
                 voxel_grid_from_volume(&entry.volume, &entry.id, pix, quantity, Some(dims))?;
             Ok::<_, DataServerError>((Arc::new(grid), valid))
         })?;
-        if computed {
-            VOXEL_GRID_MISSES.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        } else {
-            VOXEL_GRID_HITS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        }
         Ok(result)
     }
 }

--- a/crates/engine-odim/tests/integration.rs
+++ b/crates/engine-odim/tests/integration.rs
@@ -800,7 +800,7 @@ fn pvol_volume_engine_read_cells() {
         ..CellQuery::default()
     };
 
-    let (_, m0, _, _) = engine_odim::cell_set_cache_metrics();
+    let m0 = engine_odim::cell_set_cache_metrics().misses;
     let product = view.read_cells(&query).expect("read_cells over the volume");
 
     // One retained volume ⇒ one scan in the window, even with track_scans=4.
@@ -848,13 +848,13 @@ fn pvol_volume_engine_read_cells() {
     // Single scan ⇒ one single-point track per cell, no motion yet.
     assert_eq!(product.tracks.tracks.len(), set.cells.len());
     assert!(product.tracks.tracks.iter().all(|t| t.motion_ms.is_none()));
-    let (_, m1, _, _) = engine_odim::cell_set_cache_metrics();
+    let m1 = engine_odim::cell_set_cache_metrics().misses;
     assert!(m1 > m0, "first segmentation is a cache miss");
 
     // Repeat: the per-volume memo must serve the second call.
-    let (h0, _, _, _) = engine_odim::cell_set_cache_metrics();
+    let h0 = engine_odim::cell_set_cache_metrics().hits;
     let again = view.read_cells(&query).expect("read_cells repeat");
-    let (h1, _, _, _) = engine_odim::cell_set_cache_metrics();
+    let h1 = engine_odim::cell_set_cache_metrics().hits;
     assert!(h1 > h0, "repeat segmentation is a cache hit");
     assert_eq!(again.cell_sets[0].1.cells.len(), set.cells.len());
 

--- a/crates/engine-zarr/Cargo.toml
+++ b/crates/engine-zarr/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 ds-core = { path = "../core" }
 ds-storage = { path = "../storage" }
 # Compressed chunk-bytes LRU cache for the remote byte-range reader.
-quick_cache = "0.6"
+ds-cache = { path = "../ds-cache" }
 bytes = "1"
 # Zarr V2/V3 format + codec pipeline (blosc/zstd/gzip/crc32c/sharding/transpose).
 # `filesystem` gives the local-directory store used for the Phase-1 backend;

--- a/crates/engine-zarr/src/store.rs
+++ b/crates/engine-zarr/src/store.rs
@@ -22,7 +22,7 @@
 use std::sync::Arc;
 
 use bytes::Bytes;
-use quick_cache::sync::Cache;
+use ds_cache::ByteBoundedCache;
 
 use ds_storage::object_store::path::Path as ObjectPath;
 use ds_storage::DataStore;
@@ -34,12 +34,10 @@ use zarrs::storage::{
 };
 
 /// Weights cache entries by payload size (plus a small per-entry overhead).
-#[derive(Clone)]
-struct BytesWeighter;
-impl quick_cache::Weighter<String, Bytes> for BytesWeighter {
-    fn weight(&self, key: &String, val: &Bytes) -> u64 {
-        val.len() as u64 + key.len() as u64 + 64
-    }
+/// The `&String` matches the cache's `fn(&K, &V)` weight-fn shape.
+#[allow(clippy::ptr_arg)]
+fn weigh_bytes(key: &String, val: &Bytes) -> u64 {
+    val.len() as u64 + key.len() as u64 + 64
 }
 
 /// A readable + listable zarrs store backed by `ds-storage`.
@@ -49,20 +47,21 @@ pub struct DsStore {
     /// within the bucket. Empty for a locally-rooted store. No leading/trailing
     /// slashes.
     root: String,
-    cache: Cache<String, Bytes, BytesWeighter>,
+    cache: ByteBoundedCache<String, Bytes>,
 }
 
 impl DsStore {
     /// Build an adapter over `store`, rooted at `root` (the store location
     /// within the backend; `""` for a locally-rooted store), with a chunk cache
-    /// of `cache_mb` megabytes.
+    /// of `cache_mb` megabytes (floored at 1 MB).
     pub fn new(store: DataStore, root: impl Into<String>, cache_mb: u64) -> Self {
-        let max_bytes = cache_mb.saturating_mul(1024 * 1024).max(1024 * 1024);
+        let max_bytes = cache_mb.saturating_mul(ds_cache::MIB).max(ds_cache::MIB);
         Self {
             store,
             root: root.into().trim_matches('/').to_string(),
-            // 1024 is just a sizing hint; eviction is driven by `max_bytes`.
-            cache: Cache::with_weighter(1024, max_bytes, BytesWeighter),
+            // ~1 MB per chunk is just a sizing hint; eviction is driven by
+            // `max_bytes`.
+            cache: ByteBoundedCache::new(max_bytes, ds_cache::MIB, weigh_bytes),
         }
     }
 

--- a/crates/render/Cargo.toml
+++ b/crates/render/Cargo.toml
@@ -9,5 +9,6 @@ png = "0.17"
 jpeg-encoder = "0.6"
 webp = { version = "0.3", default-features = false }
 quick_cache = "0.6"
+ds-cache = { path = "../ds-cache" }
 bytes = "1"
 chrono = { version = "0.4", features = ["serde"] }

--- a/crates/render/src/lib.rs
+++ b/crates/render/src/lib.rs
@@ -16,7 +16,6 @@ pub use metatile::{render_metatiled, MetaTile, MetaTileStats, TileKeyPrefix, Til
 pub use plot::{render_chart, render_heatmap, Heatmap, Panel, Series};
 pub use rasterize::{fill_polygon, Combine};
 
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -304,15 +303,10 @@ pub fn empty_tile(width: u32, height: u32) -> Result<CachedRendered, DataServerE
     })
 }
 
-/// Weight function: count the byte size of each cached rendered image.
-#[derive(Clone)]
-struct RenderedWeighter;
-
-impl quick_cache::Weighter<CacheKey, CachedRendered> for RenderedWeighter {
-    fn weight(&self, _key: &CacheKey, val: &CachedRendered) -> u64 {
-        // bytes + 18-byte quoted 16-hex-char (64-bit FNV-1a) ETag string + 64-byte overhead
-        val.bytes().len() as u64 + val.etag().len() as u64 + 64
-    }
+/// Weight function: count the byte size of each cached rendered image
+/// (bytes + 18-byte quoted 16-hex-char ETag string + 64-byte overhead).
+fn weigh_rendered(_key: &CacheKey, val: &CachedRendered) -> u64 {
+    val.bytes().len() as u64 + val.etag().len() as u64 + 64
 }
 
 /// Cache for rendered map images (Tier 2), weighted by byte size.
@@ -320,37 +314,23 @@ impl quick_cache::Weighter<CacheKey, CachedRendered> for RenderedWeighter {
 /// No TTL — radar measurements are immutable once produced.
 /// Cache is invalidated on collection reload.
 pub struct RenderedCache {
-    cache: Cache<CacheKey, CachedRendered, RenderedWeighter>,
-    capacity_bytes: u64,
-    hits: AtomicU64,
-    misses: AtomicU64,
+    cache: ds_cache::ByteBoundedCache<CacheKey, CachedRendered>,
 }
 
 impl RenderedCache {
     pub fn new(capacity_mb: u64) -> Self {
-        let max_bytes = capacity_mb * 1024 * 1024;
-        // Estimate ~60 KB per tile for initial hash map sizing
-        let estimated_items = if capacity_mb == 0 {
-            0
-        } else {
-            ((capacity_mb * 1024 * 1024) / (60 * 1024)).max(1) as usize
-        };
+        // Estimate ~60 KB per tile for initial hash map sizing.
         Self {
-            cache: Cache::with_weighter(estimated_items, max_bytes, RenderedWeighter),
-            capacity_bytes: max_bytes,
-            hits: AtomicU64::new(0),
-            misses: AtomicU64::new(0),
+            cache: ds_cache::ByteBoundedCache::new(
+                capacity_mb.saturating_mul(ds_cache::MIB),
+                60 * 1024,
+                weigh_rendered,
+            ),
         }
     }
 
     pub fn get(&self, key: &CacheKey) -> Option<CachedRendered> {
-        let result = self.cache.get(key);
-        if result.is_some() {
-            self.hits.fetch_add(1, Ordering::Relaxed);
-        } else {
-            self.misses.fetch_add(1, Ordering::Relaxed);
-        }
-        result
+        self.cache.get(key)
     }
 
     pub fn insert(&self, key: CacheKey, value: CachedRendered) {
@@ -359,10 +339,7 @@ impl RenderedCache {
 
     /// Return (hits, misses) counters.
     pub fn stats(&self) -> (u64, u64) {
-        (
-            self.hits.load(Ordering::Relaxed),
-            self.misses.load(Ordering::Relaxed),
-        )
+        self.cache.stats()
     }
 
     /// Current weight (bytes used) of the cache.
@@ -372,7 +349,7 @@ impl RenderedCache {
 
     /// Maximum weight (bytes) the cache will hold.
     pub fn capacity(&self) -> u64 {
-        self.capacity_bytes
+        self.cache.capacity_bytes()
     }
 
     /// Number of entries currently in the cache.
@@ -382,7 +359,12 @@ impl RenderedCache {
 
     /// Whether the cache is currently empty.
     pub fn is_empty(&self) -> bool {
-        self.cache.len() == 0
+        self.cache.is_empty()
+    }
+
+    /// Snapshot for `/metrics`.
+    pub fn metrics(&self) -> ds_cache::CacheMetrics {
+        self.cache.metrics()
     }
 }
 

--- a/crates/render/src/metatile.rs
+++ b/crates/render/src/metatile.rs
@@ -30,12 +30,10 @@
 //! CRSs fall back to a direct single-shot render. Degenerate or pathologically
 //! large requests return [`MetaTile::Fallback`] so the caller renders directly.
 
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
 
 use chrono::{DateTime, Utc};
-use quick_cache::sync::Cache;
 
 use ds_core::error::DataServerError;
 use ds_core::map_engine::RasterTile;
@@ -136,19 +134,14 @@ pub struct CachedTilePixels {
     rgba: Option<Arc<[u8]>>,
 }
 
-#[derive(Clone)]
-struct TilePixelWeighter;
-
-impl quick_cache::Weighter<TileKey, CachedTilePixels> for TilePixelWeighter {
-    fn weight(&self, key: &TileKey, val: &CachedTilePixels) -> u64 {
-        // Pixel bytes (zero for a nodata marker) + a flat allowance for the
-        // owned key strings + node overhead.
-        val.rgba.as_ref().map_or(0, |r| r.len()) as u64
-            + key.layer.len() as u64
-            + key.parameter.as_ref().map_or(0, String::len) as u64
-            + key.style.len() as u64
-            + 96
-    }
+/// Weight function: pixel bytes (zero for a nodata marker) + a flat
+/// allowance for the owned key strings + node overhead.
+fn weigh_tile_pixels(key: &TileKey, val: &CachedTilePixels) -> u64 {
+    val.rgba.as_ref().map_or(0, |r| r.len()) as u64
+        + key.layer.len() as u64
+        + key.parameter.as_ref().map_or(0, String::len) as u64
+        + key.style.len() as u64
+        + 96
 }
 
 /// LRU cache of decoded, colorized meta-tiles (RGBA), weighted by byte size.
@@ -157,47 +150,40 @@ impl quick_cache::Weighter<TileKey, CachedTilePixels> for TilePixelWeighter {
 /// from the request-keyed [`crate::RenderedCache`]. This one is keyed on the
 /// fixed tile grid so overlapping fullscreen viewports reuse the same entries.
 pub struct TilePixelCache {
-    cache: Cache<TileKey, CachedTilePixels, TilePixelWeighter>,
-    capacity_bytes: u64,
-    hits: AtomicU64,
-    misses: AtomicU64,
+    cache: ds_cache::ByteBoundedCache<TileKey, CachedTilePixels>,
 }
 
 impl TilePixelCache {
     pub fn new(capacity_mb: u64) -> Self {
-        let max_bytes = capacity_mb * 1024 * 1024;
         // ~256 KB per RGBA tile for initial map sizing.
-        let estimated_items = if capacity_mb == 0 {
-            0
-        } else {
-            (max_bytes / (256 * 1024)).max(1) as usize
-        };
         Self {
-            cache: Cache::with_weighter(estimated_items, max_bytes, TilePixelWeighter),
-            capacity_bytes: max_bytes,
-            hits: AtomicU64::new(0),
-            misses: AtomicU64::new(0),
+            cache: ds_cache::ByteBoundedCache::new(
+                capacity_mb.saturating_mul(ds_cache::MIB),
+                256 * 1024,
+                weigh_tile_pixels,
+            ),
         }
     }
 
     /// (hits, misses) counters.
     pub fn stats(&self) -> (u64, u64) {
-        (
-            self.hits.load(Ordering::Relaxed),
-            self.misses.load(Ordering::Relaxed),
-        )
+        self.cache.stats()
     }
     pub fn weight(&self) -> u64 {
         self.cache.weight()
     }
     pub fn capacity(&self) -> u64 {
-        self.capacity_bytes
+        self.cache.capacity_bytes()
     }
     pub fn len(&self) -> usize {
         self.cache.len()
     }
     pub fn is_empty(&self) -> bool {
-        self.cache.len() == 0
+        self.cache.is_empty()
+    }
+    /// Snapshot for `/metrics`.
+    pub fn metrics(&self) -> ds_cache::CacheMetrics {
+        self.cache.metrics()
     }
 }
 
@@ -344,11 +330,9 @@ where
                 row,
             };
             let rgba = if let Some(c) = cache.cache.get(&key) {
-                cache.hits.fetch_add(1, Ordering::Relaxed);
                 any_data |= c.rgba.is_some();
                 c.rgba
             } else {
-                cache.misses.fetch_add(1, Ordering::Relaxed);
                 misses += 1;
                 // Tile bbox in metres → WGS84 degrees for the engine call.
                 let tx0 = -ORIGIN + col as f64 * span;

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -27,6 +27,7 @@ api-tiles = { path = "../api-tiles" }
 api-3dtiles = { path = "../api-3dtiles" }
 ds-render = { path = "../render" }
 ds-mvt = { path = "../ds-mvt" }
+ds-cache = { path = "../ds-cache" }
 arc-swap = "1"
 axum = "0.8"
 chrono = { version = "0.4", features = ["serde"] }

--- a/crates/server/src/admin.rs
+++ b/crates/server/src/admin.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, LazyLock, Mutex, RwLock};
 use std::time::Instant;
 
@@ -27,6 +28,113 @@ use ds_core::config::{CollectionConfig, StyleBundle};
 // ---------------------------------------------------------------------------
 
 static REGISTRY: LazyLock<Registry> = LazyLock::new(Registry::new);
+
+/// Build and register a plain `IntGauge`.
+fn int_gauge(name: &str, help: &str) -> IntGauge {
+    let gauge = IntGauge::new(name, help).unwrap();
+    REGISTRY.register(Box::new(gauge.clone())).unwrap();
+    gauge
+}
+
+/// A Prometheus counter fed from a *cumulative* in-process value: each
+/// [`Self::feed`] emits the delta since the last observed value. A backward
+/// step (the underlying cache was replaced on reload, resetting its counters)
+/// rebaselines without emitting a spike (`saturating_sub` → delta 0).
+struct DeltaCounter {
+    counter: IntCounter,
+    last: AtomicU64,
+}
+
+impl DeltaCounter {
+    fn new(name: &str, help: &str) -> Self {
+        let counter = IntCounter::new(name, help).unwrap();
+        REGISTRY.register(Box::new(counter.clone())).unwrap();
+        DeltaCounter {
+            counter,
+            last: AtomicU64::new(0),
+        }
+    }
+
+    /// Emit `cumulative - last_seen` (clamped at 0) and remember `cumulative`.
+    /// The atomic `swap` keeps concurrent scrapes correct: however feeds
+    /// interleave, each increment is emitted exactly once. Always called
+    /// (even with delta 0) so the `LazyLock` family registers on the first
+    /// scrape and dashboards see the series before any traffic.
+    fn feed(&self, cumulative: u64) {
+        let prev = self.last.swap(cumulative, Ordering::Relaxed);
+        self.counter.inc_by(cumulative.saturating_sub(prev));
+    }
+}
+
+/// One byte-bounded cache's standard `/metrics` family (#480): delta-tracked
+/// `{prefix}_hits_total` / `{prefix}_misses_total` counters plus
+/// `{prefix}_bytes` / `{prefix}_capacity_bytes` gauges, and optionally
+/// `{prefix}_entries`. Help strings are derived from `display` (the human
+/// name, first letter uppercased for the hits/misses text) with optional
+/// parenthetical notes — matching the previously hand-written families
+/// byte-for-byte.
+struct CacheMetricSet {
+    hits: DeltaCounter,
+    misses: DeltaCounter,
+    bytes: IntGauge,
+    capacity: IntGauge,
+    entries: Option<IntGauge>,
+}
+
+impl CacheMetricSet {
+    fn new(
+        prefix: &str,
+        display: &str,
+        hits_note: Option<&str>,
+        misses_note: Option<&str>,
+        with_entries: bool,
+    ) -> Self {
+        let capitalized = {
+            let mut chars = display.chars();
+            match chars.next() {
+                Some(f) => f.to_uppercase().collect::<String>() + chars.as_str(),
+                None => String::new(),
+            }
+        };
+        let note = |n: Option<&str>| n.map(|n| format!(" ({n})")).unwrap_or_default();
+        CacheMetricSet {
+            hits: DeltaCounter::new(
+                &format!("{prefix}_hits_total"),
+                &format!("{capitalized} hits{}", note(hits_note)),
+            ),
+            misses: DeltaCounter::new(
+                &format!("{prefix}_misses_total"),
+                &format!("{capitalized} misses{}", note(misses_note)),
+            ),
+            bytes: int_gauge(
+                &format!("{prefix}_bytes"),
+                &format!("Bytes currently held in the {display}"),
+            ),
+            capacity: int_gauge(
+                &format!("{prefix}_capacity_bytes"),
+                &format!("Configured {display} capacity in bytes"),
+            ),
+            entries: with_entries.then(|| {
+                int_gauge(
+                    &format!("{prefix}_entries"),
+                    &format!("Number of entries currently in the {display}"),
+                )
+            }),
+        }
+    }
+
+    /// Feed one scrape's snapshot. `entries` only lands if the set was built
+    /// `with_entries`.
+    fn update(&self, m: ds_cache::CacheMetrics, entries: Option<u64>) {
+        self.hits.feed(m.hits);
+        self.misses.feed(m.misses);
+        self.bytes.set(m.bytes as i64);
+        self.capacity.set(m.capacity_bytes as i64);
+        if let (Some(gauge), Some(n)) = (&self.entries, entries) {
+            gauge.set(n as i64);
+        }
+    }
+}
 
 static HTTP_REQUESTS_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(|| {
     let counter = IntCounterVec::new(
@@ -160,44 +268,14 @@ static TILE_CACHE_ENTRIES: LazyLock<IntGaugeVec> = LazyLock::new(|| {
 // decoded (native) source tiles for LOCAL files, so the ~50–190 meta-tile
 // renders tiling one viewport don't re-decompress the same source tile ~6×
 // per frame.
-static GEOTIFF_DECODED_CHUNK_CACHE_HITS: LazyLock<IntCounter> = LazyLock::new(|| {
-    let counter = IntCounter::new(
-        "geotiff_decoded_chunk_cache_hits_total",
-        "GeoTIFF decoded-chunk cache hits (local sources)",
+static GEOTIFF_DECODED_CHUNK_CACHE_METRICS: LazyLock<CacheMetricSet> = LazyLock::new(|| {
+    CacheMetricSet::new(
+        "geotiff_decoded_chunk_cache",
+        "GeoTIFF decoded-chunk cache",
+        Some("local sources"),
+        Some("tile decompressions"),
+        false,
     )
-    .unwrap();
-    REGISTRY.register(Box::new(counter.clone())).unwrap();
-    counter
-});
-
-static GEOTIFF_DECODED_CHUNK_CACHE_MISSES: LazyLock<IntCounter> = LazyLock::new(|| {
-    let counter = IntCounter::new(
-        "geotiff_decoded_chunk_cache_misses_total",
-        "GeoTIFF decoded-chunk cache misses (tile decompressions)",
-    )
-    .unwrap();
-    REGISTRY.register(Box::new(counter.clone())).unwrap();
-    counter
-});
-
-static GEOTIFF_DECODED_CHUNK_CACHE_BYTES: LazyLock<IntGauge> = LazyLock::new(|| {
-    let gauge = IntGauge::new(
-        "geotiff_decoded_chunk_cache_bytes",
-        "Bytes currently held in the GeoTIFF decoded-chunk cache",
-    )
-    .unwrap();
-    REGISTRY.register(Box::new(gauge.clone())).unwrap();
-    gauge
-});
-
-static GEOTIFF_DECODED_CHUNK_CACHE_CAPACITY_BYTES: LazyLock<IntGauge> = LazyLock::new(|| {
-    let gauge = IntGauge::new(
-        "geotiff_decoded_chunk_cache_capacity_bytes",
-        "Configured GeoTIFF decoded-chunk cache capacity in bytes",
-    )
-    .unwrap();
-    REGISTRY.register(Box::new(gauge.clone())).unwrap();
-    gauge
 });
 
 // PostGIS engine gauges (#110). All set per-scrape from live engine state — no
@@ -294,48 +372,8 @@ static POSTGIS_METADATA_REFRESH_SECONDS: LazyLock<GaugeVec> = LazyLock::new(|| {
 });
 
 // Rendered image cache (global — shared across all collections that render).
-static RENDERED_CACHE_HITS: LazyLock<IntCounter> = LazyLock::new(|| {
-    let counter =
-        IntCounter::new("rendered_cache_hits_total", "Rendered image cache hits").unwrap();
-    REGISTRY.register(Box::new(counter.clone())).unwrap();
-    counter
-});
-
-static RENDERED_CACHE_MISSES: LazyLock<IntCounter> = LazyLock::new(|| {
-    let counter =
-        IntCounter::new("rendered_cache_misses_total", "Rendered image cache misses").unwrap();
-    REGISTRY.register(Box::new(counter.clone())).unwrap();
-    counter
-});
-
-static RENDERED_CACHE_BYTES: LazyLock<IntGauge> = LazyLock::new(|| {
-    let gauge = IntGauge::new(
-        "rendered_cache_bytes",
-        "Bytes currently held in the rendered image cache",
-    )
-    .unwrap();
-    REGISTRY.register(Box::new(gauge.clone())).unwrap();
-    gauge
-});
-
-static RENDERED_CACHE_CAPACITY_BYTES: LazyLock<IntGauge> = LazyLock::new(|| {
-    let gauge = IntGauge::new(
-        "rendered_cache_capacity_bytes",
-        "Configured rendered image cache capacity in bytes",
-    )
-    .unwrap();
-    REGISTRY.register(Box::new(gauge.clone())).unwrap();
-    gauge
-});
-
-static RENDERED_CACHE_ENTRIES: LazyLock<IntGauge> = LazyLock::new(|| {
-    let gauge = IntGauge::new(
-        "rendered_cache_entries",
-        "Number of entries currently in the rendered image cache",
-    )
-    .unwrap();
-    REGISTRY.register(Box::new(gauge.clone())).unwrap();
-    gauge
+static RENDERED_CACHE_METRICS: LazyLock<CacheMetricSet> = LazyLock::new(|| {
+    CacheMetricSet::new("rendered_cache", "rendered image cache", None, None, true)
 });
 
 // PVOL lazy pixel cache (#289 / PR #290) — global byte-bounded LRU of decoded
@@ -343,292 +381,83 @@ static RENDERED_CACHE_ENTRIES: LazyLock<IntGauge> = LazyLock::new(|| {
 // failures counter surfaces the otherwise-silent degradation when a moment's
 // pixels can't be read/decoded at render time (was a hard catalog rejection
 // before lazy loading).
-static PVOL_PIXEL_CACHE_HITS: LazyLock<IntCounter> = LazyLock::new(|| {
-    let counter = IntCounter::new("pvol_pixel_cache_hits_total", "PVOL pixel cache hits").unwrap();
-    REGISTRY.register(Box::new(counter.clone())).unwrap();
-    counter
-});
+static PVOL_PIXEL_CACHE_METRICS: LazyLock<CacheMetricSet> =
+    LazyLock::new(|| CacheMetricSet::new("pvol_pixel_cache", "PVOL pixel cache", None, None, true));
 
-static PVOL_PIXEL_CACHE_MISSES: LazyLock<IntCounter> = LazyLock::new(|| {
-    let counter =
-        IntCounter::new("pvol_pixel_cache_misses_total", "PVOL pixel cache misses").unwrap();
-    REGISTRY.register(Box::new(counter.clone())).unwrap();
-    counter
-});
-
-static PVOL_PIXEL_CACHE_BYTES: LazyLock<IntGauge> = LazyLock::new(|| {
-    let gauge = IntGauge::new(
-        "pvol_pixel_cache_bytes",
-        "Bytes currently held in the PVOL pixel cache",
-    )
-    .unwrap();
-    REGISTRY.register(Box::new(gauge.clone())).unwrap();
-    gauge
-});
-
-static PVOL_PIXEL_CACHE_CAPACITY_BYTES: LazyLock<IntGauge> = LazyLock::new(|| {
-    let gauge = IntGauge::new(
-        "pvol_pixel_cache_capacity_bytes",
-        "Configured PVOL pixel cache capacity in bytes",
-    )
-    .unwrap();
-    REGISTRY.register(Box::new(gauge.clone())).unwrap();
-    gauge
-});
-
-static PVOL_PIXEL_CACHE_INSERTS: LazyLock<IntCounter> = LazyLock::new(|| {
-    let counter = IntCounter::new(
+static PVOL_PIXEL_CACHE_INSERTS: LazyLock<DeltaCounter> = LazyLock::new(|| {
+    DeltaCounter::new(
         "pvol_pixel_cache_inserts_total",
         "PVOL pixel cache inserts (request-time decodes + poll-time pre-warm). \
          Sustained inserts while entries/bytes sit at capacity = LRU eviction \
          churn: the pre-warmed working set exceeds MC_PVOL_PIXEL_CACHE_MB (#476)",
     )
-    .unwrap();
-    REGISTRY.register(Box::new(counter.clone())).unwrap();
-    counter
 });
 
-static PVOL_PIXEL_CACHE_ENTRIES: LazyLock<IntGauge> = LazyLock::new(|| {
-    let gauge = IntGauge::new(
-        "pvol_pixel_cache_entries",
-        "Number of entries currently in the PVOL pixel cache",
-    )
-    .unwrap();
-    REGISTRY.register(Box::new(gauge.clone())).unwrap();
-    gauge
-});
-
-static PVOL_PIXEL_READ_FAILURES: LazyLock<IntCounter> = LazyLock::new(|| {
-    let counter = IntCounter::new(
+static PVOL_PIXEL_READ_FAILURES: LazyLock<DeltaCounter> = LazyLock::new(|| {
+    DeltaCounter::new(
         "pvol_pixel_read_failures_total",
         "PVOL lazy pixel reads that failed (I/O or decode) and degraded to nodata",
     )
-    .unwrap();
-    REGISTRY.register(Box::new(counter.clone())).unwrap();
-    counter
 });
 
 // 3D Tiles encoded-content cache — global, the final `.pnts`/`.glb` bytes per
 // (collection, product, quantity, time, params, data-version), so repeats and
 // `If-None-Match` revalidations skip the engine read + encode entirely.
-static TILES3D_CONTENT_CACHE_HITS: LazyLock<IntCounter> = LazyLock::new(|| {
-    let counter = IntCounter::new(
-        "tiles3d_content_cache_hits_total",
-        "3D Tiles encoded-content cache hits",
+static TILES3D_CONTENT_CACHE_METRICS: LazyLock<CacheMetricSet> = LazyLock::new(|| {
+    CacheMetricSet::new(
+        "tiles3d_content_cache",
+        "3D Tiles encoded-content cache",
+        None,
+        Some("full engine read + encode"),
+        false,
     )
-    .unwrap();
-    REGISTRY.register(Box::new(counter.clone())).unwrap();
-    counter
-});
-
-static TILES3D_CONTENT_CACHE_MISSES: LazyLock<IntCounter> = LazyLock::new(|| {
-    let counter = IntCounter::new(
-        "tiles3d_content_cache_misses_total",
-        "3D Tiles encoded-content cache misses (full engine read + encode)",
-    )
-    .unwrap();
-    REGISTRY.register(Box::new(counter.clone())).unwrap();
-    counter
-});
-
-static TILES3D_CONTENT_CACHE_BYTES: LazyLock<IntGauge> = LazyLock::new(|| {
-    let gauge = IntGauge::new(
-        "tiles3d_content_cache_bytes",
-        "Bytes currently held in the 3D Tiles encoded-content cache",
-    )
-    .unwrap();
-    REGISTRY.register(Box::new(gauge.clone())).unwrap();
-    gauge
-});
-
-static TILES3D_CONTENT_CACHE_CAPACITY_BYTES: LazyLock<IntGauge> = LazyLock::new(|| {
-    let gauge = IntGauge::new(
-        "tiles3d_content_cache_capacity_bytes",
-        "Configured 3D Tiles encoded-content cache capacity in bytes",
-    )
-    .unwrap();
-    REGISTRY.register(Box::new(gauge.clone())).unwrap();
-    gauge
 });
 
 // PVOL resampled voxel-grid cache — global, the cylindrical grids the 3D Tiles
 // mesh products (isosurface / echo-top / voxels) share per (volume, quantity,
 // dims) instead of repeating the multi-million-cell polar resample.
-static PVOL_VOXEL_GRID_CACHE_HITS: LazyLock<IntCounter> = LazyLock::new(|| {
-    let counter = IntCounter::new(
-        "pvol_voxel_grid_cache_hits_total",
-        "PVOL voxel-grid cache hits",
+static PVOL_VOXEL_GRID_CACHE_METRICS: LazyLock<CacheMetricSet> = LazyLock::new(|| {
+    CacheMetricSet::new(
+        "pvol_voxel_grid_cache",
+        "PVOL voxel-grid cache",
+        None,
+        Some("full polar resamples"),
+        false,
     )
-    .unwrap();
-    REGISTRY.register(Box::new(counter.clone())).unwrap();
-    counter
-});
-
-static PVOL_VOXEL_GRID_CACHE_MISSES: LazyLock<IntCounter> = LazyLock::new(|| {
-    let counter = IntCounter::new(
-        "pvol_voxel_grid_cache_misses_total",
-        "PVOL voxel-grid cache misses (full polar resamples)",
-    )
-    .unwrap();
-    REGISTRY.register(Box::new(counter.clone())).unwrap();
-    counter
-});
-
-static PVOL_VOXEL_GRID_CACHE_BYTES: LazyLock<IntGauge> = LazyLock::new(|| {
-    let gauge = IntGauge::new(
-        "pvol_voxel_grid_cache_bytes",
-        "Bytes currently held in the PVOL voxel-grid cache",
-    )
-    .unwrap();
-    REGISTRY.register(Box::new(gauge.clone())).unwrap();
-    gauge
-});
-
-static PVOL_VOXEL_GRID_CACHE_CAPACITY_BYTES: LazyLock<IntGauge> = LazyLock::new(|| {
-    let gauge = IntGauge::new(
-        "pvol_voxel_grid_cache_capacity_bytes",
-        "Configured PVOL voxel-grid cache capacity in bytes",
-    )
-    .unwrap();
-    REGISTRY.register(Box::new(gauge.clone())).unwrap();
-    gauge
 });
 
 // COMP composite cache (#212) — process-global, byte-bounded LRU of decoded
 // ODIM composites, so a concurrent full-viewport WMS animation keeps every
 // active timestep resident instead of ping-ponging a single slot and
 // re-decoding the same (up to 134 MB OPERA) grid many times.
-static ODIM_COMPOSITE_CACHE_HITS: LazyLock<IntCounter> = LazyLock::new(|| {
-    let counter = IntCounter::new(
-        "odim_composite_cache_hits_total",
-        "ODIM COMP composite cache hits",
+static ODIM_COMPOSITE_CACHE_METRICS: LazyLock<CacheMetricSet> = LazyLock::new(|| {
+    CacheMetricSet::new(
+        "odim_composite_cache",
+        "ODIM COMP composite cache",
+        None,
+        Some("full HDF5 decodes"),
+        false,
     )
-    .unwrap();
-    REGISTRY.register(Box::new(counter.clone())).unwrap();
-    counter
-});
-
-static ODIM_COMPOSITE_CACHE_MISSES: LazyLock<IntCounter> = LazyLock::new(|| {
-    let counter = IntCounter::new(
-        "odim_composite_cache_misses_total",
-        "ODIM COMP composite cache misses (full HDF5 decodes)",
-    )
-    .unwrap();
-    REGISTRY.register(Box::new(counter.clone())).unwrap();
-    counter
-});
-
-static ODIM_COMPOSITE_CACHE_BYTES: LazyLock<IntGauge> = LazyLock::new(|| {
-    let gauge = IntGauge::new(
-        "odim_composite_cache_bytes",
-        "Bytes currently held in the ODIM COMP composite cache",
-    )
-    .unwrap();
-    REGISTRY.register(Box::new(gauge.clone())).unwrap();
-    gauge
-});
-
-static ODIM_COMPOSITE_CACHE_CAPACITY_BYTES: LazyLock<IntGauge> = LazyLock::new(|| {
-    let gauge = IntGauge::new(
-        "odim_composite_cache_capacity_bytes",
-        "Configured ODIM COMP composite cache capacity in bytes",
-    )
-    .unwrap();
-    REGISTRY.register(Box::new(gauge.clone())).unwrap();
-    gauge
 });
 
 // Storm-cell segmentation memo (#367) — per-volume `CellSet`s, so an
 // animation window / repeated tracking request re-segments only the newest
 // volume.
-static PVOL_CELL_SET_CACHE_HITS: LazyLock<IntCounter> = LazyLock::new(|| {
-    let counter = IntCounter::new(
-        "pvol_cell_set_cache_hits_total",
-        "PVOL storm-cell set cache hits",
+static PVOL_CELL_SET_CACHE_METRICS: LazyLock<CacheMetricSet> = LazyLock::new(|| {
+    CacheMetricSet::new(
+        "pvol_cell_set_cache",
+        "PVOL storm-cell set cache",
+        None,
+        Some("full segmentations"),
+        false,
     )
-    .unwrap();
-    REGISTRY.register(Box::new(counter.clone())).unwrap();
-    counter
-});
-
-static PVOL_CELL_SET_CACHE_MISSES: LazyLock<IntCounter> = LazyLock::new(|| {
-    let counter = IntCounter::new(
-        "pvol_cell_set_cache_misses_total",
-        "PVOL storm-cell set cache misses (full segmentations)",
-    )
-    .unwrap();
-    REGISTRY.register(Box::new(counter.clone())).unwrap();
-    counter
-});
-
-static PVOL_CELL_SET_CACHE_BYTES: LazyLock<IntGauge> = LazyLock::new(|| {
-    let gauge = IntGauge::new(
-        "pvol_cell_set_cache_bytes",
-        "Bytes currently held in the PVOL storm-cell set cache",
-    )
-    .unwrap();
-    REGISTRY.register(Box::new(gauge.clone())).unwrap();
-    gauge
-});
-
-static PVOL_CELL_SET_CACHE_CAPACITY_BYTES: LazyLock<IntGauge> = LazyLock::new(|| {
-    let gauge = IntGauge::new(
-        "pvol_cell_set_cache_capacity_bytes",
-        "Configured PVOL storm-cell set cache capacity in bytes",
-    )
-    .unwrap();
-    REGISTRY.register(Box::new(gauge.clone())).unwrap();
-    gauge
 });
 
 // Meta-tile pixel cache (#202) — global, decoded-RGBA tiles for the Web
 // Mercator WMS meta-tiling path. Distinct from the per-collection GeoTIFF
 // compressed-byte tile cache (`tile_cache_*`).
-static METATILE_CACHE_HITS: LazyLock<IntCounter> = LazyLock::new(|| {
-    let counter =
-        IntCounter::new("metatile_cache_hits_total", "Meta-tile pixel cache hits").unwrap();
-    REGISTRY.register(Box::new(counter.clone())).unwrap();
-    counter
-});
-
-static METATILE_CACHE_MISSES: LazyLock<IntCounter> = LazyLock::new(|| {
-    let counter = IntCounter::new(
-        "metatile_cache_misses_total",
-        "Meta-tile pixel cache misses",
-    )
-    .unwrap();
-    REGISTRY.register(Box::new(counter.clone())).unwrap();
-    counter
-});
-
-static METATILE_CACHE_BYTES: LazyLock<IntGauge> = LazyLock::new(|| {
-    let gauge = IntGauge::new(
-        "metatile_cache_bytes",
-        "Bytes currently held in the meta-tile pixel cache",
-    )
-    .unwrap();
-    REGISTRY.register(Box::new(gauge.clone())).unwrap();
-    gauge
-});
-
-static METATILE_CACHE_CAPACITY_BYTES: LazyLock<IntGauge> = LazyLock::new(|| {
-    let gauge = IntGauge::new(
-        "metatile_cache_capacity_bytes",
-        "Configured meta-tile pixel cache capacity in bytes",
-    )
-    .unwrap();
-    REGISTRY.register(Box::new(gauge.clone())).unwrap();
-    gauge
-});
-
-static METATILE_CACHE_ENTRIES: LazyLock<IntGauge> = LazyLock::new(|| {
-    let gauge = IntGauge::new(
-        "metatile_cache_entries",
-        "Number of entries currently in the meta-tile pixel cache",
-    )
-    .unwrap();
-    REGISTRY.register(Box::new(gauge.clone())).unwrap();
-    gauge
+static METATILE_CACHE_METRICS: LazyLock<CacheMetricSet> = LazyLock::new(|| {
+    CacheMetricSet::new("metatile_cache", "meta-tile pixel cache", None, None, true)
 });
 
 // GRIB grid cache (per-collection).
@@ -692,8 +521,10 @@ static GRID_CACHE_ENTRIES: LazyLock<IntGaugeVec> = LazyLock::new(|| {
 });
 
 /// Tracks the last observed (hits, misses) snapshot per (cache_kind, collection)
-/// so that the metrics handler can convert cumulative cache counters into
-/// monotonically-increasing Prometheus counters via delta tracking.
+/// for the **labelled per-collection** cache families, so that the metrics
+/// handler can convert cumulative cache counters into monotonically-increasing
+/// Prometheus counters via delta tracking. (The unlabelled global caches use
+/// [`CacheMetricSet`]/[`DeltaCounter`], which carry their own last-seen state.)
 ///
 /// On collection reload the underlying cache is replaced with a fresh one
 /// (hits/misses reset to 0), which we detect as a decrease and treat as the
@@ -705,21 +536,6 @@ static CACHE_COUNTER_STATE: LazyLock<Mutex<CacheCounterState>> =
 struct CacheCounterState {
     tile: HashMap<String, (u64, u64)>,
     grid: HashMap<String, (u64, u64)>,
-    rendered: (u64, u64),
-    metatile: (u64, u64),
-    /// PVOL pixel cache `(hits, misses, inserts, read_failures)` — global
-    /// cache, never replaced on reload, so always monotonic.
-    pvol_pixel: (u64, u64, u64, u64),
-    /// PVOL voxel-grid cache `(hits, misses)` — global cache, monotonic.
-    pvol_voxel_grid: (u64, u64),
-    /// PVOL storm-cell set cache `(hits, misses)` — global cache, monotonic.
-    pvol_cell_set: (u64, u64),
-    /// ODIM COMP composite cache `(hits, misses)` — global cache, monotonic.
-    odim_composite: (u64, u64),
-    /// GeoTIFF decoded-chunk cache `(hits, misses)` — global cache, monotonic.
-    geotiff_decoded_chunk: (u64, u64),
-    /// 3D Tiles encoded-content cache `(hits, misses)` — global, monotonic.
-    tiles3d_content: (u64, u64),
     /// PostGIS per-collection `(refreshes, refresh_failures, pings, ping_failures)`
     /// last-scraped values. Engines are replaced on reload (counts reset), so
     /// the scrape rebaselines on a backward step — see `metrics_handler`.
@@ -3319,127 +3135,66 @@ pub async fn metrics_handler(State(state): State<AdminState>) -> impl IntoRespon
     RENDER_SEMAPHORE_AVAILABLE.set(wms.render_semaphore.available_permits() as i64);
 
     // Delta-tracked cache counters: cache implementations expose cumulative
-    // (hits, misses) values but may be replaced on reload. Convert to
-    // monotonic Prometheus counters.
+    // (hits, misses) values but may be replaced on reload; each CacheMetricSet
+    // converts them to monotonic Prometheus counters (rebaselining on a
+    // backward step without emitting a spike). The per-collection labelled
+    // families further below still use CACHE_COUNTER_STATE.
     let mut counter_state = CACHE_COUNTER_STATE
         .lock()
         .unwrap_or_else(|e| e.into_inner());
 
     // Rendered image cache: global (single cache shared across collections).
-    // Always call inc_by() (even with delta 0) to ensure the LazyLock counter
-    // is registered on the first scrape, so dashboards see the series even
-    // before any rendering has happened.
-    let (r_hits, r_misses) = wms.rendered_cache.stats();
-    let (last_h, last_m) = counter_state.rendered;
-    if r_hits < last_h || r_misses < last_m {
-        // Cache was replaced (reload) — rebaseline without emitting a spike.
-        counter_state.rendered = (r_hits, r_misses);
-        RENDERED_CACHE_HITS.inc_by(0);
-        RENDERED_CACHE_MISSES.inc_by(0);
-    } else {
-        RENDERED_CACHE_HITS.inc_by(r_hits - last_h);
-        RENDERED_CACHE_MISSES.inc_by(r_misses - last_m);
-        counter_state.rendered = (r_hits, r_misses);
-    }
-    RENDERED_CACHE_BYTES.set(wms.rendered_cache.weight() as i64);
-    RENDERED_CACHE_CAPACITY_BYTES.set(wms.rendered_cache.capacity() as i64);
-    RENDERED_CACHE_ENTRIES.set(wms.rendered_cache.len() as i64);
+    RENDERED_CACHE_METRICS.update(
+        wms.rendered_cache.metrics(),
+        Some(wms.rendered_cache.len() as u64),
+    );
 
     // Meta-tile pixel cache: global, same delta-tracking as the rendered cache.
-    let (m_hits, m_misses) = wms.tile_cache.stats();
-    let (last_mh, last_mm) = counter_state.metatile;
-    if m_hits < last_mh || m_misses < last_mm {
-        counter_state.metatile = (m_hits, m_misses);
-        METATILE_CACHE_HITS.inc_by(0);
-        METATILE_CACHE_MISSES.inc_by(0);
-    } else {
-        METATILE_CACHE_HITS.inc_by(m_hits - last_mh);
-        METATILE_CACHE_MISSES.inc_by(m_misses - last_mm);
-        counter_state.metatile = (m_hits, m_misses);
-    }
-    METATILE_CACHE_BYTES.set(wms.tile_cache.weight() as i64);
-    METATILE_CACHE_CAPACITY_BYTES.set(wms.tile_cache.capacity() as i64);
-    METATILE_CACHE_ENTRIES.set(wms.tile_cache.len() as i64);
+    METATILE_CACHE_METRICS.update(wms.tile_cache.metrics(), Some(wms.tile_cache.len() as u64));
 
-    // PVOL lazy pixel cache: process-global (never replaced on reload), so the
-    // cumulative counters are strictly monotonic — a per-counter
-    // `saturating_sub` delta is correct without the rebaseline branch the
-    // replaceable rendered/metatile caches above need (and `saturating_sub`
-    // can't underflow if a counter ever does appear backward). Only emit when
-    // PVOL collections are loaded, so non-radar deployments don't carry empty
-    // `pvol_*` series. Recover from a poisoned lock (`into_inner`) — a panic
-    // elsewhere must not silently suppress the failure metric.
+    // PVOL lazy pixel cache: process-global (never replaced on reload). Only
+    // emit when PVOL collections are loaded, so non-radar deployments don't
+    // carry empty `pvol_*` series. Recover from a poisoned lock
+    // (`into_inner`) — a panic elsewhere must not silently suppress the
+    // failure metric.
     let has_pvol = !state
         .odim_volume_engines
         .read()
         .unwrap_or_else(|e| e.into_inner())
         .is_empty();
     if has_pvol {
-        let (p_hits, p_misses, p_ins, p_bytes, p_cap, p_entries, p_fail) =
-            engine_odim::pixel_cache_metrics();
-        let (last_ph, last_pm, last_pi, last_pf) = counter_state.pvol_pixel;
-        PVOL_PIXEL_CACHE_HITS.inc_by(p_hits.saturating_sub(last_ph));
-        PVOL_PIXEL_CACHE_MISSES.inc_by(p_misses.saturating_sub(last_pm));
-        PVOL_PIXEL_CACHE_INSERTS.inc_by(p_ins.saturating_sub(last_pi));
-        PVOL_PIXEL_READ_FAILURES.inc_by(p_fail.saturating_sub(last_pf));
-        counter_state.pvol_pixel = (p_hits, p_misses, p_ins, p_fail);
-        PVOL_PIXEL_CACHE_BYTES.set(p_bytes as i64);
-        PVOL_PIXEL_CACHE_CAPACITY_BYTES.set(p_cap as i64);
-        PVOL_PIXEL_CACHE_ENTRIES.set(p_entries as i64);
+        let pixel = engine_odim::pixel_cache_metrics();
+        PVOL_PIXEL_CACHE_METRICS.update(pixel.cache, Some(pixel.entries));
+        PVOL_PIXEL_CACHE_INSERTS.feed(pixel.inserts);
+        PVOL_PIXEL_READ_FAILURES.feed(pixel.read_failures);
 
-        // Voxel-grid cache: same process-global monotonic-counter shape.
-        let (v_hits, v_misses, v_bytes, v_cap) = engine_odim::voxel_grid_cache_metrics();
-        let (last_vh, last_vm) = counter_state.pvol_voxel_grid;
-        PVOL_VOXEL_GRID_CACHE_HITS.inc_by(v_hits.saturating_sub(last_vh));
-        PVOL_VOXEL_GRID_CACHE_MISSES.inc_by(v_misses.saturating_sub(last_vm));
-        counter_state.pvol_voxel_grid = (v_hits, v_misses);
-        PVOL_VOXEL_GRID_CACHE_BYTES.set(v_bytes as i64);
-        PVOL_VOXEL_GRID_CACHE_CAPACITY_BYTES.set(v_cap as i64);
-
-        // Storm-cell set cache: same process-global monotonic-counter shape.
-        let (s_hits, s_misses, s_bytes, s_cap) = engine_odim::cell_set_cache_metrics();
-        let (last_sh, last_sm) = counter_state.pvol_cell_set;
-        PVOL_CELL_SET_CACHE_HITS.inc_by(s_hits.saturating_sub(last_sh));
-        PVOL_CELL_SET_CACHE_MISSES.inc_by(s_misses.saturating_sub(last_sm));
-        counter_state.pvol_cell_set = (s_hits, s_misses);
-        PVOL_CELL_SET_CACHE_BYTES.set(s_bytes as i64);
-        PVOL_CELL_SET_CACHE_CAPACITY_BYTES.set(s_cap as i64);
+        // Voxel-grid + storm-cell set caches: same process-global shape.
+        PVOL_VOXEL_GRID_CACHE_METRICS.update(engine_odim::voxel_grid_cache_metrics(), None);
+        PVOL_CELL_SET_CACHE_METRICS.update(engine_odim::cell_set_cache_metrics(), None);
     }
 
-    // COMP composite cache: same process-global monotonic-counter shape as the
-    // PVOL caches. Only emit when COMP (`engine_type = "odim"`) collections are
-    // loaded, so non-radar / PVOL-only deployments don't carry empty
-    // `odim_composite_*` series.
+    // COMP composite cache: same process-global shape as the PVOL caches.
+    // Only emit when COMP (`engine_type = "odim"`) collections are loaded, so
+    // non-radar / PVOL-only deployments don't carry empty `odim_composite_*`
+    // series.
     let has_comp = !state
         .odim_engines
         .read()
         .unwrap_or_else(|e| e.into_inner())
         .is_empty();
     if has_comp {
-        let (cc_hits, cc_misses, cc_bytes, cc_cap) = engine_odim::composite_cache_metrics();
-        let (last_cch, last_ccm) = counter_state.odim_composite;
-        ODIM_COMPOSITE_CACHE_HITS.inc_by(cc_hits.saturating_sub(last_cch));
-        ODIM_COMPOSITE_CACHE_MISSES.inc_by(cc_misses.saturating_sub(last_ccm));
-        counter_state.odim_composite = (cc_hits, cc_misses);
-        ODIM_COMPOSITE_CACHE_BYTES.set(cc_bytes as i64);
-        ODIM_COMPOSITE_CACHE_CAPACITY_BYTES.set(cc_cap as i64);
+        ODIM_COMPOSITE_CACHE_METRICS.update(engine_odim::composite_cache_metrics(), None);
     }
 
-    // 3D Tiles encoded-content cache: process-global + monotonic, like the
-    // PVOL caches. Only emit when 3D Tiles collections are loaded, so other
-    // deployments don't carry empty `tiles3d_*` series.
+    // 3D Tiles encoded-content cache: process-global, like the PVOL caches.
+    // Only emit when 3D Tiles collections are loaded, so other deployments
+    // don't carry empty `tiles3d_*` series.
     if !state.tiles_3d.load().volume_engines.is_empty() {
-        let (c_hits, c_misses, c_bytes, c_cap) = api_3dtiles::content_cache_metrics();
-        let (last_ch, last_cm) = counter_state.tiles3d_content;
-        TILES3D_CONTENT_CACHE_HITS.inc_by(c_hits.saturating_sub(last_ch));
-        TILES3D_CONTENT_CACHE_MISSES.inc_by(c_misses.saturating_sub(last_cm));
-        counter_state.tiles3d_content = (c_hits, c_misses);
-        TILES3D_CONTENT_CACHE_BYTES.set(c_bytes as i64);
-        TILES3D_CONTENT_CACHE_CAPACITY_BYTES.set(c_cap as i64);
+        TILES3D_CONTENT_CACHE_METRICS.update(api_3dtiles::content_cache_metrics(), None);
     }
 
-    // GeoTIFF decoded-chunk cache (#463): process-global + monotonic, like the
-    // ODIM caches. Only emit when geotiff collections are loaded, so other
+    // GeoTIFF decoded-chunk cache (#463): process-global, like the ODIM
+    // caches. Only emit when geotiff collections are loaded, so other
     // deployments don't carry empty `geotiff_decoded_chunk_*` series.
     let has_geotiff = !state
         .geotiff_engines
@@ -3447,13 +3202,8 @@ pub async fn metrics_handler(State(state): State<AdminState>) -> impl IntoRespon
         .unwrap_or_else(|e| e.into_inner())
         .is_empty();
     if has_geotiff {
-        let (g_hits, g_misses, g_bytes, g_cap) = engine_geotiff::decoded_chunk_cache_metrics();
-        let (last_gh, last_gm) = counter_state.geotiff_decoded_chunk;
-        GEOTIFF_DECODED_CHUNK_CACHE_HITS.inc_by(g_hits.saturating_sub(last_gh));
-        GEOTIFF_DECODED_CHUNK_CACHE_MISSES.inc_by(g_misses.saturating_sub(last_gm));
-        counter_state.geotiff_decoded_chunk = (g_hits, g_misses);
-        GEOTIFF_DECODED_CHUNK_CACHE_BYTES.set(g_bytes as i64);
-        GEOTIFF_DECODED_CHUNK_CACHE_CAPACITY_BYTES.set(g_cap as i64);
+        GEOTIFF_DECODED_CHUNK_CACHE_METRICS
+            .update(engine_geotiff::decoded_chunk_cache_metrics(), None);
     }
 
     // Tile cache: per-collection


### PR DESCRIPTION
Closes #480.

## What

The byte-bounded LRU cache pattern (zero-value `Weighter`, `MC_*_CACHE_MB` env parse, `estimated_items` heuristic, `HITS`/`MISSES: AtomicU64`, `metrics()` snapshot) was copy-pasted **12 times**. This extracts it into one shared, dependency-light crate and migrates every copy.

### New crate: `ds-cache` (`crates/ds-cache`)

Deps: `quick_cache` + std only — usable from the framework-free `ds-render`/`ds-mvt` tier. Provides `ByteBoundedCache<K, V>`:

- weight function as a plain `fn(&K, &V) -> u64` (no per-site `Weighter` unit-struct impls)
- `from_env(var, default_mb, …)` / `env_mb` for the env-parse idiom; capacity 0 = disabled (1-byte internal clamp, nothing ever admitted)
- counted `get`, plus untracked `get`/`contains_key` + `record_hit`/`record_miss` primitives for wrappers with custom accounting
- single-flight `get_or_insert_with` (miss counted before the fallible compute; an error doesn't poison the key)
- `CacheMetrics { hits, misses, bytes, capacity_bytes }` snapshot for `/metrics`
- lookups generic over `Equivalent<K>` so borrowed-key sites (zarr's `&str` vs `String`) stay allocation-free

### Migrated call sites (key types, env vars, defaults unchanged)

| Site | Cache |
|---|---|
| `api-3dtiles/src/cache.rs` | encoded content + ETag (keeps its per-key async single-flight gates) |
| `ds-mvt/src/cache.rs` | encoded MVT tiles |
| `engine-geotiff/src/cache.rs` | compressed COG tiles (per-collection) |
| `engine-geotiff/src/decoded_cache.rs` | decoded chunks (#463) |
| `engine-grib/src/cache.rs` | decoded grids (per-collection) |
| `engine-odim/src/engine.rs` | COMP composites (#212) |
| `engine-odim/src/cells.rs` | storm-cell sets (#367) |
| `engine-odim/src/pixel_cache.rs` | PVOL pixels (keeps its count-bounded negative cache + inserts counter) |
| `engine-odim/src/volume_engine.rs` | voxel grids |
| `engine-zarr/src/store.rs` | chunk objects |
| `render/src/lib.rs` | rendered images |
| `render/src/metatile.rs` | meta-tile pixels (#202) |

`quick_cache` remains a direct dep only where the shape genuinely differs: engine-odim's count-bounded negative cache and ds-render's item-bounded empty-tile cache.

### `server/src/admin.rs` gauge wiring collapse

The ~12 near-identical global cache metric blocks (~40–50 lines each of `LazyLock<IntCounter/IntGauge>` statics + delta-tracking in `metrics_handler`) collapse into:

- `DeltaCounter` — cumulative-value → monotonic Prometheus counter (atomic `swap`, `saturating_sub` rebaseline on reload-reset, no spike)
- `CacheMetricSet` — one static + one `update()` call per cache family

**Metric names and help strings are byte-identical** (the set derives `{prefix}_hits_total`/`_misses_total`/`_bytes`/`_capacity_bytes`/`_entries` and the help text from the display name + optional notes, matching the previous hand-written strings). Per-collection labelled families (`tile_cache_*`, `grid_cache_*`) and the PostGIS wiring are untouched. Engine-type gating (only emit `pvol_*`/`odim_composite_*`/`tiles3d_*`/`geotiff_decoded_chunk_*` when such collections are loaded) is preserved.

Net: **−938 / +818 lines** while adding a fully-tested new crate; every new engine now gets this via one constructor call instead of re-deriving ~50 lines by hand.

## Behavior notes (metrics-only; no request-path changes)

- Disabled caches (0 MB) now report `*_capacity_bytes` 0 instead of the internal 1-byte clamp (the struct-wrapped sites already reported 0).
- Cell-set / voxel-grid caches now count a miss when the compute **fails** (previously only successful computes counted there) — unified on the decoded-chunk/composite convention of counting the miss before the fallible compute.
- `estimated_items` floors unify on `.max(16)` (was 1/4/16/64 per site) — a hash-map sizing hint only; eviction is always driven by the byte budget.

## Verification

- `cargo fmt` + `cargo clippy --all-targets -- -D warnings` clean
- `cargo test` (full workspace) green, including the migrated cache unit/integration tests (identity invalidation, error-no-poison, zero-capacity, eviction-by-weight, ETag stability, cache-hit counters)
- ds-cache ships its own unit tests for counting, coalescing, eviction, disabled mode, and env parsing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T22YrnSuwKW6mFebJBHaBt