### PR TITLE
feat(engine-nowcast): phase-0 motion + advection + skill core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1193,6 +1193,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "engine-nowcast"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "ds-core",
+ "engine-geotiff",
+]
+
+[[package]]
 name = "engine-odim"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "crates/engine-postgis",
     "crates/engine-querydata",
     "crates/engine-grib",
+    "crates/engine-nowcast",
     "crates/engine-odim",
     "crates/engine-cap",
     "crates/engine-zarr",

--- a/crates/engine-nowcast/Cargo.toml
+++ b/crates/engine-nowcast/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "engine-nowcast"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+
+[dev-dependencies]
+# Phase-0 skill spike only (#520): the example loads fixture composites through
+# the public GeoTiffEngine — the same decode path phase 1 consumes via
+# Arc<dyn MapEngine>. The library itself stays dependency-free.
+ds-core = { path = "../core" }
+engine-geotiff = { path = "../engine-geotiff" }
+chrono = "0.4"

--- a/crates/engine-nowcast/examples/skill_spike.rs
+++ b/crates/engine-nowcast/examples/skill_spike.rs
@@ -1,0 +1,370 @@
+//! Phase-0 hindcast harness for the nowcasting epic (#519 / #520).
+//!
+//! Loads a directory of composite GeoTIFF frames through the public
+//! `GeoTiffEngine` (the same decode path phase 1 will consume via
+//! `Arc<dyn MapEngine>`), estimates motion from each consecutive frame pair,
+//! extrapolates, and scores the extrapolation against the frame that actually
+//! followed — next to a persistence baseline.
+//!
+//! Gate: nowcast CSI must beat persistence CSI at the gate threshold, lead 1.
+//!
+//! ```text
+//! cargo run --release -p engine-nowcast --example skill_spike -- \
+//!     --dir testdata/smhi-radar-geotiff-4326 \
+//!     --template "%Y%m%d%H%M%S_smhi_radar.tif"
+//! ```
+
+use std::process::ExitCode;
+use std::time::Instant;
+
+use ds_core::config::GeoTiffConfig;
+use ds_core::map_engine::{MapEngine, OutputCrs, RasterValues};
+use engine_geotiff::GeoTiffEngine;
+use engine_nowcast::motion::{estimate_motion, MotionOptions};
+use engine_nowcast::skill::{score, Contingency};
+use engine_nowcast::{advect::advect, Grid};
+
+/// Keep the working grid at most this many pixels (halve dims until it fits).
+const MAX_PIXELS: usize = 6_000_000;
+
+struct Args {
+    dir: String,
+    template: String,
+    thresholds: Vec<f32>,
+    gate_threshold: f32,
+    min_echo: f32,
+    block: usize,
+    search: i32,
+    substeps: usize,
+    nodata: Option<f64>,
+    scale: Option<f64>,
+    offset: Option<f64>,
+}
+
+fn parse_args() -> Result<Args, String> {
+    let mut args = Args {
+        dir: String::new(),
+        template: String::new(),
+        thresholds: vec![10.0, 20.0, 35.0],
+        gate_threshold: 20.0,
+        min_echo: 10.0,
+        block: 32,
+        search: 20,
+        substeps: 4,
+        nodata: None,
+        scale: None,
+        offset: None,
+    };
+    let mut it = std::env::args().skip(1);
+    while let Some(flag) = it.next() {
+        let mut value = |name: &str| it.next().ok_or_else(|| format!("missing value for {name}"));
+        match flag.as_str() {
+            "--dir" => args.dir = value("--dir")?,
+            "--template" => args.template = value("--template")?,
+            "--thresholds" => {
+                args.thresholds = value("--thresholds")?
+                    .split(',')
+                    .map(|s| s.trim().parse::<f32>().map_err(|e| e.to_string()))
+                    .collect::<Result<_, _>>()?
+            }
+            "--gate-threshold" => {
+                args.gate_threshold = value("--gate-threshold")?
+                    .parse()
+                    .map_err(|e: std::num::ParseFloatError| e.to_string())?
+            }
+            "--min-echo" => {
+                args.min_echo = value("--min-echo")?
+                    .parse()
+                    .map_err(|e: std::num::ParseFloatError| e.to_string())?
+            }
+            "--block" => {
+                args.block = value("--block")?
+                    .parse()
+                    .map_err(|e: std::num::ParseIntError| e.to_string())?
+            }
+            "--search" => {
+                args.search = value("--search")?
+                    .parse()
+                    .map_err(|e: std::num::ParseIntError| e.to_string())?
+            }
+            "--substeps" => {
+                args.substeps = value("--substeps")?
+                    .parse()
+                    .map_err(|e: std::num::ParseIntError| e.to_string())?
+            }
+            "--nodata" => {
+                args.nodata = Some(
+                    value("--nodata")?
+                        .parse()
+                        .map_err(|e: std::num::ParseFloatError| e.to_string())?,
+                )
+            }
+            "--scale" => {
+                args.scale = Some(
+                    value("--scale")?
+                        .parse()
+                        .map_err(|e: std::num::ParseFloatError| e.to_string())?,
+                )
+            }
+            "--offset" => {
+                args.offset = Some(
+                    value("--offset")?
+                        .parse()
+                        .map_err(|e: std::num::ParseFloatError| e.to_string())?,
+                )
+            }
+            other => return Err(format!("unknown flag {other}")),
+        }
+    }
+    if args.dir.is_empty() || args.template.is_empty() {
+        return Err(
+            "usage: skill_spike --dir <fixture dir> --template <strftime filename> \
+                    [--thresholds 10,20,35] [--gate-threshold 20] [--min-echo 10] \
+                    [--block 32] [--search 20] [--substeps 4] \
+                    [--nodata <raw>] [--scale <gain>] [--offset <off>]"
+                .into(),
+        );
+    }
+    Ok(args)
+}
+
+fn tile_to_grid(values: RasterValues, width: usize, height: usize) -> Grid {
+    let data: Vec<f32> = match values {
+        RasterValues::F64(v) => v
+            .into_iter()
+            .map(|o| o.map(|x| x as f32).unwrap_or(f32::NAN))
+            .collect(),
+        RasterValues::U8 {
+            data,
+            nodata,
+            gain,
+            offset,
+        } => data
+            .into_iter()
+            .map(|raw| {
+                if nodata == Some(raw) {
+                    f32::NAN
+                } else {
+                    (raw as f64 * gain + offset) as f32
+                }
+            })
+            .collect(),
+    };
+    Grid::new(width, height, data)
+}
+
+fn fmt_ratio(r: Option<f64>) -> String {
+    r.map(|v| format!("{v:.3}")).unwrap_or_else(|| "n/a".into())
+}
+
+fn main() -> ExitCode {
+    let args = match parse_args() {
+        Ok(a) => a,
+        Err(e) => {
+            eprintln!("{e}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    let config = GeoTiffConfig {
+        filename_template: Some(args.template.clone()),
+        filename_pattern: None,
+        timestamp_format: None,
+        parameter: "reflectivity".to_string(),
+        unit: "dBZ".to_string(),
+        poll_interval_secs: 3600,
+        tile_cache_mb: 256,
+        band: 1,
+        max_files: None,
+        nodata: args.nodata,
+        scale: args.scale,
+        offset: args.offset,
+        exclude_patterns: vec![],
+        endpoint: None,
+        bucket: None,
+        prefix_pattern: None,
+        time_window: None,
+        scan_days: None,
+        stac_url: None,
+        stac_asset_key: "data".to_string(),
+        stac_asset_allowlist: None,
+    };
+    let engine = match GeoTiffEngine::new("skill-spike", Some(&args.dir), &config) {
+        Ok(e) => e,
+        Err(e) => {
+            eprintln!("failed to open {}: {e}", args.dir);
+            return ExitCode::FAILURE;
+        }
+    };
+
+    let info = engine.raster_info();
+    if info.times.len() < 3 {
+        eprintln!(
+            "need at least 3 frames for a hindcast, found {} in {}",
+            info.times.len(),
+            args.dir
+        );
+        return ExitCode::FAILURE;
+    }
+    let Some(extent) = info.spatial_extent else {
+        eprintln!("source reports no spatial extent");
+        return ExitCode::FAILURE;
+    };
+
+    let [mut w, mut h] = info.grid_size.unwrap_or([1024, 1024]);
+    while (w as usize) * (h as usize) > MAX_PIXELS {
+        w /= 2;
+        h /= 2;
+    }
+    println!(
+        "source: {} frames, native CRS {}, sampling {}x{} over {:?}",
+        info.times.len(),
+        info.native_crs,
+        w,
+        h,
+        extent
+    );
+
+    let deltas: Vec<i64> = info
+        .times
+        .windows(2)
+        .map(|p| (p[1] - p[0]).num_seconds())
+        .collect();
+    if let (Some(&min), Some(&max)) = (deltas.iter().min(), deltas.iter().max()) {
+        println!("cadence: {}s between frames", min);
+        if max as f64 > min as f64 * 1.05 {
+            eprintln!(
+                "warning: irregular cadence ({min}–{max}s); vectors are per-interval and will \
+                 mix speeds"
+            );
+        }
+    }
+
+    let mut frames: Vec<Grid> = Vec::with_capacity(info.times.len());
+    for t in &info.times {
+        let tile = match engine.get_raster_tile(
+            extent,
+            w,
+            h,
+            Some(*t),
+            &OutputCrs::Wgs84,
+            None,
+            None,
+            None,
+        ) {
+            Ok(t) => t,
+            Err(e) => {
+                eprintln!("failed to read frame {t}: {e}");
+                return ExitCode::FAILURE;
+            }
+        };
+        let grid = tile_to_grid(tile.values, tile.width as usize, tile.height as usize);
+        let finite: Vec<f32> = grid
+            .data
+            .iter()
+            .copied()
+            .filter(|v| v.is_finite())
+            .collect();
+        let echo = finite.iter().filter(|&&v| v >= args.min_echo).count();
+        let (min, max) = finite
+            .iter()
+            .fold((f32::MAX, f32::MIN), |(lo, hi), &v| (lo.min(v), hi.max(v)));
+        println!(
+            "  {t}: {} finite px, range [{min:.1}, {max:.1}] {}, {} px >= {} (echo)",
+            finite.len(),
+            info.unit,
+            echo,
+            args.min_echo
+        );
+        frames.push(grid);
+    }
+
+    let opts = MotionOptions {
+        block: args.block,
+        search_radius: args.search,
+        min_echo: args.min_echo,
+        ..MotionOptions::default()
+    };
+
+    // Aggregate (lead, threshold) → nowcast + persistence tables across every
+    // usable anchor frame i (motion from i-1→i, verify at i+lead).
+    let max_lead = frames.len() - 2;
+    let mut nowcast = vec![vec![Contingency::default(); args.thresholds.len()]; max_lead];
+    let mut persistence = vec![vec![Contingency::default(); args.thresholds.len()]; max_lead];
+
+    for i in 1..frames.len() - 1 {
+        let started = Instant::now();
+        let field = estimate_motion(&frames[i - 1], &frames[i], &opts);
+        let motion_ms = started.elapsed().as_millis();
+        let measured = field.measured.iter().filter(|&&m| m).count();
+        println!(
+            "anchor {}: motion {}ms, {} of {} blocks measured",
+            info.times[i],
+            motion_ms,
+            measured,
+            field.measured.len()
+        );
+
+        for lead in 1..=(frames.len() - 1 - i) {
+            let started = Instant::now();
+            let forecast = advect(&frames[i], &field, lead as f32, args.substeps);
+            let advect_ms = started.elapsed().as_millis();
+            println!("  lead +{lead}: advection {advect_ms}ms");
+            for (k, &thr) in args.thresholds.iter().enumerate() {
+                nowcast[lead - 1][k].merge(&score(&forecast, &frames[i + lead], thr));
+                persistence[lead - 1][k].merge(&score(&frames[i], &frames[i + lead], thr));
+            }
+        }
+    }
+
+    println!();
+    println!(
+        "lead  thr({})   CSI nowcast  CSI persist  POD nowcast  FAR nowcast",
+        info.unit
+    );
+    for (li, row) in nowcast.iter().enumerate() {
+        for (k, &thr) in args.thresholds.iter().enumerate() {
+            println!(
+                "  +{:<3} {:>6.1}   {:>11} {:>12} {:>12} {:>12}",
+                li + 1,
+                thr,
+                fmt_ratio(row[k].csi()),
+                fmt_ratio(persistence[li][k].csi()),
+                fmt_ratio(row[k].pod()),
+                fmt_ratio(row[k].far()),
+            );
+        }
+    }
+
+    // The gate (#520): beat persistence at the gate threshold, lead 1.
+    let gate_idx = args
+        .thresholds
+        .iter()
+        .position(|&t| t == args.gate_threshold)
+        .unwrap_or(0);
+    let n = nowcast[0][gate_idx].csi();
+    let p = persistence[0][gate_idx].csi();
+    println!();
+    match (n, p) {
+        (Some(n), Some(p)) if n > p => {
+            println!(
+                "GATE PASS: lead-1 CSI {} > persistence {} at {} {}",
+                fmt_ratio(Some(n)),
+                fmt_ratio(Some(p)),
+                args.thresholds[gate_idx],
+                info.unit
+            );
+            ExitCode::SUCCESS
+        }
+        (n, p) => {
+            println!(
+                "GATE FAIL: lead-1 CSI {} vs persistence {} at {} {}",
+                fmt_ratio(n),
+                fmt_ratio(p),
+                args.thresholds[gate_idx],
+                info.unit
+            );
+            ExitCode::FAILURE
+        }
+    }
+}

--- a/crates/engine-nowcast/examples/skill_spike.rs
+++ b/crates/engine-nowcast/examples/skill_spike.rs
@@ -125,6 +125,14 @@ fn parse_args() -> Result<Args, String> {
                 .into(),
         );
     }
+    // The PASS/FAIL exit code is this harness's automated signal — a gate
+    // threshold that silently fell back to another entry would be misleading.
+    if !args.thresholds.contains(&args.gate_threshold) {
+        return Err(format!(
+            "--gate-threshold {} is not among --thresholds {:?}",
+            args.gate_threshold, args.thresholds
+        ));
+    }
     Ok(args)
 }
 
@@ -266,13 +274,17 @@ fn main() -> ExitCode {
             .filter(|v| v.is_finite())
             .collect();
         let echo = finite.iter().filter(|&&v| v >= args.min_echo).count();
-        let (min, max) = finite
-            .iter()
-            .fold((f32::MAX, f32::MIN), |(lo, hi), &v| (lo.min(v), hi.max(v)));
+        let range = if finite.is_empty() {
+            "range n/a (all nodata)".to_string()
+        } else {
+            let (min, max) = finite
+                .iter()
+                .fold((f32::MAX, f32::MIN), |(lo, hi), &v| (lo.min(v), hi.max(v)));
+            format!("range [{min:.1}, {max:.1}] {}", info.unit)
+        };
         println!(
-            "  {t}: {} finite px, range [{min:.1}, {max:.1}] {}, {} px >= {} (echo)",
+            "  {t}: {} finite px, {range}, {} px >= {} (echo)",
             finite.len(),
-            info.unit,
             echo,
             args.min_echo
         );
@@ -337,11 +349,12 @@ fn main() -> ExitCode {
     }
 
     // The gate (#520): beat persistence at the gate threshold, lead 1.
+    // Membership was validated in parse_args, so position() always finds it.
     let gate_idx = args
         .thresholds
         .iter()
         .position(|&t| t == args.gate_threshold)
-        .unwrap_or(0);
+        .expect("gate threshold validated against thresholds at arg parse");
     let n = nowcast[0][gate_idx].csi();
     let p = persistence[0][gate_idx].csi();
     println!();

--- a/crates/engine-nowcast/src/advect.rs
+++ b/crates/engine-nowcast/src/advect.rs
@@ -1,0 +1,119 @@
+//! Semi-Lagrangian backward advection along a motion field.
+//!
+//! For each output pixel the departure trajectory is integrated *backward*
+//! through the motion field in substeps, then the analysis frame is sampled
+//! **once, nearest-neighbour** at the departure point. One nearest sample
+//! keeps sparse far-range echoes and their raw values intact — iterated
+//! bilinear resampling smears exactly the echoes the GeoTIFF downsampling bug
+//! (#456) taught us not to lose. Pixels whose trajectory leaves the domain
+//! (inflow boundary) become nodata; nodata never turns into echo.
+
+use crate::motion::MotionField;
+use crate::Grid;
+
+/// Extrapolate `frame` forward by `lead` frame intervals.
+///
+/// `substeps` is the number of trajectory-integration steps per interval;
+/// values around 4 track spatially varying fields well. `lead` may be
+/// fractional.
+pub fn advect(frame: &Grid, field: &MotionField, lead: f32, substeps: usize) -> Grid {
+    let steps = ((lead * substeps.max(1) as f32).ceil() as usize).max(1);
+    let h = lead / steps as f32;
+    let mut out = Grid::filled_nodata(frame.width, frame.height);
+    for y in 0..frame.height {
+        for x in 0..frame.width {
+            let mut px = x as f32 + 0.5;
+            let mut py = y as f32 + 0.5;
+            for _ in 0..steps {
+                let (u, v) = field.sample(px, py);
+                px -= u * h;
+                py -= v * h;
+            }
+            if px < 0.0 || py < 0.0 || px >= frame.width as f32 || py >= frame.height as f32 {
+                continue; // departure outside the domain: stays nodata
+            }
+            out.data[y * frame.width + x] = frame.at(px as usize, py as usize);
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::motion::{estimate_motion, MotionOptions};
+    use crate::skill::score;
+
+    fn disc_frame(w: usize, h: usize, cx: f32, cy: f32, r: f32, value: f32) -> Grid {
+        let mut data = vec![0.0f32; w * h];
+        for (i, cell) in data.iter_mut().enumerate() {
+            let (x, y) = ((i % w) as f32 + 0.5, (i / w) as f32 + 0.5);
+            if (x - cx).powi(2) + (y - cy).powi(2) <= r * r {
+                *cell = value;
+            }
+        }
+        Grid::new(w, h, data)
+    }
+
+    #[test]
+    fn zero_field_is_identity_for_finite_and_nodata_pixels() {
+        let mut frame = disc_frame(64, 64, 30.0, 30.0, 8.0, 40.0);
+        frame.data[5] = f32::NAN;
+        let field = estimate_motion(&frame, &frame, &MotionOptions::default());
+        let out = advect(&frame, &field, 1.0, 4);
+        for (a, b) in frame.data.iter().zip(&out.data) {
+            assert!(
+                (a.is_nan() && b.is_nan()) || a == b,
+                "identity advection changed a pixel: {a} -> {b}"
+            );
+        }
+    }
+
+    #[test]
+    fn extrapolation_beats_persistence_on_translating_disc() {
+        // The phase-0 gate in miniature: a disc translating (+6, -4) per
+        // interval. Estimate motion from (t0, t1), extrapolate t1 one
+        // interval, score against the true t2 — and against persistence.
+        let t0 = disc_frame(200, 200, 74.0, 124.0, 12.0, 40.0);
+        let t1 = disc_frame(200, 200, 80.0, 120.0, 12.0, 40.0);
+        let t2 = disc_frame(200, 200, 86.0, 116.0, 12.0, 40.0);
+        let opts = MotionOptions {
+            search_radius: 10,
+            ..MotionOptions::default()
+        };
+        let field = estimate_motion(&t0, &t1, &opts);
+        let forecast = advect(&t1, &field, 1.0, 4);
+
+        let nowcast = score(&forecast, &t2, 20.0).csi().unwrap();
+        let persistence = score(&t1, &t2, 20.0).csi().unwrap();
+        assert!(
+            nowcast > persistence,
+            "nowcast CSI {nowcast} must beat persistence {persistence}"
+        );
+        assert!(
+            nowcast > 0.9,
+            "nowcast CSI {nowcast} should be near-perfect"
+        );
+    }
+
+    #[test]
+    fn inflow_boundary_becomes_nodata_not_echo() {
+        // Uniform rightward motion: the left edge has no upstream data, so it
+        // must become nodata rather than repeat or invent echo.
+        let t0 = disc_frame(100, 100, 40.0, 50.0, 10.0, 40.0);
+        let t1 = disc_frame(100, 100, 48.0, 50.0, 10.0, 40.0);
+        let field = estimate_motion(&t0, &t1, &MotionOptions::default());
+        let out = advect(&t1, &field, 1.0, 4);
+        for y in 0..100 {
+            let v = out.at(0, y);
+            assert!(
+                v.is_nan() || v < 20.0,
+                "left inflow column should be nodata/background, got {v}"
+            );
+        }
+        assert!(
+            out.data.iter().filter(|v| v.is_nan()).count() > 0,
+            "expected a nodata inflow strip"
+        );
+    }
+}

--- a/crates/engine-nowcast/src/lib.rs
+++ b/crates/engine-nowcast/src/lib.rs
@@ -1,0 +1,64 @@
+//! Radar nowcasting core: motion estimation + semi-Lagrangian extrapolation.
+//!
+//! Phase 0 of the nowcasting epic (#519 / #520): the pure algorithm — no
+//! engine traits, no I/O, no dependencies. [`motion`] estimates a block-level
+//! motion field from two consecutive composite frames, [`advect`] extrapolates
+//! the latest frame along that field, and [`skill`] scores a hindcast against
+//! what actually happened (the phase-0 gate: extrapolation must beat
+//! persistence, or the motion estimator is wrong).
+//!
+//! Conventions shared by every module:
+//! - A [`Grid`] is a row-major raster, row 0 at the top, `f32` physical values
+//!   (dBZ for radar), `NaN` = nodata.
+//! - Motion vectors are in **pixels per frame interval**, `+u` = rightward
+//!   (+x), `+v` = downward (+y, image convention).
+//! - Lead times are in frame intervals, so the caller never needs wall-clock
+//!   units here; phase 1 maps intervals to timestamps.
+
+pub mod advect;
+pub mod motion;
+pub mod skill;
+
+/// A row-major 2-D raster of physical values; `NaN` = nodata.
+#[derive(Debug, Clone)]
+pub struct Grid {
+    pub width: usize,
+    pub height: usize,
+    /// `width * height` values, row-major, row 0 = top.
+    pub data: Vec<f32>,
+}
+
+impl Grid {
+    /// Build a grid, checking the buffer length.
+    pub fn new(width: usize, height: usize, data: Vec<f32>) -> Self {
+        assert_eq!(
+            data.len(),
+            width * height,
+            "Grid buffer length must be width*height"
+        );
+        Self {
+            width,
+            height,
+            data,
+        }
+    }
+
+    /// A grid filled with nodata.
+    pub fn filled_nodata(width: usize, height: usize) -> Self {
+        Self {
+            width,
+            height,
+            data: vec![f32::NAN; width * height],
+        }
+    }
+
+    /// Value at (x, y); out-of-bounds returns `NaN`.
+    #[inline]
+    pub fn at(&self, x: usize, y: usize) -> f32 {
+        if x < self.width && y < self.height {
+            self.data[y * self.width + x]
+        } else {
+            f32::NAN
+        }
+    }
+}

--- a/crates/engine-nowcast/src/motion.rs
+++ b/crates/engine-nowcast/src/motion.rs
@@ -1,0 +1,363 @@
+//! Block-matching motion estimation between two consecutive frames.
+//!
+//! pySTEPS-style Lucas–Kanade-lite: cross-correlate coarse blocks (sum of
+//! absolute differences), keep only vectors measured where the target frame
+//! actually has echo (which also stops stationary ground clutter and empty
+//! sky from anchoring the field), reject outliers against the robust global
+//! median, then fill unmeasured blocks from their neighbours and smooth into
+//! a continuous field. The result samples bilinearly at any pixel position.
+
+use crate::Grid;
+
+/// Knobs for [`estimate_motion`]. Defaults fit ~1 km composite pixels at a
+/// 5-minute cadence (40 m/s ≈ 12 km ≈ 12 px per interval).
+#[derive(Debug, Clone)]
+pub struct MotionOptions {
+    /// Block edge in pixels.
+    pub block: usize,
+    /// Search radius in pixels (max displacement per frame interval).
+    pub search_radius: i32,
+    /// Coarse search stride; a ±(stride) step-1 refinement follows.
+    pub coarse_step: i32,
+    /// Physical echo threshold (e.g. dBZ) a pixel must reach to count as echo.
+    pub min_echo: f32,
+    /// Fraction of a block's pixels that must be echo for the block to yield
+    /// a vector.
+    pub min_echo_frac: f32,
+    /// Fraction of a block's pixels that must overlap valid source pixels for
+    /// a candidate displacement to be scored.
+    pub min_overlap_frac: f32,
+    /// Robust outlier gate: vectors farther than
+    /// `max(outlier_sigmas * 1.4826 * MAD, 2 px)` from the median are dropped.
+    pub outlier_sigmas: f32,
+    /// 3×3 box-smoothing passes applied after fill.
+    pub smooth_passes: usize,
+}
+
+impl Default for MotionOptions {
+    fn default() -> Self {
+        Self {
+            block: 32,
+            search_radius: 20,
+            coarse_step: 2,
+            min_echo: 10.0,
+            min_echo_frac: 0.02,
+            min_overlap_frac: 0.5,
+            outlier_sigmas: 3.0,
+            smooth_passes: 2,
+        }
+    }
+}
+
+/// A block-level motion field over a frame, bilinear-sampled per pixel.
+///
+/// `u`/`v` are pixels per frame interval; `measured[i]` marks blocks whose
+/// vector came from an actual block match (as opposed to fill/smoothing).
+#[derive(Debug, Clone)]
+pub struct MotionField {
+    pub block: usize,
+    /// Blocks per row.
+    pub bw: usize,
+    /// Blocks per column.
+    pub bh: usize,
+    pub u: Vec<f32>,
+    pub v: Vec<f32>,
+    pub measured: Vec<bool>,
+}
+
+impl MotionField {
+    /// Bilinear sample of (u, v) at pixel position (x, y), clamped at edges.
+    pub fn sample(&self, x: f32, y: f32) -> (f32, f32) {
+        if self.bw == 0 || self.bh == 0 {
+            return (0.0, 0.0);
+        }
+        // Block centres sit at (b + 0.5) * block; express the query in block
+        // coordinates relative to centre spacing.
+        let fx = (x / self.block as f32 - 0.5).clamp(0.0, (self.bw - 1) as f32);
+        let fy = (y / self.block as f32 - 0.5).clamp(0.0, (self.bh - 1) as f32);
+        let ix = (fx.floor() as usize).min(self.bw.saturating_sub(2));
+        let iy = (fy.floor() as usize).min(self.bh.saturating_sub(2));
+        let (ix1, iy1) = ((ix + 1).min(self.bw - 1), (iy + 1).min(self.bh - 1));
+        let (tx, ty) = (fx - ix as f32, fy - iy as f32);
+        let idx = |bx: usize, by: usize| by * self.bw + bx;
+        let lerp2 = |g: &[f32]| {
+            let top = g[idx(ix, iy)] * (1.0 - tx) + g[idx(ix1, iy)] * tx;
+            let bot = g[idx(ix, iy1)] * (1.0 - tx) + g[idx(ix1, iy1)] * tx;
+            top * (1.0 - ty) + bot * ty
+        };
+        (lerp2(&self.u), lerp2(&self.v))
+    }
+}
+
+/// Estimate the motion field that carries `prev` into `next`.
+///
+/// A vector `(u, v)` for a block means `next(x, y) ≈ prev(x - u, y - v)` for
+/// pixels in that block: echoes moved by `(u, v)` over one frame interval.
+pub fn estimate_motion(prev: &Grid, next: &Grid, opts: &MotionOptions) -> MotionField {
+    assert_eq!(
+        (prev.width, prev.height),
+        (next.width, next.height),
+        "motion estimation needs equally sized frames"
+    );
+    let block = opts.block.max(4);
+    let bw = next.width.div_ceil(block);
+    let bh = next.height.div_ceil(block);
+    let mut field = MotionField {
+        block,
+        bw,
+        bh,
+        u: vec![0.0; bw * bh],
+        v: vec![0.0; bw * bh],
+        measured: vec![false; bw * bh],
+    };
+
+    for by in 0..bh {
+        for bx in 0..bw {
+            let x0 = bx * block;
+            let y0 = by * block;
+            let x1 = (x0 + block).min(next.width);
+            let y1 = (y0 + block).min(next.height);
+            let area = (x1 - x0) * (y1 - y0);
+
+            let echo_pixels = (y0..y1)
+                .flat_map(|y| (x0..x1).map(move |x| (x, y)))
+                .filter(|&(x, y)| {
+                    let v = next.at(x, y);
+                    v.is_finite() && v >= opts.min_echo
+                })
+                .count();
+            if (echo_pixels as f32) < opts.min_echo_frac * area as f32 {
+                continue;
+            }
+
+            let min_overlap = (opts.min_overlap_frac * area as f32) as usize;
+            let cost_of = |dx: i32, dy: i32| -> Option<f32> {
+                let mut sum = 0.0f64;
+                let mut n = 0usize;
+                for y in y0..y1 {
+                    for x in x0..x1 {
+                        let a = next.at(x, y);
+                        if !a.is_finite() {
+                            continue;
+                        }
+                        let sx = x as i64 - dx as i64;
+                        let sy = y as i64 - dy as i64;
+                        if sx < 0 || sy < 0 || sx >= prev.width as i64 || sy >= prev.height as i64 {
+                            continue;
+                        }
+                        let b = prev.at(sx as usize, sy as usize);
+                        if !b.is_finite() {
+                            continue;
+                        }
+                        sum += (a - b).abs() as f64;
+                        n += 1;
+                    }
+                }
+                if n < min_overlap.max(1) {
+                    return None;
+                }
+                // Tiny displacement penalty breaks ties on flat cost surfaces
+                // toward "no motion" instead of an arbitrary search corner.
+                let bias = 1e-4 * ((dx * dx + dy * dy) as f32).sqrt();
+                Some(sum as f32 / n as f32 + bias)
+            };
+
+            let step = opts.coarse_step.max(1);
+            let r = opts.search_radius.max(step);
+            let mut best: Option<(f32, i32, i32)> = None;
+            let mut dy = -r;
+            while dy <= r {
+                let mut dx = -r;
+                while dx <= r {
+                    keep_better(&mut best, cost_of(dx, dy), dx, dy);
+                    dx += step;
+                }
+                dy += step;
+            }
+            if let Some((_, cx, cy)) = best {
+                for dy in (cy - step)..=(cy + step) {
+                    for dx in (cx - step)..=(cx + step) {
+                        if dx.abs() <= r && dy.abs() <= r {
+                            keep_better(&mut best, cost_of(dx, dy), dx, dy);
+                        }
+                    }
+                }
+            }
+
+            if let Some((_, dx, dy)) = best {
+                let i = by * bw + bx;
+                field.u[i] = dx as f32;
+                field.v[i] = dy as f32;
+                field.measured[i] = true;
+            }
+        }
+    }
+
+    reject_outliers(&mut field, opts);
+    fill_unmeasured(&mut field);
+    for _ in 0..opts.smooth_passes {
+        box_smooth(&mut field);
+    }
+    field
+}
+
+/// Keep `(cost, dx, dy)` in `best` if it beats the current candidate.
+fn keep_better(best: &mut Option<(f32, i32, i32)>, cost: Option<f32>, dx: i32, dy: i32) {
+    if let Some(c) = cost {
+        if best.map(|(bc, _, _)| c < bc).unwrap_or(true) {
+            *best = Some((c, dx, dy));
+        }
+    }
+}
+
+/// Drop measured vectors far from the robust (median/MAD) global consensus.
+fn reject_outliers(field: &mut MotionField, opts: &MotionOptions) {
+    let measured: Vec<usize> = (0..field.measured.len())
+        .filter(|&i| field.measured[i])
+        .collect();
+    if measured.len() < 4 {
+        return;
+    }
+    let median_of = |vals: &mut Vec<f32>| -> f32 {
+        vals.sort_by(|a, b| a.total_cmp(b));
+        vals[vals.len() / 2]
+    };
+    let mut us: Vec<f32> = measured.iter().map(|&i| field.u[i]).collect();
+    let mut vs: Vec<f32> = measured.iter().map(|&i| field.v[i]).collect();
+    let (mu, mv) = (median_of(&mut us), median_of(&mut vs));
+    let mut du: Vec<f32> = measured.iter().map(|&i| (field.u[i] - mu).abs()).collect();
+    let mut dv: Vec<f32> = measured.iter().map(|&i| (field.v[i] - mv).abs()).collect();
+    let (mad_u, mad_v) = (median_of(&mut du), median_of(&mut dv));
+    let gate_u = (opts.outlier_sigmas * 1.4826 * mad_u).max(2.0);
+    let gate_v = (opts.outlier_sigmas * 1.4826 * mad_v).max(2.0);
+    for &i in &measured {
+        if (field.u[i] - mu).abs() > gate_u || (field.v[i] - mv).abs() > gate_v {
+            field.measured[i] = false;
+            field.u[i] = 0.0;
+            field.v[i] = 0.0;
+        }
+    }
+}
+
+/// Grow vectors outward from measured blocks until the whole field is
+/// covered; a field with no measured vectors at all stays zero.
+fn fill_unmeasured(field: &mut MotionField) {
+    let (bw, bh) = (field.bw, field.bh);
+    let mut known = field.measured.clone();
+    if !known.iter().any(|&k| k) {
+        return;
+    }
+    // Each pass fills cells adjacent to already-known cells; bounded by the
+    // grid diameter.
+    for _ in 0..(bw + bh) {
+        if known.iter().all(|&k| k) {
+            break;
+        }
+        let snapshot = known.clone();
+        for by in 0..bh {
+            for bx in 0..bw {
+                let i = by * bw + bx;
+                if snapshot[i] {
+                    continue;
+                }
+                let mut su = 0.0f32;
+                let mut sv = 0.0f32;
+                let mut n = 0u32;
+                for ny in by.saturating_sub(1)..(by + 2).min(bh) {
+                    for nx in bx.saturating_sub(1)..(bx + 2).min(bw) {
+                        let j = ny * bw + nx;
+                        if snapshot[j] {
+                            su += field.u[j];
+                            sv += field.v[j];
+                            n += 1;
+                        }
+                    }
+                }
+                if n > 0 {
+                    field.u[i] = su / n as f32;
+                    field.v[i] = sv / n as f32;
+                    known[i] = true;
+                }
+            }
+        }
+    }
+}
+
+/// One 3×3 box-smoothing pass over the block field.
+fn box_smooth(field: &mut MotionField) {
+    let (bw, bh) = (field.bw, field.bh);
+    let mut nu = field.u.clone();
+    let mut nv = field.v.clone();
+    for by in 0..bh {
+        for bx in 0..bw {
+            let mut su = 0.0f32;
+            let mut sv = 0.0f32;
+            let mut n = 0u32;
+            for ny in by.saturating_sub(1)..(by + 2).min(bh) {
+                for nx in bx.saturating_sub(1)..(bx + 2).min(bw) {
+                    let j = ny * bw + nx;
+                    su += field.u[j];
+                    sv += field.v[j];
+                    n += 1;
+                }
+            }
+            let i = by * bw + bx;
+            nu[i] = su / n as f32;
+            nv[i] = sv / n as f32;
+        }
+    }
+    field.u = nu;
+    field.v = nv;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A hard disc of `value` centred at (cx, cy) on a zero background.
+    fn disc_frame(w: usize, h: usize, cx: f32, cy: f32, r: f32, value: f32) -> Grid {
+        let mut data = vec![0.0f32; w * h];
+        for (i, cell) in data.iter_mut().enumerate() {
+            let (x, y) = ((i % w) as f32 + 0.5, (i / w) as f32 + 0.5);
+            if (x - cx).powi(2) + (y - cy).powi(2) <= r * r {
+                *cell = value;
+            }
+        }
+        Grid::new(w, h, data)
+    }
+
+    #[test]
+    fn recovers_pure_translation() {
+        let prev = disc_frame(200, 200, 80.0, 120.0, 12.0, 40.0);
+        let next = disc_frame(200, 200, 86.0, 116.0, 12.0, 40.0); // moved (+6, -4)
+        let opts = MotionOptions {
+            search_radius: 10,
+            ..MotionOptions::default()
+        };
+        let field = estimate_motion(&prev, &next, &opts);
+        let (u, v) = field.sample(86.0, 116.0);
+        assert!((u - 6.0).abs() <= 1.0, "u = {u}, expected ~6");
+        assert!((v + 4.0).abs() <= 1.0, "v = {v}, expected ~-4");
+    }
+
+    #[test]
+    fn identical_frames_yield_zero_motion() {
+        let frame = disc_frame(128, 128, 60.0, 60.0, 10.0, 35.0);
+        let field = estimate_motion(&frame, &frame, &MotionOptions::default());
+        for (&u, &v) in field.u.iter().zip(&field.v) {
+            assert!(
+                u.abs() < 0.5 && v.abs() < 0.5,
+                "expected ~zero, got ({u},{v})"
+            );
+        }
+    }
+
+    #[test]
+    fn empty_frames_yield_zero_field_not_noise() {
+        let a = Grid::filled_nodata(96, 96);
+        let b = Grid::filled_nodata(96, 96);
+        let field = estimate_motion(&a, &b, &MotionOptions::default());
+        assert!(field.measured.iter().all(|&m| !m));
+        assert!(field.u.iter().chain(&field.v).all(|&c| c == 0.0));
+    }
+}

--- a/crates/engine-nowcast/src/skill.rs
+++ b/crates/engine-nowcast/src/skill.rs
@@ -1,0 +1,123 @@
+//! Categorical forecast verification: contingency table + POD / FAR / CSI.
+//!
+//! Pixels where either grid is nodata are excluded — a nowcast must not be
+//! rewarded or punished where the observation can't see.
+
+use crate::Grid;
+
+/// 2×2 contingency table at a fixed event threshold.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct Contingency {
+    /// Forecast ≥ threshold and observed ≥ threshold.
+    pub hits: u64,
+    /// Forecast < threshold but observed ≥ threshold.
+    pub misses: u64,
+    /// Forecast ≥ threshold but observed < threshold.
+    pub false_alarms: u64,
+    /// Neither reached the threshold.
+    pub correct_negatives: u64,
+}
+
+impl Contingency {
+    /// Probability of detection: hits / (hits + misses). `None` if the event
+    /// never occurred.
+    pub fn pod(&self) -> Option<f64> {
+        ratio(self.hits, self.hits + self.misses)
+    }
+
+    /// False-alarm ratio: false_alarms / (hits + false_alarms). `None` if the
+    /// event was never forecast.
+    pub fn far(&self) -> Option<f64> {
+        ratio(self.false_alarms, self.hits + self.false_alarms)
+    }
+
+    /// Critical success index: hits / (hits + misses + false_alarms). `None`
+    /// if the event neither occurred nor was forecast.
+    pub fn csi(&self) -> Option<f64> {
+        ratio(self.hits, self.hits + self.misses + self.false_alarms)
+    }
+
+    /// Merge another table into this one (for aggregating over frame pairs).
+    pub fn merge(&mut self, other: &Contingency) {
+        self.hits += other.hits;
+        self.misses += other.misses;
+        self.false_alarms += other.false_alarms;
+        self.correct_negatives += other.correct_negatives;
+    }
+}
+
+fn ratio(num: u64, den: u64) -> Option<f64> {
+    (den > 0).then(|| num as f64 / den as f64)
+}
+
+/// Score `forecast` against `observed` at `threshold`, skipping pixels where
+/// either grid is nodata.
+pub fn score(forecast: &Grid, observed: &Grid, threshold: f32) -> Contingency {
+    assert_eq!(
+        (forecast.width, forecast.height),
+        (observed.width, observed.height),
+        "skill scoring needs equally sized grids"
+    );
+    let mut table = Contingency::default();
+    for (&f, &o) in forecast.data.iter().zip(&observed.data) {
+        if !f.is_finite() || !o.is_finite() {
+            continue;
+        }
+        match (f >= threshold, o >= threshold) {
+            (true, true) => table.hits += 1,
+            (false, true) => table.misses += 1,
+            (true, false) => table.false_alarms += 1,
+            (false, false) => table.correct_negatives += 1,
+        }
+    }
+    table
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn table_and_scores_are_pinned() {
+        let forecast = Grid::new(4, 1, vec![40.0, 0.0, 40.0, f32::NAN]);
+        let observed = Grid::new(4, 1, vec![40.0, 40.0, 0.0, 40.0]);
+        let t = score(&forecast, &observed, 20.0);
+        assert_eq!(
+            t,
+            Contingency {
+                hits: 1,
+                misses: 1,
+                false_alarms: 1,
+                correct_negatives: 0,
+            }
+        );
+        assert_eq!(t.pod(), Some(0.5));
+        assert_eq!(t.far(), Some(0.5));
+        assert_eq!(t.csi(), Some(1.0 / 3.0));
+    }
+
+    #[test]
+    fn empty_denominators_are_none_not_nan() {
+        let quiet = Grid::new(2, 1, vec![0.0, 0.0]);
+        let t = score(&quiet, &quiet, 20.0);
+        assert_eq!(t.pod(), None);
+        assert_eq!(t.far(), None);
+        assert_eq!(t.csi(), None);
+        assert_eq!(t.correct_negatives, 2);
+    }
+
+    #[test]
+    fn merge_accumulates() {
+        let mut a = Contingency {
+            hits: 1,
+            misses: 2,
+            false_alarms: 3,
+            correct_negatives: 4,
+        };
+        a.merge(&a.clone());
+        assert_eq!(a.hits, 2);
+        assert_eq!(a.misses, 4);
+        assert_eq!(a.false_alarms, 6);
+        assert_eq!(a.correct_negatives, 8);
+    }
+}


### PR DESCRIPTION
Phase 0 of the radar nowcasting epic #519. Closes #520.

## What

New crate `crates/engine-nowcast` — the pure extrapolation core, **zero dependencies**, no engine traits yet (those are phase 1, #522):

- **`motion`** — block cross-correlation (SAD) between consecutive frames: vectors only from blocks with real echo (stationary clutter and empty sky can't anchor the field), robust median/MAD outlier rejection, neighbour fill + box smoothing, bilinear per-pixel sampling. Two-stage (coarse+refine) search.
- **`advect`** — semi-Lagrangian backward advection: trajectory integrated in substeps through the field, then **one nearest-neighbour sample** of the analysis frame — deliberately not bilinear, so sparse far-range echoes survive (the #456 lesson). Inflow boundary becomes nodata; nodata never becomes echo.
- **`skill`** — nodata-aware contingency table with POD/FAR/CSI.
- **`examples/skill_spike`** — hindcast harness: loads a GeoTIFF composite sequence through the public `GeoTiffEngine` (the same decode path phase 1 will consume via `Arc<dyn MapEngine>`), estimates motion from each consecutive pair, extrapolates across all available leads, and prints nowcast-vs-persistence skill.

9 unit tests pin: translation recovery within 1 px, identity advection (bitwise), inflow-nodata behaviour, extrapolation-beats-persistence on synthetic motion, and exact contingency/score math.

## Gate result — PASS

Hindcast on a **25-frame live SMHI Sweden composite** (2026-07-20 20:50–22:50Z, 5-min cadence, real widespread precipitation; gain 0.4 / offset −30 / nodata 255 per SMHI's README):

| lead | CSI 20 dBZ nowcast | CSI 20 dBZ persistence | rel. gain |
|---|---|---|---|
| +5 min | **0.676** | 0.623 | +9% |
| +15 min | **0.556** | 0.449 | +24% |
| +30 min | **0.448** | 0.346 | +29% |
| +60 min | **0.339** | 0.273 | +24% |
| +115 min | **0.263** | 0.210 | +25% |

Same picture at 10 dBZ; at 35 dBZ the nowcast wins through ~+55 min, beyond which pure advection can't track convective core growth/decay (known limitation, phase-4 territory). The skill margin **grows with lead**, which is exactly the signature of real motion skill rather than noise.

Cost on a 1006×671 grid (release, M-series laptop): motion ~25 ms per generation, advection ~30 ms per lead frame — a full 24-frame generation lands well under 1 s, comfortably inside the phase-1 poll-loop budget.

## Findings for later phases

- `engine-geotiff` **silently drops** files it can't use during the catalog scan — the spike burned significant time on live SMHI files that are strip-organized (not tiled) and in SWEREF99; the catalog just came back empty with no diagnostic in the example (tracing warnings exist but need a subscriber). The strip-support gap is the old backlog idea; worth a visibility improvement regardless.
- Live-fixture recipe (also in the phase-0 issue): SMHI day-zip → `gdalwarp -srcnodata 255 -dstnodata 255 -t_srs EPSG:4326 -co TILED=YES -co COMPRESS=DEFLATE`. Forgetting `-srcnodata` clamps the out-of-coverage ring 255→254 = fake 71.6 dBZ everywhere, which inflates CSI to ~0.99 and invalidates the whole comparison.

🤖 Generated with [Claude Code](https://claude.com/claude-code)