### PR TITLE
feat(api-edr): CoverageJSON Point domain type for scattered events

### DIFF
--- a/crates/api-edr/src/plot_convert.rs
+++ b/crates/api-edr/src/plot_convert.rs
@@ -136,6 +136,9 @@ fn build_panel(param: &str, coverages: &[QueryResult]) -> Result<Panel, DataServ
         DomainDescription::Section { .. } => Err(DataServerError::InvalidParameter(
             "PNG output is not available for cross-section (trajectory) responses".into(),
         )),
+        DomainDescription::Point { .. } => Err(DataServerError::InvalidParameter(
+            "PNG output is not available for point-event responses".into(),
+        )),
     }
 }
 
@@ -146,6 +149,7 @@ fn domain_kind(d: &DomainDescription) -> &'static str {
         DomainDescription::PointSeries { .. } => "PointSeries",
         DomainDescription::Grid { .. } => "Grid",
         DomainDescription::Section { .. } => "Section",
+        DomainDescription::Point { .. } => "Point",
     }
 }
 

--- a/crates/api-edr/src/response.rs
+++ b/crates/api-edr/src/response.rs
@@ -118,8 +118,13 @@ fn build_ndarray(ndarray: &ds_core::model::NdArray) -> Value {
     let mut obj = Map::with_capacity(5);
     obj.insert("type".into(), Value::String("NdArray".into()));
     obj.insert("dataType".into(), Value::String("float".into()));
-    obj.insert("axisNames".into(), json!(ndarray.axis_names));
-    obj.insert("shape".into(), json!(ndarray.shape));
+    // A 0-d scalar range (a `Point` coverage's single value) omits
+    // `axisNames`/`shape` per the CoverageJSON spec; any dimensioned
+    // array keeps both.
+    if !(ndarray.axis_names.is_empty() && ndarray.shape.is_empty()) {
+        obj.insert("axisNames".into(), json!(ndarray.axis_names));
+        obj.insert("shape".into(), json!(ndarray.shape));
+    }
     obj.insert("values".into(), Value::Array(values));
     Value::Object(obj)
 }
@@ -155,6 +160,7 @@ pub fn query_result_to_coverage_json(result: &QueryResult) -> Value {
 /// CoverageJSON `domainType` string for a domain description.
 fn domain_type_name(domain: &DomainDescription) -> &'static str {
     match domain {
+        DomainDescription::Point { .. } => "Point",
         DomainDescription::PointSeries { .. } => "PointSeries",
         DomainDescription::Grid { .. } => "Grid",
         DomainDescription::VerticalProfile { .. } => "VerticalProfile",
@@ -220,6 +226,26 @@ pub fn coverage_response_to_json(result: &CoverageResponse) -> Value {
 
 fn build_domain(desc: &DomainDescription) -> Value {
     match desc {
+        DomainDescription::Point { x, y, t, z } => {
+            let mut axes = Map::new();
+            axes.insert("x".into(), json!({ "values": [x] }));
+            axes.insert("y".into(), json!({ "values": [y] }));
+            let mut referencing = vec![spatial_ref()];
+            if let Some(time) = t {
+                axes.insert("t".into(), json!({ "values": [time.to_rfc3339()] }));
+                referencing.push(temporal_ref());
+            }
+            if let Some(zc) = z {
+                axes.insert("z".into(), json!({ "values": zc.values }));
+                referencing.push(vertical_ref(zc));
+            }
+            json!({
+                "type": "Domain",
+                "domainType": "Point",
+                "axes": axes,
+                "referencing": referencing
+            })
+        }
         DomainDescription::PointSeries { x, y, t, z } => {
             let times: Vec<String> = t.iter().map(|t| t.to_rfc3339()).collect();
             let mut axes = Map::new();

--- a/crates/api-edr/tests/covjson_validation.rs
+++ b/crates/api-edr/tests/covjson_validation.rs
@@ -790,3 +790,118 @@ fn section_coverage_validates_against_schema() {
 
     validate(&json, &schema);
 }
+
+// --- Point domain tests (scattered events, e.g. lightning strikes #501) ---
+
+/// One event = one `Point` coverage: x/y/t single-value axes, each range a
+/// 0-d scalar NdArray (no `shape`/`axisNames` — the CoverageJSON spec's
+/// scalar form).
+fn make_point_result(hour: u32, params: Vec<(&str, &str, Option<f64>)>) -> QueryResult {
+    let mut parameters = HashMap::new();
+    let mut ranges = HashMap::new();
+
+    for (name, unit, value) in &params {
+        parameters.insert(
+            name.to_string(),
+            ParameterDescription {
+                label: name.replace('_', " "),
+                unit: unit.to_string(),
+                observed_property: name.to_string(),
+            },
+        );
+        ranges.insert(
+            name.to_string(),
+            NdArray {
+                shape: vec![],
+                axis_names: vec![],
+                values: vec![*value],
+            },
+        );
+    }
+
+    QueryResult {
+        domain: DomainDescription::Point {
+            x: 24.9384 + f64::from(hour) * 0.1,
+            y: 60.1699,
+            t: Some(make_time(hour)),
+            z: None,
+        },
+        parameters,
+        ranges,
+    }
+}
+
+#[test]
+fn point_coverage_validates() {
+    let schema = load_schema();
+    let result = make_point_result(
+        3,
+        vec![
+            ("peak_current", "kA", Some(-18.0)),
+            ("multiplicity", "", Some(2.0)),
+        ],
+    );
+
+    let json = query_result_to_coverage_json(&result);
+
+    let domain = &json["domain"];
+    assert_eq!(domain["domainType"], "Point");
+    assert_eq!(domain["axes"]["x"]["values"].as_array().unwrap().len(), 1);
+    assert_eq!(domain["axes"]["y"]["values"].as_array().unwrap().len(), 1);
+    assert_eq!(domain["axes"]["t"]["values"].as_array().unwrap().len(), 1);
+
+    // Scalar ranges omit shape/axisNames (0-d NdArray).
+    let range = &json["ranges"]["peak_current"];
+    assert_eq!(range["type"], "NdArray");
+    assert!(range.get("shape").is_none(), "scalar range must omit shape");
+    assert!(
+        range.get("axisNames").is_none(),
+        "scalar range must omit axisNames"
+    );
+    assert_eq!(range["values"], serde_json::json!([-18.0]));
+
+    validate(&json, &schema);
+}
+
+#[test]
+fn point_coverage_without_time_validates() {
+    let schema = load_schema();
+    let mut result = make_point_result(0, vec![("peak_current", "kA", Some(7.5))]);
+    result.domain = DomainDescription::Point {
+        x: 24.9384,
+        y: 60.1699,
+        t: None,
+        z: None,
+    };
+
+    let json = query_result_to_coverage_json(&result);
+    assert_eq!(json["domain"]["domainType"], "Point");
+    assert!(json["domain"]["axes"].get("t").is_none());
+
+    validate(&json, &schema);
+}
+
+/// The events response shape (#502): a `CoverageCollection` of `Point`
+/// coverages, one per strike, parameters hoisted to collection level.
+#[test]
+fn point_coverage_collection_validates() {
+    let schema = load_schema();
+    let coverages = vec![
+        make_point_result(0, vec![("peak_current", "kA", Some(-12.3))]),
+        make_point_result(1, vec![("peak_current", "kA", Some(31.0))]),
+        make_point_result(2, vec![("peak_current", "kA", None)]),
+    ];
+
+    let result = CoverageResponse::Collection(coverages);
+    let json = coverage_response_to_json(&result);
+
+    assert_eq!(json["type"], "CoverageCollection");
+    assert_eq!(json["domainType"], "Point");
+    assert!(json["parameters"]["peak_current"].is_object());
+    assert_eq!(json["coverages"].as_array().unwrap().len(), 3);
+    for cov in json["coverages"].as_array().unwrap() {
+        assert_eq!(cov["domain"]["domainType"], "Point");
+    }
+
+    validate(&json, &schema);
+}

--- a/crates/core/src/model.rs
+++ b/crates/core/src/model.rs
@@ -21,6 +21,17 @@ pub struct VerticalCoord {
 
 #[derive(Debug, Clone)]
 pub enum DomainDescription {
+    /// A single point at a single (optional) time — one scattered event,
+    /// e.g. a lightning strike. An events query returns a
+    /// `CoverageResponse::Collection` of these, one coverage per event.
+    /// The CoverageJSON `Point` domain allows only single-value axes, so
+    /// `z`, when present, must carry exactly one level.
+    Point {
+        x: f64,
+        y: f64,
+        t: Option<DateTime<Utc>>,
+        z: Option<VerticalCoord>,
+    },
     /// A time series at a single point (x, y fixed, t varies). `z`, when
     /// present, pins the series to a single vertical level.
     PointSeries {


### PR DESCRIPTION
Closes #501. Prerequisite for the events shape (#502, lightning — design on #113).

## What

- `DomainDescription::Point` in ds-core: x/y single-value axes, optional single-value `t` and `z` — one scattered event (e.g. a lightning strike) per coverage; an events query returns a `CoverageCollection` of these.
- `build_domain()` arm emitting the schema's `Point` constraints exactly (mandatory single-value x/y, optional single-value t/z, `additionalProperties: false`).
- Scalar ranges: `build_ndarray` omits `axisNames`/`shape` when both are empty (the CoverageJSON 0-d scalar form, which is what a Point coverage's single value is). Dimensioned arrays unchanged.
- `f=png` plot path rejects Point responses with an explicit message (not a time series), mirroring the Grid/Section arms; `domain_kind` covers the new variant.

## Tests

- `point_coverage_validates` — single Point coverage against the OGC CoverageJSON 1.0 schema; asserts the scalar-range form (no shape/axisNames) and single-value axes.
- `point_coverage_without_time_validates` — optional `t` axis omitted.
- `point_coverage_collection_validates` — the #502 response shape: a CoverageCollection of Point coverages with hoisted parameters and collection-level `domainType: "Point"`, including a null value.

`cargo test -p api-edr` (all suites incl. schema validation) and `cargo clippy --all-targets -- -D warnings` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T22YrnSuwKW6mFebJBHaBt