### PR TITLE
chore(engine-geotiff): fix clippy 1.97 for_kv_map drift

### DIFF
--- a/crates/engine-geotiff/src/lib.rs
+++ b/crates/engine-geotiff/src/lib.rs
@@ -1804,7 +1804,7 @@ impl EdrEngine for GeoTiffEngine {
             let nx = x.len();
             let expected_len = nt * ny * nx;
             let (col_start, row_start) = pixel_range.map_or((0, 0), |(c, r, _, _)| (c, r));
-            for (_name, ndarray) in result.ranges.iter_mut() {
+            for ndarray in result.ranges.values_mut() {
                 if ndarray.values.len() != expected_len {
                     tracing::error!(
                         "NdArray length mismatch: expected {} ({}*{}*{}), got {}",


### PR DESCRIPTION
Stable Rust 1.97 (2026-07-07) newly fires `clippy::for_kv_map` on the EDR grid-range loop in `crates/engine-geotiff/src/lib.rs` — CI clippy floats @stable with `-D warnings`, so every open PR is red on it (first bitten: #495). One-line fix: `for (_name, ndarray) in result.ranges.iter_mut()` → `for ndarray in result.ranges.values_mut()`.

Verified: `cargo clippy --all-targets -- -D warnings` clean across the whole workspace on local 1.97; `cargo test -p engine-geotiff` green.

Ships separately per the established drift convention so unrelated PRs can rebase on green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T22YrnSuwKW6mFebJBHaBt