### PR TITLE
perf(server): jemalloc global allocator + process/allocator memory gauges (#493)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4064,6 +4064,8 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "tikv-jemalloc-ctl",
+ "tikv-jemallocator",
  "tokio",
  "toml",
  "tower",
@@ -4342,6 +4344,37 @@ dependencies = [
  "quick-error",
  "weezl",
  "zune-jpeg",
+]
+
+[[package]]
+name = "tikv-jemalloc-ctl"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a184c43b8ab2f41df2733b55556e3f5f632f4aeaa205b1bb018f574b7f5f142"
+dependencies = [
+ "libc",
+ "paste",
+ "tikv-jemalloc-sys",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.7.1+5.3.1-0-g81034ce1f1373e37dc865038e1bc8eeecf559ce8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a2825c78386b4ae0314074867860ba9577875de945f05992c38815cbec327f0"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "249f09e49ab1609436f34c776e84231bead18d6a955f119f939bdc1d847561bd"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -49,3 +49,7 @@ http-body-util = "0.1"
 tempfile = "3"
 toml = "0.8"
 tower = { version = "0.5", features = ["util"] }
+
+[target.'cfg(not(target_env = "msvc"))'.dependencies]
+tikv-jemalloc-ctl = { version = "0.7", features = ["stats"] }
+tikv-jemallocator = { version = "0.7", features = ["stats"] }

--- a/crates/server/src/admin.rs
+++ b/crates/server/src/admin.rs
@@ -173,6 +173,102 @@ static COLLECTIONS_TOTAL: LazyLock<IntGauge> = LazyLock::new(|| {
     gauge
 });
 
+// Process + allocator memory (#493). RSS/swap come from /proc/self/status
+// (Linux only; the series stay 0 elsewhere). The jemalloc_* gauges expose the
+// allocator's own accounting so the fragmentation multiplier is visible in
+// prod: `allocated` = live bytes the application holds, `resident` = physical
+// pages jemalloc keeps — resident far above allocated means allocator
+// retention (the glibc failure mode this deployment hit was ~3×).
+static PROCESS_MEM_GAUGES: LazyLock<[IntGauge; 2]> = LazyLock::new(|| {
+    let mk = |name: &str, help: &str| {
+        let g = IntGauge::new(name, help).unwrap();
+        REGISTRY.register(Box::new(g.clone())).unwrap();
+        g
+    };
+    [
+        mk(
+            "process_resident_memory_bytes",
+            "Resident set size (VmRSS) of the server process",
+        ),
+        mk(
+            "process_swap_memory_bytes",
+            "Swapped-out anonymous memory (VmSwap) of the server process",
+        ),
+    ]
+});
+
+#[cfg(not(target_env = "msvc"))]
+static JEMALLOC_GAUGES: LazyLock<[IntGauge; 5]> = LazyLock::new(|| {
+    let mk = |name: &str, help: &str| {
+        let g = IntGauge::new(name, help).unwrap();
+        REGISTRY.register(Box::new(g.clone())).unwrap();
+        g
+    };
+    [
+        mk(
+            "jemalloc_allocated_bytes",
+            "Bytes in live allocations (application-held)",
+        ),
+        mk(
+            "jemalloc_active_bytes",
+            "Bytes in active pages backing allocations (>= allocated; gap = internal fragmentation)",
+        ),
+        mk(
+            "jemalloc_resident_bytes",
+            "Physical bytes jemalloc keeps mapped (>= active; gap = dirty pages awaiting decay)",
+        ),
+        mk(
+            "jemalloc_mapped_bytes",
+            "Total bytes in jemalloc extent mappings",
+        ),
+        mk(
+            "jemalloc_retained_bytes",
+            "Virtual address space retained for reuse (not physically backed)",
+        ),
+    ]
+});
+
+/// Refresh the process/allocator memory gauges. Called per `/metrics` scrape.
+fn update_memory_gauges() {
+    // Touch the family even where /proc is unavailable so dashboards see the
+    // series (it just stays 0 off-Linux).
+    LazyLock::force(&PROCESS_MEM_GAUGES);
+    #[cfg(target_os = "linux")]
+    if let Ok(status) = std::fs::read_to_string("/proc/self/status") {
+        let kb = |key: &str| -> Option<i64> {
+            let line = status.lines().find(|l| l.starts_with(key))?;
+            line.split_whitespace().nth(1)?.parse::<i64>().ok()
+        };
+        if let Some(rss_kb) = kb("VmRSS:") {
+            PROCESS_MEM_GAUGES[0].set(rss_kb * 1024);
+        }
+        if let Some(swap_kb) = kb("VmSwap:") {
+            PROCESS_MEM_GAUGES[1].set(swap_kb * 1024);
+        }
+    }
+
+    #[cfg(not(target_env = "msvc"))]
+    {
+        use tikv_jemalloc_ctl::{epoch, stats};
+        // Stats are snapshotted inside jemalloc; advancing the epoch refreshes
+        // them before reading.
+        if epoch::advance().is_ok() {
+            let stats: [Result<usize, _>; 5] = [
+                stats::allocated::read(),
+                stats::active::read(),
+                stats::resident::read(),
+                stats::mapped::read(),
+                stats::retained::read(),
+            ];
+            for (gauge, value) in JEMALLOC_GAUGES.iter().zip(stats) {
+                if let Ok(v) = value {
+                    gauge.set(v as i64);
+                }
+            }
+        }
+    }
+}
+
 static COLLECTIONS_HEALTHY: LazyLock<IntGauge> = LazyLock::new(|| {
     let gauge = IntGauge::new("collections_healthy", "Collections in ready state").unwrap();
     REGISTRY.register(Box::new(gauge.clone())).unwrap();
@@ -3144,6 +3240,7 @@ pub async fn metrics_handler(State(state): State<AdminState>) -> impl IntoRespon
     // Read from current WMS state (survives reloads via ArcSwap)
     let wms = state.wms.load();
     RENDER_SEMAPHORE_AVAILABLE.set(wms.render_semaphore.available_permits() as i64);
+    update_memory_gauges();
 
     // Delta-tracked cache counters: cache implementations expose cumulative
     // (hits, misses) values but may be replaced on reload; each CacheMetricSet

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -5,6 +5,18 @@ mod watcher;
 
 use std::sync::{Arc, OnceLock, RwLock};
 
+/// jemalloc as the global allocator (#493). The default glibc malloc
+/// fragments badly under this workload — many threads cycling 1–32 MB
+/// decode/render buffers interleaved with long-lived byte-bounded cache
+/// entries pins nearly every 64 MB arena heap: prod reached a ~52 GB
+/// anonymous footprint holding only ~16 GiB of live cache (~3× retention).
+/// jemalloc's size-classed extents and dirty-page decay return freed memory
+/// to the OS instead. Allocator stats are exported on `/metrics` as the
+/// `jemalloc_*` gauges (see `admin.rs`) to watch the multiplier in prod.
+#[cfg(not(target_env = "msvc"))]
+#[global_allocator]
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
 /// Dedicated multi-thread runtime for background collection poll loops.
 ///
 /// Poll/scan loops do blocking I/O via `ds_storage::DataStore`, which parks the

--- a/docker/grafana/dashboards/meteocore-overview.json
+++ b/docker/grafana/dashboards/meteocore-overview.json
@@ -1453,7 +1453,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 73
+        "y": 81
       },
       "panels": []
     },
@@ -1466,7 +1466,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 74
+        "y": 82
       },
       "datasource": {
         "type": "prometheus",
@@ -1532,7 +1532,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 74
+        "y": 82
       },
       "datasource": {
         "type": "prometheus",
@@ -1578,7 +1578,7 @@
         "h": 4,
         "w": 6,
         "x": 0,
-        "y": 82
+        "y": 90
       },
       "datasource": {
         "type": "prometheus",
@@ -1625,7 +1625,7 @@
         "h": 4,
         "w": 6,
         "x": 6,
-        "y": 82
+        "y": 90
       },
       "datasource": {
         "type": "prometheus",
@@ -1672,7 +1672,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 86
+        "y": 94
       },
       "panels": []
     },
@@ -1685,7 +1685,7 @@
         "h": 4,
         "w": 4,
         "x": 0,
-        "y": 87
+        "y": 95
       },
       "datasource": {
         "type": "prometheus",
@@ -1736,7 +1736,7 @@
         "h": 8,
         "w": 10,
         "x": 4,
-        "y": 87
+        "y": 95
       },
       "datasource": {
         "type": "prometheus",
@@ -1797,7 +1797,7 @@
         "h": 8,
         "w": 10,
         "x": 14,
-        "y": 87
+        "y": 95
       },
       "datasource": {
         "type": "prometheus",
@@ -1853,7 +1853,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 95
+        "y": 103
       },
       "panels": []
     },
@@ -1866,7 +1866,7 @@
         "h": 9,
         "w": 24,
         "x": 0,
-        "y": 96
+        "y": 104
       },
       "datasource": {
         "type": "loki",
@@ -1899,7 +1899,7 @@
         "h": 10,
         "w": 24,
         "x": 0,
-        "y": 105
+        "y": 113
       },
       "datasource": {
         "type": "loki",
@@ -1920,6 +1920,74 @@
           "expr": "{job=\"meteocore\"} | json | line_format \"{{.method}} {{.path}} → {{.status}} ({{.duration_ms}}ms) rid={{.request_id}} {{if .query}}?{{.query}}{{end}}\"",
           "refId": "A",
           "maxLines": 200
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Process memory — RSS, swap & allocator accounting",
+      "description": "Verifies the #493 fix (jemalloc). Healthy: process RSS ≈ jemalloc resident, and resident within ~1.5× of allocated (live application bytes). resident ≫ allocated = allocator retention/fragmentation (the glibc failure mode was ~3×). RSS ≫ jemalloc resident = memory outside the allocator (mmap'd files, thread stacks). Sustained process swap > 0 = host memory pressure — check what else grew on the box. 'live cache bytes' is the sum of every byte-bounded cache family, the floor the process can't go below.",
+      "id": 40,
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 73
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "custom": {
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "process_resident_memory_bytes",
+          "refId": "A",
+          "legendFormat": "process RSS"
+        },
+        {
+          "expr": "process_swap_memory_bytes",
+          "refId": "B",
+          "legendFormat": "process swap"
+        },
+        {
+          "expr": "jemalloc_resident_bytes",
+          "refId": "C",
+          "legendFormat": "jemalloc resident"
+        },
+        {
+          "expr": "jemalloc_allocated_bytes",
+          "refId": "D",
+          "legendFormat": "jemalloc allocated (live)"
+        },
+        {
+          "expr": "sum({__name__=~\".+_cache_bytes\"})",
+          "refId": "E",
+          "legendFormat": "live cache bytes"
         }
       ]
     }


### PR DESCRIPTION
Step 2 of the #493 fix plan (step 1, `MALLOC_ARENA_MAX=2`, is already applied to prod as a container-env mitigation).

## Problem

Prod reached a **~52 GB anonymous footprint holding only ~16.4 GiB of live cache** within 12 h of restart, exhausting the host's 32 GB swap. `/proc/1/smaps` showed 574 pinned ~64 MB glibc arena heaps (44 GB dirty in the 32–68 MB bucket, no mapping >260 MB) — classic glibc arena fragmentation under many threads cycling 1–32 MB decode/render buffers interleaved with long-lived byte-bounded cache entries. Full evidence in #493.

## Change

- **jemalloc as `#[global_allocator]`** in the server binary (`tikv-jemallocator` 0.7 / jemalloc 5.3.1, gated `cfg(not(target_env = "msvc"))`, default decay settings). Size-classed extents + dirty-page decay return freed memory to the OS under exactly this profile.
- **Memory observability on `/metrics`** (this incident was invisible — the monitoring stack scrapes only the app, and the app exported no memory numbers):
  - `process_resident_memory_bytes` / `process_swap_memory_bytes` from `/proc/self/status` (Linux; series stay 0 elsewhere)
  - `jemalloc_{allocated,active,resident,mapped,retained}_bytes` via `tikv-jemalloc-ctl`, epoch-advanced per scrape
- **Grafana**: new full-width "Process memory — RSS, swap & allocator accounting" panel at the end of the Caches section, plotting RSS/swap/jemalloc-resident/jemalloc-allocated against summed live cache bytes. Reading guide in the panel description: resident ≫ allocated = allocator retention; RSS ≫ resident = memory outside the allocator; sustained swap > 0 = host pressure.

## Build notes

- jemalloc builds from source in the Docker builder stage — `make`/`clang` are already installed there (libaec-sys needs them too).
- Single `tikv-jemalloc-sys` in the graph (`links = "jemalloc"` enforces this); `cargo tree -i` verified.

## Verification

- Booted against the `testdata/fmi-radar` fixture: `jemalloc_allocated_bytes 4408024` / `jemalloc_resident_bytes 12189696` on `/metrics` (non-zero ⇒ allocator active and ctl wired), WMS GetMap renders unchanged (HTTP 200, PNG8).
- `cargo fmt`, `clippy --all-targets -D warnings`, `cargo test -p server` (75+10) all green.
- Prod acceptance after deploy: watch the new panel — expect RSS to settle near jemalloc resident, within ~1.5× of allocated (vs the ~3× glibc multiplier), and the smaps 32–68 MB bucket to shrink from ~44 GB to a small multiple of live cache bytes.

Part of #493 — remaining steps (cache budget right-sizing if needed, #476 prewarm churn, node-level metrics/alerting) stay open there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T22YrnSuwKW6mFebJBHaBt