### PR TITLE
perf(render): pixel-proportional meta-tile budget instead of fixed 256-tile cap (#491)

### DIFF
--- a/crates/api-wms/src/handlers.rs
+++ b/crates/api-wms/src/handlers.rs
@@ -29,7 +29,8 @@ enum RenderPath {
     /// Meta-tiling path, every covered pixel nodata — carries the tile-loop
     /// timing (assemble/encode skipped).
     MetaEmpty(ds_render::MetaTileStats),
-    /// Meta-tiling declined (degenerate / >MAX_TILES / extreme zoom) → direct.
+    /// Meta-tiling declined (degenerate bbox / over tile budget / extreme
+    /// zoom) → direct.
     Fallback,
     /// Genuine non-meta path (non-3857 CRS, or meta cache disabled).
     Direct,

--- a/crates/render/src/metatile.rs
+++ b/crates/render/src/metatile.rs
@@ -30,6 +30,7 @@
 //! CRSs fall back to a direct single-shot render. Degenerate or pathologically
 //! large requests return [`MetaTile::Fallback`] so the caller renders directly.
 
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -52,9 +53,41 @@ const ORIGIN: f64 = std::f64::consts::PI * R;
 const Z0_RES: f64 = (2.0 * ORIGIN) / TILE_PX as f64;
 /// Maximum half-octave ladder level (`level/2 ≈ zoom`, so ~zoom 24).
 const MAX_LEVEL: i32 = 48;
-/// Safety cap on covering tiles per request. A request that would need more
-/// (tiny resolution over a huge bbox) declines to [`MetaTile::Fallback`].
-const MAX_TILES: usize = 256;
+/// Tile-budget floor so small requests always qualify regardless of rounding.
+const MIN_TILE_BUDGET: usize = 64;
+/// Tile-budget multiplier over the request's own pixel-implied tile count
+/// (`width·height / 256²`). Half-octave snapping inflates each axis by at most
+/// √2 (≈2× tiles) and grid straddle adds one row and column, so a square-pixel
+/// request never needs more than ~3× its pixel-implied count; 4× leaves margin.
+const TILE_BUDGET_FACTOR: usize = 4;
+
+/// Maximum covering tiles allowed for a `width × height` request before
+/// meta-tiling declines to a direct render (#491). Pixel-proportional: a fixed
+/// 256-tile cap put retina-class viewports (≥4K) right on the cliff, randomly
+/// flipping the same window between cached meta-tiling and uncached direct
+/// rendering depending on how the bbox landed on the ladder. Scaling with the
+/// request keeps every square-pixel viewport cacheable (WMS bounds requests at
+/// 8000 px/dim, 64 Mpx) while still declining the pathology the guard exists
+/// for: a bbox whose aspect wildly mismatches the pixel aspect snaps to a fine
+/// level along one axis and demands orders of magnitude more tiles than the
+/// pixels justify.
+fn tile_budget(width: u32, height: u32) -> usize {
+    let px_tiles =
+        (width as usize).saturating_mul(height as usize) / (TILE_PX as usize * TILE_PX as usize);
+    TILE_BUDGET_FACTOR.saturating_mul(px_tiles) + MIN_TILE_BUDGET
+}
+
+/// Requests declined because their covering tile count exceeded
+/// [`tile_budget`] (cumulative since process start). Surfaced on `/metrics` as
+/// `metatile_declines_total`; a sustained rate means clients are sending
+/// viewports outside the cacheable envelope (extreme bbox/pixel aspect
+/// mismatch) and paying an uncached direct render every frame.
+static BUDGET_DECLINES: AtomicU64 = AtomicU64::new(0);
+
+/// Cumulative count of tile-budget declines, for the `/metrics` scrape.
+pub fn budget_declines_total() -> u64 {
+    BUDGET_DECLINES.load(Ordering::Relaxed)
+}
 
 // Web Mercator metre <-> WGS84 degree conversions come from the shared
 // `ds_core::web_mercator` module (the single source of truth, #452): `lat_to_y`
@@ -218,8 +251,9 @@ pub enum MetaTile {
     /// transparent tile (matching the existing all-nodata fast path). `stats`
     /// still carries the tile-loop timing (assemble/encode are skipped, so 0).
     Empty { stats: MetaTileStats },
-    /// Meta-tiling declined (degenerate bbox or > `MAX_TILES` tiles); the caller
-    /// should fall back to a direct single-shot render.
+    /// Meta-tiling declined (degenerate bbox, over-zoom past the ladder, or a
+    /// covering tile count above [`tile_budget`]); the caller should fall back
+    /// to a direct single-shot render.
     Fallback,
 }
 
@@ -295,7 +329,8 @@ where
         ((ORIGIN - lat_to_y(s.clamp(-LAT_LIMIT_DEG, LAT_LIMIT_DEG)) - eps) / span).floor() as i64;
     let ncols = (col1 - col0 + 1).max(1) as usize;
     let nrows = (row1 - row0 + 1).max(1) as usize;
-    if ncols.saturating_mul(nrows) > MAX_TILES {
+    if ncols.saturating_mul(nrows) > tile_budget(width, height) {
+        BUDGET_DECLINES.fetch_add(1, Ordering::Relaxed);
         return Ok(MetaTile::Fallback);
     }
 
@@ -731,7 +766,16 @@ mod tests {
     }
 
     #[test]
-    fn huge_tile_count_falls_back() {
+    fn tile_budget_scales_with_request_pixels() {
+        // `4 · (W·H / 256²) + 64`, integer math pinned exactly.
+        assert_eq!(tile_budget(10, 10), 64); // floor dominates tiny requests
+        assert_eq!(tile_budget(1920, 1080), 188);
+        assert_eq!(tile_budget(4503, 2255), 680); // observed prod retina client
+        assert_eq!(tile_budget(8192, 8192), 4160);
+    }
+
+    #[test]
+    fn aspect_mismatch_tile_count_falls_back() {
         let cache = TilePixelCache::new(16);
         let prefix = TileKeyPrefix {
             layer: "l".into(),
@@ -741,10 +785,16 @@ mod tests {
             z: None,
             reference_time: None,
         };
-        // Whole-world bbox at a tiny resolution forces > MAX_TILES → fallback.
+        // The pathology the budget guards (#491): a whole-world-wide bbox on a
+        // tall, narrow image. The fine y-resolution snaps the ladder deep, so
+        // the world-spanning x-axis needs ~46 columns → ~2100 tiles, while the
+        // request's own pixels justify a budget of only 192. Must decline (and
+        // count the decline) rather than render a tile grid orders of
+        // magnitude larger than the viewport.
+        let declined_before = budget_declines_total();
         let out = render_metatiled(
             [-179.0, -85.0, 179.0, 85.0],
-            8192,
+            256,
             8192,
             &prefix,
             &SolidRed,
@@ -754,6 +804,64 @@ mod tests {
         )
         .unwrap();
         assert!(matches!(out, MetaTile::Fallback));
+        assert!(budget_declines_total() > declined_before);
+    }
+
+    #[test]
+    fn retina_viewport_above_old_cap_still_metatiles() {
+        let cache = TilePixelCache::new(256);
+        let prefix = TileKeyPrefix {
+            layer: "l".into(),
+            parameter: None,
+            style: "default".into(),
+            time: None,
+            z: None,
+            reference_time: None,
+        };
+        // Regression pin for #491: a square-pixel 4K-retina viewport whose
+        // requested resolution sits just above a ladder step, so the half-
+        // octave snap inflates the cover past the old fixed cap of 256 tiles.
+        // It must meta-tile (cacheable) instead of falling back to an uncached
+        // direct render. Build the bbox in Mercator metres around southern
+        // Finland at 1.38× a ladder resolution, square pixels on both axes.
+        let (width, height) = (3840u32, 2160u32);
+        let res = level_res(12) * 1.38; // snaps to level 12, ~1.38×/axis inflation
+        let (cx, cy) = (2_700_000.0, 8_500_000.0);
+        let half_w = width as f64 * res / 2.0;
+        let half_h = height as f64 * res / 2.0;
+        let bbox = [
+            x_to_lon(cx - half_w),
+            y_to_lat(cy - half_h),
+            x_to_lon(cx + half_w),
+            y_to_lat(cy + half_h),
+        ];
+        let out = render_metatiled(
+            bbox,
+            width,
+            height,
+            &prefix,
+            &SolidRed,
+            ImageFormat::Png,
+            &cache,
+            solid_tile,
+        )
+        .unwrap();
+        match out {
+            MetaTile::Image { stats, .. } => {
+                assert!(
+                    stats.tiles as usize > 256,
+                    "cover ({} tiles) should exceed the old fixed cap for this pin to bite",
+                    stats.tiles
+                );
+                assert!(
+                    (stats.tiles as usize) <= tile_budget(width, height),
+                    "cover ({} tiles) must fit the pixel-proportional budget ({})",
+                    stats.tiles,
+                    tile_budget(width, height)
+                );
+            }
+            _ => panic!("expected MetaTile::Image, got Fallback/Empty"),
+        }
     }
 
     #[test]

--- a/crates/server/src/admin.rs
+++ b/crates/server/src/admin.rs
@@ -460,6 +460,17 @@ static METATILE_CACHE_METRICS: LazyLock<CacheMetricSet> = LazyLock::new(|| {
     CacheMetricSet::new("metatile_cache", "meta-tile pixel cache", None, None, true)
 });
 
+static METATILE_DECLINES: LazyLock<DeltaCounter> = LazyLock::new(|| {
+    DeltaCounter::new(
+        "metatile_declines_total",
+        "WMS renders where meta-tiling declined because the covering tile \
+         count exceeded the pixel-proportional budget, falling back to an \
+         uncached direct render (#491). A sustained rate means clients are \
+         sending viewports outside the cacheable envelope (extreme bbox/pixel \
+         aspect mismatch) and re-render every frame",
+    )
+});
+
 // GRIB grid cache (per-collection).
 static GRID_CACHE_HITS: LazyLock<IntCounterVec> = LazyLock::new(|| {
     let counter = IntCounterVec::new(
@@ -3151,6 +3162,7 @@ pub async fn metrics_handler(State(state): State<AdminState>) -> impl IntoRespon
 
     // Meta-tile pixel cache: global, same delta-tracking as the rendered cache.
     METATILE_CACHE_METRICS.update(wms.tile_cache.metrics(), Some(wms.tile_cache.len() as u64));
+    METATILE_DECLINES.feed(ds_render::metatile::budget_declines_total());
 
     // PVOL lazy pixel cache: process-global (never replaced on reload). Only
     // emit when PVOL collections are loaded, so non-radar deployments don't

--- a/docker/grafana/dashboards/meteocore-overview.json
+++ b/docker/grafana/dashboards/meteocore-overview.json
@@ -775,7 +775,7 @@
     {
       "type": "timeseries",
       "title": "Cold tile renders per second",
-      "description": "Meta-tile cache misses = tiles actually rendered (decode + resample + colorize). This is the render COST signal: p99 spikes track this, not request rate. Animation scrubbing is always cold here (TIME is in the tile key) — the rendered-output cache is what serves repeat loops.",
+      "description": "Meta-tile cache misses = tiles actually rendered (decode + resample + colorize). This is the render COST signal: p99 spikes track this, not request rate. Animation scrubbing is always cold here (TIME is in the tile key) — the rendered-output cache is what serves repeat loops. Declines = requests whose covering tile count exceeded the pixel-proportional budget (#491) and fell back to an UNCACHED direct render; a sustained rate means clients send viewports outside the cacheable envelope (extreme bbox/pixel aspect mismatch) and re-render every frame.",
       "id": 17,
       "gridPos": {
         "h": 8,
@@ -820,6 +820,11 @@
           "expr": "rate(rendered_cache_misses_total[$__rate_interval])",
           "refId": "B",
           "legendFormat": "full-viewport renders /s"
+        },
+        {
+          "expr": "rate(metatile_declines_total[$__rate_interval])",
+          "refId": "C",
+          "legendFormat": "meta-tiling declines (uncached direct) /s"
         }
       ]
     },


### PR DESCRIPTION
## Problem

`render_metatiled` declined to an **uncached** direct render whenever the covering tile grid exceeded a fixed `MAX_TILES = 256`. The half-octave ladder snap inflates each axis by up to √2, so square-pixel retina viewports sit right on that cliff:

| Viewport | best case | worst case |
|---|---|---|
| 1920×1080 | ~40 | ~102 |
| 3840×2160 (4K retina) | ~150 | ~299 |
| 4503×2255 (observed prod client) | ~162 | ~364 |
| 5120×2880 (5K) | ~230 | ~510 |

The same window randomly flipped between cached meta-tiling and uncached direct rendering depending on how the bbox landed on the ladder — confirmed in prod slow-WMS logs (2026-07-06): 4503×2255 requests on `fi-radar-pvol-fivih/DBZH` alternating between 231-tile meta renders and `meta-tiling fell back to direct` at the same size.

## Change

- **Pixel-proportional budget** (`tile_budget`): decline only when the cover exceeds `4·(W·H/256²) + 64`. Every square-pixel viewport within the WMS request caps (8000 px/dim, 64 Mpx in `params.rs`) now always meta-tiles; the pathology the guard exists for — extreme bbox/pixel aspect mismatch demanding orders of magnitude more tiles than the pixels justify — still declines.
- **`metatile_declines_total`** counter on `/metrics` (cumulative atomic in ds-render, delta-tracked `DeltaCounter` in admin.rs), so declines are visible in Grafana instead of only in >400 ms slow-render logs.
- Grafana: third query + description update on the "Cold tile renders per second" panel.

## Tests

- `tile_budget_scales_with_request_pixels` — pins the budget arithmetic.
- `aspect_mismatch_tile_count_falls_back` — repurposes the old `huge_tile_count_falls_back` (a square-pixel whole-world 8192² render is now *legitimately* meta-tileable) into the actual pathology: whole-world-wide bbox on a 256×8192 image (~2100 tiles vs budget 192) declines and increments the counter.
- `retina_viewport_above_old_cap_still_metatiles` — regression pin: a 3840×2160 square-pixel request engineered to need >256 tiles returns `MetaTile::Image` within budget.

## End-to-end verification

Booted the server against the `testdata/fmi-radar` fixture:
- 3840×2160 GetMap needing **286 tiles** (old cap would decline): meta-tiled — `metatile_cache_misses_total` +286, `metatile_declines_total` 0, valid PNG8 output.
- 256×8000 whole-world GetMap: declined, still rendered correctly via the direct path (HTTP 200), `metatile_declines_total` → 1, no tiles rendered.

Cost note: one fully cold 8192×8192 render (~2100 tiles) inserts ~550 MB into the byte-bounded tile cache — LRU absorbs it, RSS does not grow. A single cold render is not faster (meta-tiling over-renders up to ~2× vs direct); the win is cache reuse for pans/other users and removing the random cached/uncached cliff.

Closes #491

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T22YrnSuwKW6mFebJBHaBt