### PR TITLE
feat(engine-postgis): events shape — EDR area queries for non-station event tables

### DIFF
--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -2149,6 +2149,17 @@ impl ServerConfig {
                     ))
                 })?;
                 validate_postgis(id, postgis)?;
+                // The events shape serves EDR only for now — its
+                // FeatureEngine surface is #503. Without this check an
+                // `apis = ["features"]` events collection would load
+                // cleanly and silently serve an empty station inventory.
+                if postgis.observations.shape == "events" {
+                    if let Some(api) = collection.apis.iter().find(|a| a.as_str() != "edr") {
+                        return Err(crate::error::DataServerError::Config(format!(
+                            "Collection '{id}': apis entry '{api}' is not supported for observations.shape 'events' (only \"edr\" until #503 implements event features)"
+                        )));
+                    }
+                }
             } else if collection.postgis.is_some() {
                 return Err(crate::error::DataServerError::Config(format!(
                     "Collection '{id}': [collections.postgis] is set but engine_type is '{}'",
@@ -3703,6 +3714,21 @@ unit = "1"
             .to_string();
         assert!(
             err.contains("id_col is only valid for observations.shape 'events'"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn postgis_events_rejects_non_edr_apis() {
+        let tmp = TempDir::new().unwrap();
+        let toml =
+            lightning_events_toml().replace("apis = [\"edr\"]", "apis = [\"edr\", \"features\"]");
+        let path = write_config(tmp.path(), "config.toml", &toml);
+        let err = ServerConfig::from_file(path.to_str().unwrap())
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("'features' is not supported for observations.shape 'events'"),
             "got: {err}"
         );
     }

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -1026,6 +1026,20 @@ pub struct PostgisObservationsConfig {
     /// `per_parameter` shape: one entry per parameter → table mapping.
     #[serde(default)]
     pub tables: Vec<PostgisObservationTable>,
+    /// `events` shape: unique/tiebreak column for deterministic ordering
+    /// (`ORDER BY time DESC, id`). Required for `events`, forbidden otherwise.
+    #[serde(default)]
+    pub id_col: Option<String>,
+    /// `events` shape: window applied when a query carries no `datetime`
+    /// (ISO 8601 duration, e.g. `"PT1H"`; that is also the default). Event
+    /// tables are never scanned over full history by an unqualified query.
+    #[serde(default)]
+    pub default_datetime: Option<String>,
+    /// `events` shape: advertised spatial extent `[west, south, east, north]`
+    /// (CRS84). Static config — computing `ST_Extent` over a large event
+    /// table on every metadata refresh is a full-scan trap.
+    #[serde(default)]
+    pub extent_bbox: Option<[f64; 4]>,
 }
 
 impl PostgisObservationsConfig {
@@ -1196,8 +1210,15 @@ fn validate_postgis(id: &str, cfg: &PostgisConfig) -> Result<(), crate::error::D
     // -- stations (optional) ----------------------------------------------
     // The stations table may be omitted entirely (mode A): locations are then
     // derived from the observations table's own geometry. When present, all
-    // identifiers are validated exactly as before.
-    if let Some(s) = &cfg.stations {
+    // identifiers are validated exactly as before. The `events` shape has no
+    // station concept at all — a stations table is rejected outright.
+    if cfg.observations.shape == "events" {
+        if cfg.stations.is_some() {
+            return Err(Config(format!(
+                "Collection '{id}': observations.shape 'events' does not use a [postgis.stations] table — every event row carries its own geometry"
+            )));
+        }
+    } else if let Some(s) = &cfg.stations {
         validate_qualified_table(&s.table)
             .map_err(|e| Config(format!("Collection '{id}': stations.table: {e}")))?;
         for (field, value) in [
@@ -1231,13 +1252,29 @@ fn validate_postgis(id: &str, cfg: &PostgisConfig) -> Result<(), crate::error::D
 
     // -- observations (shape-dependent) -----------------------------------
     let o = &cfg.observations;
+    // The events-only fields are meaningless on station shapes — reject
+    // rather than silently ignore (the silently-dropped-config footgun).
+    if o.shape != "events" {
+        for (field, present) in [
+            ("id_col", o.id_col.is_some()),
+            ("default_datetime", o.default_datetime.is_some()),
+            ("extent_bbox", o.extent_bbox.is_some()),
+        ] {
+            if present {
+                return Err(Config(format!(
+                    "Collection '{id}': observations.{field} is only valid for observations.shape 'events'"
+                )));
+            }
+        }
+    }
     match o.shape.as_str() {
         "long" => validate_observations_long(id, o)?,
         "wide" => validate_observations_wide(id, o)?,
         "per_parameter" => validate_observations_per_parameter(id, o)?,
+        "events" => validate_observations_events(id, o)?,
         other => {
             return Err(Config(format!(
-                "Collection '{id}': observations.shape '{other}' is not one of 'long', 'wide', 'per_parameter'"
+                "Collection '{id}': observations.shape '{other}' is not one of 'long', 'wide', 'per_parameter', 'events'"
             )));
         }
     }
@@ -1247,6 +1284,11 @@ fn validate_postgis(id: &str, cfg: &PostgisConfig) -> Result<(), crate::error::D
     // default (applied at engine resolve). Validate the string parses now so a
     // typo fails at config load, not at the first metadata refresh.
     if let Some(w) = o.locations_window.as_deref() {
+        if o.shape == "events" {
+            return Err(Config(format!(
+                "Collection '{id}': observations.locations_window is not valid for shape 'events' (no locations are derived) — use default_datetime for the query window"
+            )));
+        }
         if !w.eq_ignore_ascii_case("all") {
             crate::datetime::parse_iso8601_duration(w).map_err(|e| {
                 Config(format!(
@@ -1284,7 +1326,91 @@ fn validate_postgis(id: &str, cfg: &PostgisConfig) -> Result<(), crate::error::D
                 }
             }
         }
+        "events" => {
+            // For events the source_key IS the column name emitted into SQL
+            // (there is no columns/tables mapping to launder it through), so
+            // it must pass the identifier whitelist here.
+            for p in &cfg.parameters {
+                let key = p.source_key.as_deref().unwrap_or(p.name.as_str());
+                if !is_valid_sql_identifier(key) {
+                    return Err(Config(format!(
+                        "Collection '{id}': parameter '{}' source_key '{key}' is not a valid SQL identifier (events source_keys are column names)",
+                        p.name
+                    )));
+                }
+            }
+        }
         _ => {} // long: source_key is a string literal, no cross-ref
+    }
+
+    Ok(())
+}
+
+fn validate_observations_events(
+    id: &str,
+    o: &PostgisObservationsConfig,
+) -> Result<(), crate::error::DataServerError> {
+    use crate::error::DataServerError::Config;
+
+    let table = o.table.as_deref().ok_or_else(|| {
+        Config(format!(
+            "Collection '{id}': observations.shape 'events' requires observations.table"
+        ))
+    })?;
+    validate_qualified_table(table)
+        .map_err(|e| Config(format!("Collection '{id}': observations.table: {e}")))?;
+
+    for (field, value) in [
+        ("time_col", &o.time_col),
+        ("geom_col", &o.geom_col),
+        ("id_col", &o.id_col),
+    ] {
+        let v = value.as_deref().ok_or_else(|| {
+            Config(format!(
+                "Collection '{id}': observations.shape 'events' requires observations.{field}"
+            ))
+        })?;
+        if !is_valid_sql_identifier(v) {
+            return Err(Config(format!(
+                "Collection '{id}': observations.{field} '{v}' is not a valid SQL identifier"
+            )));
+        }
+    }
+
+    for (field, present) in [
+        ("station_fk_col", o.station_fk_col.is_some()),
+        ("param_col", o.param_col.is_some()),
+        ("value_col", o.value_col.is_some()),
+        ("columns", !o.columns.is_empty()),
+        ("tables", !o.tables.is_empty()),
+    ] {
+        if present {
+            return Err(Config(format!(
+                "Collection '{id}': observations.{field} is not valid for shape 'events'"
+            )));
+        }
+    }
+
+    if let Some(w) = o.default_datetime.as_deref() {
+        crate::datetime::parse_iso8601_duration(w).map_err(|e| {
+            Config(format!(
+                "Collection '{id}': observations.default_datetime '{w}' is not a valid ISO 8601 duration: {e}"
+            ))
+        })?;
+    }
+
+    if let Some([west, south, east, north]) = o.extent_bbox {
+        let ok = west < east
+            && south < north
+            && (-180.0..=180.0).contains(&west)
+            && (-180.0..=180.0).contains(&east)
+            && (-90.0..=90.0).contains(&south)
+            && (-90.0..=90.0).contains(&north);
+        if !ok {
+            return Err(Config(format!(
+                "Collection '{id}': observations.extent_bbox must be [west, south, east, north] in CRS84 with west < east and south < north"
+            )));
+        }
     }
 
     Ok(())
@@ -3410,6 +3536,178 @@ observed_property = "wind_speed"
         assert_eq!(pg.observations.shape, "per_parameter");
         assert_eq!(pg.observations.tables.len(), 2);
         assert_eq!(pg.parameters.len(), 2);
+    }
+
+    fn lightning_events_toml() -> &'static str {
+        r#"
+[server]
+host = "127.0.0.1"
+port = 8000
+
+[[collections]]
+id = "lightning"
+title = "Lightning strikes"
+description = "Lightning detection network events"
+engine_type = "postgis"
+apis = ["edr"]
+
+[collections.postgis]
+dsn_env = "NEXUS_DSN"
+
+[collections.postgis.observations]
+shape = "events"
+table = "public.lightning"
+time_col = "time"
+time_col_tz = "UTC"
+geom_col = "the_geom"
+id_col = "id"
+default_datetime = "PT1H"
+extent_bbox = [4.0, 54.0, 42.0, 72.0]
+
+[[collections.postgis.parameters]]
+name = "peak_current"
+label = "Peak current"
+unit = "kA"
+observed_property = "peak_current"
+
+[[collections.postgis.parameters]]
+name = "multiplicity"
+label = "Multiplicity"
+unit = "1"
+"#
+    }
+
+    #[test]
+    fn postgis_events_shape_parses_clean() {
+        let tmp = TempDir::new().unwrap();
+        let path = write_config(tmp.path(), "config.toml", lightning_events_toml());
+        let (config, _) = ServerConfig::from_file(path.to_str().unwrap()).unwrap();
+        let pg = config.collections[0].postgis.as_ref().unwrap();
+        assert_eq!(pg.observations.shape, "events");
+        assert_eq!(pg.observations.id_col.as_deref(), Some("id"));
+        assert_eq!(pg.observations.default_datetime.as_deref(), Some("PT1H"));
+        assert_eq!(pg.observations.extent_bbox, Some([4.0, 54.0, 42.0, 72.0]));
+    }
+
+    #[test]
+    fn postgis_events_rejects_stations_block() {
+        let tmp = TempDir::new().unwrap();
+        let toml = format!(
+            "{}\n[collections.postgis.stations]\ntable = \"weather.stations\"\nid_col = \"id\"\nlabel_col = \"name\"\ngeom_col = \"the_geom\"\n",
+            lightning_events_toml()
+        );
+        let path = write_config(tmp.path(), "config.toml", &toml);
+        let err = ServerConfig::from_file(path.to_str().unwrap())
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("does not use a [postgis.stations]"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn postgis_events_requires_id_col() {
+        let tmp = TempDir::new().unwrap();
+        let toml = lightning_events_toml().replace("id_col = \"id\"\n", "");
+        let path = write_config(tmp.path(), "config.toml", &toml);
+        let err = ServerConfig::from_file(path.to_str().unwrap())
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("requires observations.id_col"), "got: {err}");
+    }
+
+    #[test]
+    fn postgis_events_rejects_station_fk_col() {
+        let tmp = TempDir::new().unwrap();
+        let toml = lightning_events_toml().replace(
+            "time_col = \"time\"\n",
+            "time_col = \"time\"\nstation_fk_col = \"nope\"\n",
+        );
+        let path = write_config(tmp.path(), "config.toml", &toml);
+        let err = ServerConfig::from_file(path.to_str().unwrap())
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("station_fk_col is not valid for shape 'events'"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn postgis_events_rejects_inverted_extent_bbox() {
+        let tmp = TempDir::new().unwrap();
+        let toml = lightning_events_toml().replace(
+            "extent_bbox = [4.0, 54.0, 42.0, 72.0]",
+            "extent_bbox = [42.0, 54.0, 4.0, 72.0]",
+        );
+        let path = write_config(tmp.path(), "config.toml", &toml);
+        let err = ServerConfig::from_file(path.to_str().unwrap())
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("extent_bbox"), "got: {err}");
+    }
+
+    #[test]
+    fn postgis_events_rejects_bad_default_datetime() {
+        let tmp = TempDir::new().unwrap();
+        let toml = lightning_events_toml().replace(
+            "default_datetime = \"PT1H\"",
+            "default_datetime = \"garbage\"",
+        );
+        let path = write_config(tmp.path(), "config.toml", &toml);
+        let err = ServerConfig::from_file(path.to_str().unwrap())
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("default_datetime"), "got: {err}");
+    }
+
+    #[test]
+    fn postgis_events_rejects_invalid_source_key_identifier() {
+        let tmp = TempDir::new().unwrap();
+        let toml = lightning_events_toml().replace(
+            "name = \"peak_current\"",
+            "name = \"peak_current\"\nsource_key = \"bad name; drop\"",
+        );
+        let path = write_config(tmp.path(), "config.toml", &toml);
+        let err = ServerConfig::from_file(path.to_str().unwrap())
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("not a valid SQL identifier"), "got: {err}");
+    }
+
+    #[test]
+    fn postgis_station_shape_rejects_events_only_fields() {
+        let tmp = TempDir::new().unwrap();
+        let toml = nexus_postgis_toml().replace(
+            "shape = \"per_parameter\"\n",
+            "shape = \"per_parameter\"\nid_col = \"id\"\n",
+        );
+        let path = write_config(tmp.path(), "config.toml", &toml);
+        let err = ServerConfig::from_file(path.to_str().unwrap())
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("id_col is only valid for observations.shape 'events'"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn postgis_events_rejects_locations_window() {
+        let tmp = TempDir::new().unwrap();
+        let toml = lightning_events_toml().replace(
+            "default_datetime = \"PT1H\"",
+            "default_datetime = \"PT1H\"\nlocations_window = \"PT24H\"",
+        );
+        let path = write_config(tmp.path(), "config.toml", &toml);
+        let err = ServerConfig::from_file(path.to_str().unwrap())
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("locations_window is not valid for shape 'events'"),
+            "got: {err}"
+        );
     }
 
     #[test]

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -1391,6 +1391,14 @@ fn validate_observations_events(
         }
     }
 
+    if let Some(tz) = &o.time_col_tz {
+        if !validate_tz_name(tz) {
+            return Err(Config(format!(
+                "Collection '{id}': observations.time_col_tz '{tz}' is not a valid IANA-like name"
+            )));
+        }
+    }
+
     if let Some(w) = o.default_datetime.as_deref() {
         crate::datetime::parse_iso8601_duration(w).map_err(|e| {
             Config(format!(
@@ -1399,18 +1407,24 @@ fn validate_observations_events(
         })?;
     }
 
-    if let Some([west, south, east, north]) = o.extent_bbox {
-        let ok = west < east
-            && south < north
-            && (-180.0..=180.0).contains(&west)
-            && (-180.0..=180.0).contains(&east)
-            && (-90.0..=90.0).contains(&south)
-            && (-90.0..=90.0).contains(&north);
-        if !ok {
-            return Err(Config(format!(
-                "Collection '{id}': observations.extent_bbox must be [west, south, east, north] in CRS84 with west < east and south < north"
-            )));
-        }
+    // Required, not optional: with no stations there is no other source of a
+    // spatial extent — omitting it would silently publish a collection with
+    // no `extent.spatial` at all.
+    let Some([west, south, east, north]) = o.extent_bbox else {
+        return Err(Config(format!(
+            "Collection '{id}': observations.shape 'events' requires observations.extent_bbox (the only spatial-extent source for a station-less collection)"
+        )));
+    };
+    let ok = west < east
+        && south < north
+        && (-180.0..=180.0).contains(&west)
+        && (-180.0..=180.0).contains(&east)
+        && (-90.0..=90.0).contains(&south)
+        && (-90.0..=90.0).contains(&north);
+    if !ok {
+        return Err(Config(format!(
+            "Collection '{id}': observations.extent_bbox must be [west, south, east, north] in CRS84 with west < east and south < north"
+        )));
     }
 
     Ok(())
@@ -3691,6 +3705,32 @@ unit = "1"
             err.contains("id_col is only valid for observations.shape 'events'"),
             "got: {err}"
         );
+    }
+
+    #[test]
+    fn postgis_events_requires_extent_bbox() {
+        let tmp = TempDir::new().unwrap();
+        let toml = lightning_events_toml().replace("extent_bbox = [4.0, 54.0, 42.0, 72.0]\n", "");
+        let path = write_config(tmp.path(), "config.toml", &toml);
+        let err = ServerConfig::from_file(path.to_str().unwrap())
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("requires observations.extent_bbox"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn postgis_events_rejects_bad_time_col_tz() {
+        let tmp = TempDir::new().unwrap();
+        let toml =
+            lightning_events_toml().replace("time_col_tz = \"UTC\"", "time_col_tz = \"Bad TZ!!\"");
+        let path = write_config(tmp.path(), "config.toml", &toml);
+        let err = ServerConfig::from_file(path.to_str().unwrap())
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("not a valid IANA-like name"), "got: {err}");
     }
 
     #[test]

--- a/crates/engine-postgis/README.md
+++ b/crates/engine-postgis/README.md
@@ -277,6 +277,63 @@ If none of the three shapes fit your schema, expose a Postgres `VIEW` that does.
 The DSL deliberately does not support joins, computed expressions, or column
 transforms.
 
+## Events shape (non-station event data)
+
+The fourth shape, `events` (#113), serves tables where each row is an
+independent event with its own time and point geometry — no stations, no
+interval. Reference dataset: a lightning-strike table
+`(id, time, the_geom, multiplicity, peak_current, cloud_indicator, ellipse_major)`.
+
+```toml
+# collections.d/lightning.toml
+id = "lightning"
+title = "Lightning strikes"
+engine_type = "postgis"
+apis = ["edr"]
+
+[postgis]
+dsn_env = "MC_OBS_DSN"
+
+[postgis.observations]
+shape = "events"
+table = "public.lightning"
+time_col = "time"
+time_col_tz = "UTC"           # mandatory for `timestamp without time zone`
+geom_col = "the_geom"
+id_col = "id"                 # ORDER BY time DESC, id tiebreak
+default_datetime = "PT1H"     # window when the query has no datetime (default PT1H)
+extent_bbox = [4.0, 54.0, 42.0, 72.0]   # advertised extent; never ST_Extent
+
+[[postgis.parameters]]
+name = "peak_current"         # source_key defaults to name = the column name
+label = "Peak current"
+unit = "kA"
+
+[[postgis.parameters]]
+name = "multiplicity"
+label = "Multiplicity"
+unit = "1"
+```
+
+Behaviour:
+
+- **EDR `area` only.** One SQL statement per request (time-range + polygon
+  intersect, `ORDER BY time DESC, id`), no fan-out — the fan-out semaphore is
+  not involved. `position`/`locations` return 400 pointing at the area query.
+- **Response**: a CoverageJSON `CoverageCollection` of `Point` coverages — one
+  per event, each with its own single-value `t` axis and 0-d scalar ranges.
+  An empty window is a valid empty collection, not a 404.
+- **No `datetime`** never means full history: the `default_datetime` window
+  (ending "now") applies.
+- The response-value budget charges `rows × selected parameters`; a breach is
+  an HTTP 400 naming the numbers.
+- Parameter columns are cast `::double precision` in SQL, so `smallint` /
+  `numeric(p,s)` columns work without config.
+- A `[postgis.stations]` block, `station_fk_col`, `locations_window`, or
+  `columns`/`tables` entries are rejected for this shape at config load.
+- Recommended index: `btree (time DESC, geom) INCLUDE (<parameter columns>)`
+  plus the usual gist on the geometry column.
+
 ## Optional stations / orphan locations
 
 The `[collections.postgis.stations]` block is **optional**. When the observation

--- a/crates/engine-postgis/README.md
+++ b/crates/engine-postgis/README.md
@@ -302,7 +302,7 @@ time_col_tz = "UTC"           # mandatory for `timestamp without time zone`
 geom_col = "the_geom"
 id_col = "id"                 # ORDER BY time DESC, id tiebreak
 default_datetime = "PT1H"     # window when the query has no datetime (default PT1H)
-extent_bbox = [4.0, 54.0, 42.0, 72.0]   # advertised extent; never ST_Extent
+extent_bbox = [4.0, 54.0, 42.0, 72.0]   # REQUIRED: the only spatial-extent source; never ST_Extent
 
 [[postgis.parameters]]
 name = "peak_current"         # source_key defaults to name = the column name

--- a/crates/engine-postgis/src/config.rs
+++ b/crates/engine-postgis/src/config.rs
@@ -23,8 +23,9 @@ const DEFAULT_LOCATIONS_WINDOW_HOURS: i64 = 24;
 
 /// `events` shape: default query window when a request carries no `datetime`
 /// and the config sets no `default_datetime` (1 h). An unqualified events
-/// query never scans full history.
-const DEFAULT_EVENTS_WINDOW_HOURS: i64 = 1;
+/// query never scans full history. `pub(crate)` so the engine's fallback
+/// (`query_area_events`) cannot drift from this value.
+pub(crate) const DEFAULT_EVENTS_WINDOW_HOURS: i64 = 1;
 
 /// Default pool size — matches the render-semaphore sizing (`max(4, cores*2)`
 /// capped at 16). Override via `[postgis].pool_size`; hard-capped at 32 at

--- a/crates/engine-postgis/src/config.rs
+++ b/crates/engine-postgis/src/config.rs
@@ -13,13 +13,18 @@ use ds_core::datetime::parse_iso8601_duration;
 use thiserror::Error;
 
 use crate::schema::{
-    check_identifier, LocationSource, ObservationSchema, SchemaError, StationsMapping,
+    check_identifier, EventsShape, LocationSource, ObservationSchema, SchemaError, StationsMapping,
 };
 
 /// Default window for deriving the location list from observations when
 /// `observations.locations_window` is absent (24h). Keeps the `DISTINCT ON`
 /// scan on recent hypertable chunks.
 const DEFAULT_LOCATIONS_WINDOW_HOURS: i64 = 24;
+
+/// `events` shape: default query window when a request carries no `datetime`
+/// and the config sets no `default_datetime` (1 h). An unqualified events
+/// query never scans full history.
+const DEFAULT_EVENTS_WINDOW_HOURS: i64 = 1;
 
 /// Default pool size — matches the render-semaphore sizing (`max(4, cores*2)`
 /// capped at 16). Override via `[postgis].pool_size`; hard-capped at 32 at
@@ -49,6 +54,8 @@ pub enum PostgisConfigError {
     NoLocationSource,
     #[error("invalid observations.locations_window: {0}")]
     InvalidLocationsWindow(String),
+    #[error("invalid observations.default_datetime: {0}")]
+    InvalidDefaultDatetime(String),
     #[error("parameter '{name}' (source_key '{key}') is not mapped in observations.{where_}")]
     ParameterNotMapped {
         name: String,
@@ -80,6 +87,12 @@ pub struct PostgisEngineConfig {
     /// recent chunks); `None` ⇒ full history (`observations.locations_window =
     /// "all"`). Only consulted when `location_source` derives from observations.
     pub locations_window: Option<Duration>,
+    /// `events` shape: window ending "now" applied when a query has no
+    /// `datetime` (default 1 h). Unset for station shapes.
+    pub events_default_window: Option<Duration>,
+    /// `events` shape: advertised spatial extent from config
+    /// (`observations.extent_bbox`) — never computed via `ST_Extent`.
+    pub events_extent_bbox: Option<[f64; 4]>,
 }
 
 /// Parameter descriptor after cross-checking against the observation shape.
@@ -109,20 +122,36 @@ impl PostgisEngineConfig {
     pub fn resolve(cfg: &PostgisConfig) -> Result<Self, PostgisConfigError> {
         let (dsn, dsn_was_literal) = resolve_dsn(&cfg.dsn_env)?;
 
+        let observations = ObservationSchema::from_config(&cfg.observations)?;
+
         // Resolve the location source from the presence of a stations table and
         // whether the observations carry a usable geometry (mirrors the core
         // `validate_postgis` rule; this is the engine's defense-in-depth pass).
-        let obs_geom = cfg.observations.obs_geom_available();
-        let location_source = match (&cfg.stations, obs_geom) {
-            (Some(s), true) => {
-                LocationSource::StationsWithOrphans(StationsMapping::from_config(s)?)
+        // The events shape has no location concept at all.
+        let location_source = if matches!(observations, ObservationSchema::Events(_)) {
+            LocationSource::None
+        } else {
+            let obs_geom = cfg.observations.obs_geom_available();
+            match (&cfg.stations, obs_geom) {
+                (Some(s), true) => {
+                    LocationSource::StationsWithOrphans(StationsMapping::from_config(s)?)
+                }
+                (Some(s), false) => LocationSource::Stations(StationsMapping::from_config(s)?),
+                (None, true) => LocationSource::Observations,
+                (None, false) => return Err(PostgisConfigError::NoLocationSource),
             }
-            (Some(s), false) => LocationSource::Stations(StationsMapping::from_config(s)?),
-            (None, true) => LocationSource::Observations,
-            (None, false) => return Err(PostgisConfigError::NoLocationSource),
         };
-        let observations = ObservationSchema::from_config(&cfg.observations)?;
         let locations_window = resolve_locations_window(&cfg.observations.locations_window)?;
+        let events_default_window = match &observations {
+            ObservationSchema::Events(_) => {
+                Some(resolve_events_window(&cfg.observations.default_datetime)?)
+            }
+            _ => None,
+        };
+        let events_extent_bbox = match &observations {
+            ObservationSchema::Events(_) => cfg.observations.extent_bbox,
+            _ => None,
+        };
 
         let mut parameters = Vec::with_capacity(cfg.parameters.len());
         for p in &cfg.parameters {
@@ -151,6 +180,12 @@ impl PostgisEngineConfig {
                     }
                 }
                 ObservationSchema::Long(_) => {}
+                ObservationSchema::Events(_) => {
+                    // The source_key IS the column name emitted into SQL —
+                    // there is no columns/tables mapping to launder it
+                    // through, so it must pass the identifier whitelist.
+                    check_identifier(&source_key, "parameters[].source_key (events column)")?;
+                }
             }
             parameters.push(ValidatedParameter {
                 name: check_identifier(&p.name, "parameters[].name")?,
@@ -178,7 +213,28 @@ impl PostgisEngineConfig {
             observations,
             parameters,
             locations_window,
+            events_default_window,
+            events_extent_bbox,
         })
+    }
+
+    /// The events shape lowered from this config, when it is one.
+    pub fn events(&self) -> Option<&EventsShape> {
+        match &self.observations {
+            ObservationSchema::Events(ev) => Some(ev),
+            _ => None,
+        }
+    }
+}
+
+/// Resolve `observations.default_datetime` (events shape) to a duration:
+/// absent ⇒ 1 h default. Defense-in-depth — `ds-core`'s `validate_postgis`
+/// already rejects a bad string at config load.
+fn resolve_events_window(raw: &Option<String>) -> Result<Duration, PostgisConfigError> {
+    match raw.as_deref() {
+        None => Ok(Duration::hours(DEFAULT_EVENTS_WINDOW_HOURS)),
+        Some(s) => parse_iso8601_duration(s)
+            .map_err(|e| PostgisConfigError::InvalidDefaultDatetime(e.to_string())),
     }
 }
 
@@ -282,6 +338,9 @@ mod tests {
                 value_col: Some("value".into()),
                 geom_col: Some("the_geom".into()),
                 locations_window: None,
+                id_col: None,
+                default_datetime: None,
+                extent_bbox: None,
                 columns: vec![],
                 tables: vec![
                     PostgisObservationTable {
@@ -473,6 +532,9 @@ mod tests {
             value_col: None,
             geom_col: None,
             locations_window: None,
+            id_col: None,
+            default_datetime: None,
+            extent_bbox: None,
             columns: vec![PostgisObservationColumn {
                 parameter: "t2m".into(),
                 column: "temperature".into(),
@@ -503,6 +565,9 @@ mod tests {
             value_col: Some("value".into()),
             geom_col: None,
             locations_window: None,
+            id_col: None,
+            default_datetime: None,
+            extent_bbox: None,
             columns: vec![],
             tables: vec![],
         };
@@ -521,5 +586,81 @@ mod tests {
         cfg.pool_size = Some(100);
         let resolved = PostgisEngineConfig::resolve(&cfg).unwrap();
         assert_eq!(resolved.pool_size, 32);
+    }
+
+    // ---- events ------------------------------------------------------------
+
+    fn events_config() -> PostgisConfig {
+        PostgisConfig {
+            dsn_env: "TEST_DSN".into(),
+            pool_size: None,
+            pool_label: None,
+            metadata_refresh_secs: None,
+            stations: None,
+            observations: PostgisObservationsConfig {
+                shape: "events".into(),
+                table: Some("public.lightning".into()),
+                station_fk_col: None,
+                time_col: Some("time".into()),
+                time_col_tz: Some("UTC".into()),
+                param_col: None,
+                value_col: None,
+                geom_col: Some("the_geom".into()),
+                locations_window: None,
+                columns: vec![],
+                tables: vec![],
+                id_col: Some("id".into()),
+                default_datetime: None,
+                extent_bbox: Some([4.0, 54.0, 42.0, 72.0]),
+            },
+            parameters: vec![PostgisParameterConfig {
+                name: "peak_current".into(),
+                label: "Peak current".into(),
+                unit: "kA".into(),
+                observed_property: None,
+                source_key: None,
+            }],
+        }
+    }
+
+    #[test]
+    fn resolve_events_no_location_source_and_defaults() {
+        let g = env_guard();
+        g.set("TEST_DSN", Some("postgres://from-env/obs"));
+        let resolved = PostgisEngineConfig::resolve(&events_config()).unwrap();
+        assert!(matches!(resolved.location_source, LocationSource::None));
+        assert!(resolved.events().is_some());
+        // default_datetime absent ⇒ the 1 h default; extent from config.
+        assert_eq!(resolved.events_default_window, Some(Duration::hours(1)));
+        assert_eq!(resolved.events_extent_bbox, Some([4.0, 54.0, 42.0, 72.0]));
+    }
+
+    #[test]
+    fn resolve_events_parses_default_datetime() {
+        let g = env_guard();
+        g.set("TEST_DSN", Some("postgres://from-env/obs"));
+        let mut cfg = events_config();
+        cfg.observations.default_datetime = Some("PT15M".into());
+        let resolved = PostgisEngineConfig::resolve(&cfg).unwrap();
+        assert_eq!(resolved.events_default_window, Some(Duration::minutes(15)));
+    }
+
+    #[test]
+    fn resolve_events_rejects_invalid_source_key() {
+        let g = env_guard();
+        g.set("TEST_DSN", Some("postgres://from-env/obs"));
+        let mut cfg = events_config();
+        cfg.parameters[0].source_key = Some("bad;drop".into());
+        let err = PostgisEngineConfig::resolve(&cfg).unwrap_err();
+        assert!(matches!(err, PostgisConfigError::Schema(_)));
+    }
+
+    #[test]
+    fn resolve_station_shapes_have_no_events_window() {
+        let g = env_guard();
+        g.set("TEST_DSN", Some("postgres://from-env/obs"));
+        let resolved = PostgisEngineConfig::resolve(&nexus_config()).unwrap();
+        assert_eq!(resolved.events_default_window, None);
+        assert_eq!(resolved.events_extent_bbox, None);
     }
 }

--- a/crates/engine-postgis/src/engine.rs
+++ b/crates/engine-postgis/src/engine.rs
@@ -1017,12 +1017,18 @@ fn decode_event_rows(rows: &[Row], source_keys: &[&str]) -> Result<Vec<EventRow>
         let time: DateTime<Utc> = row
             .try_get("time")
             .map_err(|e| DataServerError::Engine(format!("decode event time: {e}")))?;
-        let lon: f64 = row
+        // NULL geometries never pass the WHERE clause (`NULL && x` is NULL),
+        // but ST_X/ST_Y are still NULL for degenerate geometries such as
+        // `POINT EMPTY` — skip the row instead of failing the whole request.
+        let lon: Option<f64> = row
             .try_get("lon")
             .map_err(|e| DataServerError::Engine(format!("decode event lon: {e}")))?;
-        let lat: f64 = row
+        let lat: Option<f64> = row
             .try_get("lat")
             .map_err(|e| DataServerError::Engine(format!("decode event lat: {e}")))?;
+        let (Some(lon), Some(lat)) = (lon, lat) else {
+            continue;
+        };
         let mut values = Vec::with_capacity(source_keys.len());
         for key in source_keys {
             let v: Option<f64> = row
@@ -1534,6 +1540,78 @@ mod tests {
         assert_eq!(keys, vec!["TEMP"]);
 
         assert!(resolve_source_keys(&cfg, Some(&["unknown".into()])).is_err());
+    }
+
+    /// Build a full engine (lazy pool — no DB I/O until a query needs a
+    /// connection) around the given config to exercise the EdrEngine trait
+    /// surface. The events rejection paths bail before touching the pool.
+    fn engine_with(config: PostgisEngineConfig) -> PostgisEngine {
+        let mut registry = crate::pool::PoolRegistry::new();
+        let pool = registry
+            .get_or_create(
+                "postgres://user:pw@127.0.0.1:1/db",
+                std::num::NonZeroU32::new(2).unwrap(),
+            )
+            .expect("lazy pool");
+        PostgisEngine::new("test", Arc::new(config), pool)
+    }
+
+    fn events_engine_config() -> PostgisEngineConfig {
+        use crate::config::ValidatedParameter;
+        use crate::schema::{EventsShape, QualifiedTable};
+        PostgisEngineConfig {
+            dsn: "postgres://user:pw@127.0.0.1:1/db".into(),
+            dsn_was_literal: false,
+            pool_size: 2,
+            pool_label: None,
+            metadata_refresh_secs: 300,
+            location_source: crate::schema::LocationSource::None,
+            observations: ObservationSchema::Events(EventsShape {
+                table: QualifiedTable {
+                    schema: "public".into(),
+                    table: "lightning".into(),
+                },
+                time_col: "time".into(),
+                time_col_tz: Some("UTC".into()),
+                geom_col: "the_geom".into(),
+                id_col: "id".into(),
+            }),
+            parameters: vec![ValidatedParameter {
+                name: "peak_current".into(),
+                label: "Peak current".into(),
+                unit: "kA".into(),
+                observed_property: "peak_current".into(),
+                source_key: "peak_current".into(),
+            }],
+            locations_window: None,
+            events_default_window: Some(chrono::Duration::hours(1)),
+            events_extent_bbox: Some([4.0, 54.0, 42.0, 72.0]),
+        }
+    }
+
+    #[test]
+    fn events_engine_advertises_area_only() {
+        let engine = engine_with(events_engine_config());
+        assert_eq!(engine.supported_query_types(), vec!["area".to_string()]);
+    }
+
+    #[test]
+    fn events_engine_rejects_station_queries_with_400() {
+        let engine = engine_with(events_engine_config());
+        let err = engine
+            .query_location("some-station", None, None, None, None)
+            .unwrap_err();
+        assert!(
+            matches!(err, DataServerError::InvalidParameter(ref m) if m.contains("area")),
+            "got: {err:?}"
+        );
+        let err = engine
+            .query_position("POINT(25 61)", None, None, None, None)
+            .unwrap_err();
+        assert!(
+            matches!(err, DataServerError::InvalidParameter(ref m) if m.contains("area")),
+            "got: {err:?}"
+        );
     }
 
     #[test]

--- a/crates/engine-postgis/src/engine.rs
+++ b/crates/engine-postgis/src/engine.rs
@@ -278,14 +278,15 @@ impl PostgisEngine {
         let polygon_wkt = normalize_area_wkt(coords)?;
 
         // No `datetime` never means full history — fall back to the
-        // configured window ending "now".
+        // configured window ending "now". `events_default_window` is always
+        // Some for an events config (resolve sets it unconditionally); the
+        // fallback shares the resolve-time constant so they cannot drift.
         let (t0, t1) = match datetime {
             Some(range) => range,
             None => {
-                let window = self
-                    .config
-                    .events_default_window
-                    .unwrap_or_else(|| chrono::Duration::hours(1));
+                let window = self.config.events_default_window.unwrap_or_else(|| {
+                    chrono::Duration::hours(crate::config::DEFAULT_EVENTS_WINDOW_HOURS)
+                });
                 let now = Utc::now();
                 (now - window, now)
             }
@@ -300,7 +301,7 @@ impl PostgisEngine {
 
         let rows = run_single_query_sync(&self.pool, built)?;
         if rows.len() * per_row > MAX_RESPONSE_VALUES {
-            return Err(budget_exceeded());
+            return Err(events_budget_exceeded());
         }
         let events = decode_event_rows(&rows, &key_refs)?;
         Ok(CoverageResponse::Collection(assemble_event_coverages(
@@ -518,12 +519,23 @@ fn enforce_area_query_count(
     Ok(())
 }
 
-/// The response-budget breach error. One message for every path so clients
-/// see a consistent, actionable 400.
-fn budget_exceeded() -> DataServerError {
+/// The response-budget breach error. One message per shape family so the
+/// dimensions named actually exist on the collection being queried.
+fn budget_exceeded_for(dimensions: &str) -> DataServerError {
     DataServerError::QueryTooLarge(format!(
-        "response would exceed the {MAX_RESPONSE_VALUES}-value budget (stations × parameters × timesteps) — narrow the time range, the polygon, or the parameter list"
+        "response would exceed the {MAX_RESPONSE_VALUES}-value budget ({dimensions}) — narrow the time range, the polygon, or the parameter list"
     ))
+}
+
+/// Station-shape budget breach (position/location/area fan-out paths).
+fn budget_exceeded() -> DataServerError {
+    budget_exceeded_for("stations × parameters × timesteps")
+}
+
+/// Events-shape budget breach — there are no stations or timesteps here,
+/// the budget is rows × selected parameter columns.
+fn events_budget_exceeded() -> DataServerError {
+    budget_exceeded_for("events × parameters")
 }
 
 /// Station-keyed queries (position, location) are meaningless on an events

--- a/crates/engine-postgis/src/engine.rs
+++ b/crates/engine-postgis/src/engine.rs
@@ -29,11 +29,11 @@ use crate::config::PostgisEngineConfig;
 use crate::health::{Health, HealthSnapshot, HealthStatus};
 use crate::metadata::{CollectionMeta, MetadataCache};
 use crate::query::{
-    build_location, build_position, build_stations_in_polygon, params_as_refs, BuiltQuery,
-    DEFAULT_POSITION_RADIUS_M, MAX_AREA_QUERIES, MAX_OBSERVATION_ROWS, MAX_RESPONSE_VALUES,
-    MAX_STATIONS_IN_POLYGON,
+    build_events_area, build_location, build_position, build_stations_in_polygon, params_as_refs,
+    BuiltQuery, DEFAULT_POSITION_RADIUS_M, MAX_AREA_QUERIES, MAX_OBSERVATION_ROWS,
+    MAX_RESPONSE_VALUES, MAX_STATIONS_IN_POLYGON,
 };
-use crate::schema::ObservationSchema;
+use crate::schema::{EventsShape, ObservationSchema};
 
 /// Time-ordered observation values for a single parameter. Exists to
 /// keep the Clippy `type_complexity` lint happy without papering over
@@ -261,6 +261,54 @@ impl PostgisEngine {
     fn load_meta(&self) -> Arc<CollectionMeta> {
         self.cache.load()
     }
+
+    /// Events-shape area query: one SQL statement over the event table, one
+    /// `Point` coverage per returned event row. An empty window is a valid
+    /// empty `CoverageCollection` (no strikes in the area is an answer, not
+    /// a 404 — unlike a missing station).
+    fn query_area_events(
+        &self,
+        shape: &EventsShape,
+        coords: &str,
+        datetime: Option<(DateTime<Utc>, DateTime<Utc>)>,
+        parameters: Option<&[String]>,
+    ) -> Result<CoverageResponse, DataServerError> {
+        let source_keys = resolve_source_keys(&self.config, parameters)?;
+        let key_refs: Vec<&str> = source_keys.iter().map(String::as_str).collect();
+        let polygon_wkt = normalize_area_wkt(coords)?;
+
+        // No `datetime` never means full history — fall back to the
+        // configured window ending "now".
+        let (t0, t1) = match datetime {
+            Some(range) => range,
+            None => {
+                let window = self
+                    .config
+                    .events_default_window
+                    .unwrap_or_else(|| chrono::Duration::hours(1));
+                let now = Utc::now();
+                (now - window, now)
+            }
+        };
+
+        let per_row = key_refs.len().max(1);
+        // +1 sentinel row: crossing the budget is detected as "one more row
+        // than fits" rather than silently truncating an over-budget window.
+        let row_limit = MAX_RESPONSE_VALUES / per_row + 1;
+        let built = build_events_area(shape, &polygon_wkt, (t0, t1), &key_refs, row_limit)
+            .map_err(|e| DataServerError::Engine(format!("build_events_area: {e}")))?;
+
+        let rows = run_single_query_sync(&self.pool, built)?;
+        if rows.len() * per_row > MAX_RESPONSE_VALUES {
+            return Err(budget_exceeded());
+        }
+        let events = decode_event_rows(&rows, &key_refs)?;
+        Ok(CoverageResponse::Collection(assemble_event_coverages(
+            &self.config,
+            &key_refs,
+            events,
+        )))
+    }
 }
 
 // ─── Engine trait ────────────────────────────────────────────────────────────
@@ -291,6 +339,11 @@ impl EdrEngine for PostgisEngine {
     }
 
     fn supported_query_types(&self) -> Vec<String> {
+        if self.config.events().is_some() {
+            // Events have no stations: no locations, no position (a point
+            // has probability zero of hitting an event) — area only.
+            return vec!["area".to_string()];
+        }
         vec![
             "locations".to_string(),
             "position".to_string(),
@@ -307,6 +360,7 @@ impl EdrEngine for PostgisEngine {
         _z: Option<&[f64]>,
         _reference_time: Option<DateTime<Utc>>,
     ) -> Result<CoverageResponse, DataServerError> {
+        reject_station_query_on_events(&self.config)?;
         let source_keys = resolve_source_keys(&self.config, parameters)?;
         let key_refs: Vec<&str> = source_keys.iter().map(String::as_str).collect();
 
@@ -342,6 +396,7 @@ impl EdrEngine for PostgisEngine {
         z: Option<&[f64]>,
         reference_time: Option<DateTime<Utc>>,
     ) -> Result<CoverageResponse, DataServerError> {
+        reject_station_query_on_events(&self.config)?;
         let (lon, lat) = parse_coords(coords)?;
         // Observations-derived modes (A/B) resolve the nearest station in-memory
         // from the cached location set — a scan over a few thousand points is
@@ -370,6 +425,12 @@ impl EdrEngine for PostgisEngine {
         _z: Option<&[f64]>,
         _reference_time: Option<DateTime<Utc>>,
     ) -> Result<CoverageResponse, DataServerError> {
+        if let ObservationSchema::Events(ev) = &self.config.observations {
+            // Clone the shape so the borrow on `self.config` ends here —
+            // `query_area_events` needs `&self` too.
+            let ev = ev.clone();
+            return self.query_area_events(&ev, coords, datetime, parameters);
+        }
         let source_keys = resolve_source_keys(&self.config, parameters)?;
         let key_refs: Vec<&str> = source_keys.iter().map(String::as_str).collect();
 
@@ -463,6 +524,17 @@ fn budget_exceeded() -> DataServerError {
     DataServerError::QueryTooLarge(format!(
         "response would exceed the {MAX_RESPONSE_VALUES}-value budget (stations × parameters × timesteps) — narrow the time range, the polygon, or the parameter list"
     ))
+}
+
+/// Station-keyed queries (position, location) are meaningless on an events
+/// collection — reject with an actionable pointer at the area query.
+fn reject_station_query_on_events(cfg: &PostgisEngineConfig) -> Result<(), DataServerError> {
+    if cfg.events().is_some() {
+        return Err(DataServerError::InvalidParameter(
+            "this collection holds event data with no stations — use the area query".into(),
+        ));
+    }
+    Ok(())
 }
 
 fn resolve_source_keys(
@@ -680,6 +752,24 @@ fn run_area_fanout(
     Ok(results.into_iter().flatten().collect())
 }
 
+/// Run one built query on a pooled connection (sync bridge). Used by the
+/// events area path — a single statement, no fan-out, no budget rewrite
+/// (the LIMIT bind already carries the budget sentinel).
+fn run_single_query_sync(pool: &Pool, built: BuiltQuery) -> Result<Vec<Row>, DataServerError> {
+    let pool = pool.clone();
+    block_on_async(async move {
+        let client = pool
+            .get()
+            .await
+            .map_err(|e| DataServerError::Engine(format!("pool acquire failed: {e}")))?;
+        let refs = params_as_refs(&built.params);
+        client
+            .query(&built.sql, &refs)
+            .await
+            .map_err(|e| map_pg_error(e, &built))
+    })
+}
+
 fn run_stations_in_polygon_sync(
     pool: &Pool,
     cfg: &PostgisEngineConfig,
@@ -890,7 +980,114 @@ fn assemble_query_result(
         ObservationSchema::PerParameter(_) => {
             assemble_per_parameter(cfg, lon, lat, queries, rows_per_query)
         }
+        // Events never reach the station assembly path — their area query
+        // assembles Point coverages via `assemble_event_coverages`.
+        ObservationSchema::Events(_) => Err(DataServerError::Engine(
+            "events shape has no station-keyed assembly".into(),
+        )),
     }
+}
+
+// ─── event row assembly (events shape) ──────────────────────────────────────
+
+/// One decoded event row: `(time, lon, lat)` plus one optional value per
+/// requested source_key, in request order.
+struct EventRow {
+    time: DateTime<Utc>,
+    lon: f64,
+    lat: f64,
+    values: Vec<Option<f64>>,
+}
+
+fn decode_event_rows(rows: &[Row], source_keys: &[&str]) -> Result<Vec<EventRow>, DataServerError> {
+    let mut out = Vec::with_capacity(rows.len());
+    for row in rows {
+        let time: DateTime<Utc> = row
+            .try_get("time")
+            .map_err(|e| DataServerError::Engine(format!("decode event time: {e}")))?;
+        let lon: f64 = row
+            .try_get("lon")
+            .map_err(|e| DataServerError::Engine(format!("decode event lon: {e}")))?;
+        let lat: f64 = row
+            .try_get("lat")
+            .map_err(|e| DataServerError::Engine(format!("decode event lat: {e}")))?;
+        let mut values = Vec::with_capacity(source_keys.len());
+        for key in source_keys {
+            let v: Option<f64> = row
+                .try_get(*key)
+                .map_err(|e| DataServerError::Engine(format!("decode event {key}: {e}")))?;
+            values.push(v);
+        }
+        out.push(EventRow {
+            time,
+            lon,
+            lat,
+            values,
+        });
+    }
+    Ok(out)
+}
+
+/// One `Point` coverage per event: single-value x/y/t axes and a 0-d scalar
+/// range per parameter (`shape`/`axis_names` empty — the CoverageJSON scalar
+/// form). Serialised as a `CoverageCollection` with `domainType: "Point"`.
+fn assemble_event_coverages(
+    cfg: &PostgisEngineConfig,
+    source_keys: &[&str],
+    events: Vec<EventRow>,
+) -> Vec<QueryResult> {
+    // Descriptor per requested key, resolved once — every event coverage
+    // shares them (the API layer hoists parameters to collection level).
+    let descs: Vec<(String, ParameterDescription)> = source_keys
+        .iter()
+        .map(|key| {
+            let pname = source_key_to_param_name(cfg, key);
+            let desc = cfg
+                .parameters
+                .iter()
+                .find(|p| p.name == pname)
+                .map(|p| ParameterDescription {
+                    label: p.label.clone(),
+                    unit: p.unit.clone(),
+                    observed_property: p.observed_property.clone(),
+                })
+                .unwrap_or_else(|| ParameterDescription {
+                    label: pname.clone(),
+                    unit: String::new(),
+                    observed_property: pname.clone(),
+                });
+            (pname, desc)
+        })
+        .collect();
+
+    events
+        .into_iter()
+        .map(|ev| {
+            let mut parameters = HashMap::with_capacity(descs.len());
+            let mut ranges = HashMap::with_capacity(descs.len());
+            for ((pname, desc), v) in descs.iter().zip(&ev.values) {
+                parameters.insert(pname.clone(), desc.clone());
+                ranges.insert(
+                    pname.clone(),
+                    NdArray {
+                        shape: vec![],
+                        axis_names: vec![],
+                        values: vec![*v],
+                    },
+                );
+            }
+            QueryResult {
+                domain: DomainDescription::Point {
+                    x: ev.lon,
+                    y: ev.lat,
+                    t: Some(ev.time),
+                    z: None,
+                },
+                parameters,
+                ranges,
+            }
+        })
+        .collect()
 }
 
 fn assemble_long(
@@ -1315,6 +1512,8 @@ mod tests {
                 },
             ],
             locations_window: None,
+            events_default_window: None,
+            events_extent_bbox: None,
         };
         let keys = resolve_source_keys(&cfg, None).unwrap();
         assert_eq!(keys, vec!["TEMP", "WIND"]);
@@ -1323,6 +1522,78 @@ mod tests {
         assert_eq!(keys, vec!["TEMP"]);
 
         assert!(resolve_source_keys(&cfg, Some(&["unknown".into()])).is_err());
+    }
+
+    #[test]
+    fn assemble_event_coverages_one_point_per_event() {
+        use crate::config::ValidatedParameter;
+        use crate::schema::{EventsShape, QualifiedTable};
+        let cfg = PostgisEngineConfig {
+            dsn: "postgres://x/y".into(),
+            dsn_was_literal: false,
+            pool_size: 4,
+            pool_label: None,
+            metadata_refresh_secs: 300,
+            location_source: crate::schema::LocationSource::None,
+            observations: ObservationSchema::Events(EventsShape {
+                table: QualifiedTable {
+                    schema: "public".into(),
+                    table: "lightning".into(),
+                },
+                time_col: "time".into(),
+                time_col_tz: Some("UTC".into()),
+                geom_col: "the_geom".into(),
+                id_col: "id".into(),
+            }),
+            parameters: vec![ValidatedParameter {
+                name: "peak_current".into(),
+                label: "Peak current".into(),
+                unit: "kA".into(),
+                observed_property: "peak_current".into(),
+                source_key: "peak_current".into(),
+            }],
+            locations_window: None,
+            events_default_window: Some(chrono::Duration::hours(1)),
+            events_extent_bbox: None,
+        };
+        let t0: DateTime<Utc> = "2026-07-11T17:00:00Z".parse().unwrap();
+        let t1: DateTime<Utc> = "2026-07-11T17:05:00Z".parse().unwrap();
+        let events = vec![
+            EventRow {
+                time: t0,
+                lon: 25.0,
+                lat: 61.0,
+                values: vec![Some(-12.5)],
+            },
+            EventRow {
+                time: t1,
+                lon: 26.0,
+                lat: 62.0,
+                values: vec![None],
+            },
+        ];
+
+        let out = assemble_event_coverages(&cfg, &["peak_current"], events);
+        assert_eq!(out.len(), 2);
+
+        match &out[0].domain {
+            DomainDescription::Point { x, y, t, z } => {
+                assert_eq!(*x, 25.0);
+                assert_eq!(*y, 61.0);
+                assert_eq!(*t, Some(t0));
+                assert!(z.is_none());
+            }
+            other => panic!("expected Point domain, got {other:?}"),
+        }
+        // 0-d scalar ranges: empty shape/axis_names, exactly one value —
+        // the CoverageJSON scalar NdArray form the API layer emits.
+        let nd = &out[0].ranges["peak_current"];
+        assert!(nd.shape.is_empty());
+        assert!(nd.axis_names.is_empty());
+        assert_eq!(nd.values, vec![Some(-12.5)]);
+        assert_eq!(out[0].parameters["peak_current"].unit, "kA");
+        // A null measurement stays null, not zero.
+        assert_eq!(out[1].ranges["peak_current"].values, vec![None]);
     }
 
     fn meta_with(locations: Vec<Location>) -> CollectionMeta {

--- a/crates/engine-postgis/src/metadata.rs
+++ b/crates/engine-postgis/src/metadata.rs
@@ -146,7 +146,13 @@ impl MetadataCache {
             .collect();
         let station_idx = build_station_idx(&feature_stations);
         let parameters = build_parameter_descriptions(&cfg.parameters);
-        let spatial = spatial_extent_from(&locations);
+        // Events shape: the location list is empty, so the spatial extent
+        // comes from config (`extent_bbox`) — never from an `ST_Extent`
+        // full scan over the event table.
+        let spatial = match cfg.events_extent_bbox {
+            Some(bbox) => Some(bbox),
+            None => spatial_extent_from(&locations),
+        };
         let temporal = fetch_temporal_extent(cfg, pool).await?;
 
         let previous = self.inner.load();
@@ -232,6 +238,8 @@ async fn fetch_locations(
             let stations = fetch_station_rows(cfg, pool).await?;
             Ok(enrich_with_stations(reporters, stations))
         }
+        // Events shape: no station/location concept, nothing to fetch.
+        LocationSource::None => Ok(Vec::new()),
     }
 }
 
@@ -485,6 +493,11 @@ async fn fetch_temporal_extent(
                 first.time_col.as_str(),
                 first.time_col_tz.as_deref(),
             )
+        }
+        ObservationSchema::Events(ev) => {
+            // MIN/MAX over the event time column — index-only on any table
+            // with a leading-time btree (the documented deployment shape).
+            (&ev.table, ev.time_col.as_str(), ev.time_col_tz.as_deref())
         }
     };
 

--- a/crates/engine-postgis/src/query.rs
+++ b/crates/engine-postgis/src/query.rs
@@ -21,7 +21,9 @@ use chrono::{DateTime, Utc};
 use thiserror::Error;
 
 use crate::config::PostgisEngineConfig;
-use crate::schema::{LongShape, ObservationSchema, PerParameterShape, QualifiedTable, WideShape};
+use crate::schema::{
+    EventsShape, LongShape, ObservationSchema, PerParameterShape, QualifiedTable, WideShape,
+};
 use crate::security::{quote_ident, QuoteError};
 
 /// Maximum rows returned by a locations list query. 50_001 covers the
@@ -293,6 +295,8 @@ pub fn build_locations_from_observations(
             }
             Ok(queries)
         }
+        // Events have no station concept — nothing to derive.
+        ObservationSchema::Events(_) => Err(BuildError::NoStations),
     }
 }
 
@@ -490,7 +494,67 @@ pub fn build_location(
         ObservationSchema::PerParameter(pp) => {
             build_location_per_parameter(pp, station_id, time_range, &effective, row_limit)
         }
+        // Events have no stations; the engine layer rejects station-keyed
+        // queries before reaching the builder.
+        ObservationSchema::Events(_) => Err(BuildError::NoStations),
     }
+}
+
+// ─── events (non-station event tables) ─────────────────────────────────────
+
+/// Events-shape area query (#113): one statement fetching every event inside
+/// the polygon × time window. Each returned row is one event —
+/// `(time, lon, lat, <one column per requested source_key>)` — so
+/// `values_per_row` is the requested-column count for the response budget.
+/// `ORDER BY time DESC, <id>` keeps results deterministic (newest first, id
+/// tiebreak on equal timestamps); `LIMIT $4` is the budget in rows.
+///
+/// The `::double precision` cast on every parameter column also normalises
+/// `numeric`-typed columns (e.g. a `numeric(3,1)` accuracy radius) to `f64`
+/// at the SQL layer.
+pub fn build_events_area(
+    shape: &EventsShape,
+    polygon_wkt: &str,
+    time_range: (DateTime<Utc>, DateTime<Utc>),
+    source_keys: &[&str],
+    row_limit: usize,
+) -> Result<BuiltQuery, BuildError> {
+    if polygon_wkt.trim().is_empty() {
+        return Err(BuildError::EmptyPolygonWkt);
+    }
+    let table = fq_table(&shape.table)?;
+    let time_col = quote_ident(&shape.time_col)?;
+    let geom = quote_ident(&shape.geom_col)?;
+    let id = quote_ident(&shape.id_col)?;
+    let time_select = time_select_expr(&time_col, shape.time_col_tz.as_deref());
+    let tz = shape.time_col_tz.as_deref();
+
+    let mut projection = format!("{time_select} AS time, ST_X({geom}) AS lon, ST_Y({geom}) AS lat");
+    for key in source_keys {
+        // source_key == column name == row alias (identifier-validated at
+        // config load and at engine resolve).
+        let col = quote_ident(key)?;
+        projection.push_str(&format!(", {col}::double precision AS {col}"));
+    }
+
+    let rhs_lo = time_filter_rhs("$1", tz);
+    let rhs_hi = time_filter_rhs("$2", tz);
+    let mut sql = String::from("SELECT ");
+    sql.push_str(&format!(
+        "{projection} \
+         FROM {table} \
+         WHERE {time_col} >= {rhs_lo} AND {time_col} <= {rhs_hi} \
+         AND {geom} && ST_GeomFromText($3, 4326) \
+         AND ST_Intersects({geom}, ST_GeomFromText($3, 4326)) \
+         ORDER BY {time_col} DESC, {id} LIMIT $4"
+    ));
+    let params = vec![
+        SqlParam::Timestamp(time_range.0),
+        SqlParam::Timestamp(time_range.1),
+        SqlParam::Text(polygon_wkt.to_string()),
+        SqlParam::Int(row_limit as i64),
+    ];
+    Ok(BuiltQuery::new(sql, params).with_row_limit(3, source_keys.len().max(1)))
 }
 
 fn build_location_long(
@@ -751,6 +815,8 @@ mod tests {
             observations,
             parameters,
             locations_window: None,
+            events_default_window: None,
+            events_extent_bbox: None,
         }
     }
 
@@ -766,6 +832,8 @@ mod tests {
             observations,
             parameters: vec![param("t2m", "t", "°C", "t2m", "t2m")],
             locations_window: None,
+            events_default_window: None,
+            events_extent_bbox: None,
         }
     }
 
@@ -1011,6 +1079,9 @@ mod tests {
             value_col: Some("value".into()),
             geom_col: Some("the_geom".into()), // shared default
             locations_window: None,
+            id_col: None,
+            default_datetime: None,
+            extent_bbox: None,
             columns: vec![],
             tables: vec![PostgisObservationTable {
                 parameter: "t2m".into(),
@@ -1293,5 +1364,101 @@ mod tests {
         let err = build_location(&cfg, "s", None, &["not_a_real_param"], MAX_OBSERVATION_ROWS)
             .unwrap_err();
         assert!(matches!(err, BuildError::UnknownParameter(_)));
+    }
+
+    // ---- events ------------------------------------------------------------
+
+    fn lightning_shape() -> EventsShape {
+        EventsShape {
+            table: QualifiedTable {
+                schema: "public".into(),
+                table: "lightning".into(),
+            },
+            time_col: "time".into(),
+            time_col_tz: Some("UTC".into()),
+            geom_col: "the_geom".into(),
+            id_col: "id".into(),
+        }
+    }
+
+    #[test]
+    fn events_area_sql_shape_and_binds() {
+        let q = build_events_area(
+            &lightning_shape(),
+            "POLYGON((21 59,29 59,29 66,21 66,21 59))",
+            (t(2026, 7, 11, 17), t(2026, 7, 11, 18)),
+            &["peak_current", "multiplicity"],
+            125_001,
+        )
+        .unwrap();
+
+        // Projection: timestamptz time + coords + one cast column per key.
+        assert!(q.sql.contains("(\"time\" AT TIME ZONE 'UTC') AS time"));
+        assert!(q.sql.contains("ST_X(\"the_geom\") AS lon"));
+        assert!(q.sql.contains("ST_Y(\"the_geom\") AS lat"));
+        assert!(q
+            .sql
+            .contains("\"peak_current\"::double precision AS \"peak_current\""));
+        assert!(q
+            .sql
+            .contains("\"multiplicity\"::double precision AS \"multiplicity\""));
+        // Time filter wraps the BINDS (index-preserving), not the column.
+        assert!(q.sql.contains("\"time\" >= ($1 AT TIME ZONE 'UTC')"));
+        assert!(q.sql.contains("\"time\" <= ($2 AT TIME ZONE 'UTC')"));
+        // Polygon test: bbox operator prefilter + exact intersects, one bind.
+        assert!(q.sql.contains("\"the_geom\" && ST_GeomFromText($3, 4326)"));
+        assert!(q
+            .sql
+            .contains("ST_Intersects(\"the_geom\", ST_GeomFromText($3, 4326))"));
+        // Deterministic newest-first ordering with id tiebreak; bound LIMIT.
+        assert!(q.sql.contains("ORDER BY \"time\" DESC, \"id\" LIMIT $4"));
+
+        assert_eq!(q.params.len(), 4);
+        assert_eq!(
+            q.params[2],
+            SqlParam::Text("POLYGON((21 59,29 59,29 66,21 66,21 59))".into())
+        );
+        assert_eq!(q.params[3], SqlParam::Int(125_001));
+        assert_eq!(q.limit_param_idx, Some(3));
+        assert_eq!(q.values_per_row, 2);
+    }
+
+    #[test]
+    fn events_area_without_tz_uses_bare_binds() {
+        let mut shape = lightning_shape();
+        shape.time_col_tz = None;
+        let q = build_events_area(
+            &shape,
+            "POLYGON((0 0,1 0,1 1,0 1,0 0))",
+            (t(2026, 7, 11, 17), t(2026, 7, 11, 18)),
+            &["peak_current"],
+            10,
+        )
+        .unwrap();
+        assert!(q.sql.contains("\"time\" >= $1 AND \"time\" <= $2"));
+        assert!(!q.sql.contains("AT TIME ZONE"));
+        assert_eq!(q.values_per_row, 1);
+    }
+
+    #[test]
+    fn events_area_rejects_empty_wkt() {
+        let err = build_events_area(
+            &lightning_shape(),
+            "  ",
+            (t(2026, 7, 11, 17), t(2026, 7, 11, 18)),
+            &["peak_current"],
+            10,
+        )
+        .unwrap_err();
+        assert!(matches!(err, BuildError::EmptyPolygonWkt));
+    }
+
+    #[test]
+    fn events_station_builders_reject_events_shape() {
+        let cfg = mk_cfg_obs_only(ObservationSchema::Events(lightning_shape()));
+        let err = build_location(&cfg, "s", None, &["peak_current"], 10).unwrap_err();
+        assert!(matches!(err, BuildError::NoStations));
+        let err = build_locations_from_observations(&cfg, None).unwrap_err();
+        assert!(matches!(err, BuildError::NoStations));
     }
 }

--- a/crates/engine-postgis/src/schema.rs
+++ b/crates/engine-postgis/src/schema.rs
@@ -109,6 +109,10 @@ pub enum LocationSource {
     /// observations whose `station_fk` has no stations row are filled from the
     /// observations geometry (mode B, orphan fallback).
     StationsWithOrphans(StationsMapping),
+    /// The collection has no station/location concept at all (`events`
+    /// shape) — the location list is empty and position/locations queries
+    /// are rejected at the engine layer.
+    None,
 }
 
 impl LocationSource {
@@ -117,7 +121,7 @@ impl LocationSource {
     pub fn stations(&self) -> Option<&StationsMapping> {
         match self {
             LocationSource::Stations(s) | LocationSource::StationsWithOrphans(s) => Some(s),
-            LocationSource::Observations => None,
+            LocationSource::Observations | LocationSource::None => None,
         }
     }
 
@@ -138,6 +142,7 @@ pub enum ObservationSchema {
     Long(LongShape),
     Wide(WideShape),
     PerParameter(PerParameterShape),
+    Events(EventsShape),
 }
 
 #[derive(Debug, Clone)]
@@ -167,6 +172,20 @@ pub struct PerParameterShape {
     pub tables: Vec<PerParameterTable>,
 }
 
+/// `events` shape (#113): non-station event data — each row is an
+/// independent event with its own time and point geometry (e.g. a lightning
+/// strike). Parameter `source_key`s name columns on this table directly
+/// (validated as identifiers at config load and again at engine resolve).
+#[derive(Debug, Clone)]
+pub struct EventsShape {
+    pub table: QualifiedTable,
+    pub time_col: String,
+    pub time_col_tz: Option<String>,
+    pub geom_col: String,
+    /// Unique/tiebreak column for deterministic `ORDER BY time DESC, id`.
+    pub id_col: String,
+}
+
 #[derive(Debug, Clone)]
 pub struct PerParameterTable {
     pub parameter: String,
@@ -184,6 +203,7 @@ impl ObservationSchema {
             "long" => Ok(Self::Long(LongShape::from_config(cfg)?)),
             "wide" => Ok(Self::Wide(WideShape::from_config(cfg)?)),
             "per_parameter" => Ok(Self::PerParameter(PerParameterShape::from_config(cfg)?)),
+            "events" => Ok(Self::Events(EventsShape::from_config(cfg)?)),
             other => Err(SchemaError::ShapeMismatch(format!(
                 "unknown shape '{other}'"
             ))),
@@ -308,6 +328,41 @@ impl PerParameterShape {
             tables.push(PerParameterTable::from_config(cfg, entry)?);
         }
         Ok(Self { tables })
+    }
+}
+
+impl EventsShape {
+    fn from_config(cfg: &PostgisObservationsConfig) -> Result<Self, SchemaError> {
+        let table = cfg.table.as_deref().ok_or_else(|| {
+            SchemaError::ShapeMismatch("'events' requires observations.table".into())
+        })?;
+        let time_col = cfg.time_col.as_deref().ok_or_else(|| {
+            SchemaError::ShapeMismatch("'events' requires observations.time_col".into())
+        })?;
+        let geom_col = cfg.geom_col.as_deref().ok_or_else(|| {
+            SchemaError::ShapeMismatch("'events' requires observations.geom_col".into())
+        })?;
+        let id_col = cfg.id_col.as_deref().ok_or_else(|| {
+            SchemaError::ShapeMismatch("'events' requires observations.id_col".into())
+        })?;
+        if cfg.station_fk_col.is_some() || cfg.param_col.is_some() || cfg.value_col.is_some() {
+            return Err(SchemaError::ShapeMismatch(
+                "'events' does not allow station_fk_col / param_col / value_col".into(),
+            ));
+        }
+        if !cfg.columns.is_empty() || !cfg.tables.is_empty() {
+            return Err(SchemaError::ShapeMismatch(
+                "'events' does not allow [[observations.columns]] / [[observations.tables]]".into(),
+            ));
+        }
+
+        Ok(Self {
+            table: QualifiedTable::parse(table)?,
+            time_col: check_identifier(time_col, "observations.time_col")?,
+            time_col_tz: cfg.time_col_tz.clone(),
+            geom_col: check_identifier(geom_col, "observations.geom_col")?,
+            id_col: check_identifier(id_col, "observations.id_col")?,
+        })
     }
 }
 
@@ -457,6 +512,9 @@ mod tests {
             value_col: Some("value".into()),
             geom_col: None,
             locations_window: None,
+            id_col: None,
+            default_datetime: None,
+            extent_bbox: None,
             columns: vec![],
             tables: vec![],
         }
@@ -489,6 +547,9 @@ mod tests {
             value_col: None,
             geom_col: None,
             locations_window: None,
+            id_col: None,
+            default_datetime: None,
+            extent_bbox: None,
             columns: vec![
                 PostgisObservationColumn {
                     parameter: "t2m".into(),
@@ -523,6 +584,9 @@ mod tests {
             value_col: Some("value".into()),
             geom_col: Some("the_geom".into()),
             locations_window: None,
+            id_col: None,
+            default_datetime: None,
+            extent_bbox: None,
             columns: vec![],
             tables: vec![PostgisObservationTable {
                 parameter: "t2m".into(),
@@ -572,6 +636,9 @@ mod tests {
             value_col: Some("value".into()),
             geom_col: None,
             locations_window: None,
+            id_col: None,
+            default_datetime: None,
+            extent_bbox: None,
             columns: vec![],
             tables: vec![PostgisObservationTable {
                 parameter: "t2m".into(),
@@ -585,5 +652,72 @@ mod tests {
         };
         let err = ObservationSchema::from_config(&cfg).unwrap_err();
         assert!(matches!(err, SchemaError::ShapeMismatch(msg) if msg.contains("station_fk_col")));
+    }
+
+    fn minimal_events() -> PostgisObservationsConfig {
+        PostgisObservationsConfig {
+            shape: "events".into(),
+            table: Some("public.lightning".into()),
+            station_fk_col: None,
+            time_col: Some("time".into()),
+            time_col_tz: Some("UTC".into()),
+            param_col: None,
+            value_col: None,
+            geom_col: Some("the_geom".into()),
+            locations_window: None,
+            columns: vec![],
+            tables: vec![],
+            id_col: Some("id".into()),
+            default_datetime: Some("PT1H".into()),
+            extent_bbox: Some([4.0, 54.0, 42.0, 72.0]),
+        }
+    }
+
+    #[test]
+    fn observation_schema_events_from_config() {
+        let schema = ObservationSchema::from_config(&minimal_events()).unwrap();
+        match schema {
+            ObservationSchema::Events(ev) => {
+                assert_eq!(ev.table.schema, "public");
+                assert_eq!(ev.table.table, "lightning");
+                assert_eq!(ev.time_col, "time");
+                assert_eq!(ev.time_col_tz.as_deref(), Some("UTC"));
+                assert_eq!(ev.geom_col, "the_geom");
+                assert_eq!(ev.id_col, "id");
+            }
+            _ => panic!("expected Events"),
+        }
+    }
+
+    #[test]
+    fn events_requires_id_col() {
+        let mut cfg = minimal_events();
+        cfg.id_col = None;
+        let err = ObservationSchema::from_config(&cfg).unwrap_err();
+        assert!(matches!(err, SchemaError::ShapeMismatch(msg) if msg.contains("id_col")));
+    }
+
+    #[test]
+    fn events_requires_geom_col() {
+        let mut cfg = minimal_events();
+        cfg.geom_col = None;
+        let err = ObservationSchema::from_config(&cfg).unwrap_err();
+        assert!(matches!(err, SchemaError::ShapeMismatch(msg) if msg.contains("geom_col")));
+    }
+
+    #[test]
+    fn events_rejects_station_machinery() {
+        let mut cfg = minimal_events();
+        cfg.station_fk_col = Some("station_id".into());
+        let err = ObservationSchema::from_config(&cfg).unwrap_err();
+        assert!(matches!(err, SchemaError::ShapeMismatch(_)));
+
+        let mut cfg = minimal_events();
+        cfg.columns = vec![PostgisObservationColumn {
+            parameter: "x".into(),
+            column: "x".into(),
+        }];
+        let err = ObservationSchema::from_config(&cfg).unwrap_err();
+        assert!(matches!(err, SchemaError::ShapeMismatch(_)));
     }
 }


### PR DESCRIPTION
Closes #502. Implements the #113 events-shape design (prerequisite #501 merged as #505). Restores lightning data for the EDR client after the GeoServer retirement.

## What

**Config** (`observations.shape = "events"` — a fourth shape rather than the separate `[postgis.events]` block sketched on #113; it reuses the whole observations validation/lowering machinery, and the semantics are identical):

- New fields `id_col` (ORDER BY tiebreak), `default_datetime` (window when the query has no `datetime` — an unqualified query never scans full history; default PT1H), `extent_bbox` (advertised spatial extent — never `ST_Extent`, a full-scan trap on a 1.7M-row hypertable). Each rejected on station shapes.
- A `[postgis.stations]` block, `station_fk_col`/`param_col`/`value_col`, `columns`/`tables`, or `locations_window` on an events collection are config-load errors.
- Events `source_key`s are identifier-validated at load and at engine resolve — they name SQL columns directly, with no columns/tables mapping to launder them through.

**Engine**:

- `EventsShape` + `LocationSource::None`; the exhaustive matches surfaced every station-path assumption at compile time.
- EDR **area only** (`supported_query_types()` → `data_queries` advertises just area); `position`/`location` return 400 with "use the area query".
- One SQL statement per request: time-range binds wrapped bind-side (`$1 AT TIME ZONE` — index/chunk-pruning preserved), `&&` bbox prefilter + exact `ST_Intersects`, `ORDER BY time DESC, id`, `LIMIT` bound to the response-value budget (#498) with a +1 sentinel. No fan-out; the fan-out semaphore is not involved and one pooled connection per request coexists with station collections on the shared pool.
- Response: `CoverageCollection` of `Point` coverages (one per event, 0-d scalar ranges — #501/#505). An empty window is a valid **empty collection**, not a 404 — no strikes in the area is an answer.
- Parameter columns cast `::double precision` in the SELECT, so `smallint` and `numeric(p,s)` (the lightning table's `ellipse_major`) work with zero config.
- Metadata: temporal extent via index-only `MIN`/`MAX`; spatial from config; ping/refresh/health machinery reused untouched.

## Tests

- ds-core: 9 TOML round-trip tests (accept + every rejection path).
- engine-postgis: shape lowering, resolve (LocationSource::None, window default/parse, bad source_key), `build_events_area` SQL/bind/limit/values-per-row assertions, station-builder rejection, and pure `assemble_event_coverages` (Point domain, scalar NdArray, null-stays-null).
- `cargo test -p ds-core -p engine-postgis` and `cargo clippy --all-targets -- -D warnings` clean.

## End-to-end smoke test (live data)

Ran the built server against the production lightning hypertable (1.76M rows) over an SSH tunnel, storm evening in progress:

- Collection metadata: `data_queries: [area]`, live temporal extent, config bbox, 4 parameters.
- Whole-Finland 6 h window: **HTTP 200, 11,051 Point coverages, 1.7 s** (debug build over tunnel), values decode correctly incl. the `numeric` column.
- No `datetime` → default window applied (16.8k strikes / 24 h); `parameter-name=peak_current` filters ranges.
- `position` → 400 "use the area query"; full-year whole-extent → 400 naming the 500k value budget.

Follow-ups: #503 (FeatureEngine/GeoJSON for events), #504 (optional WMS layer). EDR `radius` is not implemented — the query type doesn't exist in `EdrEngine`/api-edr at all yet; noted as a possible later addition since `area` covers the client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T22YrnSuwKW6mFebJBHaBt