### PR TITLE
feat(engine-nowcast): phase-1 derived-collection engine — WMS/Maps/Tiles serving

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,8 +31,8 @@ of these crates, read its file — it holds that crate's rules and gotchas:
   resampling, storm cells.
 - `crates/engine-geotiff/CLAUDE.md`, `crates/engine-grib/CLAUDE.md`,
   `crates/engine-querydata/CLAUDE.md`, `crates/engine-zarr/CLAUDE.md`,
-  `crates/engine-cap/CLAUDE.md`, `crates/engine-postgis/CLAUDE.md` — one file
-  per engine.
+  `crates/engine-cap/CLAUDE.md`, `crates/engine-postgis/CLAUDE.md`,
+  `crates/engine-nowcast/CLAUDE.md` — one file per engine.
 
 This root file holds only workspace-wide rules.
 
@@ -323,6 +323,7 @@ they were found. Critical Rules 5–7, 9 and 10 above are part of this set.
 | ODIM PVOL | `EdrEngine` + `MapEngine` + `VolumeEngine` (per-site views) + `FeatureEngine` (network engine) | EDR (position, locations, area, trajectory), WMS, Maps, Tiles, 3D Tiles, Features (site inventory) |
 | QueryData | `EdrEngine` + `MapEngine` | EDR (position only), WMS, Maps, Tiles |
 | Zarr | `EdrEngine` + `MapEngine` | EDR (position), WMS, Maps, Tiles; local + S3/HTTP |
+| Nowcast | `MapEngine` (derived: wraps another collection's engine) | WMS, Maps, Tiles — motion-extrapolated frames with future TIME values (EDR + instances = phase 2, #523) |
 | PostGIS | `EdrEngine` + `FeatureEngine` + `MapEngine` (events shape only) | EDR (position, locations, area), Features; events shape: EDR (area) + WMS/Maps/Tiles (age-colored strike layer) |
 
 ## Config Format
@@ -389,6 +390,22 @@ style_bundle = "radar_multi"
 # NOT constrain the underlying engine.
 [collections.preview]
 time_window = "PT12H"
+
+# Derived nowcast collection (#519): motion-extrapolates another collection's
+# frames into the future. `source` must be a non-derived collection in the
+# same config with wms/maps/tiles enabled.
+[[collections]]
+id = "radar-nowcast"
+engine_type = "nowcast"
+apis = ["wms", "maps", "tiles"]
+
+[collections.nowcast]
+source = "radar"        # collection id to extrapolate
+horizon = "PT2H"        # how far into the future (default PT2H)
+# step = "PT5M"         # timestep spacing (default: source cadence)
+
+[collections.wms]
+colormap = "radar_dbz"
 ```
 
 See config struct definitions in each engine crate and `ds-core/src/config.rs`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1196,9 +1196,12 @@ dependencies = [
 name = "engine-nowcast"
 version = "0.1.0"
 dependencies = [
+ "arc-swap",
  "chrono",
  "ds-core",
  "engine-geotiff",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -4063,6 +4066,7 @@ dependencies = [
  "engine-geojson",
  "engine-geotiff",
  "engine-grib",
+ "engine-nowcast",
  "engine-odim",
  "engine-postgis",
  "engine-querydata",

--- a/crates/api-edr/tests/instances_tests.rs
+++ b/crates/api-edr/tests/instances_tests.rs
@@ -217,6 +217,7 @@ fn config(id: &str, engine_type: &str) -> CollectionConfig {
         odim: None,
         cap: None,
         postgis: None,
+        nowcast: None,
         preview: None,
     }
 }

--- a/crates/api-edr/tests/ogc_edr_api_tests.rs
+++ b/crates/api-edr/tests/ogc_edr_api_tests.rs
@@ -203,6 +203,7 @@ fn make_edr_state(engine: Arc<dyn EdrEngine>) -> Arc<ArcSwap<EdrState>> {
             odim: None,
             cap: None,
             postgis: None,
+            nowcast: None,
             preview: None,
         },
     );
@@ -1478,6 +1479,7 @@ mod metadata_extras {
                 odim: None,
                 cap: None,
                 postgis: None,
+                nowcast: None,
                 preview: None,
             },
         );

--- a/crates/api-edr/tests/performance_tests.rs
+++ b/crates/api-edr/tests/performance_tests.rs
@@ -176,6 +176,7 @@ fn make_edr_state(engine: Arc<dyn EdrEngine>) -> Arc<ArcSwap<EdrState>> {
             odim: None,
             cap: None,
             postgis: None,
+            nowcast: None,
             preview: None,
         },
     );

--- a/crates/api-edr/tests/png_plot_tests.rs
+++ b/crates/api-edr/tests/png_plot_tests.rs
@@ -170,6 +170,7 @@ fn router_with(engine: Arc<dyn EdrEngine>) -> axum::Router {
             odim: None,
             cap: None,
             postgis: None,
+            nowcast: None,
             preview: None,
         },
     );

--- a/crates/api-edr/tests/security_tests.rs
+++ b/crates/api-edr/tests/security_tests.rs
@@ -116,6 +116,7 @@ fn make_edr_state(engine: Arc<dyn EdrEngine>) -> Arc<ArcSwap<EdrState>> {
             odim: None,
             cap: None,
             postgis: None,
+            nowcast: None,
             preview: None,
         },
     );

--- a/crates/api-edr/tests/spec_compliance_tests.rs
+++ b/crates/api-edr/tests/spec_compliance_tests.rs
@@ -131,6 +131,7 @@ fn make_edr_state(engine: Arc<dyn EdrEngine>) -> Arc<ArcSwap<EdrState>> {
             odim: None,
             cap: None,
             postgis: None,
+            nowcast: None,
             preview: None,
         },
     );

--- a/crates/api-features/tests/ogc_features_api_tests.rs
+++ b/crates/api-features/tests/ogc_features_api_tests.rs
@@ -150,6 +150,7 @@ fn build_router() -> axum::Router {
             odim: None,
             cap: None,
             postgis: None,
+            nowcast: None,
             preview: None,
         },
     );
@@ -448,6 +449,7 @@ mod vector_tile_discovery {
                 odim: None,
                 cap: None,
                 postgis: None,
+                nowcast: None,
                 preview: None,
             },
         );
@@ -916,6 +918,7 @@ mod metadata_extras {
                 odim: None,
                 cap: None,
                 postgis: None,
+                nowcast: None,
                 preview: None,
             },
         );

--- a/crates/api-maps/src/handlers.rs
+++ b/crates/api-maps/src/handlers.rs
@@ -1228,7 +1228,13 @@ async fn render_map(
                     );
                     MapsError::BadRequest(e.to_string())
                 }
-                DSE::CollectionNotFound(_) | DSE::LocationNotFound(_) => {
+                // ReferenceTimeNotFound is documented to map to 404 (EDR
+                // already does); reachable here when a pinned run is pruned
+                // between resolution and render — routine for nowcast
+                // generations (#522), not an internal error.
+                DSE::CollectionNotFound(_)
+                | DSE::LocationNotFound(_)
+                | DSE::ReferenceTimeNotFound(_) => {
                     tracing::debug!(
                         "Maps render not-found for collection '{}': {e}",
                         collection_id

--- a/crates/api-maps/tests/integration.rs
+++ b/crates/api-maps/tests/integration.rs
@@ -140,6 +140,7 @@ fn build_router_with_engine(engine: Arc<dyn MapEngine>) -> axum::Router {
             odim: None,
             cap: None,
             postgis: None,
+            nowcast: None,
             preview: None,
         },
     );
@@ -199,6 +200,7 @@ fn build_router_with_apis(apis: Vec<String>) -> axum::Router {
             odim: None,
             cap: None,
             postgis: None,
+            nowcast: None,
             preview: None,
         },
     );
@@ -307,6 +309,7 @@ async fn fetch_collection_json(engine: Arc<dyn MapEngine>, id: &str, apis: Vec<S
             odim: None,
             cap: None,
             postgis: None,
+            nowcast: None,
             preview: None,
         },
     );
@@ -354,6 +357,7 @@ fn router_with(
             odim: None,
             cap: None,
             postgis: None,
+            nowcast: None,
             preview: None,
         },
     );
@@ -1269,6 +1273,7 @@ fn build_empty_router() -> axum::Router {
             odim: None,
             cap: None,
             postgis: None,
+            nowcast: None,
             preview: None,
         },
     );
@@ -1387,6 +1392,7 @@ fn build_multi_param_router() -> axum::Router {
             odim: None,
             cap: None,
             postgis: None,
+            nowcast: None,
             preview: None,
         },
     );
@@ -1831,6 +1837,7 @@ mod searchable {
                     odim: None,
                     cap: None,
                     postgis: None,
+                    nowcast: None,
                     preview: None,
                 },
             );

--- a/crates/api-tiles/src/handlers.rs
+++ b/crates/api-tiles/src/handlers.rs
@@ -1558,7 +1558,12 @@ async fn render_tile(
                 );
                 TilesError::BadRequest(e.to_string())
             }
-            DSE::CollectionNotFound(_) | DSE::LocationNotFound(_) => {
+            // ReferenceTimeNotFound is documented to map to 404 (EDR already
+            // does); reachable when a pinned run is pruned between resolution
+            // and render — routine for nowcast generations (#522).
+            DSE::CollectionNotFound(_)
+            | DSE::LocationNotFound(_)
+            | DSE::ReferenceTimeNotFound(_) => {
                 tracing::debug!(
                     "Tiles render not-found for collection '{}': {e}",
                     collection_id

--- a/crates/api-tiles/tests/integration.rs
+++ b/crates/api-tiles/tests/integration.rs
@@ -137,6 +137,7 @@ fn build_router() -> axum::Router {
             odim: None,
             cap: None,
             postgis: None,
+            nowcast: None,
             preview: None,
         },
     );
@@ -216,6 +217,7 @@ fn build_router_with_engine(engine: Arc<dyn MapEngine>) -> axum::Router {
             odim: None,
             cap: None,
             postgis: None,
+            nowcast: None,
             preview: None,
         },
     );
@@ -1036,6 +1038,7 @@ fn build_empty_router() -> axum::Router {
             odim: None,
             cap: None,
             postgis: None,
+            nowcast: None,
             preview: None,
         },
     );
@@ -1157,6 +1160,7 @@ fn build_multi_param_router() -> axum::Router {
             odim: None,
             cap: None,
             postgis: None,
+            nowcast: None,
             preview: None,
         },
     );
@@ -1376,6 +1380,7 @@ mod mvt {
                 odim: None,
                 cap: None,
                 postgis: None,
+                nowcast: None,
                 preview: None,
             },
         );
@@ -1464,6 +1469,7 @@ mod mvt {
                 odim: None,
                 cap: None,
                 postgis: None,
+                nowcast: None,
                 preview: None,
             },
         );
@@ -1778,6 +1784,7 @@ mod temporal_grid_jitter {
                 odim: None,
                 cap: None,
                 postgis: None,
+                nowcast: None,
                 preview: None,
             },
         );
@@ -1949,6 +1956,7 @@ mod metadata_extras {
                 odim: None,
                 cap: None,
                 postgis: None,
+                nowcast: None,
                 preview: None,
             },
         );

--- a/crates/api-wms/tests/integration.rs
+++ b/crates/api-wms/tests/integration.rs
@@ -93,6 +93,7 @@ fn build_empty_router() -> axum::Router {
             odim: None,
             cap: None,
             postgis: None,
+            nowcast: None,
             preview: None,
         },
     );
@@ -268,6 +269,7 @@ fn build_failing_router() -> axum::Router {
             odim: None,
             cap: None,
             postgis: None,
+            nowcast: None,
             preview: None,
         },
     );
@@ -416,6 +418,7 @@ fn build_populated_router() -> axum::Router {
             odim: None,
             cap: None,
             postgis: None,
+            nowcast: None,
             preview: None,
         },
     );
@@ -781,6 +784,7 @@ fn build_counting_router(
             odim: None,
             cap: None,
             postgis: None,
+            nowcast: None,
             preview: None,
         },
     );
@@ -956,6 +960,7 @@ fn build_snapping_router(initial_times: &[&str]) -> SnappingRouter {
             odim: None,
             cap: None,
             postgis: None,
+            nowcast: None,
             preview: None,
         },
     );
@@ -1206,6 +1211,7 @@ fn site_collection_config(id: &str) -> CollectionConfig {
         odim: None,
         cap: None,
         postgis: None,
+        nowcast: None,
         preview: None,
     }
 }
@@ -1341,6 +1347,7 @@ fn capabilities_single_param_layer_emits_keywords_and_attribution() {
             odim: None,
             cap: None,
             postgis: None,
+            nowcast: None,
             preview: None,
         },
     );
@@ -1492,6 +1499,7 @@ fn build_forecast_router_with_engine(engine: Arc<dyn MapEngine>) -> axum::Router
             odim: None,
             cap: None,
             postgis: None,
+            nowcast: None,
             preview: None,
         },
     );
@@ -1565,6 +1573,7 @@ fn capabilities_emit_reference_time_dimension_for_forecast() {
             odim: None,
             cap: None,
             postgis: None,
+            nowcast: None,
             preview: None,
         },
     );
@@ -1627,6 +1636,7 @@ fn capabilities_omit_reference_time_dimension_for_non_forecast() {
             odim: None,
             cap: None,
             postgis: None,
+            nowcast: None,
             preview: None,
         },
     );
@@ -1949,6 +1959,7 @@ fn build_run_swap_router(initial_runs: &[&str]) -> RunSwapRouter {
             odim: None,
             cap: None,
             postgis: None,
+            nowcast: None,
             preview: None,
         },
     );
@@ -2131,6 +2142,7 @@ fn build_advancing_router() -> AdvancingFixture {
             odim: None,
             cap: None,
             postgis: None,
+            nowcast: None,
             preview: None,
         },
     );

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -173,8 +173,72 @@ pub struct CollectionConfig {
     pub wms: Option<WmsConfig>,
     /// PostGIS-specific configuration. Required when engine_type = "postgis".
     pub postgis: Option<PostgisConfig>,
+    /// Nowcast derived-collection configuration. Required when
+    /// engine_type = "nowcast".
+    pub nowcast: Option<NowcastConfig>,
     /// Preview-SPA-specific tuning (e.g. bound the time slider). Optional.
     pub preview: Option<PreviewConfig>,
+}
+
+/// Configuration for the nowcast derived-collection engine (#522): wraps an
+/// already-configured raster collection and serves motion-extrapolated
+/// frames with TIME values in the future.
+#[derive(Debug, Clone, Deserialize)]
+pub struct NowcastConfig {
+    /// Collection id of the raster collection to extrapolate. Must be a
+    /// non-derived collection defined in the same config (load order is
+    /// two-pass: base engines first, then nowcast engines).
+    pub source: String,
+    /// How far to extrapolate, ISO 8601 duration (default 2 hours).
+    #[serde(default = "default_nowcast_horizon")]
+    pub horizon: String,
+    /// Spacing of the extrapolated timesteps, ISO 8601 duration. Default:
+    /// the source's own frame cadence.
+    #[serde(default)]
+    pub step: Option<String>,
+    /// Source frames fetched per generation (motion uses the last pair;
+    /// extras are reserved for cross-generation smoothing, #524).
+    #[serde(default = "default_nowcast_history_frames")]
+    pub history_frames: usize,
+    /// How often to check the source for a new frame (seconds).
+    #[serde(default = "default_nowcast_poll_interval")]
+    pub poll_interval_secs: u64,
+    /// Generations retained for `reference_time` pinning / EDR instances.
+    #[serde(default = "default_nowcast_max_generations")]
+    pub max_generations: usize,
+    /// Pixel budget for the working grid; the source's native grid is halved
+    /// until it fits (bounds memory and generation cost).
+    #[serde(default = "default_nowcast_max_pixels")]
+    pub max_pixels: usize,
+    /// Echo threshold (physical units, e.g. dBZ) below which a block yields
+    /// no motion vector — keeps clutter and empty sky from anchoring the
+    /// field.
+    #[serde(default = "default_nowcast_min_echo")]
+    pub min_echo: f64,
+}
+
+fn default_nowcast_horizon() -> String {
+    "PT2H".to_string()
+}
+
+fn default_nowcast_history_frames() -> usize {
+    3
+}
+
+fn default_nowcast_poll_interval() -> u64 {
+    30
+}
+
+fn default_nowcast_max_generations() -> usize {
+    6
+}
+
+fn default_nowcast_max_pixels() -> usize {
+    4_000_000
+}
+
+fn default_nowcast_min_echo() -> f64 {
+    10.0
 }
 
 /// License metadata for a collection's data.

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -2108,6 +2108,31 @@ impl ServerConfig {
                 }
             }
 
+            // Nowcast engine requires nowcast config section (and vice versa).
+            if collection.engine_type == "nowcast" && collection.nowcast.is_none() {
+                return Err(crate::error::DataServerError::Config(format!(
+                    "Collection '{id}': engine_type 'nowcast' requires a [collections.nowcast] config section"
+                )));
+            }
+            if collection.nowcast.is_some() && collection.engine_type != "nowcast" {
+                return Err(crate::error::DataServerError::Config(format!(
+                    "Collection '{id}': [collections.nowcast] is set but engine_type is '{}'",
+                    collection.engine_type
+                )));
+            }
+            if let Some(nowcast) = &collection.nowcast {
+                if nowcast.source.trim().is_empty() {
+                    return Err(crate::error::DataServerError::Config(format!(
+                        "Collection '{id}': [collections.nowcast].source must be a collection id"
+                    )));
+                }
+                if nowcast.source == collection.id {
+                    return Err(crate::error::DataServerError::Config(format!(
+                        "Collection '{id}': nowcast source cannot be the collection itself"
+                    )));
+                }
+            }
+
             // Zarr engine requires zarr config section.
             if collection.engine_type == "zarr" && collection.zarr.is_none() {
                 return Err(crate::error::DataServerError::Config(format!(
@@ -2778,6 +2803,30 @@ url = "https://creativecommons.org/licenses/by/4.0/"
         assert!(dotdot.validate().is_err());
         // A normal relative sub-path is fine.
         let ok = zarr_collection("data_path = \"x\"\npath = \"sub/data.zarr\"\n");
+        assert!(ok.validate().is_ok());
+    }
+
+    #[test]
+    fn validate_nowcast_config_pairing() {
+        // engine_type nowcast requires the section…
+        let missing = collection_with("engine_type = \"nowcast\"\n");
+        assert!(missing.validate().is_err());
+        // …and the section requires the engine type.
+        let mismatched = collection_with(
+            "engine_type = \"csv\"\ndata_path = \"x.csv\"\n[collections.nowcast]\nsource = \"radar\"\n",
+        );
+        assert!(mismatched.validate().is_err());
+        // Self-referential and empty sources are rejected.
+        let self_ref =
+            collection_with("engine_type = \"nowcast\"\n[collections.nowcast]\nsource = \"c\"\n");
+        assert!(self_ref.validate().is_err());
+        let empty =
+            collection_with("engine_type = \"nowcast\"\n[collections.nowcast]\nsource = \" \"\n");
+        assert!(empty.validate().is_err());
+        // A well-formed pair passes.
+        let ok = collection_with(
+            "engine_type = \"nowcast\"\n[collections.nowcast]\nsource = \"radar\"\n",
+        );
         assert!(ok.validate().is_ok());
     }
 

--- a/crates/engine-nowcast/CLAUDE.md
+++ b/crates/engine-nowcast/CLAUDE.md
@@ -1,0 +1,62 @@
+# engine-nowcast crate — Claude Instructions
+
+Radar nowcasting: motion-extrapolated frames from another collection's
+raster data, served with TIME values in the future (epic #519). Read the
+root `CLAUDE.md` first — Critical Rules 5–7 apply, and this engine is the
+reason `MapEngine::resolve_reference_time` exists (#521).
+
+## Architecture: a DERIVED collection
+
+- The engine wraps an `Arc<dyn MapEngine>` of its **source** collection
+  (`[collections.nowcast] source = "<id>"`). `server/src/admin.rs` wires it
+  in a **second pass** after all base engines exist; nowcast-of-nowcast is
+  rejected at load. The source must have at least one of wms/maps/tiles in
+  its `apis` (that's the registry the lookup snapshots).
+- Poll loop (background runtime, both boot and reload paths — #442 lesson)
+  watches the source's `raster_info().times`; each new latest frame triggers
+  a **generation**: fetch the last frames at the source's native cell count
+  on a regular WGS84 grid, estimate motion, advect the analysis frame
+  `horizon` far at `step` spacing (default: source cadence).
+- The algorithm modules (`motion`, `advect`, `skill`) are dependency-free
+  pure functions — keep them that way; the engine module owns all I/O and
+  state. `examples/skill_spike.rs` is the phase-0 hindcast harness
+  (extrapolation must beat persistence; see #520 for the gate results).
+
+## Cache-correctness contracts (do not weaken)
+
+- **Every generation is a model run** (`reference_time` = the source anchor
+  frame). `RasterInfo.reference_times` is populated and
+  `resolve_reference_time` is overridden — this is LOAD-BEARING: the no-TTL
+  rendered/meta caches key the run axis on it, and a nowcast rewrites all
+  future valid times every ~5 minutes (#521).
+- `resolve_time`, `resolve_reference_time`, and `get_raster_tile` share
+  `select_generation` + `select_time` (#507/#521 — one selection
+  implementation, cannot drift).
+
+## Rendering & storage
+
+- Internal frames live on a **regular WGS84 grid** (source native cell
+  count, halved to fit `max_pixels`, default 4 Mpx), so the output→source
+  map is affine; Projected output goes through `ProjectionGrid` +
+  `footprint_pixel_window` exactly like engine-zarr. Sampling is
+  nearest-neighbour (raw values; discrete radar palettes + PNG8 survive).
+- A `RasterValues::U8` source with a nodata byte stays raw bytes end to end
+  (1 B/px; `advect_u8` moves bytes); anything else falls back to f32
+  (4 B/px — the FMI S3 COG path lands here until #475-style typed paths).
+- Motion is estimated on a coarsened grid sized so the physical search
+  window (40 m/s × source interval) fits ~24 px, then the field is scaled
+  back — deliberate scale handling; do NOT rely on the pixel budget to do
+  this implicitly.
+
+## Gotchas
+
+- Advection is Lagrangian persistence: no growth/decay; 35+ dBZ convective
+  cores lose skill beyond ~1 h (phase-4 territory). Inflow boundaries
+  become nodata — never echo.
+- A TIME-less request resolves to `times.last()` = the FURTHEST forecast
+  (API-layer convention). Clients should send explicit TIME; /preview does.
+- `min_echo` is in the source's physical display units (dBZ for radar
+  composites). A unit-converted source (e.g. K) needs it overridden.
+- Config: `horizon` (default PT2H), `step` (default source cadence),
+  `history_frames` ≥ 2, `poll_interval_secs` (30), `max_generations` (6),
+  `max_pixels` (4 M), `min_echo` (10.0).

--- a/crates/engine-nowcast/CLAUDE.md
+++ b/crates/engine-nowcast/CLAUDE.md
@@ -48,6 +48,17 @@ reason `MapEngine::resolve_reference_time` exists (#521).
   back — deliberate scale handling; do NOT rely on the pixel budget to do
   this implicitly.
 
+## Memory sizing (retention multiplies!)
+
+Resident bytes ≈ `max_pixels × (leads + 1) × max_generations × bytes/px`
+(1 B/px for the U8 path, 4 B/px for the f32 fallback). At the defaults
+(4 Mpx, 24 leads, 6 generations) that is ~600 MB per U8 collection and
+~2.4 GB for an f32-fallback source — PVOL-max_files territory (#493).
+Until phase 2 (#523) makes deep retention useful (EDR `/instances`; today
+only an explicit `DIM_REFERENCE_TIME` pin reads old generations), set
+`max_generations = 2` in production configs. A generation-thinning
+follow-up (full frames only for the latest generation) is scoped in #523.
+
 ## Gotchas
 
 - Advection is Lagrangian persistence: no growth/decay; 35+ dBZ convective

--- a/crates/engine-nowcast/Cargo.toml
+++ b/crates/engine-nowcast/Cargo.toml
@@ -4,11 +4,16 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+# The algorithm modules (motion/advect/skill) are dependency-free pure
+# functions; these dependencies serve only the engine module (#522).
+ds-core = { path = "../core" }
+chrono = "0.4"
+arc-swap = "1"
+tokio = { version = "1", features = ["rt", "sync", "time", "macros"] }
+tracing = "0.1"
 
 [dev-dependencies]
-# Phase-0 skill spike only (#520): the example loads fixture composites through
-# the public GeoTiffEngine — the same decode path phase 1 consumes via
-# Arc<dyn MapEngine>. The library itself stays dependency-free.
-ds-core = { path = "../core" }
+# Phase-0 skill spike (#520): the example loads fixture composites through
+# the public GeoTiffEngine — the same decode path the engine consumes via
+# Arc<dyn MapEngine>.
 engine-geotiff = { path = "../engine-geotiff" }
-chrono = "0.4"

--- a/crates/engine-nowcast/src/advect.rs
+++ b/crates/engine-nowcast/src/advect.rs
@@ -11,17 +11,22 @@
 use crate::motion::MotionField;
 use crate::Grid;
 
-/// Extrapolate `frame` forward by `lead` frame intervals.
-///
-/// `substeps` is the number of trajectory-integration steps per interval;
-/// values around 4 track spatially varying fields well. `lead` may be
-/// fractional.
-pub fn advect(frame: &Grid, field: &MotionField, lead: f32, substeps: usize) -> Grid {
+/// Walk every output pixel's backward trajectory and hand the caller the
+/// source-pixel index it departs from (`None` when the trajectory leaves the
+/// domain). Shared core for the `f32` and raw-`u8` advection variants so
+/// their trajectory math cannot drift apart.
+fn for_each_departure(
+    width: usize,
+    height: usize,
+    field: &MotionField,
+    lead: f32,
+    substeps: usize,
+    mut emit: impl FnMut(usize, Option<usize>),
+) {
     let steps = ((lead * substeps.max(1) as f32).ceil() as usize).max(1);
     let h = lead / steps as f32;
-    let mut out = Grid::filled_nodata(frame.width, frame.height);
-    for y in 0..frame.height {
-        for x in 0..frame.width {
+    for y in 0..height {
+        for x in 0..width {
             let mut px = x as f32 + 0.5;
             let mut py = y as f32 + 0.5;
             for _ in 0..steps {
@@ -29,12 +34,57 @@ pub fn advect(frame: &Grid, field: &MotionField, lead: f32, substeps: usize) -> 
                 px -= u * h;
                 py -= v * h;
             }
-            if px < 0.0 || py < 0.0 || px >= frame.width as f32 || py >= frame.height as f32 {
-                continue; // departure outside the domain: stays nodata
-            }
-            out.data[y * frame.width + x] = frame.at(px as usize, py as usize);
+            let src = if px < 0.0 || py < 0.0 || px >= width as f32 || py >= height as f32 {
+                None // departure outside the domain: inflow boundary
+            } else {
+                Some(py as usize * width + px as usize)
+            };
+            emit(y * width + x, src);
         }
     }
+}
+
+/// Extrapolate `frame` forward by `lead` frame intervals.
+///
+/// `substeps` is the number of trajectory-integration steps per interval;
+/// values around 4 track spatially varying fields well. `lead` may be
+/// fractional.
+pub fn advect(frame: &Grid, field: &MotionField, lead: f32, substeps: usize) -> Grid {
+    let mut out = Grid::filled_nodata(frame.width, frame.height);
+    for_each_departure(
+        frame.width,
+        frame.height,
+        field,
+        lead,
+        substeps,
+        |dst, src| {
+            if let Some(src) = src {
+                out.data[dst] = frame.data[src];
+            }
+        },
+    );
+    out
+}
+
+/// Raw-byte advection: extrapolate an 8-bit frame without decoding it, so a
+/// `RasterValues::U8`-shaped source stays 1 byte/pixel end to end. Inflow
+/// pixels get the `nodata` byte.
+pub fn advect_u8(
+    frame: &[u8],
+    width: usize,
+    height: usize,
+    nodata: u8,
+    field: &MotionField,
+    lead: f32,
+    substeps: usize,
+) -> Vec<u8> {
+    assert_eq!(frame.len(), width * height, "frame length must be w*h");
+    let mut out = vec![nodata; frame.len()];
+    for_each_departure(width, height, field, lead, substeps, |dst, src| {
+        if let Some(src) = src {
+            out[dst] = frame[src];
+        }
+    });
     out
 }
 
@@ -94,6 +144,30 @@ mod tests {
             nowcast > 0.9,
             "nowcast CSI {nowcast} should be near-perfect"
         );
+    }
+
+    /// The raw-u8 path must move exactly the same source pixels as the f32
+    /// path — they share `for_each_departure`, and this pins that contract.
+    #[test]
+    fn advect_u8_matches_f32_path_pixel_for_pixel() {
+        let t0 = disc_frame(120, 90, 50.0, 40.0, 9.0, 40.0);
+        let t1 = disc_frame(120, 90, 56.0, 36.0, 9.0, 40.0);
+        let field = estimate_motion(&t0, &t1, &MotionOptions::default());
+
+        // Encode t1 as raw u8: value 40.0 → raw 80 (gain 0.5), background 0,
+        // nodata byte 255.
+        let raw: Vec<u8> = t1
+            .data
+            .iter()
+            .map(|v| if v.is_nan() { 255 } else { (v * 2.0) as u8 })
+            .collect();
+
+        let f32_out = advect(&t1, &field, 1.0, 4);
+        let u8_out = advect_u8(&raw, 120, 90, 255, &field, 1.0, 4);
+        for (a, b) in f32_out.data.iter().zip(&u8_out) {
+            let expected = if a.is_nan() { 255 } else { (a * 2.0) as u8 };
+            assert_eq!(expected, *b, "u8 and f32 advection diverged");
+        }
     }
 
     #[test]

--- a/crates/engine-nowcast/src/engine.rs
+++ b/crates/engine-nowcast/src/engine.rs
@@ -376,9 +376,15 @@ impl NowcastEngine {
         // Working grid: the source's native cell counts, halved until the
         // pixel budget fits (FMI's 250 m composite lands at ~1 km here).
         let [mut w, mut h] = source_info.grid_size.unwrap_or([1024, 1024]);
-        while (w as usize) * (h as usize) > self.cfg.max_pixels && w > 64 && h > 64 {
-            w /= 2;
-            h /= 2;
+        // Halve the larger axis until the budget fits — guaranteed to
+        // terminate and to hold for any aspect ratio (a per-axis floor
+        // instead would let an elongated grid blow past the budget).
+        while (w as usize) * (h as usize) > self.cfg.max_pixels && w.max(h) > 1 {
+            if w >= h {
+                w = (w / 2).max(1);
+            } else {
+                h = (h / 2).max(1);
+            }
         }
         let geom = GridGeom {
             west: extent[0],

--- a/crates/engine-nowcast/src/engine.rs
+++ b/crates/engine-nowcast/src/engine.rs
@@ -361,10 +361,16 @@ impl NowcastEngine {
             source_info.times[n.saturating_sub(self.cfg.history_frames)..].to_vec();
         let prev_time = history[history.len() - 2];
         let interval = anchor - prev_time;
-        if interval <= Duration::zero() {
-            return Err(DataServerError::Engine(
-                "nowcast source times are not strictly ascending".into(),
-            ));
+        // Reject sub-second cadence too, not just non-ascending times:
+        // `num_seconds()` truncates, so a <1 s interval would evaluate to 0
+        // in the lead-interval division below — Infinity leads would explode
+        // `advect`'s substep count and wedge the poll runtime.
+        if interval < Duration::seconds(1) {
+            return Err(DataServerError::Engine(format!(
+                "nowcast source cadence must be at least 1 second and ascending \
+                 (got {} ms between {prev_time} and {anchor})",
+                interval.num_milliseconds()
+            )));
         }
 
         // Working grid: the source's native cell counts, halved until the
@@ -454,7 +460,10 @@ impl NowcastEngine {
         for i in 1..=k {
             let lead_time = anchor + step * (i as i32);
             let lead_intervals =
-                (step.num_seconds() as f64 * i as f64 / interval.num_seconds() as f64) as f32;
+                // `interval` ≥ 1 s is guaranteed by the cadence guard above;
+                // `.max(1)` keeps this division safe against future edits.
+                (step.num_seconds() as f64 * i as f64 / interval.num_seconds().max(1) as f64)
+                    as f32;
             let frame = match &frames[0] {
                 FrameData::U8 {
                     data,

--- a/crates/engine-nowcast/src/engine.rs
+++ b/crates/engine-nowcast/src/engine.rs
@@ -1,0 +1,775 @@
+//! The nowcast derived-collection engine (#522, epic #519).
+//!
+//! Wraps another collection's `MapEngine` (its "source"): a poll loop on the
+//! background runtime watches the source's timesteps, and each new source
+//! frame triggers a *generation* — fetch the last few frames on a regular
+//! WGS84 grid, estimate a motion field ([`crate::motion`]), and extrapolate
+//! the latest frame `horizon`-far into the future ([`crate::advect`]). The
+//! stored frames then serve through the normal `MapEngine` raster path, so
+//! WMS/Maps/Tiles animation and TIME dimensions work unchanged — with TIME
+//! values in the future.
+//!
+//! Contracts honoured here:
+//! - **#507**: `resolve_time` and `get_raster_tile` share the same
+//!   generation + timestep selection helpers, so the API-layer cache keys
+//!   can't drift from what is actually rendered.
+//! - **#521**: every generation is a model run (`reference_time` = the source
+//!   frame the extrapolation anchors on); `RasterInfo.reference_times` is
+//!   populated so the API layers key their no-TTL caches on the concrete
+//!   generation.
+//! - **Critical Rule 5**: output→source mapping goes through
+//!   `OutputCrs::project_node` / `ProjectionGrid` — the internal grid is a
+//!   regular WGS84 grid, so the source-pixel map is affine.
+//! - **Critical Rule 6/7**: `poll_loop` runs on the dedicated background
+//!   runtime; source fetches (which may do blocking storage I/O internally)
+//!   happen only there, never on a request worker.
+
+use std::collections::BTreeMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+use arc_swap::ArcSwap;
+use chrono::{DateTime, Duration, Utc};
+use tokio::sync::watch;
+
+use ds_core::config::NowcastConfig;
+use ds_core::datetime::parse_iso8601_duration;
+use ds_core::error::DataServerError;
+use ds_core::map_engine::{MapEngine, OutputCrs, RasterInfo, RasterTile, RasterValues};
+use ds_core::resample::ProjectionGrid;
+
+use crate::advect::advect_u8;
+use crate::motion::{estimate_motion, MotionOptions};
+use crate::Grid;
+
+/// Fastest cell motion the search window must cover (m/s). 40 m/s ≈ 144 km/h
+/// matches the cell-tracker gate in `ds_core::cells`.
+const MAX_SPEED_MS: f64 = 40.0;
+/// Target search radius (px) on the motion-estimation grid; frames are
+/// coarsened until the physical search window fits.
+const TARGET_SEARCH_PX: i32 = 24;
+/// Trajectory integration substeps per frame interval.
+const SUBSTEPS: usize = 4;
+/// Hard cap on extrapolated frames per generation.
+const MAX_LEADS: usize = 96;
+
+/// Parsed, validated engine configuration.
+struct EngineCfg {
+    horizon: Duration,
+    /// `None` ⇒ use the source cadence.
+    step: Option<Duration>,
+    history_frames: usize,
+    poll_interval: std::time::Duration,
+    max_generations: usize,
+    max_pixels: usize,
+    min_echo: f32,
+}
+
+/// The regular WGS84 grid every stored frame lives on.
+#[derive(Debug, Clone, Copy)]
+struct GridGeom {
+    west: f64,
+    south: f64,
+    east: f64,
+    north: f64,
+    width: u32,
+    height: u32,
+}
+
+impl GridGeom {
+    /// Unclamped fractional source pixel for a WGS84 position — may fall
+    /// outside `[0,w)×[0,h)` or be non-finite; callers bounds-check at sample
+    /// time (the `ProjectionGrid` contract). Affine — the grid is linear in
+    /// lon/lat by construction.
+    #[inline]
+    fn frac_px_unclamped(&self, lon: f64, lat: f64) -> (f64, f64) {
+        (
+            (lon - self.west) / (self.east - self.west) * self.width as f64,
+            (self.north - lat) / (self.north - self.south) * self.height as f64,
+        )
+    }
+
+    /// Bounds-checked source pixel for a WGS84 position; `None` outside.
+    #[inline]
+    fn frac_px(&self, lon: f64, lat: f64) -> Option<(f64, f64)> {
+        if !lon.is_finite() || !lat.is_finite() {
+            return None;
+        }
+        let (fx, fy) = self.frac_px_unclamped(lon, lat);
+        if fx < 0.0 || fy < 0.0 || fx >= self.width as f64 || fy >= self.height as f64 {
+            return None;
+        }
+        Some((fx, fy))
+    }
+}
+
+/// One stored frame: either raw bytes with decode parameters (preferred — 1
+/// byte/px end to end) or decoded f32 (sources that return boxed `F64`).
+enum FrameData {
+    U8 {
+        data: Vec<u8>,
+        nodata: u8,
+        gain: f64,
+        offset: f64,
+    },
+    F32(Vec<f32>),
+}
+
+/// One generation: the analysis frame plus extrapolated leads, anchored on a
+/// source frame (`reference_time`).
+struct Generation {
+    reference_time: DateTime<Utc>,
+    /// Valid times, ascending: `reference_time`, then the leads.
+    times: Vec<DateTime<Utc>>,
+    frames: Vec<FrameData>,
+    geom: GridGeom,
+}
+
+/// Atomically swapped engine state.
+struct NowcastState {
+    /// Retained generations keyed by reference time (the instances contract).
+    generations: BTreeMap<DateTime<Utc>, Arc<Generation>>,
+    /// Pre-built snapshot for the O(1) `raster_info()` contract.
+    info: RasterInfo,
+}
+
+pub struct NowcastEngine {
+    collection_id: String,
+    source_id: String,
+    source: Arc<dyn MapEngine>,
+    cfg: EngineCfg,
+    state: ArcSwap<NowcastState>,
+    shutdown_tx: watch::Sender<()>,
+    // Metrics (read by the server's /metrics handler).
+    generations_total: AtomicU64,
+    generation_failures_total: AtomicU64,
+    last_generation_ms: AtomicU64,
+    /// Seconds between the source anchor frame and the wall clock at the end
+    /// of the last generation (how far the nowcast lags reality).
+    source_lag_secs: AtomicU64,
+}
+
+impl NowcastEngine {
+    /// Build the engine around an already-constructed source engine. The
+    /// server wires this in a second pass after all base engines exist.
+    pub fn new(
+        collection_id: &str,
+        source_id: &str,
+        source: Arc<dyn MapEngine>,
+        config: &NowcastConfig,
+    ) -> Result<Self, DataServerError> {
+        let horizon = parse_iso8601_duration(&config.horizon)?;
+        if horizon <= Duration::zero() {
+            return Err(DataServerError::Config(
+                "nowcast horizon must be positive".into(),
+            ));
+        }
+        let step = match &config.step {
+            Some(s) => {
+                let d = parse_iso8601_duration(s)?;
+                if d <= Duration::zero() {
+                    return Err(DataServerError::Config(
+                        "nowcast step must be positive".into(),
+                    ));
+                }
+                Some(d)
+            }
+            None => None,
+        };
+        if config.history_frames < 2 {
+            return Err(DataServerError::Config(
+                "nowcast history_frames must be at least 2 (motion needs a frame pair)".into(),
+            ));
+        }
+
+        let (shutdown_tx, _) = watch::channel(());
+        let source_info = source.raster_info();
+        Ok(Self {
+            collection_id: collection_id.to_string(),
+            source_id: source_id.to_string(),
+            source,
+            cfg: EngineCfg {
+                horizon,
+                step,
+                history_frames: config.history_frames,
+                poll_interval: std::time::Duration::from_secs(config.poll_interval_secs.max(5)),
+                max_generations: config.max_generations.max(1),
+                max_pixels: config.max_pixels.clamp(65_536, 16_000_000),
+                min_echo: config.min_echo as f32,
+            },
+            state: ArcSwap::from_pointee(NowcastState {
+                generations: BTreeMap::new(),
+                info: empty_info(&source_info),
+            }),
+            shutdown_tx,
+            generations_total: AtomicU64::new(0),
+            generation_failures_total: AtomicU64::new(0),
+            last_generation_ms: AtomicU64::new(0),
+            source_lag_secs: AtomicU64::new(0),
+        })
+    }
+
+    pub fn collection_id(&self) -> &str {
+        &self.collection_id
+    }
+
+    pub fn source_id(&self) -> &str {
+        &self.source_id
+    }
+
+    /// True once at least one generation has been produced (health gate).
+    pub fn has_data(&self) -> bool {
+        !self.state.load().generations.is_empty()
+    }
+
+    /// Age of the latest generation's anchor frame (health `data_age_secs`).
+    pub fn catalog_age(&self) -> Option<chrono::Duration> {
+        let state = self.state.load();
+        let (&latest, _) = state.generations.iter().next_back()?;
+        Some(Utc::now() - latest)
+    }
+
+    /// (generations_total, failures_total, last_generation_ms, source_lag_secs,
+    /// retained_generations, frames_in_latest) — one snapshot for /metrics.
+    pub fn metrics(&self) -> (u64, u64, u64, u64, usize, usize) {
+        let state = self.state.load();
+        let frames = state
+            .generations
+            .iter()
+            .next_back()
+            .map(|(_, g)| g.frames.len())
+            .unwrap_or(0);
+        (
+            self.generations_total.load(Ordering::Relaxed),
+            self.generation_failures_total.load(Ordering::Relaxed),
+            self.last_generation_ms.load(Ordering::Relaxed),
+            self.source_lag_secs.load(Ordering::Relaxed),
+            state.generations.len(),
+            frames,
+        )
+    }
+
+    /// Signal the poll loop to exit (server reload/shutdown).
+    pub fn shutdown(&self) {
+        let _ = self.shutdown_tx.send(());
+    }
+
+    /// Poll the source for a new frame; spawn on the BACKGROUND runtime only.
+    pub async fn poll_loop(&self) {
+        let mut shutdown_rx = self.shutdown_tx.subscribe();
+        let mut ticker = tokio::time::interval(self.cfg.poll_interval);
+        // A generation can outlast the interval on big grids; don't replay
+        // missed ticks as a burst afterwards (#443 pattern).
+        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        loop {
+            tokio::select! {
+                biased;
+                _ = shutdown_rx.changed() => {
+                    tracing::info!("[{}] nowcast poll loop shutting down", self.collection_id);
+                    break;
+                }
+                _ = ticker.tick() => self.poll_once(),
+            }
+        }
+    }
+
+    /// One poll cycle: regenerate iff the source's latest frame moved.
+    /// Public so tests (and pre-warm paths) can drive generations without the
+    /// loop.
+    pub fn poll_once(&self) {
+        let source_info = self.source.raster_info();
+        let Some(&anchor) = source_info.times.last() else {
+            return; // source has no data yet
+        };
+        {
+            let state = self.state.load();
+            if state.generations.contains_key(&anchor) {
+                return; // already generated for this source frame
+            }
+        }
+        let started = std::time::Instant::now();
+        match self.generate(&source_info, anchor) {
+            Ok(generation) => {
+                let elapsed_ms = started.elapsed().as_millis() as u64;
+                let old = self.state.load();
+                let mut generations = old.generations.clone();
+                generations.insert(anchor, Arc::new(generation));
+                while generations.len() > self.cfg.max_generations {
+                    let oldest = *generations.keys().next().unwrap();
+                    generations.remove(&oldest);
+                }
+                let info = build_info(&source_info, &generations);
+                self.state
+                    .store(Arc::new(NowcastState { generations, info }));
+                self.generations_total.fetch_add(1, Ordering::Relaxed);
+                self.last_generation_ms.store(elapsed_ms, Ordering::Relaxed);
+                let lag = (Utc::now() - anchor).num_seconds().max(0) as u64;
+                self.source_lag_secs.store(lag, Ordering::Relaxed);
+                tracing::info!(
+                    "[{}] nowcast generation for {} in {}ms",
+                    self.collection_id,
+                    anchor,
+                    elapsed_ms
+                );
+            }
+            Err(e) => {
+                self.generation_failures_total
+                    .fetch_add(1, Ordering::Relaxed);
+                tracing::warn!(
+                    "[{}] nowcast generation for {} failed: {}",
+                    self.collection_id,
+                    anchor,
+                    e
+                );
+            }
+        }
+    }
+
+    /// Produce one generation anchored on `anchor` (the source's latest
+    /// frame). Runs on the background runtime.
+    fn generate(
+        &self,
+        source_info: &RasterInfo,
+        anchor: DateTime<Utc>,
+    ) -> Result<Generation, DataServerError> {
+        let extent = source_info.spatial_extent.ok_or_else(|| {
+            DataServerError::Engine("nowcast source reports no spatial extent".into())
+        })?;
+        let n = source_info.times.len();
+        if n < 2 {
+            return Err(DataServerError::Engine(
+                "nowcast needs at least 2 source frames for motion".into(),
+            ));
+        }
+        let history: Vec<DateTime<Utc>> =
+            source_info.times[n.saturating_sub(self.cfg.history_frames)..].to_vec();
+        let prev_time = history[history.len() - 2];
+        let interval = anchor - prev_time;
+        if interval <= Duration::zero() {
+            return Err(DataServerError::Engine(
+                "nowcast source times are not strictly ascending".into(),
+            ));
+        }
+
+        // Working grid: the source's native cell counts, halved until the
+        // pixel budget fits (FMI's 250 m composite lands at ~1 km here).
+        let [mut w, mut h] = source_info.grid_size.unwrap_or([1024, 1024]);
+        while (w as usize) * (h as usize) > self.cfg.max_pixels && w > 64 && h > 64 {
+            w /= 2;
+            h /= 2;
+        }
+        let geom = GridGeom {
+            west: extent[0],
+            south: extent[1],
+            east: extent[2],
+            north: extent[3],
+            width: w,
+            height: h,
+        };
+
+        // Fetch the anchor + previous frame on the working grid.
+        let prev = self.fetch_frame(&geom, prev_time)?;
+        let analysis = self.fetch_frame(&geom, anchor)?;
+        let prev_f32 = frame_to_grid(&prev, w as usize, h as usize);
+        let analysis_f32 = frame_to_grid(&analysis, w as usize, h as usize);
+
+        // Deliberate scale handling (not the phase-0 accident): estimate
+        // motion on a grid coarse enough that the physical search window
+        // (MAX_SPEED × interval) fits in TARGET_SEARCH_PX, then scale the
+        // field back to working-grid units.
+        let mid_lat = ((geom.south + geom.north) / 2.0).to_radians();
+        let px_meters =
+            ((geom.east - geom.west) * 111_320.0 * mid_lat.cos().abs().max(0.05)) / w as f64;
+        let max_shift_px = MAX_SPEED_MS * interval.num_seconds() as f64 / px_meters.max(1.0);
+        let mut factor = 1u32;
+        while max_shift_px / factor as f64 > TARGET_SEARCH_PX as f64
+            && (w / (factor * 2)) >= 128
+            && (h / (factor * 2)) >= 128
+        {
+            factor *= 2;
+        }
+        let search_radius =
+            ((max_shift_px / factor as f64).ceil() as i32).clamp(4, TARGET_SEARCH_PX * 2);
+        let opts = MotionOptions {
+            search_radius,
+            min_echo: self.cfg.min_echo,
+            ..MotionOptions::default()
+        };
+        // Vectors come out in pixels per source interval; the leads below are
+        // expressed in the same interval unit, so no time scaling is needed.
+        let field = if factor > 1 {
+            let prev_coarse = downsample(&prev_f32, factor as usize);
+            let analysis_coarse = downsample(&analysis_f32, factor as usize);
+            let mut f = estimate_motion(&prev_coarse, &analysis_coarse, &opts);
+            // Coarse-grid vectors/blocks → working-grid units.
+            f.block *= factor as usize;
+            for v in f.u.iter_mut().chain(f.v.iter_mut()) {
+                *v *= factor as f32;
+            }
+            f
+        } else {
+            estimate_motion(&prev_f32, &analysis_f32, &opts)
+        };
+
+        // Lead schedule.
+        let step = self.cfg.step.unwrap_or(interval);
+        let k = ((self.cfg.horizon.num_seconds() as f64 / step.num_seconds().max(1) as f64).ceil()
+            as usize)
+            .clamp(1, MAX_LEADS);
+
+        let mut times = Vec::with_capacity(k + 1);
+        let mut frames = Vec::with_capacity(k + 1);
+        times.push(anchor);
+        frames.push(analysis);
+        for i in 1..=k {
+            let lead_time = anchor + step * (i as i32);
+            let lead_intervals =
+                (step.num_seconds() as f64 * i as f64 / interval.num_seconds() as f64) as f32;
+            let frame = match &frames[0] {
+                FrameData::U8 {
+                    data,
+                    nodata,
+                    gain,
+                    offset,
+                } => FrameData::U8 {
+                    data: advect_u8(
+                        data,
+                        w as usize,
+                        h as usize,
+                        *nodata,
+                        &field,
+                        lead_intervals,
+                        SUBSTEPS,
+                    ),
+                    nodata: *nodata,
+                    gain: *gain,
+                    offset: *offset,
+                },
+                FrameData::F32(_) => {
+                    let advected =
+                        crate::advect::advect(&analysis_f32, &field, lead_intervals, SUBSTEPS);
+                    FrameData::F32(advected.data)
+                }
+            };
+            times.push(lead_time);
+            frames.push(frame);
+        }
+
+        Ok(Generation {
+            reference_time: anchor,
+            times,
+            frames,
+            geom,
+        })
+    }
+
+    /// Fetch one source frame on the working WGS84 grid.
+    fn fetch_frame(
+        &self,
+        geom: &GridGeom,
+        time: DateTime<Utc>,
+    ) -> Result<FrameData, DataServerError> {
+        let tile = self.source.get_raster_tile(
+            [geom.west, geom.south, geom.east, geom.north],
+            geom.width,
+            geom.height,
+            Some(time),
+            &OutputCrs::Wgs84,
+            None,
+            None,
+            None,
+        )?;
+        if (tile.width, tile.height) != (geom.width, geom.height) {
+            return Err(DataServerError::Engine(format!(
+                "nowcast source returned {}x{}, requested {}x{}",
+                tile.width, tile.height, geom.width, geom.height
+            )));
+        }
+        Ok(match tile.values {
+            // Keep the raw-byte form only when a nodata byte exists — the
+            // advected inflow boundary needs one to stay transparent.
+            RasterValues::U8 {
+                data,
+                nodata: Some(nodata),
+                gain,
+                offset,
+            } => FrameData::U8 {
+                data,
+                nodata,
+                gain,
+                offset,
+            },
+            RasterValues::U8 {
+                data,
+                nodata: None,
+                gain,
+                offset,
+            } => FrameData::F32(
+                data.into_iter()
+                    .map(|raw| (raw as f64 * gain + offset) as f32)
+                    .collect(),
+            ),
+            RasterValues::F64(values) => FrameData::F32(
+                values
+                    .into_iter()
+                    .map(|v| v.map(|x| x as f32).unwrap_or(f32::NAN))
+                    .collect(),
+            ),
+        })
+    }
+
+    /// Generation selection shared by `get_raster_tile` and `resolve_time`
+    /// (#521): `None` ⇒ latest, `Some` ⇒ exact.
+    fn select_generation(
+        state: &NowcastState,
+        reference_time: Option<DateTime<Utc>>,
+    ) -> Option<Arc<Generation>> {
+        match reference_time {
+            None => state.generations.iter().next_back().map(|(_, g)| g.clone()),
+            Some(rt) => state.generations.get(&rt).cloned(),
+        }
+    }
+
+    /// Timestep selection shared by `get_raster_tile` and `resolve_time`
+    /// (#507): latest-not-after, clamped to the first frame.
+    fn select_time(generation: &Generation, time: Option<DateTime<Utc>>) -> DateTime<Utc> {
+        match time {
+            None => *generation.times.last().expect("generation has frames"),
+            Some(t) => generation
+                .times
+                .iter()
+                .rev()
+                .find(|&&ts| ts <= t)
+                .copied()
+                .unwrap_or(generation.times[0]),
+        }
+    }
+}
+
+/// `RasterInfo` before the first generation: source geometry, no times.
+fn empty_info(source_info: &RasterInfo) -> RasterInfo {
+    RasterInfo {
+        native_crs: "CRS:84".into(),
+        spatial_extent: source_info.spatial_extent,
+        times: Vec::new(),
+        parameter: source_info.parameter.clone(),
+        unit: source_info.unit.clone(),
+        parameters: Vec::new(),
+        vertical: None,
+        grid_size: None,
+        layer_subtitle: None,
+        reference_times: Vec::new(),
+    }
+}
+
+/// Snapshot `RasterInfo` from the retained generations (O(1) to serve).
+fn build_info(
+    source_info: &RasterInfo,
+    generations: &BTreeMap<DateTime<Utc>, Arc<Generation>>,
+) -> RasterInfo {
+    let latest = generations.iter().next_back().map(|(_, g)| g);
+    RasterInfo {
+        native_crs: "CRS:84".into(),
+        spatial_extent: source_info.spatial_extent,
+        times: latest.map(|g| g.times.clone()).unwrap_or_default(),
+        parameter: source_info.parameter.clone(),
+        unit: source_info.unit.clone(),
+        parameters: Vec::new(),
+        vertical: None,
+        grid_size: latest.map(|g| [g.geom.width, g.geom.height]),
+        layer_subtitle: None,
+        // Ascending by BTreeMap order — the #521 cache-pinning contract.
+        reference_times: generations.keys().copied().collect(),
+    }
+}
+
+/// NaN-for-nodata f32 view of a stored frame (motion estimation input).
+fn frame_to_grid(frame: &FrameData, width: usize, height: usize) -> Grid {
+    let data: Vec<f32> = match frame {
+        FrameData::U8 {
+            data,
+            nodata,
+            gain,
+            offset,
+        } => data
+            .iter()
+            .map(|&raw| {
+                if raw == *nodata {
+                    f32::NAN
+                } else {
+                    (raw as f64 * *gain + *offset) as f32
+                }
+            })
+            .collect(),
+        FrameData::F32(values) => values.clone(),
+    };
+    Grid::new(width, height, data)
+}
+
+/// Nearest-neighbour 1/f downsample (motion estimation only — stored frames
+/// stay full resolution).
+fn downsample(grid: &Grid, factor: usize) -> Grid {
+    let w = (grid.width / factor).max(1);
+    let h = (grid.height / factor).max(1);
+    let mut data = Vec::with_capacity(w * h);
+    for y in 0..h {
+        for x in 0..w {
+            data.push(grid.at(x * factor, y * factor));
+        }
+    }
+    Grid::new(w, h, data)
+}
+
+impl MapEngine for NowcastEngine {
+    fn get_raster_tile(
+        &self,
+        bbox: [f64; 4],
+        width: u32,
+        height: u32,
+        time: Option<DateTime<Utc>>,
+        output_crs: &OutputCrs,
+        _parameter: Option<&str>,
+        _z: Option<f64>,
+        reference_time: Option<DateTime<Utc>>,
+    ) -> Result<RasterTile, DataServerError> {
+        let state = self.state.load();
+        let generation =
+            Self::select_generation(&state, reference_time).ok_or_else(
+                || match reference_time {
+                    Some(rt) => DataServerError::Engine(format!(
+                        "nowcast generation {rt} is no longer retained"
+                    )),
+                    None => DataServerError::Engine("nowcast has no generations yet".into()),
+                },
+            )?;
+        let resolved = Self::select_time(&generation, time);
+        let idx = generation
+            .times
+            .iter()
+            .position(|&t| t == resolved)
+            .expect("select_time returns a member of times");
+        let frame = &generation.frames[idx];
+        let geom = generation.geom;
+        let n = (width as usize) * (height as usize);
+
+        // Output→source mapping. The internal grid is linear in lon/lat, so
+        // `frac_px` is affine; Wgs84/WebMercator nodes are cheap to project
+        // per pixel, while a projected CRS goes through the coarse
+        // `ProjectionGrid` (Critical Rule 5), mirroring engine-zarr.
+        let src_index = |lon: f64, lat: f64| -> Option<usize> {
+            geom.frac_px(lon, lat)
+                .map(|(fx, fy)| fy as usize * geom.width as usize + fx as usize)
+        };
+        let mut indices: Vec<Option<usize>> = Vec::with_capacity(n);
+        match output_crs {
+            OutputCrs::Wgs84 | OutputCrs::WebMercator => {
+                for row in 0..height {
+                    let fy = (row as f64 + 0.5) / height as f64;
+                    for col in 0..width {
+                        let fx = (col as f64 + 0.5) / width as f64;
+                        let (lon, lat) = output_crs.project_node(bbox, fx, fy);
+                        indices.push(src_index(lon, lat));
+                    }
+                }
+            }
+            OutputCrs::Projected { .. } => {
+                let grid = ProjectionGrid::build_2d(
+                    width,
+                    height,
+                    geom.width,
+                    geom.height,
+                    |fx, fy| output_crs.project_node(bbox, fx, fy),
+                    |lon, lat| geom.frac_px_unclamped(lon, lat),
+                );
+                let env = [geom.west, geom.south, geom.east, geom.north];
+                let (px_lo, px_hi, py_lo, py_hi) =
+                    output_crs.footprint_pixel_window(bbox, env, width, height);
+                for oy in 0..height {
+                    let in_y = oy >= py_lo && oy <= py_hi;
+                    for ox in 0..width {
+                        if !in_y || ox < px_lo || ox > px_hi {
+                            indices.push(None);
+                            continue;
+                        }
+                        let (fx, fy) = grid.sample(ox, oy);
+                        if fx < 0.0
+                            || fy < 0.0
+                            || fx >= geom.width as f64
+                            || fy >= geom.height as f64
+                            || !fx.is_finite()
+                            || !fy.is_finite()
+                        {
+                            indices.push(None);
+                        } else {
+                            indices.push(Some(fy as usize * geom.width as usize + fx as usize));
+                        }
+                    }
+                }
+            }
+        }
+
+        let values = match frame {
+            FrameData::U8 {
+                data,
+                nodata,
+                gain,
+                offset,
+            } => RasterValues::U8 {
+                data: indices
+                    .iter()
+                    .map(|src| src.map(|i| data[i]).unwrap_or(*nodata))
+                    .collect(),
+                nodata: Some(*nodata),
+                gain: *gain,
+                offset: *offset,
+            },
+            FrameData::F32(field) => RasterValues::F64(
+                indices
+                    .iter()
+                    .map(|src| {
+                        src.and_then(|i| {
+                            let v = field[i];
+                            v.is_finite().then_some(v as f64)
+                        })
+                    })
+                    .collect(),
+            ),
+        };
+        Ok(RasterTile {
+            width,
+            height,
+            values,
+        })
+    }
+
+    fn raster_info(&self) -> RasterInfo {
+        self.state.load().info.clone()
+    }
+
+    fn resolve_time(
+        &self,
+        time: Option<DateTime<Utc>>,
+        reference_time: Option<DateTime<Utc>>,
+    ) -> Option<DateTime<Utc>> {
+        let state = self.state.load();
+        let generation = Self::select_generation(&state, reference_time)?;
+        Some(Self::select_time(&generation, time))
+    }
+
+    fn resolve_reference_time(
+        &self,
+        _time: Option<DateTime<Utc>>,
+        reference_time: Option<DateTime<Utc>>,
+    ) -> Option<DateTime<Utc>> {
+        // The run-axis cache-key authority (#521) — load-bearing here: every
+        // generation rewrites ALL future valid times, so a `None`-keyed cache
+        // entry would freeze the first generation's pixels within minutes.
+        // Same `select_generation` the render path uses (`None` ⇒ latest
+        // generation, `Some` ⇒ exact); an unretained pin echoes back (the
+        // render errors and caches nothing).
+        let state = self.state.load();
+        Self::select_generation(&state, reference_time)
+            .map(|g| Some(g.reference_time))
+            .unwrap_or(reference_time)
+    }
+}

--- a/crates/engine-nowcast/src/engine.rs
+++ b/crates/engine-nowcast/src/engine.rs
@@ -147,6 +147,9 @@ pub struct NowcastEngine {
     /// Seconds between the source anchor frame and the wall clock at the end
     /// of the last generation (how far the nowcast lags reality).
     source_lag_secs: AtomicU64,
+    /// One-shot latch for the lead-cap warning (source-cadence default step
+    /// only; an explicit step is validated at construction).
+    lead_cap_warned: std::sync::atomic::AtomicBool,
 }
 
 impl NowcastEngine {
@@ -171,6 +174,18 @@ impl NowcastEngine {
                     return Err(DataServerError::Config(
                         "nowcast step must be positive".into(),
                     ));
+                }
+                // Fail fast on a horizon/step pair the per-generation lead
+                // cap would silently truncate (root rule: no silent caps).
+                // With `step = None` the cadence is unknown until data
+                // arrives; that case warns at generation time instead.
+                let step_secs = d.num_seconds().max(1);
+                let leads = (horizon.num_seconds() + step_secs - 1) / step_secs;
+                if leads > MAX_LEADS as i64 {
+                    return Err(DataServerError::Config(format!(
+                        "nowcast horizon/step = {leads} lead frames exceeds the cap of \
+                         {MAX_LEADS}; increase step or shorten horizon"
+                    )));
                 }
                 Some(d)
             }
@@ -206,6 +221,7 @@ impl NowcastEngine {
             generation_failures_total: AtomicU64::new(0),
             last_generation_ms: AtomicU64::new(0),
             source_lag_secs: AtomicU64::new(0),
+            lead_cap_warned: std::sync::atomic::AtomicBool::new(false),
         })
     }
 
@@ -411,11 +427,25 @@ impl NowcastEngine {
             estimate_motion(&prev_f32, &analysis_f32, &opts)
         };
 
-        // Lead schedule.
+        // Lead schedule. An explicit step was validated against MAX_LEADS at
+        // construction; the source-cadence default can still exceed it (a
+        // fast-cadence source under a long horizon), so make the truncation
+        // visible instead of silent (root rule: no silent caps). Warned once
+        // per engine — the same clamp would otherwise log every generation.
         let step = self.cfg.step.unwrap_or(interval);
-        let k = ((self.cfg.horizon.num_seconds() as f64 / step.num_seconds().max(1) as f64).ceil()
-            as usize)
-            .clamp(1, MAX_LEADS);
+        let wanted = ((self.cfg.horizon.num_seconds() as f64 / step.num_seconds().max(1) as f64)
+            .ceil() as usize)
+            .max(1);
+        let k = wanted.min(MAX_LEADS);
+        if wanted > MAX_LEADS && !self.lead_cap_warned.swap(true, Ordering::Relaxed) {
+            tracing::warn!(
+                "[{}] nowcast horizon needs {wanted} lead frames at the source cadence but \
+                 the cap is {MAX_LEADS}: serving only {} of the configured horizon — set an \
+                 explicit larger `step` or shorten `horizon`",
+                self.collection_id,
+                format_args!("{}s", step.num_seconds() * MAX_LEADS as i64),
+            );
+        }
 
         let mut times = Vec::with_capacity(k + 1);
         let mut frames = Vec::with_capacity(k + 1);

--- a/crates/engine-nowcast/src/engine.rs
+++ b/crates/engine-nowcast/src/engine.rs
@@ -396,8 +396,11 @@ impl NowcastEngine {
         };
 
         // Fetch the anchor + previous frame on the working grid.
-        let prev = self.fetch_frame(&geom, prev_time)?;
-        let analysis = self.fetch_frame(&geom, anchor)?;
+        // Resolve the source's current run ONCE and pin both fetches to it
+        // (see fetch_frame). `None` for non-forecast sources.
+        let source_run = self.source.resolve_reference_time(Some(anchor), None);
+        let prev = self.fetch_frame(&geom, prev_time, source_run)?;
+        let analysis = self.fetch_frame(&geom, anchor, source_run)?;
         let prev_f32 = frame_to_grid(&prev, w as usize, h as usize);
         let analysis_f32 = frame_to_grid(&analysis, w as usize, h as usize);
 
@@ -513,6 +516,7 @@ impl NowcastEngine {
         &self,
         geom: &GridGeom,
         time: DateTime<Utc>,
+        source_run: Option<DateTime<Utc>>,
     ) -> Result<FrameData, DataServerError> {
         let tile = self.source.get_raster_tile(
             [geom.west, geom.south, geom.east, geom.north],
@@ -522,7 +526,12 @@ impl NowcastEngine {
             &OutputCrs::Wgs84,
             None,
             None,
-            None,
+            // Both frames of a generation pin the SAME source run: if the
+            // source is itself a forecast engine, a run rollover landing
+            // between the two fetches must fail the generation (retried next
+            // poll) rather than silently mix runs into the motion estimate.
+            // Non-forecast sources resolve this to `None` — no change.
+            source_run,
         )?;
         if (tile.width, tile.height) != (geom.width, geom.height) {
             return Err(DataServerError::Engine(format!(
@@ -681,7 +690,9 @@ impl MapEngine for NowcastEngine {
         let generation =
             Self::select_generation(&state, reference_time).ok_or_else(
                 || match reference_time {
-                    Some(rt) => DataServerError::Engine(format!(
+                    // A syntactically valid run the engine no longer retains
+                    // maps to HTTP 404 — the GRIB/QueryData convention.
+                    Some(rt) => DataServerError::ReferenceTimeNotFound(format!(
                         "nowcast generation {rt} is no longer retained"
                     )),
                     None => DataServerError::Engine("nowcast has no generations yet".into()),

--- a/crates/engine-nowcast/src/lib.rs
+++ b/crates/engine-nowcast/src/lib.rs
@@ -1,23 +1,31 @@
-//! Radar nowcasting core: motion estimation + semi-Lagrangian extrapolation.
+//! Radar nowcasting: motion estimation + semi-Lagrangian extrapolation, and
+//! the derived-collection engine serving the result (epic #519).
 //!
-//! Phase 0 of the nowcasting epic (#519 / #520): the pure algorithm — no
-//! engine traits, no I/O, no dependencies. [`motion`] estimates a block-level
-//! motion field from two consecutive composite frames, [`advect`] extrapolates
-//! the latest frame along that field, and [`skill`] scores a hindcast against
-//! what actually happened (the phase-0 gate: extrapolation must beat
-//! persistence, or the motion estimator is wrong).
+//! The algorithm modules stay dependency-free pure functions: [`motion`]
+//! estimates a block-level motion field from two consecutive composite
+//! frames, [`advect`] extrapolates the latest frame along that field, and
+//! [`skill`] scores a hindcast against what actually happened (the phase-0
+//! gate: extrapolation must beat persistence, or the motion estimator is
+//! wrong — see `examples/skill_spike.rs`).
+//!
+//! [`engine::NowcastEngine`] (phase 1, #522) wraps another collection's
+//! `MapEngine` and turns generations of extrapolated frames into an ordinary
+//! raster collection with TIME values in the future.
 //!
 //! Conventions shared by every module:
 //! - A [`Grid`] is a row-major raster, row 0 at the top, `f32` physical values
 //!   (dBZ for radar), `NaN` = nodata.
 //! - Motion vectors are in **pixels per frame interval**, `+u` = rightward
 //!   (+x), `+v` = downward (+y, image convention).
-//! - Lead times are in frame intervals, so the caller never needs wall-clock
-//!   units here; phase 1 maps intervals to timestamps.
+//! - Lead times are in frame intervals; the engine maps intervals to
+//!   timestamps.
 
 pub mod advect;
+pub mod engine;
 pub mod motion;
 pub mod skill;
+
+pub use engine::NowcastEngine;
 
 /// A row-major 2-D raster of physical values; `NaN` = nodata.
 #[derive(Debug, Clone)]

--- a/crates/engine-nowcast/tests/integration.rs
+++ b/crates/engine-nowcast/tests/integration.rs
@@ -1,0 +1,264 @@
+//! End-to-end engine tests against a synthetic translating-echo source.
+//!
+//! The mock source is the truth generator: a hard disc of reflectivity
+//! translating at a constant pixel velocity, rendered for ANY requested time
+//! from a closed-form position. That lets the tests verify the engine's
+//! extrapolation against the source's actual future — the phase-0 gate wired
+//! through the full `MapEngine` surface.
+
+use std::sync::{Arc, RwLock};
+
+use chrono::{DateTime, Duration, Utc};
+
+use ds_core::config::NowcastConfig;
+use ds_core::error::DataServerError;
+use ds_core::map_engine::{MapEngine, OutputCrs, RasterInfo, RasterTile, RasterValues};
+use engine_nowcast::NowcastEngine;
+
+const W: u32 = 200;
+const H: u32 = 200;
+/// WGS84 extent of the mock grid: 10°×10°.
+const EXTENT: [f64; 4] = [0.0, 50.0, 10.0, 60.0];
+/// Disc translation in pixels per 5-minute frame interval.
+const DX_PER_FRAME: f64 = 2.0;
+/// Raw byte for ~40 dBZ under gain 0.4 / offset −30.
+const ECHO_RAW: u8 = 175;
+const NODATA: u8 = 255;
+
+fn t0() -> DateTime<Utc> {
+    "2026-07-20T12:00:00Z".parse().unwrap()
+}
+
+/// Disc centre (px) at time `t`: starts at (60, 100), moves +x only.
+fn disc_center(t: DateTime<Utc>) -> (f64, f64) {
+    let intervals = (t - t0()).num_seconds() as f64 / 300.0;
+    (60.0 + DX_PER_FRAME * intervals, 100.0)
+}
+
+/// Render the truth frame for time `t` as raw bytes (0 = clear, 175 = echo).
+fn truth_frame(t: DateTime<Utc>) -> Vec<u8> {
+    let (cx, cy) = disc_center(t);
+    let mut data = vec![0u8; (W * H) as usize];
+    for (i, cell) in data.iter_mut().enumerate() {
+        let x = (i % W as usize) as f64 + 0.5;
+        let y = (i / W as usize) as f64 + 0.5;
+        if (x - cx).powi(2) + (y - cy).powi(2) <= 15.0 * 15.0 {
+            *cell = ECHO_RAW;
+        }
+    }
+    data
+}
+
+/// Mock raster source: advertises a mutable frame catalog and renders the
+/// closed-form disc for whatever time the engine asks.
+struct MockSource {
+    times: RwLock<Vec<DateTime<Utc>>>,
+}
+
+impl MapEngine for MockSource {
+    fn get_raster_tile(
+        &self,
+        _bbox: [f64; 4],
+        width: u32,
+        height: u32,
+        time: Option<DateTime<Utc>>,
+        _output_crs: &OutputCrs,
+        _parameter: Option<&str>,
+        _z: Option<f64>,
+        _reference_time: Option<DateTime<Utc>>,
+    ) -> Result<RasterTile, DataServerError> {
+        assert_eq!((width, height), (W, H), "engine must fetch the native grid");
+        let t = time.ok_or_else(|| DataServerError::Engine("mock needs a time".into()))?;
+        Ok(RasterTile {
+            width,
+            height,
+            values: RasterValues::U8 {
+                data: truth_frame(t),
+                nodata: Some(NODATA),
+                gain: 0.4,
+                offset: -30.0,
+            },
+        })
+    }
+
+    fn raster_info(&self) -> RasterInfo {
+        RasterInfo {
+            native_crs: "CRS:84".into(),
+            spatial_extent: Some(EXTENT),
+            times: self.times.read().unwrap().clone(),
+            parameter: "reflectivity".into(),
+            unit: "dBZ".into(),
+            parameters: vec![],
+            vertical: None,
+            grid_size: Some([W, H]),
+            layer_subtitle: None,
+            reference_times: Vec::new(),
+        }
+    }
+}
+
+fn build(horizon: &str, source_times: &[DateTime<Utc>]) -> (Arc<MockSource>, NowcastEngine) {
+    let source = Arc::new(MockSource {
+        times: RwLock::new(source_times.to_vec()),
+    });
+    let config = NowcastConfig {
+        source: "mock".into(),
+        horizon: horizon.into(),
+        step: None,
+        history_frames: 2,
+        poll_interval_secs: 30,
+        max_generations: 4,
+        max_pixels: 4_000_000,
+        min_echo: 10.0,
+    };
+    let engine =
+        NowcastEngine::new("mock-nowcast", "mock", source.clone(), &config).expect("engine builds");
+    (source, engine)
+}
+
+/// Raw bytes of a full-extent render at `time`.
+fn render_raw(engine: &NowcastEngine, time: DateTime<Utc>) -> Vec<u8> {
+    let tile = engine
+        .get_raster_tile(
+            EXTENT,
+            W,
+            H,
+            Some(time),
+            &OutputCrs::Wgs84,
+            None,
+            None,
+            None,
+        )
+        .expect("render succeeds");
+    match tile.values {
+        RasterValues::U8 { data, nodata, .. } => {
+            assert_eq!(nodata, Some(NODATA), "nodata byte must survive end to end");
+            data
+        }
+        RasterValues::F64(_) => panic!("U8 source must stay on the raw-byte path"),
+    }
+}
+
+#[test]
+fn generation_produces_future_frames_and_instances_contract() {
+    let anchor = t0() + Duration::minutes(5);
+    let (_source, engine) = build("PT1H", &[t0(), anchor]);
+    assert!(!engine.has_data(), "no generation before the first poll");
+
+    engine.poll_once();
+    assert!(engine.has_data());
+
+    let info = engine.raster_info();
+    // Analysis frame + 12 five-minute leads over PT1H.
+    assert_eq!(info.times.len(), 13);
+    assert_eq!(info.times[0], anchor);
+    assert_eq!(*info.times.last().unwrap(), anchor + Duration::hours(1));
+    assert_eq!(info.reference_times, vec![anchor]);
+    assert_eq!(info.grid_size, Some([W, H]));
+
+    // #521 contract: None resolves to the concrete latest generation.
+    assert_eq!(engine.resolve_reference_time(None, None), Some(anchor));
+    // #507 contract: latest-not-after snapping onto the generated steps.
+    assert_eq!(
+        engine.resolve_time(Some(anchor + Duration::minutes(17)), None),
+        Some(anchor + Duration::minutes(15))
+    );
+}
+
+#[test]
+fn extrapolation_tracks_the_translating_source() {
+    let anchor = t0() + Duration::minutes(5);
+    let (_source, engine) = build("PT1H", &[t0(), anchor]);
+    engine.poll_once();
+
+    // +30 minutes: compare the engine's extrapolation against the source's
+    // actual (closed-form) future frame. Pure translation should recover
+    // nearly the exact disc; require IoU well above what a stationary
+    // (persistence) disc could score.
+    let lead_time = anchor + Duration::minutes(30);
+    let forecast = render_raw(&engine, lead_time);
+    let truth = truth_frame(lead_time);
+    let (mut inter, mut union) = (0u32, 0u32);
+    for (f, o) in forecast.iter().zip(&truth) {
+        let (fe, oe) = (*f == ECHO_RAW, *o == ECHO_RAW);
+        if fe && oe {
+            inter += 1;
+        }
+        if fe || oe {
+            union += 1;
+        }
+    }
+    let iou = inter as f64 / union as f64;
+    assert!(
+        iou > 0.8,
+        "extrapolated disc must track the truth (IoU {iou})"
+    );
+
+    // Persistence baseline for context: the disc moved 12 px over 6
+    // intervals; a stationary 15 px-radius disc overlaps ~55% — the gate
+    // ensures we beat that by a wide margin.
+    let persistence = truth_frame(anchor);
+    let (mut p_inter, mut p_union) = (0u32, 0u32);
+    for (f, o) in persistence.iter().zip(&truth) {
+        let (fe, oe) = (*f == ECHO_RAW, *o == ECHO_RAW);
+        if fe && oe {
+            p_inter += 1;
+        }
+        if fe || oe {
+            p_union += 1;
+        }
+    }
+    let p_iou = p_inter as f64 / p_union as f64;
+    assert!(
+        iou > p_iou,
+        "extrapolation (IoU {iou}) must beat persistence (IoU {p_iou})"
+    );
+}
+
+/// The #507 contract wired end to end: rendering at a raw between-steps
+/// instant produces byte-identical output to rendering at the resolved step.
+#[test]
+fn resolve_time_and_render_share_one_selection() {
+    let anchor = t0() + Duration::minutes(5);
+    let (_source, engine) = build("PT1H", &[t0(), anchor]);
+    engine.poll_once();
+
+    let raw = anchor + Duration::minutes(23);
+    let resolved = engine.resolve_time(Some(raw), None).unwrap();
+    assert_eq!(resolved, anchor + Duration::minutes(20));
+    assert_eq!(
+        render_raw(&engine, raw),
+        render_raw(&engine, resolved),
+        "raw-instant render must serve the resolved step's frame"
+    );
+}
+
+#[test]
+fn new_source_frame_rolls_a_new_generation() {
+    let anchor1 = t0() + Duration::minutes(5);
+    let (source, engine) = build("PT30M", &[t0(), anchor1]);
+    engine.poll_once();
+    assert_eq!(engine.raster_info().reference_times, vec![anchor1]);
+
+    // Re-polling without new source data must not add generations.
+    engine.poll_once();
+    assert_eq!(engine.raster_info().reference_times.len(), 1);
+
+    // A new source frame lands → new generation, ascending reference_times,
+    // and the run axis resolves to the new one (#521).
+    let anchor2 = anchor1 + Duration::minutes(5);
+    source.times.write().unwrap().push(anchor2);
+    engine.poll_once();
+    let info = engine.raster_info();
+    assert_eq!(info.reference_times, vec![anchor1, anchor2]);
+    assert_eq!(engine.resolve_reference_time(None, None), Some(anchor2));
+    // Pinning the previous generation still serves it.
+    assert_eq!(
+        engine.resolve_reference_time(None, Some(anchor1)),
+        Some(anchor1)
+    );
+    assert_eq!(
+        engine.resolve_time(None, Some(anchor1)),
+        Some(anchor1 + Duration::minutes(30))
+    );
+}

--- a/crates/engine-nowcast/tests/integration.rs
+++ b/crates/engine-nowcast/tests/integration.rs
@@ -261,6 +261,30 @@ fn new_source_frame_rolls_a_new_generation() {
         engine.resolve_time(None, Some(anchor1)),
         Some(anchor1 + Duration::minutes(30))
     );
+
+    // An unretained pin is the 404 shape (ReferenceTimeNotFound), matching
+    // the GRIB/QueryData convention — not a generic engine error.
+    let gone = anchor1 - Duration::hours(6);
+    let err = match engine.get_raster_tile(
+        EXTENT,
+        W,
+        H,
+        None,
+        &OutputCrs::Wgs84,
+        None,
+        None,
+        Some(gone),
+    ) {
+        Err(e) => e,
+        Ok(_) => panic!("unretained generation must error"),
+    };
+    assert!(
+        matches!(
+            err,
+            ds_core::error::DataServerError::ReferenceTimeNotFound(_)
+        ),
+        "expected ReferenceTimeNotFound, got: {err}"
+    );
 }
 
 /// No silent caps: a horizon/step pair exceeding the per-generation lead cap

--- a/crates/engine-nowcast/tests/integration.rs
+++ b/crates/engine-nowcast/tests/integration.rs
@@ -262,3 +262,29 @@ fn new_source_frame_rolls_a_new_generation() {
         Some(anchor1 + Duration::minutes(30))
     );
 }
+
+/// No silent caps: a horizon/step pair exceeding the per-generation lead cap
+/// is a config error at construction, not a silently shortened horizon.
+#[test]
+fn excessive_lead_count_is_rejected_at_construction() {
+    let source = Arc::new(MockSource {
+        times: RwLock::new(vec![t0()]),
+    });
+    let config = NowcastConfig {
+        source: "mock".into(),
+        horizon: "PT2H".into(),
+        step: Some("PT1M".into()), // 120 leads > cap
+        history_frames: 2,
+        poll_interval_secs: 30,
+        max_generations: 4,
+        max_pixels: 4_000_000,
+        min_echo: 10.0,
+    };
+    let err = NowcastEngine::new("mock-nowcast", "mock", source, &config)
+        .err()
+        .expect("must reject a lead count over the cap");
+    assert!(
+        err.to_string().contains("exceeds the cap"),
+        "error should name the cap: {err}"
+    );
+}

--- a/crates/engine-nowcast/tests/integration.rs
+++ b/crates/engine-nowcast/tests/integration.rs
@@ -288,3 +288,17 @@ fn excessive_lead_count_is_rejected_at_construction() {
         "error should name the cap: {err}"
     );
 }
+
+/// Sub-second source cadence must fail the generation cleanly instead of
+/// producing Infinity lead intervals (which would explode advection's
+/// substep count and wedge the poll runtime).
+#[test]
+fn sub_second_cadence_fails_generation_cleanly() {
+    let t1 = t0() + Duration::milliseconds(500);
+    let (_source, engine) = build("PT1H", &[t0(), t1]);
+    engine.poll_once();
+    assert!(!engine.has_data(), "sub-second cadence must not generate");
+    let (generations, failures, ..) = engine.metrics();
+    assert_eq!(generations, 0);
+    assert_eq!(failures, 1, "the failure must be counted, not hidden");
+}

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -19,6 +19,7 @@ engine-zarr = { path = "../engine-zarr" }
 engine-odim = { path = "../engine-odim" }
 engine-cap = { path = "../engine-cap" }
 engine-postgis = { path = "../engine-postgis" }
+engine-nowcast = { path = "../engine-nowcast" }
 api-edr = { path = "../api-edr" }
 api-features = { path = "../api-features" }
 api-wms = { path = "../api-wms" }

--- a/crates/server/src/admin.rs
+++ b/crates/server/src/admin.rs
@@ -660,7 +660,88 @@ struct CacheCounterState {
     /// last-scraped values. Engines are replaced on reload (counts reset), so
     /// the scrape rebaselines on a backward step — see `metrics_handler`.
     postgis: HashMap<String, (u64, u64, u64, u64)>,
+    /// Nowcast per-collection `(generations, failures)` last-scraped values —
+    /// same reload-rebaseline scheme.
+    nowcast: HashMap<String, (u64, u64)>,
 }
+
+static NOWCAST_GENERATIONS: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    let counter = IntCounterVec::new(
+        Opts::new(
+            "nowcast_generations_total",
+            "Nowcast generations produced (one per new source frame)",
+        ),
+        &["collection"],
+    )
+    .unwrap();
+    REGISTRY.register(Box::new(counter.clone())).unwrap();
+    counter
+});
+
+static NOWCAST_GENERATION_FAILURES: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    let counter = IntCounterVec::new(
+        Opts::new(
+            "nowcast_generation_failures_total",
+            "Nowcast generations that failed (source fetch or extrapolation error)",
+        ),
+        &["collection"],
+    )
+    .unwrap();
+    REGISTRY.register(Box::new(counter.clone())).unwrap();
+    counter
+});
+
+static NOWCAST_LAST_GENERATION_MS: LazyLock<IntGaugeVec> = LazyLock::new(|| {
+    let gauge = IntGaugeVec::new(
+        Opts::new(
+            "nowcast_last_generation_duration_ms",
+            "Wall-clock duration of the most recent nowcast generation",
+        ),
+        &["collection"],
+    )
+    .unwrap();
+    REGISTRY.register(Box::new(gauge.clone())).unwrap();
+    gauge
+});
+
+static NOWCAST_SOURCE_LAG_SECONDS: LazyLock<IntGaugeVec> = LazyLock::new(|| {
+    let gauge = IntGaugeVec::new(
+        Opts::new(
+            "nowcast_source_lag_seconds",
+            "Age of the source anchor frame when the last generation finished",
+        ),
+        &["collection"],
+    )
+    .unwrap();
+    REGISTRY.register(Box::new(gauge.clone())).unwrap();
+    gauge
+});
+
+static NOWCAST_RETAINED_GENERATIONS: LazyLock<IntGaugeVec> = LazyLock::new(|| {
+    let gauge = IntGaugeVec::new(
+        Opts::new(
+            "nowcast_retained_generations",
+            "Generations currently retained (reference_time pinning window)",
+        ),
+        &["collection"],
+    )
+    .unwrap();
+    REGISTRY.register(Box::new(gauge.clone())).unwrap();
+    gauge
+});
+
+static NOWCAST_FRAMES: LazyLock<IntGaugeVec> = LazyLock::new(|| {
+    let gauge = IntGaugeVec::new(
+        Opts::new(
+            "nowcast_frames",
+            "Frames (analysis + leads) in the latest nowcast generation",
+        ),
+        &["collection"],
+    )
+    .unwrap();
+    REGISTRY.register(Box::new(gauge.clone())).unwrap();
+    gauge
+});
 
 static RENDER_SEMAPHORE_AVAILABLE: LazyLock<IntGauge> = LazyLock::new(|| {
     let gauge = IntGauge::new(
@@ -733,6 +814,7 @@ pub struct ServerState {
     pub odim_volume_engines: RwLock<Vec<Arc<engine_odim::PolarVolumeEngine>>>,
     pub cap_engines: RwLock<Vec<Arc<engine_cap::CapEngine>>>,
     pub postgis_engines: RwLock<Vec<Arc<engine_postgis::PostgisEngine>>>,
+    pub nowcast_engines: RwLock<Vec<Arc<engine_nowcast::NowcastEngine>>>,
     /// Serializes reload requests to prevent concurrent reloads from racing.
     pub reload_lock: tokio::sync::Mutex<()>,
     /// Bearer token for admin endpoint authentication.
@@ -762,6 +844,7 @@ pub struct LoadResult {
     pub odim_volume_engines: Vec<Arc<engine_odim::PolarVolumeEngine>>,
     pub cap_engines: Vec<Arc<engine_cap::CapEngine>>,
     pub postgis_engines: Vec<Arc<engine_postgis::PostgisEngine>>,
+    pub nowcast_engines: Vec<Arc<engine_nowcast::NowcastEngine>>,
 }
 
 /// Render caches carried across a reload so a config reload **preserves** the
@@ -824,6 +907,10 @@ pub fn load_collections(
     let mut odim_volume_engines: Vec<Arc<engine_odim::PolarVolumeEngine>> = Vec::new();
     let mut cap_engines: Vec<Arc<engine_cap::CapEngine>> = Vec::new();
     let mut postgis_engines: Vec<Arc<engine_postgis::PostgisEngine>> = Vec::new();
+    let mut nowcast_engines: Vec<Arc<engine_nowcast::NowcastEngine>> = Vec::new();
+    // Derived collections wire in a second pass, after every base engine
+    // exists (#522). Collected here during the main loop.
+    let mut nowcast_pending: Vec<&CollectionConfig> = Vec::new();
     // Pool registry is local to this load: collections sharing a DSN share a
     // pool via Arc<Pool>. Across reloads, pools are rebuilt — documented
     // v1 trade-off; reuse-by-identity across reloads is a follow-up.
@@ -852,6 +939,7 @@ pub fn load_collections(
             "odim-volume" => &["edr", "wms", "maps", "tiles", "3dtiles", "features"],
             "cap" => &["features", "wms", "maps", "tiles"],
             "postgis" => &["edr", "features", "tiles", "wms", "maps"],
+            "nowcast" => &["wms", "maps", "tiles"],
             _ => &[],
         };
         let unsupported: Vec<&str> = collection
@@ -2186,6 +2274,11 @@ pub fn load_collections(
                     error: status_err,
                 });
             }
+            // Derived collections defer to the second pass below, after all
+            // base engines exist (#522).
+            "nowcast" => {
+                nowcast_pending.push(collection);
+            }
             other => {
                 tracing::error!(
                     "Collection '{}': unknown engine type '{}', skipping",
@@ -2201,6 +2294,116 @@ pub fn load_collections(
                 continue;
             }
         }
+    }
+
+    // ------------------------------------------------------------------
+    // Second pass: derived nowcast collections (#522). Every base engine
+    // now exists; snapshot the raster-engine lookup BEFORE constructing any
+    // nowcast engine, so a nowcast can wrap any base collection but never
+    // another nowcast (chaining extrapolations compounds error and the
+    // derived engine's poll cadence assumptions).
+    // ------------------------------------------------------------------
+    let base_raster_engines: HashMap<String, Arc<dyn ds_core::map_engine::MapEngine>> = map_engines
+        .iter()
+        .chain(maps_engines.iter())
+        .chain(tiles_engines.iter())
+        .map(|(id, e)| (id.clone(), e.clone()))
+        .collect();
+    for collection in nowcast_pending {
+        let mut fail = |error: String| {
+            tracing::error!("Collection '{}': {error}, skipping", collection.id);
+            health.push(CollectionHealth {
+                id: collection.id.clone(),
+                engine_type: "nowcast".into(),
+                status: CollectionStatus::Failed,
+                error: Some(error),
+            });
+        };
+        let Some(nowcast_config) = collection.nowcast.as_ref() else {
+            fail("missing [collections.nowcast] config".into());
+            continue;
+        };
+        if collections
+            .iter()
+            .any(|c| c.id == nowcast_config.source && c.engine_type == "nowcast")
+        {
+            fail(format!(
+                "nowcast source '{}' is itself a nowcast collection (chaining is not supported)",
+                nowcast_config.source
+            ));
+            continue;
+        }
+        let Some(source) = base_raster_engines.get(&nowcast_config.source) else {
+            fail(format!(
+                "nowcast source collection '{}' not found (it must exist in the same config \
+                 and have at least one of wms/maps/tiles in its `apis`)",
+                nowcast_config.source
+            ));
+            continue;
+        };
+        let engine = match engine_nowcast::NowcastEngine::new(
+            &collection.id,
+            &nowcast_config.source,
+            source.clone(),
+            nowcast_config,
+        ) {
+            Ok(e) => Arc::new(e),
+            Err(e) => {
+                fail(format!("failed to initialize nowcast engine: {e}"));
+                continue;
+            }
+        };
+        nowcast_engines.push(engine.clone());
+
+        if collection.apis.contains(&"wms".to_string()) {
+            map_engines.insert(
+                collection.id.clone(),
+                engine.clone() as Arc<dyn ds_core::map_engine::MapEngine>,
+            );
+            map_collections.insert(collection.id.clone(), collection.clone());
+            map_styles.insert(
+                collection.id.clone(),
+                build_styles(collection, &bundle_index),
+            );
+            info!("Collection '{}': wired to WMS API", collection.id);
+        }
+        if collection.apis.contains(&"maps".to_string()) {
+            maps_engines.insert(
+                collection.id.clone(),
+                engine.clone() as Arc<dyn ds_core::map_engine::MapEngine>,
+            );
+            maps_collections.insert(collection.id.clone(), collection.clone());
+            maps_styles.insert(
+                collection.id.clone(),
+                build_styles(collection, &bundle_index),
+            );
+            info!("Collection '{}': wired to Maps API", collection.id);
+        }
+        if collection.apis.contains(&"tiles".to_string()) {
+            tiles_engines.insert(
+                collection.id.clone(),
+                engine.clone() as Arc<dyn ds_core::map_engine::MapEngine>,
+            );
+            tiles_collections.insert(collection.id.clone(), collection.clone());
+            tiles_styles.insert(
+                collection.id.clone(),
+                build_styles(collection, &bundle_index),
+            );
+            info!("Collection '{}': wired to Tiles API", collection.id);
+        }
+
+        // A nowcast starts degraded: the first generation needs the source's
+        // initial data plus one poll cycle.
+        health.push(CollectionHealth {
+            id: collection.id.clone(),
+            engine_type: "nowcast".into(),
+            status: CollectionStatus::Degraded,
+            error: Some("waiting for first nowcast generation".into()),
+        });
+        info!(
+            "Collection '{}': nowcast wrapping '{}'",
+            collection.id, nowcast_config.source
+        );
     }
 
     // Determine rendered cache size from first WMS collection config, or default
@@ -2323,6 +2526,7 @@ pub fn load_collections(
         odim_volume_engines,
         cap_engines,
         postgis_engines,
+        nowcast_engines,
     }
 }
 
@@ -2967,6 +3171,14 @@ pub(crate) fn do_reload(state: &AdminState) -> Result<ReloadOutcome, ReloadError
         {
             engine.shutdown();
         }
+        for engine in state
+            .nowcast_engines
+            .read()
+            .unwrap_or_else(|e| e.into_inner())
+            .iter()
+        {
+            engine.shutdown();
+        }
     }
 
     // Spawn poll loops for new engines on the dedicated background runtime
@@ -3022,6 +3234,15 @@ pub(crate) fn do_reload(state: &AdminState) -> Result<ReloadOutcome, ReloadError
             poller.poll_loop().await;
         });
     }
+    // Nowcast generation loop: watches the source engine and regenerates
+    // extrapolated frames. Source fetches do blocking storage I/O internally,
+    // so this must stay on the background runtime (#221, Critical Rule 7).
+    for engine in &result.nowcast_engines {
+        let poller = engine.clone();
+        crate::poll_runtime().spawn(async move {
+            poller.poll_loop().await;
+        });
+    }
 
     // Atomically swap state
     state.edr.store(Arc::new(result.edr_state));
@@ -3065,6 +3286,10 @@ pub(crate) fn do_reload(state: &AdminState) -> Result<ReloadOutcome, ReloadError
         .postgis_engines
         .write()
         .unwrap_or_else(|e| e.into_inner()) = result.postgis_engines;
+    *state
+        .nowcast_engines
+        .write()
+        .unwrap_or_else(|e| e.into_inner()) = result.nowcast_engines;
 
     // Recount from the final `result.health` — the vanished-site block above
     // appends `Degraded` entries after the guard's `ready` was computed, so
@@ -3236,6 +3461,34 @@ pub async fn health_handler(State(state): State<AdminState>) -> impl IntoRespons
                 if let Some(temporal) = temporal_from_times(&times) {
                     temporal_info.insert(format!("{}-{}", engine.collection_id(), nod), temporal);
                 }
+            }
+        }
+    }
+
+    {
+        // Nowcast engines: `data_age_secs` is the age of the latest
+        // generation's anchor frame; the boot `Degraded ("waiting for first
+        // nowcast generation")` flips to `Ready` once a generation exists.
+        let engines = state
+            .nowcast_engines
+            .read()
+            .unwrap_or_else(|e| e.into_inner());
+        let mut has_data: HashMap<&str, bool> = HashMap::new();
+        for engine in engines.iter() {
+            let id = engine.collection_id().to_string();
+            has_data.insert(engine.collection_id(), engine.has_data());
+            if let Some(age) = engine.catalog_age() {
+                data_ages.insert(id.clone(), age.num_seconds());
+            }
+            let times = ds_core::map_engine::MapEngine::raster_info(engine.as_ref()).times;
+            if let Some(temporal) = temporal_from_times(&times) {
+                temporal_info.insert(id, temporal);
+            }
+        }
+        for h in health.iter_mut().filter(|h| h.engine_type == "nowcast") {
+            if has_data.get(h.id.as_str()).copied().unwrap_or(false) {
+                h.status = CollectionStatus::Ready;
+                h.error = None;
             }
         }
     }
@@ -3549,6 +3802,48 @@ pub async fn metrics_handler(State(state): State<AdminState>) -> impl IntoRespon
             POSTGIS_POOL_WAITING
                 .with_label_values(&[pk])
                 .set(st.waiting as i64);
+        }
+    }
+
+    // Nowcast: per-collection generation counters (delta pattern — engines
+    // are replaced on reload, detected as a backward step) and gauges.
+    if let Ok(engines) = state.nowcast_engines.read() {
+        for engine in engines.iter() {
+            let collection = engine.collection_id();
+            let (generations, failures, last_ms, lag_secs, retained, frames) = engine.metrics();
+            let entry = counter_state
+                .nowcast
+                .entry(collection.to_string())
+                .or_insert((0, 0));
+            if generations < entry.0 || failures < entry.1 {
+                *entry = (generations, failures);
+            } else {
+                let dg = generations - entry.0;
+                let df = failures - entry.1;
+                if dg > 0 {
+                    NOWCAST_GENERATIONS
+                        .with_label_values(&[collection])
+                        .inc_by(dg);
+                }
+                if df > 0 {
+                    NOWCAST_GENERATION_FAILURES
+                        .with_label_values(&[collection])
+                        .inc_by(df);
+                }
+                *entry = (generations, failures);
+            }
+            NOWCAST_LAST_GENERATION_MS
+                .with_label_values(&[collection])
+                .set(last_ms as i64);
+            NOWCAST_SOURCE_LAG_SECONDS
+                .with_label_values(&[collection])
+                .set(lag_secs as i64);
+            NOWCAST_RETAINED_GENERATIONS
+                .with_label_values(&[collection])
+                .set(retained as i64);
+            NOWCAST_FRAMES
+                .with_label_values(&[collection])
+                .set(frames as i64);
         }
     }
 

--- a/crates/server/src/admin.rs
+++ b/crates/server/src/admin.rs
@@ -785,7 +785,7 @@ pub struct CollectionHealth {
     pub error: Option<String>,
 }
 
-#[derive(Clone, Copy, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum CollectionStatus {
     Ready,
@@ -4089,6 +4089,157 @@ mod tests {
     use ds_core::config::{CollectionConfig, StyleBundle};
     use std::collections::HashMap;
     use std::sync::Arc;
+
+    // --- nowcast second-pass wiring (#522) ---
+
+    /// A minimal collection config for the nowcast wiring tests.
+    fn nowcast_test_collection(
+        id: &str,
+        engine_type: &str,
+        source: Option<&str>,
+    ) -> CollectionConfig {
+        CollectionConfig {
+            id: id.to_string(),
+            title: id.to_string(),
+            description: String::new(),
+            data_path: None,
+            apis: vec!["wms".to_string()],
+            engine_type: engine_type.to_string(),
+            keywords: Vec::new(),
+            license: None,
+            geotiff: None,
+            querydata: None,
+            wms: None,
+            grib: None,
+            zarr: None,
+            odim: None,
+            cap: None,
+            postgis: None,
+            nowcast: source.map(|s| ds_core::config::NowcastConfig {
+                source: s.to_string(),
+                horizon: "PT1H".to_string(),
+                step: None,
+                history_frames: 2,
+                poll_interval_secs: 30,
+                max_generations: 2,
+                max_pixels: 500_000,
+                min_echo: 10.0,
+            }),
+            preview: None,
+        }
+    }
+
+    /// A geotiff source collection over the committed TM35FIN fixture.
+    fn tm35_source_collection(id: &str) -> CollectionConfig {
+        let mut c = nowcast_test_collection(id, "geotiff", None);
+        c.data_path = Some("../../testdata/radar-tm35fin".to_string());
+        c.geotiff = Some(ds_core::config::GeoTiffConfig {
+            filename_template: Some("radar_tm35_%Y%m%dT%H%MZ.tif".to_string()),
+            filename_pattern: None,
+            timestamp_format: None,
+            parameter: "reflectivity".to_string(),
+            unit: "dBZ".to_string(),
+            poll_interval_secs: 3600,
+            tile_cache_mb: 16,
+            band: 1,
+            max_files: None,
+            nodata: None,
+            scale: None,
+            offset: None,
+            exclude_patterns: vec![],
+            endpoint: None,
+            bucket: None,
+            prefix_pattern: None,
+            time_window: None,
+            scan_days: None,
+            stac_url: None,
+            stac_asset_key: "data".to_string(),
+            stac_asset_allowlist: None,
+        });
+        c
+    }
+
+    fn health_of<'a>(result: &'a super::LoadResult, id: &str) -> &'a super::CollectionHealth {
+        result
+            .health
+            .iter()
+            .find(|h| h.id == id)
+            .unwrap_or_else(|| panic!("no health entry for {id}"))
+    }
+
+    #[test]
+    fn nowcast_unknown_source_fails_that_collection_only() {
+        let result = super::load_collections(
+            &[nowcast_test_collection("nc", "nowcast", Some("no-such"))],
+            &[],
+            "http://x",
+            false,
+            0,
+            super::ReusableCaches::default(),
+        );
+        let h = health_of(&result, "nc");
+        assert_eq!(h.status, super::CollectionStatus::Failed);
+        assert!(
+            h.error.as_deref().unwrap_or("").contains("not found"),
+            "error should name the missing source: {:?}",
+            h.error
+        );
+        assert!(!result.wms_state.engines.contains_key("nc"));
+    }
+
+    #[test]
+    fn nowcast_of_nowcast_is_rejected() {
+        let result = super::load_collections(
+            &[
+                tm35_source_collection("radar"),
+                nowcast_test_collection("nc1", "nowcast", Some("radar")),
+                nowcast_test_collection("nc2", "nowcast", Some("nc1")),
+            ],
+            &[],
+            "http://x",
+            false,
+            0,
+            super::ReusableCaches::default(),
+        );
+        let h = health_of(&result, "nc2");
+        assert_eq!(h.status, super::CollectionStatus::Failed);
+        assert!(
+            h.error.as_deref().unwrap_or("").contains("chaining"),
+            "error should name the chaining rejection: {:?}",
+            h.error
+        );
+        assert!(!result.wms_state.engines.contains_key("nc2"));
+        // The first-level nowcast is unaffected.
+        assert!(result.wms_state.engines.contains_key("nc1"));
+    }
+
+    #[test]
+    fn nowcast_wires_into_registries_and_boots_degraded() {
+        let result = super::load_collections(
+            &[
+                tm35_source_collection("radar"),
+                nowcast_test_collection("nc", "nowcast", Some("radar")),
+            ],
+            &[],
+            "http://x",
+            false,
+            0,
+            super::ReusableCaches::default(),
+        );
+        assert!(result.wms_state.engines.contains_key("nc"));
+        assert_eq!(result.nowcast_engines.len(), 1);
+        assert_eq!(result.nowcast_engines[0].source_id(), "radar");
+        let h = health_of(&result, "nc");
+        assert_eq!(h.status, super::CollectionStatus::Degraded);
+        assert!(
+            h.error
+                .as_deref()
+                .unwrap_or("")
+                .contains("waiting for first nowcast generation"),
+            "boot health should explain the degraded state: {:?}",
+            h.error
+        );
+    }
 
     // --- reload preserves the warm render caches (ReusableCaches) ---
 

--- a/crates/server/src/auto.rs
+++ b/crates/server/src/auto.rs
@@ -392,6 +392,7 @@ fn mk_collection(
         cap: None,
         wms: None,
         postgis: None,
+        nowcast: None,
         preview: None,
     }
 }

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -520,6 +520,14 @@ async fn main() {
             poller.poll_loop().await;
         });
     }
+    // Nowcast generation loop — watches the source engine and regenerates
+    // extrapolated frames (blocking source I/O; background runtime only).
+    for engine in &result.nowcast_engines {
+        let poller = engine.clone();
+        poll_runtime().spawn(async move {
+            poller.poll_loop().await;
+        });
+    }
 
     // Set initial health gauges
     admin::update_health_gauges(&result.health);
@@ -600,6 +608,7 @@ async fn main() {
         odim_volume_engines: RwLock::new(result.odim_volume_engines),
         cap_engines: RwLock::new(result.cap_engines),
         postgis_engines: RwLock::new(result.postgis_engines),
+        nowcast_engines: RwLock::new(result.nowcast_engines),
         reload_lock: tokio::sync::Mutex::new(()),
         admin_token,
     });

--- a/crates/server/src/preview.rs
+++ b/crates/server/src/preview.rs
@@ -994,6 +994,7 @@ mod tests {
             odim_volume_engines: RwLock::new(Vec::new()),
             cap_engines: RwLock::new(Vec::new()),
             postgis_engines: RwLock::new(Vec::new()),
+            nowcast_engines: RwLock::new(Vec::new()),
             reload_lock: tokio::sync::Mutex::new(()),
             admin_token: None,
         })
@@ -1017,6 +1018,7 @@ mod tests {
             odim: None,
             cap: None,
             postgis: None,
+            nowcast: None,
             preview: None,
         }
     }

--- a/crates/server/src/watcher.rs
+++ b/crates/server/src/watcher.rs
@@ -262,6 +262,7 @@ mod tests {
             odim_volume_engines: RwLock::new(result.odim_volume_engines),
             cap_engines: RwLock::new(result.cap_engines),
             postgis_engines: RwLock::new(result.postgis_engines),
+            nowcast_engines: RwLock::new(result.nowcast_engines),
             reload_lock: tokio::sync::Mutex::new(()),
             admin_token: None,
         })

--- a/crates/server/tests/middleware.rs
+++ b/crates/server/tests/middleware.rs
@@ -89,6 +89,7 @@ fn make_collection(id: &str) -> CollectionConfig {
         odim: None,
         cap: None,
         postgis: None,
+        nowcast: None,
         preview: None,
     }
 }


### PR DESCRIPTION
Phase 1 of the nowcasting epic #519. Closes #522. **Stacked on #526** (the `resolve_reference_time` machinery this engine's cache correctness depends on) — merge #526 first; this PR auto-retargets to main.

## What

The phase-0 extrapolation core (#525) becomes a servable engine: a **derived collection** that wraps another collection's `MapEngine` and serves motion-extrapolated frames with TIME values up to `horizon` in the future, through the normal WMS/Maps/Tiles pipeline.

```toml
[[collections]]
id = "radar-nowcast"
engine_type = "nowcast"
apis = ["wms", "maps", "tiles"]

[collections.nowcast]
source = "radar"        # collection id to extrapolate
horizon = "PT2H"        # default PT2H
# step = "PT5M"         # default: source cadence
```

- **Two-pass wiring** in `server/src/admin.rs`: base engines first, then nowcast engines get an `Arc<dyn MapEngine>` of their source (unknown source / nowcast-of-nowcast → clear load error). Poll loops spawned on the background runtime on BOTH boot and reload paths (the #442 lesson).
- **Generation**: on each new source frame — fetch the last frames on a regular WGS84 grid at the source's native cell count (halved to fit `max_pixels`, default 4 Mpx); estimate motion on a deliberately coarsened grid (search window derived from pixel size × cadence × 40 m/s, not the phase-0 accident); semi-Lagrangian advection across the horizon. U8 sources with a nodata byte stay raw bytes end to end (`advect_u8`, 1 B/px ≈ 100 MB per collection at defaults); others fall back to f32.
- **Cache contracts**: every generation is a model run (`reference_times` populated, generations retained in a BTreeMap — the instances shape phase 2 builds on). `resolve_time` / `resolve_reference_time` / `get_raster_tile` share one selection implementation (#507/#521) — load-bearing here because a nowcast rewrites ALL future valid times every source cadence; this engine is why #521 exists.
- **Rendering**: `OutputCrs`/`ProjectionGrid` with an affine source map (regular lat/lon internal grid, mirrors engine-zarr's structure incl. the #449 footprint guard); nearest-neighbour sampling keeps discrete radar palettes + PNG8 intact.
- **Ops**: health degraded until the first generation then live-flips to ready with `data_age_secs` + temporal extent; six `/metrics` families (`nowcast_generations_total`, `_generation_failures_total`, `_last_generation_duration_ms`, `_source_lag_seconds`, `_retained_generations`, `_frames`). Grafana row rides with phase 3 (#524, explicitly scoped there).
- Docs: `crates/engine-nowcast/CLAUDE.md`, root capability table + config example, new `MapEngine` contract note.

## Verification

- **14 tests**: phase-0 algorithm pins + new engine integration tests driving a synthetic translating source through the full `MapEngine` surface — extrapolation at +30 min scores IoU > 0.8 against the source's *actual* closed-form future and beats persistence; #507 contract pinned end to end (raw-instant render byte-identical to resolved-step render); generation/instances contract pinned.
- **End-to-end smoke test** (engine checklist item 8) against a real 25-frame live SMHI composite sequence: collection boots degraded → ready after first generation; GetCapabilities advertises the layer + `reference_time` dimension; GetMap renders future TIME values (frames differ per lead); Maps + Tiles serve; run pinning works, unknown run → 400; all metric families live. Generation cost: ~0.4 s release on a 1006×671 grid.
- Full workspace: 69 suites green, clippy `-D warnings` clean.

## Known limitations (by design, tracked)

- Pure Lagrangian persistence — no growth/decay (phase 4). EDR + `/instances` routes are phase 2 (#523).
- A TIME-less request resolves to `times.last()` = the furthest forecast (API-layer convention); clients should send explicit TIME.
- F64-returning sources (e.g. remote COG) pay 4 B/px internal storage until a typed path (#475).

🤖 Generated with [Claude Code](https://claude.com/claude-code)