### PR TITLE
fix(api-edr): breached postgis area/row caps are HTTP 400, not opaque 500

### DIFF
--- a/crates/api-3dtiles/src/error.rs
+++ b/crates/api-3dtiles/src/error.rs
@@ -38,9 +38,10 @@ impl From<ds_core::error::DataServerError> for Tiles3dError {
     fn from(e: ds_core::error::DataServerError) -> Self {
         use ds_core::error::DataServerError as E;
         match e {
-            E::InvalidParameter(m) | E::InvalidBbox(m) | E::InvalidDatetime(m) => {
-                Tiles3dError::BadRequest(m)
-            }
+            E::InvalidParameter(m)
+            | E::InvalidBbox(m)
+            | E::InvalidDatetime(m)
+            | E::QueryTooLarge(m) => Tiles3dError::BadRequest(m),
             E::CollectionNotFound(m) | E::LocationNotFound(m) | E::FeatureNotFound(m) => {
                 Tiles3dError::NotFound(m)
             }

--- a/crates/api-edr/src/handlers.rs
+++ b/crates/api-edr/src/handlers.rs
@@ -1161,7 +1161,8 @@ pub async fn location_query(
                 StatusCode::NOT_FOUND,
                 Json(json!({ "code": "NotFound", "description": e.to_string() })),
             ),
-            ds_core::error::DataServerError::InvalidParameter(_) => (
+            ds_core::error::DataServerError::InvalidParameter(_)
+            | ds_core::error::DataServerError::QueryTooLarge(_) => (
                 StatusCode::BAD_REQUEST,
                 Json(json!({ "code": "BadRequest", "description": e.to_string() })),
             ),
@@ -1238,7 +1239,8 @@ async fn run_position_query(
     let map_engine_error = |e: &ds_core::error::DataServerError| match e {
         ds_core::error::DataServerError::InvalidParameter(_)
         | ds_core::error::DataServerError::InvalidBbox(_)
-        | ds_core::error::DataServerError::InvalidDatetime(_) => (
+        | ds_core::error::DataServerError::InvalidDatetime(_)
+        | ds_core::error::DataServerError::QueryTooLarge(_) => (
             StatusCode::BAD_REQUEST,
             Json(json!({ "code": "BadRequest", "description": e.to_string() })),
         ),
@@ -1369,7 +1371,8 @@ async fn run_area_query(
         .map_err(|e| match &e {
             ds_core::error::DataServerError::InvalidParameter(_)
             | ds_core::error::DataServerError::InvalidBbox(_)
-            | ds_core::error::DataServerError::InvalidDatetime(_) => (
+            | ds_core::error::DataServerError::InvalidDatetime(_)
+            | ds_core::error::DataServerError::QueryTooLarge(_) => (
                 StatusCode::BAD_REQUEST,
                 Json(json!({ "code": "BadRequest", "description": e.to_string() })),
             ),
@@ -1482,7 +1485,8 @@ pub async fn trajectory_query(
     .map_err(|e| match &e {
         ds_core::error::DataServerError::InvalidParameter(_)
         | ds_core::error::DataServerError::InvalidBbox(_)
-        | ds_core::error::DataServerError::InvalidDatetime(_) => (
+        | ds_core::error::DataServerError::InvalidDatetime(_)
+        | ds_core::error::DataServerError::QueryTooLarge(_) => (
             StatusCode::BAD_REQUEST,
             Json(json!({ "code": "BadRequest", "description": e.to_string() })),
         ),

--- a/crates/api-maps/src/handlers.rs
+++ b/crates/api-maps/src/handlers.rs
@@ -1197,7 +1197,10 @@ async fn render_map(
             // bbox/datetime) is a 400 with the engine's helpful message —
             // not a 500 that hides it behind "Internal server error".
             return Err(match e {
-                DSE::InvalidParameter(_) | DSE::InvalidBbox(_) | DSE::InvalidDatetime(_) => {
+                DSE::InvalidParameter(_)
+                | DSE::InvalidBbox(_)
+                | DSE::InvalidDatetime(_)
+                | DSE::QueryTooLarge(_) => {
                     // 4xx-class: traced at DEBUG (not WARN) so a misconfigured
                     // client is still diagnosable server-side without inflating
                     // the warn stream with routine bad requests.

--- a/crates/api-tiles/src/handlers.rs
+++ b/crates/api-tiles/src/handlers.rs
@@ -1532,7 +1532,10 @@ async fn render_tile(
         // parameter, bad bbox/datetime) is a 400 with the engine's message,
         // not a 500 that hides it.
         match e {
-            DSE::InvalidParameter(_) | DSE::InvalidBbox(_) | DSE::InvalidDatetime(_) => {
+            DSE::InvalidParameter(_)
+            | DSE::InvalidBbox(_)
+            | DSE::InvalidDatetime(_)
+            | DSE::QueryTooLarge(_) => {
                 // 4xx-class: DEBUG (not WARN) so a misconfigured client stays
                 // diagnosable without flooding the warn stream.
                 tracing::debug!(

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -29,6 +29,13 @@ pub enum DataServerError {
     #[error("Invalid bbox: {0}")]
     InvalidBbox(String),
 
+    /// A well-formed request whose result set would exceed a hard server cap
+    /// (station count, row count). Maps to HTTP 400 — the client remediates by
+    /// narrowing the polygon, bbox, or time range — never 500: the server is
+    /// healthy and the message is safe to return verbatim.
+    #[error("Query too large: {0}")]
+    QueryTooLarge(String),
+
     #[error("Invalid parameter: {0}")]
     InvalidParameter(String),
 

--- a/crates/engine-postgis/CLAUDE.md
+++ b/crates/engine-postgis/CLAUDE.md
@@ -103,7 +103,12 @@ Derivation rules (hard-won from production timeouts):
 
 - Row caps (non-configurable invariants): locations `LIMIT 50_001`,
   per-observation-query `LIMIT 10_001`, stations-in-polygon prefilter
-  `LIMIT 501`, nearest-station `LIMIT 1`.
+  `LIMIT 501`, nearest-station `LIMIT 1`. A breached station or row cap is
+  `DataServerError::QueryTooLarge` → HTTP 400 with a "narrow the polygon /
+  time range" message, never `Engine` (which the API layer hides behind an
+  opaque 500 — that misread a too-large polygon as a server fault in
+  production). Raising the 500-station area cap is gated on the N+1
+  per-station query fan-out (#115).
 - **Time-zone columns:** `time_col_tz` is required when `time_col` is
   `timestamp without time zone`. The WHERE clause wraps the BIND
   (`$N AT TIME ZONE '<tz>'`) so the column index stays usable; the SELECT

--- a/crates/engine-postgis/src/engine.rs
+++ b/crates/engine-postgis/src/engine.rs
@@ -383,12 +383,7 @@ impl EdrEngine for PostgisEngine {
         if stations.is_empty() {
             return Ok(CoverageResponse::Collection(vec![]));
         }
-        if stations.len() >= MAX_STATIONS_IN_POLYGON {
-            return Err(DataServerError::Engine(format!(
-                "area query hit the {} station cap — narrow the polygon or time range",
-                MAX_STATIONS_IN_POLYGON - 1
-            )));
-        }
+        let stations = enforce_station_cap(stations)?;
 
         let mut results = Vec::with_capacity(stations.len());
         for station in &stations {
@@ -417,6 +412,21 @@ impl EdrEngine for PostgisEngine {
 }
 
 // ─── helpers ───────────────────────────────────────────────────────────────
+
+/// Both area prefilters (SQL `LIMIT 501`, in-memory `.take(501)`) fetch one
+/// row past the advertised cap; a full batch means the polygon matched more
+/// stations than the server will fan out over. `QueryTooLarge` → HTTP 400,
+/// telling the client to narrow the polygon rather than masquerading as a
+/// server fault.
+fn enforce_station_cap(stations: Vec<Location>) -> Result<Vec<Location>, DataServerError> {
+    if stations.len() >= MAX_STATIONS_IN_POLYGON {
+        return Err(DataServerError::QueryTooLarge(format!(
+            "area query matched more than the {} station cap — narrow the polygon",
+            MAX_STATIONS_IN_POLYGON - 1
+        )));
+    }
+    Ok(stations)
+}
 
 fn resolve_source_keys(
     cfg: &PostgisEngineConfig,
@@ -481,8 +491,9 @@ fn run_queries_sync(pool: &Pool, queries: &[BuiltQuery]) -> Result<Vec<Vec<Row>>
                 .await
                 .map_err(|e| map_pg_error(e, q))?;
             if rows.len() >= MAX_OBSERVATION_ROWS {
-                return Err(DataServerError::Engine(format!(
-                    "result row count hit cap {MAX_OBSERVATION_ROWS}; narrow bbox or time range"
+                return Err(DataServerError::QueryTooLarge(format!(
+                    "result row count hit the {} row cap — narrow the bbox or time range",
+                    MAX_OBSERVATION_ROWS - 1
                 )));
             }
             out.push(rows);
@@ -1169,6 +1180,30 @@ mod tests {
             label: id.into(),
             latitude: lat,
             longitude: lon,
+        }
+    }
+
+    #[test]
+    fn station_cap_maps_to_query_too_large_not_engine_error() {
+        // 500 stations pass through untouched.
+        let under: Vec<Location> = (0..MAX_STATIONS_IN_POLYGON - 1)
+            .map(|i| loc(&format!("s{i}"), 24.0, 60.0))
+            .collect();
+        assert_eq!(
+            enforce_station_cap(under).unwrap().len(),
+            MAX_STATIONS_IN_POLYGON - 1
+        );
+
+        // A full 501-row batch signals the cap was breached → QueryTooLarge
+        // (HTTP 400 with the message), never Engine (opaque HTTP 500).
+        let over: Vec<Location> = (0..MAX_STATIONS_IN_POLYGON)
+            .map(|i| loc(&format!("s{i}"), 24.0, 60.0))
+            .collect();
+        match enforce_station_cap(over).unwrap_err() {
+            DataServerError::QueryTooLarge(msg) => {
+                assert!(msg.contains("narrow the polygon"), "message: {msg}")
+            }
+            other => panic!("expected QueryTooLarge, got: {other:?}"),
         }
     }
 


### PR DESCRIPTION
## Problem

A client developer hit 5xx errors on live EDR area queries against `fmi-obs` (postgis engine): polygons matching ≲480 stations worked, ~520 failed. Reproduced on production:

- `POLYGON((24 60,26 60,26 61,24 61,24 60))` → 200, 126 coverages, 0.31 s
- `POLYGON((19 59,32 59,32 71,19 71,19 59))` → `500 {"code":"ServerError","description":"Internal server error"}`

The cause is the intentional `MAX_STATIONS_IN_POLYGON = 501` prefilter cap — but the breach raised `DataServerError::Engine`, which the EDR handlers map to an opaque 500. The engine's actionable message ("narrow the polygon") never reached the client, and a client-remediable request polluted 5xx metrics. Live `fmi-obs` advertises 8,276 stations, so any country-sized polygon breaches the cap.

## Fix

- New `DataServerError::QueryTooLarge(String)` in ds-core: a well-formed request whose result set would exceed a hard server cap. Documented as HTTP 400, message safe to return verbatim.
- engine-postgis raises it for the area station cap and the `MAX_OBSERVATION_ROWS` row cap; the station-cap check is extracted into `enforce_station_cap` and unit-tested at the 500/501 boundary.
- api-edr maps it to `400 BadRequest` in the position/area/location/trajectory handlers.
- api-maps/api-tiles/api-3dtiles add it to their existing BadRequest arms (same "client mistake is a 400 with the engine's message" intent already documented there), so a future engine emitting it on a render path doesn't regress to a 500.
- engine-postgis CLAUDE.md documents the mapping.

After this, the failing request above returns `400 {"code":"BadRequest","description":"Query too large: area query matched more than the 500 station cap — narrow the polygon"}`.

## Not in scope

Raising the cap itself. With the current serial per-station fan-out (~2.4 ms/station marginal on live), that's gated on the N+1 area-query fix — production numbers posted to #115.

## Testing

- `cargo test -p engine-postgis -p api-edr` — all green, including new `station_cap_maps_to_query_too_large_not_engine_error`.
- `cargo fmt` + `cargo clippy --all-targets -- -D warnings` on all six touched crates — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T22YrnSuwKW6mFebJBHaBt