### PR TITLE
feat(engine-nowcast): motion stabilization — multi-pair estimation + cross-generation EMA

### DIFF
--- a/crates/engine-nowcast/CLAUDE.md
+++ b/crates/engine-nowcast/CLAUDE.md
@@ -44,9 +44,21 @@ reason `MapEngine::resolve_reference_time` exists (#521).
   (1 B/px; `advect_u8` moves bytes); anything else falls back to f32
   (4 B/px — the FMI S3 COG path lands here until #475-style typed paths).
 - Motion is estimated on a coarsened grid sized so the physical search
-  window (40 m/s × source interval) fits ~24 px, then the field is scaled
-  back — deliberate scale handling; do NOT rely on the pixel budget to do
-  this implicitly.
+  window (40 m/s × source interval) fits `TARGET_SEARCH_PX` (48 — keeps
+  the FMI 500 m grid uncoarsened), then the field is scaled back —
+  deliberate scale handling; do NOT rely on the pixel budget to do this
+  implicitly.
+- **Motion stabilization (#524 part 1)** — two mechanisms against the
+  rubber-band animation artifact (single-pair block matching re-reads
+  convective growth/decay as motion noise every generation):
+  1. multi-pair estimation: every consecutive history pair contributes
+     measurements (scaled to the last interval's unit), averaged per
+     block, then ONE shared outlier/fill/smooth pass;
+  2. temporal EMA with the previous generation's field
+     (`Generation.field`, weights `EMA_ALPHA_MEASURED = 0.7` /
+     `EMA_ALPHA_FILLED = 0.4`; auto-skipped when the block grid changes).
+  Weakening either brings the between-generation oscillation back —
+  verify with an animation loop, not stills.
 
 ## Memory sizing (retention multiplies!)
 

--- a/crates/engine-nowcast/src/engine.rs
+++ b/crates/engine-nowcast/src/engine.rs
@@ -63,6 +63,9 @@ const EMA_ALPHA_FILLED: f32 = 0.4;
 const SUBSTEPS: usize = 4;
 /// Hard cap on extrapolated frames per generation.
 const MAX_LEADS: usize = 96;
+/// Hard cap on `history_frames`: each is one sequential blocking source
+/// fetch per generation, and pair-averaging saturates after a few pairs.
+const MAX_HISTORY_FRAMES: usize = 8;
 
 /// Parsed, validated engine configuration.
 struct EngineCfg {
@@ -209,6 +212,17 @@ impl NowcastEngine {
             return Err(DataServerError::Config(
                 "nowcast history_frames must be at least 2 (motion needs a frame pair)".into(),
             ));
+        }
+        // Each history frame is one sequential blocking source fetch per
+        // generation (Critical Rule 9: never loop unbounded blocking I/O on
+        // one thread) — and motion averaging saturates after a few pairs
+        // anyway. Fail fast rather than silently clamp.
+        if config.history_frames > MAX_HISTORY_FRAMES {
+            return Err(DataServerError::Config(format!(
+                "nowcast history_frames = {} exceeds the cap of {MAX_HISTORY_FRAMES} \
+                 (each frame is one blocking source fetch per generation)",
+                config.history_frames
+            )));
         }
 
         let (shutdown_tx, _) = watch::channel(());

--- a/crates/engine-nowcast/src/engine.rs
+++ b/crates/engine-nowcast/src/engine.rs
@@ -39,15 +39,26 @@ use ds_core::map_engine::{MapEngine, OutputCrs, RasterInfo, RasterTile, RasterVa
 use ds_core::resample::ProjectionGrid;
 
 use crate::advect::TrajectoryIntegrator;
-use crate::motion::{estimate_motion, MotionOptions};
+use crate::motion::{estimate_motion_multi, MotionField, MotionOptions};
 use crate::Grid;
 
 /// Fastest cell motion the search window must cover (m/s). 40 m/s ≈ 144 km/h
 /// matches the cell-tracker gate in `ds_core::cells`.
 const MAX_SPEED_MS: f64 = 40.0;
 /// Target search radius (px) on the motion-estimation grid; frames are
-/// coarsened until the physical search window fits.
-const TARGET_SEARCH_PX: i32 = 24;
+/// coarsened until the physical search window fits. 48 keeps the FMI
+/// composite's ~500 m working grid uncoarsened (~16 km motion blocks
+/// instead of ~25 km — small convective cells get a closer-fitting
+/// vector), affordable since #529 made generation cost linear in leads.
+const TARGET_SEARCH_PX: i32 = 48;
+/// Temporal EMA weights for blending each generation's motion field with
+/// the previous one (#524): the new field keeps this share, per block.
+/// Measured blocks carry fresh information; filled blocks are inferred and
+/// lean harder on history. 0.7 ≈ one-and-a-half generations of memory —
+/// enough to damp single-pair convective noise without lagging a genuine
+/// wind shift by more than a couple of cadence intervals.
+const EMA_ALPHA_MEASURED: f32 = 0.7;
+const EMA_ALPHA_FILLED: f32 = 0.4;
 /// Trajectory integration substeps per frame interval.
 const SUBSTEPS: usize = 4;
 /// Hard cap on extrapolated frames per generation.
@@ -123,6 +134,9 @@ struct Generation {
     times: Vec<DateTime<Utc>>,
     frames: Vec<FrameData>,
     geom: GridGeom,
+    /// The (blended) motion field this generation advected along — the
+    /// EMA history for the NEXT generation (#524).
+    field: MotionField,
 }
 
 /// Atomically swapped engine state.
@@ -395,14 +409,31 @@ impl NowcastEngine {
             height: h,
         };
 
-        // Fetch the anchor + previous frame on the working grid.
-        // Resolve the source's current run ONCE and pin both fetches to it
-        // (see fetch_frame). `None` for non-forecast sources.
+        // Fetch the motion history + anchor frame on the working grid,
+        // every fetch pinned to ONE resolved source run (see fetch_frame).
+        // `history` holds up to `history_frames` timestamps ending at the
+        // anchor; a fetch failure on an OLDER frame degrades to fewer pairs
+        // rather than failing the generation (the last pair is mandatory).
         let source_run = self.source.resolve_reference_time(Some(anchor), None);
-        let prev = self.fetch_frame(&geom, prev_time, source_run)?;
+        let mut motion_frames: Vec<(DateTime<Utc>, Grid)> = Vec::with_capacity(history.len());
+        for &t in history.iter().rev().skip(1).rev() {
+            // All but the anchor (fetched below as the stored analysis frame).
+            match self.fetch_frame(&geom, t, source_run) {
+                Ok(f) => motion_frames.push((t, frame_to_grid(&f, w as usize, h as usize))),
+                Err(e) if t != prev_time => {
+                    tracing::debug!(
+                        "[{}] nowcast history frame {t} unavailable ({e}); \
+                         continuing with fewer motion pairs",
+                        self.collection_id
+                    );
+                }
+                Err(e) => return Err(e),
+            }
+        }
         let analysis = self.fetch_frame(&geom, anchor, source_run)?;
-        let prev_f32 = frame_to_grid(&prev, w as usize, h as usize);
         let analysis_f32 = frame_to_grid(&analysis, w as usize, h as usize);
+        motion_frames.push((anchor, analysis_f32));
+        let analysis_f32 = &motion_frames.last().expect("anchor pushed").1;
 
         // Deliberate scale handling (not the phase-0 accident): estimate
         // motion on a grid coarse enough that the physical search window
@@ -426,12 +457,25 @@ impl NowcastEngine {
             min_echo: self.cfg.min_echo,
             ..MotionOptions::default()
         };
-        // Vectors come out in pixels per source interval; the leads below are
-        // expressed in the same interval unit, so no time scaling is needed.
-        let field = if factor > 1 {
-            let prev_coarse = downsample(&prev_f32, factor as usize);
-            let analysis_coarse = downsample(&analysis_f32, factor as usize);
-            let mut f = estimate_motion(&prev_coarse, &analysis_coarse, &opts);
+
+        // Multi-pair estimation (#524): every consecutive history pair
+        // contributes measurements, scaled to px-per-LAST-interval so a
+        // mildly irregular cadence still averages correctly (a degenerate
+        // pair interval skips that pair inside estimate_motion_multi).
+        // Vectors come out in pixels per source interval; the leads below
+        // are expressed in the same interval unit — no time scaling needed.
+        let interval_secs = interval.num_seconds().max(1) as f32;
+        let scales: Vec<f32> = motion_frames
+            .windows(2)
+            .map(|p| interval_secs / (p[1].0 - p[0].0).num_seconds().max(0) as f32)
+            .collect();
+        let mut field = if factor > 1 {
+            let coarse: Vec<Grid> = motion_frames
+                .iter()
+                .map(|(_, g)| downsample(g, factor as usize))
+                .collect();
+            let coarse_refs: Vec<&Grid> = coarse.iter().collect();
+            let mut f = estimate_motion_multi(&coarse_refs, &scales, &opts);
             // Coarse-grid vectors/blocks → working-grid units.
             f.block *= factor as usize;
             for v in f.u.iter_mut().chain(f.v.iter_mut()) {
@@ -439,8 +483,20 @@ impl NowcastEngine {
             }
             f
         } else {
-            estimate_motion(&prev_f32, &analysis_f32, &opts)
+            let refs: Vec<&Grid> = motion_frames.iter().map(|(_, g)| g).collect();
+            estimate_motion_multi(&refs, &scales, &opts)
         };
+
+        // Temporal EMA with the previous generation's field (#524): stops
+        // the per-generation motion-noise oscillation that reads as
+        // rubber-banding in animations. No-op when the block grid changed
+        // (blend_with_previous checks dims).
+        {
+            let state = self.state.load();
+            if let Some((_, latest)) = state.generations.iter().next_back() {
+                field.blend_with_previous(&latest.field, EMA_ALPHA_MEASURED, EMA_ALPHA_FILLED);
+            }
+        }
 
         // Lead schedule. An explicit step was validated against MAX_LEADS at
         // construction; the source-cadence default can still exceed it (a
@@ -494,17 +550,19 @@ impl NowcastEngine {
                     gain: *gain,
                     offset: *offset,
                 },
-                FrameData::F32(_) => FrameData::F32(trajectories.sample(&analysis_f32).data),
+                FrameData::F32(_) => FrameData::F32(trajectories.sample(analysis_f32).data),
             };
             times.push(lead_time);
             frames.push(frame);
         }
+        drop(trajectories); // release the borrow of `field` before moving it
 
         Ok(Generation {
             reference_time: anchor,
             times,
             frames,
             geom,
+            field,
         })
     }
 

--- a/crates/engine-nowcast/src/motion.rs
+++ b/crates/engine-nowcast/src/motion.rs
@@ -66,6 +66,39 @@ pub struct MotionField {
 }
 
 impl MotionField {
+    /// Temporal EMA with the previous generation's field (#524): per block,
+    /// `self = alpha·self + (1−alpha)·prev`, where `alpha` is
+    /// `alpha_measured` for blocks this generation actually measured and the
+    /// (lower) `alpha_filled` for blocks whose vector came from fill/
+    /// smoothing — a filled block carries no new information, so it should
+    /// lean harder on history. No-op when the grids don't match (working
+    /// geometry changed, e.g. a config edit) — blending across different
+    /// grids would be nonsense.
+    ///
+    /// This is what stops nowcast animations rubber-banding between
+    /// generations: single-pair block matching re-reads convective
+    /// growth/decay as motion noise every generation, and the EMA gives the
+    /// field ~1/(1−alpha) generations of memory.
+    pub fn blend_with_previous(
+        &mut self,
+        prev: &MotionField,
+        alpha_measured: f32,
+        alpha_filled: f32,
+    ) {
+        if (self.bw, self.bh, self.block) != (prev.bw, prev.bh, prev.block) {
+            return;
+        }
+        for j in 0..self.u.len() {
+            let alpha = if self.measured[j] {
+                alpha_measured
+            } else {
+                alpha_filled
+            };
+            self.u[j] = alpha * self.u[j] + (1.0 - alpha) * prev.u[j];
+            self.v[j] = alpha * self.v[j] + (1.0 - alpha) * prev.v[j];
+        }
+    }
+
     /// Bilinear sample of (u, v) at pixel position (x, y), clamped at edges.
     pub fn sample(&self, x: f32, y: f32) -> (f32, f32) {
         if self.bw == 0 || self.bh == 0 {
@@ -94,6 +127,82 @@ impl MotionField {
 /// A vector `(u, v)` for a block means `next(x, y) ≈ prev(x - u, y - v)` for
 /// pixels in that block: echoes moved by `(u, v)` over one frame interval.
 pub fn estimate_motion(prev: &Grid, next: &Grid, opts: &MotionOptions) -> MotionField {
+    let mut field = measure_pair(prev, next, opts);
+    postprocess(&mut field, opts);
+    field
+}
+
+/// Multi-pair motion estimation (#524): measure each consecutive frame pair,
+/// scale pair *i*'s vectors by `interval_scales[i]` (converting them to the
+/// reference interval's unit — pass `1.0` for a uniform cadence), average the
+/// per-block measurements, then run the shared outlier/fill/smooth pipeline
+/// ONCE on the combined field. Averaging measured vectors across pairs damps
+/// the single-pair noise that convective growth/decay masquerades as —
+/// the dominant source of generation-to-generation nowcast rubber-banding.
+///
+/// `frames` is oldest → newest, length ≥ 2; `interval_scales.len()` must be
+/// `frames.len() - 1`.
+pub fn estimate_motion_multi(
+    frames: &[&Grid],
+    interval_scales: &[f32],
+    opts: &MotionOptions,
+) -> MotionField {
+    assert!(frames.len() >= 2, "multi-pair estimation needs >= 2 frames");
+    assert_eq!(
+        interval_scales.len(),
+        frames.len() - 1,
+        "one interval scale per consecutive pair"
+    );
+
+    let mut combined: Option<MotionField> = None;
+    let mut counts: Vec<u32> = Vec::new();
+    for (i, scale) in interval_scales.iter().enumerate() {
+        if !scale.is_finite() || *scale <= 0.0 {
+            continue; // degenerate pair interval — skip the pair
+        }
+        let pair = measure_pair(frames[i], frames[i + 1], opts);
+        match &mut combined {
+            None => {
+                counts = pair.measured.iter().map(|&m| u32::from(m)).collect();
+                let mut first = pair;
+                for (j, m) in first.measured.iter().enumerate() {
+                    if *m {
+                        first.u[j] *= scale;
+                        first.v[j] *= scale;
+                    }
+                }
+                combined = Some(first);
+            }
+            Some(acc) => {
+                debug_assert_eq!((acc.bw, acc.bh), (pair.bw, pair.bh));
+                for (j, count) in counts.iter_mut().enumerate() {
+                    if pair.measured[j] {
+                        acc.u[j] += pair.u[j] * scale;
+                        acc.v[j] += pair.v[j] * scale;
+                        acc.measured[j] = true;
+                        *count += 1;
+                    }
+                }
+            }
+        }
+    }
+
+    let mut field = combined
+        .unwrap_or_else(|| measure_pair(frames[frames.len() - 2], frames[frames.len() - 1], opts));
+    for (j, &n) in counts.iter().enumerate() {
+        if n > 1 {
+            field.u[j] /= n as f32;
+            field.v[j] /= n as f32;
+        }
+    }
+    postprocess(&mut field, opts);
+    field
+}
+
+/// The raw block-matching stage: per-block SAD search, no outlier rejection,
+/// no fill, no smoothing. Shared by the single-pair and multi-pair paths so
+/// the measurement itself cannot drift between them.
+fn measure_pair(prev: &Grid, next: &Grid, opts: &MotionOptions) -> MotionField {
     assert_eq!(
         (prev.width, prev.height),
         (next.width, next.height),
@@ -193,12 +302,17 @@ pub fn estimate_motion(prev: &Grid, next: &Grid, opts: &MotionOptions) -> Motion
         }
     }
 
-    reject_outliers(&mut field, opts);
-    fill_unmeasured(&mut field);
-    for _ in 0..opts.smooth_passes {
-        box_smooth(&mut field);
-    }
     field
+}
+
+/// The shared post-measurement pipeline: robust outlier rejection, fill,
+/// smoothing.
+fn postprocess(field: &mut MotionField, opts: &MotionOptions) {
+    reject_outliers(field, opts);
+    fill_unmeasured(field);
+    for _ in 0..opts.smooth_passes {
+        box_smooth(field);
+    }
 }
 
 /// Keep `(cost, dx, dy)` in `best` if it beats the current candidate.
@@ -324,6 +438,75 @@ mod tests {
             }
         }
         Grid::new(w, h, data)
+    }
+
+    #[test]
+    fn multi_pair_matches_single_pair_on_uniform_motion() {
+        // Three frames of the same translation: averaging the two pairs must
+        // agree with the last pair alone (each pair measures the same shift).
+        let t0 = disc_frame(200, 200, 74.0, 124.0, 12.0, 40.0);
+        let t1 = disc_frame(200, 200, 80.0, 120.0, 12.0, 40.0);
+        let t2 = disc_frame(200, 200, 86.0, 116.0, 12.0, 40.0);
+        let opts = MotionOptions {
+            search_radius: 10,
+            ..MotionOptions::default()
+        };
+        let single = estimate_motion(&t1, &t2, &opts);
+        let multi = estimate_motion_multi(&[&t0, &t1, &t2], &[1.0, 1.0], &opts);
+        let (su, sv) = single.sample(86.0, 116.0);
+        let (mu, mv) = multi.sample(86.0, 116.0);
+        assert!(
+            (su - mu).abs() <= 1.0 && (sv - mv).abs() <= 1.0,
+            "uniform motion: multi ({mu},{mv}) must agree with single ({su},{sv})"
+        );
+    }
+
+    #[test]
+    fn multi_pair_skips_degenerate_interval_scales() {
+        let t0 = disc_frame(160, 160, 60.0, 80.0, 10.0, 40.0);
+        let t1 = disc_frame(160, 160, 66.0, 80.0, 10.0, 40.0);
+        let opts = MotionOptions {
+            search_radius: 10,
+            ..MotionOptions::default()
+        };
+        // First pair carries a non-finite scale (degenerate interval) — it
+        // must be skipped, leaving the second pair's measurement intact.
+        let multi = estimate_motion_multi(&[&t0, &t0, &t1], &[f32::INFINITY, 1.0], &opts);
+        let (u, v) = multi.sample(66.0, 80.0);
+        assert!((u - 6.0).abs() <= 1.0, "u = {u}, expected ~6");
+        assert!(v.abs() <= 1.0, "v = {v}, expected ~0");
+    }
+
+    #[test]
+    fn blend_with_previous_applies_per_block_alpha() {
+        let frame = disc_frame(128, 128, 60.0, 60.0, 10.0, 35.0);
+        let moved = disc_frame(128, 128, 66.0, 60.0, 10.0, 35.0);
+        let mut new = estimate_motion(&frame, &moved, &MotionOptions::default());
+        let mut prev = new.clone();
+        // Previous generation thought everything moved (0, 8).
+        for j in 0..prev.u.len() {
+            prev.u[j] = 0.0;
+            prev.v[j] = 8.0;
+        }
+        let before_u = new.u.clone();
+        let before_v = new.v.clone();
+        new.blend_with_previous(&prev, 0.7, 0.4);
+        for j in 0..new.u.len() {
+            let a = if new.measured[j] { 0.7 } else { 0.4 };
+            assert!((new.u[j] - a * before_u[j]).abs() < 1e-4);
+            assert!((new.v[j] - (a * before_v[j] + (1.0 - a) * 8.0)).abs() < 1e-4);
+        }
+    }
+
+    #[test]
+    fn blend_with_previous_is_noop_on_dimension_mismatch() {
+        let a0 = disc_frame(128, 128, 60.0, 60.0, 10.0, 35.0);
+        let mut a = estimate_motion(&a0, &a0, &MotionOptions::default());
+        let b0 = disc_frame(64, 64, 30.0, 30.0, 8.0, 35.0);
+        let b = estimate_motion(&b0, &b0, &MotionOptions::default());
+        let before = a.u.clone();
+        a.blend_with_previous(&b, 0.7, 0.4);
+        assert_eq!(a.u, before, "mismatched grids must not blend");
     }
 
     #[test]

--- a/crates/engine-nowcast/tests/integration.rs
+++ b/crates/engine-nowcast/tests/integration.rs
@@ -361,3 +361,26 @@ fn sub_second_cadence_fails_generation_cleanly() {
     assert_eq!(generations, 0);
     assert_eq!(failures, 1, "the failure must be counted, not hidden");
 }
+
+/// history_frames is bounded: each frame is a blocking source fetch per
+/// generation, so an oversized value is a config error, not a silent cap.
+#[test]
+fn oversized_history_frames_is_rejected() {
+    let source = Arc::new(MockSource {
+        times: RwLock::new(vec![t0()]),
+    });
+    let config = NowcastConfig {
+        source: "mock".into(),
+        horizon: "PT1H".into(),
+        step: None,
+        history_frames: 24,
+        poll_interval_secs: 30,
+        max_generations: 4,
+        max_pixels: 4_000_000,
+        min_echo: 10.0,
+    };
+    let err = NowcastEngine::new("mock-nowcast", "mock", source, &config)
+        .err()
+        .expect("must reject oversized history_frames");
+    assert!(err.to_string().contains("exceeds the cap"), "got: {err}");
+}

--- a/crates/engine-nowcast/tests/integration.rs
+++ b/crates/engine-nowcast/tests/integration.rs
@@ -98,6 +98,14 @@ impl MapEngine for MockSource {
 }
 
 fn build(horizon: &str, source_times: &[DateTime<Utc>]) -> (Arc<MockSource>, NowcastEngine) {
+    build_with_history(horizon, source_times, 2)
+}
+
+fn build_with_history(
+    horizon: &str,
+    source_times: &[DateTime<Utc>],
+    history_frames: usize,
+) -> (Arc<MockSource>, NowcastEngine) {
     let source = Arc::new(MockSource {
         times: RwLock::new(source_times.to_vec()),
     });
@@ -105,7 +113,7 @@ fn build(horizon: &str, source_times: &[DateTime<Utc>]) -> (Arc<MockSource>, Now
         source: "mock".into(),
         horizon: horizon.into(),
         step: None,
-        history_frames: 2,
+        history_frames,
         poll_interval_secs: 30,
         max_generations: 4,
         max_pixels: 4_000_000,
@@ -114,6 +122,33 @@ fn build(horizon: &str, source_times: &[DateTime<Utc>]) -> (Arc<MockSource>, Now
     let engine =
         NowcastEngine::new("mock-nowcast", "mock", source.clone(), &config).expect("engine builds");
     (source, engine)
+}
+
+/// Multi-pair motion (#524): a three-frame history must extrapolate the
+/// translating source just as accurately end to end.
+#[test]
+fn multi_pair_history_tracks_the_source() {
+    let anchor = t0() + Duration::minutes(10);
+    let (_source, engine) =
+        build_with_history("PT1H", &[t0(), t0() + Duration::minutes(5), anchor], 3);
+    engine.poll_once();
+    assert!(engine.has_data());
+
+    let lead_time = anchor + Duration::minutes(30);
+    let forecast = render_raw(&engine, lead_time);
+    let truth = truth_frame(lead_time);
+    let (mut inter, mut union) = (0u32, 0u32);
+    for (f, o) in forecast.iter().zip(&truth) {
+        let (fe, oe) = (*f == ECHO_RAW, *o == ECHO_RAW);
+        if fe && oe {
+            inter += 1;
+        }
+        if fe || oe {
+            union += 1;
+        }
+    }
+    let iou = inter as f64 / union as f64;
+    assert!(iou > 0.8, "multi-pair extrapolation must track (IoU {iou})");
 }
 
 /// Raw bytes of a full-extent render at `time`.


### PR DESCRIPTION
Part 1 of #524 (leaves it open — PVOL cell-track fusion, Grafana row, and per-generation skill logging remain). Fixes the user-reported "stretchy elastic back-and-forth" animation artifact, worst on convective cells.

## Diagnosis

Two stacked effects:
1. **Between generations** (the back-and-forth): motion was estimated from a single frame pair, and convective growth/decay reads as spurious motion to a block matcher. Every 5-minute generation re-estimated from scratch, so the +1–2 h frames swung position each time the client re-pinned — classic nowcast rubber-banding (the reason pySTEPS defaults to multi-frame motion).
2. **Within a loop** (the stretching): at the prod 500 m working grid the coarsened motion blocks were ~25 km — a 3–5 km cell sits inside the bilinear gradient between block vectors and gets differentially advected, elongating with lead time.

## Fix

- **`estimate_motion_multi`**: every consecutive history pair contributes block measurements (scaled to the last interval's unit for mildly irregular cadences; degenerate pairs skipped), averaged per block, then ONE shared outlier/fill/smooth pass. The engine fetches up to `history_frames` (default 3) frames per generation, all pinned to one source run; a missing older frame degrades to fewer pairs instead of failing the generation.
- **Cross-generation EMA**: each new field blends with the previous generation's (`0.7` new for measured blocks, `0.4` for filled — inferred vectors lean harder on history; auto-skipped when the block grid changes). The blended field is stored on the generation as the next one's history — ~1.5 generations of memory, enough to damp pair noise without lagging a real wind shift by more than a couple of cadence intervals.
- **`TARGET_SEARCH_PX` 24 → 48**: the FMI ~500 m grid stays uncoarsened, halving effective motion-block size to ~16 km so small cells get a closer-fitting vector — affordable since #529 made generation cost linear in leads.

## Verification

- 23 tests: new multi-pair units (uniform-motion agreement with single-pair, degenerate-interval skipping), EMA blend units (per-block alpha math, dimension-mismatch no-op), and a 3-frame end-to-end extrapolation gate (IoU > 0.8 against the mock source's closed-form future). All prior gates unchanged.
- Generation cost on the smoke fixture: 2,516 ms vs 2,380 ms (~5% for the extra pair). Expect a similar marginal increase on prod's 27 s.
- The artifact itself is an animation-domain effect — final verification is the tutka loop after deploy; the between-generation oscillation should visibly damp within two generations of the deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)