### PR TITLE
feat(engine-nowcast): cell intelligence — severity rank, tracks, deviant-mover flag

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -323,7 +323,7 @@ they were found. Critical Rules 5–7, 9 and 10 above are part of this set.
 | ODIM PVOL | `EdrEngine` + `MapEngine` + `VolumeEngine` (per-site views) + `FeatureEngine` (network engine) | EDR (position, locations, area, trajectory), WMS, Maps, Tiles, 3D Tiles, Features (site inventory) |
 | QueryData | `EdrEngine` + `MapEngine` | EDR (position only), WMS, Maps, Tiles |
 | Zarr | `EdrEngine` + `MapEngine` | EDR (position), WMS, Maps, Tiles; local + S3/HTTP |
-| Nowcast | `MapEngine` (derived: wraps another collection's engine) | WMS, Maps, Tiles — motion-extrapolated frames with future TIME values (EDR + instances = phase 2, #523) |
+| Nowcast | `MapEngine` + `FeatureEngine` (derived: wraps another collection's engine) | WMS, Maps, Tiles — motion-extrapolated future frames; Features — tracked cell intelligence (severity, deviant movers, #544). EDR + instances = #523 |
 | PostGIS | `EdrEngine` + `FeatureEngine` + `MapEngine` (events shape only) | EDR (position, locations, area), Features; events shape: EDR (area) + WMS/Maps/Tiles (age-colored strike layer) |
 
 ## Config Format

--- a/crates/engine-nowcast/CLAUDE.md
+++ b/crates/engine-nowcast/CLAUDE.md
@@ -85,6 +85,18 @@ follow-up (full frames only for the latest generation) is scoped in #523.
   `nowcast_lead1_persistence_csi_permille`. A persistent gap collapse in
   prod = motion or data regression; check before blaming the client.
 
+## Cell intelligence (V2.2, #544)
+
+- `cells2d` tracks the analysis frame's 35 dBZ cells across generations
+  (anisotropic km matching): TRT-lite severity (max dBZ 45/50/55 steps +
+  area ≥ 50 km² — deliberately NOT VoxelGrid attributes while voxels are
+  beta/unverified), velocity EMA, and the deviant-mover flag = sustained
+  ≥5 m/s residual between the track and the ambient motion field (the
+  estimator-disagreement right-mover detector). Served as Point features
+  via `FeatureEngine` when the collection lists `features` in `apis`.
+- Lightning join (flash counts/jump per track) is part 2 — needs a ds-core
+  event-source trait + engine-postgis impl.
+
 ## Gotchas
 
 - Advection is Lagrangian persistence: no growth/decay; 35+ dBZ convective

--- a/crates/engine-nowcast/src/cells2d.rs
+++ b/crates/engine-nowcast/src/cells2d.rs
@@ -19,8 +19,12 @@ use crate::objects::{match_cells, CellBlob, PixelScale};
 pub const CELL_THRESHOLD_DBZ: f32 = 35.0;
 /// Minimum component size in pixels.
 pub const CELL_MIN_AREA_PX: usize = 5;
-/// Matching gate (km) for track continuity between generations.
+/// Matching gate (km) for track continuity between generations, per
+/// [`TRACK_GATE_BASE_SECS`] of elapsed time — the gate scales linearly
+/// with the actual span (a skipped generation doubles the distance a
+/// storm legitimately covers), never below one base gate.
 pub const TRACK_GATE_KM: f32 = 20.0;
+pub const TRACK_GATE_BASE_SECS: f32 = 300.0;
 /// Residual speed (m/s) between cell track and ambient field that counts
 /// as deviant, provided the cell itself moves faster than
 /// [`DEVIANT_MIN_CELL_SPEED_MS`].
@@ -132,8 +136,9 @@ pub fn advance_tracks(
     mut next_id: impl FnMut() -> u64,
 ) -> Vec<CellTrack> {
     let prev_blobs: Vec<CellBlob> = previous.iter().map(|t| t.blob.clone()).collect();
+    let gate = TRACK_GATE_KM * (displacement_secs / TRACK_GATE_BASE_SECS).max(1.0);
     let mut matched_prev: Vec<Option<usize>> = vec![None; blobs.len()];
-    for (pi, ci) in match_cells(&prev_blobs, &blobs, scale, TRACK_GATE_KM) {
+    for (pi, ci) in match_cells(&prev_blobs, &blobs, scale, gate) {
         matched_prev[ci] = Some(pi);
     }
 

--- a/crates/engine-nowcast/src/cells2d.rs
+++ b/crates/engine-nowcast/src/cells2d.rs
@@ -1,0 +1,284 @@
+//! Cell intelligence (#544, v2.2 part 1): tracked 2D composite cells with a
+//! TRT-lite severity rank and a deviant-mover flag.
+//!
+//! Built on the VERIFIED 2D objects machinery (#543) — deliberately NOT on
+//! the 3D `VoxelGrid` attributes (beta, non-verified, slow as of 2026-07);
+//! echo-top/VIL enrichment of the rank waits for verified voxels.
+//!
+//! The deviant-mover detector is the estimator-disagreement idea: the block
+//! motion field measures the ambient echo flow, the cell track measures the
+//! storm's own displacement — a sustained residual between them marks
+//! deviant movers (right-movers etc.), the storms pure advection misplaces
+//! first.
+
+use crate::motion::MotionField;
+use crate::objects::{match_cells, CellBlob, PixelScale};
+
+/// Cell threshold (dBZ) for intelligence tracking — the Ritvanen-style
+/// convective contour, matching the verification harness default.
+pub const CELL_THRESHOLD_DBZ: f32 = 35.0;
+/// Minimum component size in pixels.
+pub const CELL_MIN_AREA_PX: usize = 5;
+/// Matching gate (km) for track continuity between generations.
+pub const TRACK_GATE_KM: f32 = 20.0;
+/// Residual speed (m/s) between cell track and ambient field that counts
+/// as deviant, provided the cell itself moves faster than
+/// [`DEVIANT_MIN_CELL_SPEED_MS`].
+pub const DEVIANT_RESIDUAL_MS: f32 = 5.0;
+pub const DEVIANT_MIN_CELL_SPEED_MS: f32 = 3.0;
+/// Consecutive deviant generations before the flag is raised (single-scan
+/// residuals are mostly track noise).
+pub const DEVIANT_STREAK: u32 = 2;
+
+/// TRT-lite severity rank from 2D attributes (documented heuristic v1).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Severity {
+    Weak,
+    Moderate,
+    Severe,
+    VerySevere,
+}
+
+impl Severity {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Severity::Weak => "weak",
+            Severity::Moderate => "moderate",
+            Severity::Severe => "severe",
+            Severity::VerySevere => "very_severe",
+        }
+    }
+}
+
+/// Rank a cell from max intensity and area: one point per crossed max-dBZ
+/// step (45/50/55) plus one for area ≥ 50 km² — 0 ⇒ weak … 3+ ⇒ very
+/// severe. Deliberately simple and monotone; a tree-based model replaces
+/// this in V2.4.
+pub fn severity(blob: &CellBlob, area_km2: f64) -> Severity {
+    let mut points = 0u32;
+    for step in [45.0f32, 50.0, 55.0] {
+        if blob.max_value >= step {
+            points += 1;
+        }
+    }
+    if area_km2 >= 50.0 {
+        points += 1;
+    }
+    match points {
+        0 => Severity::Weak,
+        1 => Severity::Moderate,
+        2 => Severity::Severe,
+        _ => Severity::VerySevere,
+    }
+}
+
+/// One tracked cell (current generation's snapshot plus track state).
+#[derive(Debug, Clone)]
+pub struct CellTrack {
+    pub id: u64,
+    pub blob: CellBlob,
+    /// Generations this track has been observed in (1 = newborn).
+    pub age: u32,
+    /// EMA of the track's own velocity, km/interval in grid axes
+    /// (+x east, +y south). `None` until the second observation.
+    pub velocity_km: Option<(f32, f32)>,
+    /// Consecutive generations the track-vs-field residual exceeded the
+    /// deviant gates.
+    pub deviant_streak: u32,
+    pub severity: Severity,
+}
+
+impl CellTrack {
+    /// Sustained deviant mover?
+    pub fn deviant(&self) -> bool {
+        self.deviant_streak >= DEVIANT_STREAK
+    }
+
+    /// Ground speed in m/s over one source interval.
+    pub fn speed_ms(&self, interval_secs: f32) -> Option<f32> {
+        self.velocity_km
+            .map(|(vx, vy)| (vx * vx + vy * vy).sqrt() * 1000.0 / interval_secs.max(1.0))
+    }
+
+    /// Compass bearing (degrees, 0 = north, clockwise) the cell moves toward.
+    pub fn bearing_deg(&self) -> Option<f64> {
+        self.velocity_km.map(|(vx, vy)| {
+            // +y is SOUTH in grid coordinates.
+            (f64::from(vx).atan2(f64::from(-vy)).to_degrees() + 360.0) % 360.0
+        })
+    }
+}
+
+/// Advance tracks by one generation: match previous tracks to newly
+/// segmented blobs (anisotropic km gate), carry ids/age, update the
+/// velocity EMA, and re-evaluate severity and the deviant streak against
+/// the generation's motion `field` (vectors in px/interval).
+///
+/// `next_id` supplies ids for newborn tracks.
+#[allow(clippy::too_many_arguments)]
+pub fn advance_tracks(
+    previous: &[CellTrack],
+    blobs: Vec<CellBlob>,
+    scale: PixelScale,
+    field: &MotionField,
+    interval_secs: f32,
+    mut next_id: impl FnMut() -> u64,
+) -> Vec<CellTrack> {
+    let prev_blobs: Vec<CellBlob> = previous.iter().map(|t| t.blob.clone()).collect();
+    let mut matched_prev: Vec<Option<usize>> = vec![None; blobs.len()];
+    for (pi, ci) in match_cells(&prev_blobs, &blobs, scale, TRACK_GATE_KM) {
+        matched_prev[ci] = Some(pi);
+    }
+
+    blobs
+        .into_iter()
+        .zip(matched_prev)
+        .map(|(blob, prev_idx)| {
+            let area_km2 = blob.area as f64 * f64::from(scale.x) * f64::from(scale.y);
+            let severity = severity(&blob, area_km2);
+            match prev_idx {
+                None => CellTrack {
+                    id: next_id(),
+                    blob,
+                    age: 1,
+                    velocity_km: None,
+                    deviant_streak: 0,
+                    severity,
+                },
+                Some(pi) => {
+                    let prev = &previous[pi];
+                    // Track displacement over one interval, km in grid axes.
+                    let dx = (blob.centroid.0 - prev.blob.centroid.0) * scale.x;
+                    let dy = (blob.centroid.1 - prev.blob.centroid.1) * scale.y;
+                    let (vx_km, vy_km) = match prev.velocity_km {
+                        // EMA keeps single-scan centroid jitter out of the
+                        // deviant residual.
+                        Some((px, py)) => (0.5 * dx + 0.5 * px, 0.5 * dy + 0.5 * py),
+                        None => (dx, dy),
+                    };
+
+                    // Ambient flow at the cell, converted px/interval → km.
+                    let (fu, fv) = field.sample(blob.centroid.0, blob.centroid.1);
+                    let (fx_km, fy_km) = (fu * scale.x, fv * scale.y);
+                    let to_ms = 1000.0 / interval_secs.max(1.0);
+                    let residual_ms =
+                        (((vx_km - fx_km).powi(2) + (vy_km - fy_km).powi(2)).sqrt()) * to_ms;
+                    let cell_speed_ms = (vx_km * vx_km + vy_km * vy_km).sqrt() * to_ms;
+                    let deviant_now = residual_ms > DEVIANT_RESIDUAL_MS
+                        && cell_speed_ms > DEVIANT_MIN_CELL_SPEED_MS;
+
+                    CellTrack {
+                        id: prev.id,
+                        blob,
+                        age: prev.age + 1,
+                        velocity_km: Some((vx_km, vy_km)),
+                        deviant_streak: if deviant_now {
+                            prev.deviant_streak + 1
+                        } else {
+                            0
+                        },
+                        severity,
+                    }
+                }
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::motion::{estimate_motion, MotionOptions};
+    use crate::objects::segment_cells;
+    use crate::Grid;
+
+    fn disc(w: usize, h: usize, cx: f32, cy: f32, r: f32, v: f32) -> Grid {
+        let mut data = vec![0.0f32; w * h];
+        for (i, cell) in data.iter_mut().enumerate() {
+            let (x, y) = ((i % w) as f32 + 0.5, (i / w) as f32 + 0.5);
+            if (x - cx).powi(2) + (y - cy).powi(2) <= r * r {
+                *cell = v;
+            }
+        }
+        Grid::new(w, h, data)
+    }
+
+    #[test]
+    fn severity_rank_is_monotone_in_intensity_and_area() {
+        let weak = CellBlob {
+            centroid: (0.0, 0.0),
+            area: 10,
+            volume: 10.0,
+            max_value: 40.0,
+        };
+        assert_eq!(severity(&weak, 10.0), Severity::Weak);
+        let mut b = weak.clone();
+        b.max_value = 47.0;
+        assert_eq!(severity(&b, 10.0), Severity::Moderate);
+        b.max_value = 52.0;
+        assert_eq!(severity(&b, 60.0), Severity::VerySevere);
+        b.max_value = 57.0;
+        assert_eq!(severity(&b, 60.0), Severity::VerySevere);
+    }
+
+    #[test]
+    fn tracks_carry_id_age_velocity_and_flag_deviant_movers() {
+        // Ambient field: everything (the big disc) moves +4 px/interval in x.
+        // The small disc moves -4 px/interval — against the flow.
+        let scale = PixelScale { x: 1.0, y: 1.0 }; // 1 km/px, interval 300 s
+        let f0 = |big_x: f32, small_x: f32| {
+            let mut g = disc(300, 120, big_x, 60.0, 25.0, 45.0);
+            let s = disc(300, 120, small_x, 30.0, 5.0, 50.0);
+            for (a, b) in g.data.iter_mut().zip(&s.data) {
+                *a = a.max(*b);
+            }
+            g
+        };
+        let frame_a = f0(150.0, 250.0);
+        let frame_b = f0(154.0, 246.0);
+        let field = estimate_motion(&frame_a, &frame_b, &MotionOptions::default());
+
+        let mut counter = 0u64;
+        let mut id_gen = || {
+            counter += 1;
+            counter
+        };
+        let t0 = advance_tracks(
+            &[],
+            segment_cells(&frame_a, CELL_THRESHOLD_DBZ, CELL_MIN_AREA_PX),
+            scale,
+            &field,
+            300.0,
+            &mut id_gen,
+        );
+        assert_eq!(t0.len(), 2);
+        assert!(t0.iter().all(|t| t.age == 1 && t.velocity_km.is_none()));
+
+        let mut tracks = t0;
+        for step in 1..=2 {
+            let fa = f0(150.0 + 4.0 * step as f32, 250.0 - 4.0 * step as f32);
+            tracks = advance_tracks(
+                &tracks,
+                segment_cells(&fa, CELL_THRESHOLD_DBZ, CELL_MIN_AREA_PX),
+                scale,
+                &field,
+                300.0,
+                &mut id_gen,
+            );
+        }
+        assert_eq!(tracks.len(), 2);
+        assert!(tracks.iter().all(|t| t.age == 3), "ids persisted");
+        let small = tracks.iter().find(|t| t.blob.area < 200).unwrap();
+        let big = tracks.iter().find(|t| t.blob.area >= 200).unwrap();
+        assert!(
+            small.deviant(),
+            "counter-flow cell must be flagged (streak {})",
+            small.deviant_streak
+        );
+        assert!(!big.deviant(), "with-flow cell must not be flagged");
+        // ~4 km / 300 s ≈ 13 m/s, moving due west vs due east.
+        assert!((small.speed_ms(300.0).unwrap() - 13.3).abs() < 4.0);
+        assert!((big.bearing_deg().unwrap() - 90.0).abs() < 20.0);
+        assert!((small.bearing_deg().unwrap() - 270.0).abs() < 20.0);
+    }
+}

--- a/crates/engine-nowcast/src/cells2d.rs
+++ b/crates/engine-nowcast/src/cells2d.rs
@@ -79,9 +79,11 @@ pub struct CellTrack {
     pub blob: CellBlob,
     /// Generations this track has been observed in (1 = newborn).
     pub age: u32,
-    /// EMA of the track's own velocity, km/interval in grid axes
-    /// (+x east, +y south). `None` until the second observation.
-    pub velocity_km: Option<(f32, f32)>,
+    /// EMA of the track's own velocity, km/SECOND in grid axes
+    /// (+x east, +y south) — time-base free, so lead-step configs and
+    /// skipped generations cannot skew it. `None` until the second
+    /// observation.
+    pub velocity_kms: Option<(f32, f32)>,
     /// Consecutive generations the track-vs-field residual exceeded the
     /// deviant gates.
     pub deviant_streak: u32,
@@ -94,15 +96,15 @@ impl CellTrack {
         self.deviant_streak >= DEVIANT_STREAK
     }
 
-    /// Ground speed in m/s over one source interval.
-    pub fn speed_ms(&self, interval_secs: f32) -> Option<f32> {
-        self.velocity_km
-            .map(|(vx, vy)| (vx * vx + vy * vy).sqrt() * 1000.0 / interval_secs.max(1.0))
+    /// Ground speed in m/s.
+    pub fn speed_ms(&self) -> Option<f32> {
+        self.velocity_kms
+            .map(|(vx, vy)| (vx * vx + vy * vy).sqrt() * 1000.0)
     }
 
     /// Compass bearing (degrees, 0 = north, clockwise) the cell moves toward.
     pub fn bearing_deg(&self) -> Option<f64> {
-        self.velocity_km.map(|(vx, vy)| {
+        self.velocity_kms.map(|(vx, vy)| {
             // +y is SOUTH in grid coordinates.
             (f64::from(vx).atan2(f64::from(-vy)).to_degrees() + 360.0) % 360.0
         })
@@ -121,7 +123,12 @@ pub fn advance_tracks(
     blobs: Vec<CellBlob>,
     scale: PixelScale,
     field: &MotionField,
-    interval_secs: f32,
+    // Wall-clock seconds the tracked DISPLACEMENT spans (previous
+    // generation's anchor → this anchor — 2× cadence after a skipped
+    // generation), distinct from the seconds one FIELD vector spans (the
+    // source interval motion was estimated over).
+    displacement_secs: f32,
+    field_interval_secs: f32,
     mut next_id: impl FnMut() -> u64,
 ) -> Vec<CellTrack> {
     let prev_blobs: Vec<CellBlob> = previous.iter().map(|t| t.blob.clone()).collect();
@@ -141,26 +148,28 @@ pub fn advance_tracks(
                     id: next_id(),
                     blob,
                     age: 1,
-                    velocity_km: None,
+                    velocity_kms: None,
                     deviant_streak: 0,
                     severity,
                 },
                 Some(pi) => {
                     let prev = &previous[pi];
                     // Track displacement over one interval, km in grid axes.
-                    let dx = (blob.centroid.0 - prev.blob.centroid.0) * scale.x;
-                    let dy = (blob.centroid.1 - prev.blob.centroid.1) * scale.y;
-                    let (vx_km, vy_km) = match prev.velocity_km {
+                    let ds = displacement_secs.max(1.0);
+                    let dx = (blob.centroid.0 - prev.blob.centroid.0) * scale.x / ds;
+                    let dy = (blob.centroid.1 - prev.blob.centroid.1) * scale.y / ds;
+                    let (vx_km, vy_km) = match prev.velocity_kms {
                         // EMA keeps single-scan centroid jitter out of the
                         // deviant residual.
                         Some((px, py)) => (0.5 * dx + 0.5 * px, 0.5 * dy + 0.5 * py),
                         None => (dx, dy),
                     };
 
-                    // Ambient flow at the cell, converted px/interval → km.
+                    // Ambient flow at the cell: px/field-interval → km/s.
+                    let fs = field_interval_secs.max(1.0);
                     let (fu, fv) = field.sample(blob.centroid.0, blob.centroid.1);
-                    let (fx_km, fy_km) = (fu * scale.x, fv * scale.y);
-                    let to_ms = 1000.0 / interval_secs.max(1.0);
+                    let (fx_km, fy_km) = (fu * scale.x / fs, fv * scale.y / fs);
+                    let to_ms = 1000.0;
                     let residual_ms =
                         (((vx_km - fx_km).powi(2) + (vy_km - fy_km).powi(2)).sqrt()) * to_ms;
                     let cell_speed_ms = (vx_km * vx_km + vy_km * vy_km).sqrt() * to_ms;
@@ -171,7 +180,7 @@ pub fn advance_tracks(
                         id: prev.id,
                         blob,
                         age: prev.age + 1,
-                        velocity_km: Some((vx_km, vy_km)),
+                        velocity_kms: Some((vx_km, vy_km)),
                         deviant_streak: if deviant_now {
                             prev.deviant_streak + 1
                         } else {
@@ -249,10 +258,11 @@ mod tests {
             scale,
             &field,
             300.0,
+            300.0,
             &mut id_gen,
         );
         assert_eq!(t0.len(), 2);
-        assert!(t0.iter().all(|t| t.age == 1 && t.velocity_km.is_none()));
+        assert!(t0.iter().all(|t| t.age == 1 && t.velocity_kms.is_none()));
 
         let mut tracks = t0;
         for step in 1..=2 {
@@ -262,6 +272,7 @@ mod tests {
                 segment_cells(&fa, CELL_THRESHOLD_DBZ, CELL_MIN_AREA_PX),
                 scale,
                 &field,
+                300.0,
                 300.0,
                 &mut id_gen,
             );
@@ -277,7 +288,7 @@ mod tests {
         );
         assert!(!big.deviant(), "with-flow cell must not be flagged");
         // ~4 km / 300 s ≈ 13 m/s, moving due west vs due east.
-        assert!((small.speed_ms(300.0).unwrap() - 13.3).abs() < 4.0);
+        assert!((small.speed_ms().unwrap() - 13.3).abs() < 4.0);
         assert!((big.bearing_deg().unwrap() - 90.0).abs() < 20.0);
         assert!((small.bearing_deg().unwrap() - 270.0).abs() < 20.0);
     }

--- a/crates/engine-nowcast/src/engine.rs
+++ b/crates/engine-nowcast/src/engine.rs
@@ -144,6 +144,8 @@ struct Generation {
     /// The (blended) motion field this generation advected along — the
     /// EMA history for the NEXT generation (#524).
     field: MotionField,
+    /// Source interval (s) the field's vectors span.
+    interval_secs: f32,
 }
 
 /// Atomically swapped engine state.
@@ -388,11 +390,15 @@ impl NowcastEngine {
                         g.width,
                         g.height,
                     );
-                    let interval_secs = generation
-                        .times
-                        .get(1)
-                        .map(|t| (*t - generation.times[0]).num_seconds() as f32)
-                        .unwrap_or(300.0);
+                    // Displacement spans the previous generation's anchor →
+                    // this one (2× cadence after a skipped generation); field
+                    // vectors span the source interval.
+                    let displacement_secs = old
+                        .generations
+                        .iter()
+                        .next_back()
+                        .map(|(&p, _)| (anchor - p).num_seconds() as f32)
+                        .unwrap_or(generation.interval_secs);
                     Arc::new(advance_tracks(
                         &old.cells,
                         blobs,
@@ -401,7 +407,8 @@ impl NowcastEngine {
                             y: ky as f32,
                         },
                         &generation.field,
-                        interval_secs,
+                        displacement_secs,
+                        generation.interval_secs,
                         || self.next_track_id.fetch_add(1, Ordering::Relaxed),
                     ))
                 };
@@ -697,6 +704,7 @@ impl NowcastEngine {
             frames,
             geom,
             field,
+            interval_secs: interval.num_seconds() as f32,
         })
     }
 
@@ -1032,11 +1040,6 @@ impl FeatureEngine for NowcastEngine {
             });
         };
         let g = latest.geom;
-        let interval_secs = latest
-            .times
-            .get(1)
-            .map(|t| (*t - latest.times[0]).num_seconds() as f32)
-            .unwrap_or(300.0);
         let (kx, ky) =
             crate::lonlat_grid_km_per_px([g.west, g.south, g.east, g.north], g.width, g.height);
         let matched: Vec<Feature> = state
@@ -1069,7 +1072,7 @@ impl FeatureEngine for NowcastEngine {
                 props.insert("deviant_mover".into(), PropertyValue::Bool(t.deviant()));
                 props.insert(
                     "speed_ms".into(),
-                    t.speed_ms(interval_secs)
+                    t.speed_ms()
                         .map(|v| PropertyValue::Float(f64::from(v)))
                         .unwrap_or(PropertyValue::Null),
                 );

--- a/crates/engine-nowcast/src/engine.rs
+++ b/crates/engine-nowcast/src/engine.rs
@@ -1036,6 +1036,60 @@ impl MapEngine for NowcastEngine {
     }
 }
 
+/// Build one cell feature: lon/lat from the grid geometry plus the served
+/// property set. Shared by `get_features` and `get_feature` so the two
+/// paths cannot drift (and the by-id path needn't materialize every cell).
+fn cell_feature(
+    t: &CellTrack,
+    g: GridGeom,
+    kx: f64,
+    ky: f64,
+    anchor: DateTime<Utc>,
+) -> (f64, f64, Feature) {
+    let lon = g.west + (f64::from(t.blob.centroid.0) / f64::from(g.width)) * (g.east - g.west);
+    let lat = g.north - (f64::from(t.blob.centroid.1) / f64::from(g.height)) * (g.north - g.south);
+    let mut props = std::collections::HashMap::new();
+    props.insert(
+        "severity".into(),
+        PropertyValue::String(t.severity.as_str().into()),
+    );
+    props.insert(
+        "max_dbz".into(),
+        PropertyValue::Float(f64::from(t.blob.max_value)),
+    );
+    props.insert(
+        "area_km2".into(),
+        PropertyValue::Float(t.blob.area as f64 * kx * ky),
+    );
+    props.insert("track_age".into(), PropertyValue::Integer(t.age as i64));
+    props.insert("deviant_mover".into(), PropertyValue::Bool(t.deviant()));
+    props.insert(
+        "speed_ms".into(),
+        t.speed_ms()
+            .map(|v| PropertyValue::Float(f64::from(v)))
+            .unwrap_or(PropertyValue::Null),
+    );
+    props.insert(
+        "bearing_deg".into(),
+        t.bearing_deg()
+            .map(PropertyValue::Float)
+            .unwrap_or(PropertyValue::Null),
+    );
+    props.insert(
+        "observed".into(),
+        PropertyValue::String(anchor.to_rfc3339()),
+    );
+    (
+        lon,
+        lat,
+        Feature {
+            id: t.id.to_string(),
+            geometry: Arc::new(Geometry::Point { x: lon, y: lat }),
+            properties: Arc::new(props),
+        },
+    )
+}
+
 impl FeatureEngine for NowcastEngine {
     /// Tracked cells of the latest analysis frame as Point features (#544).
     fn get_features(&self, query: &FeatureQuery) -> Result<FeaturePage, DataServerError> {
@@ -1070,51 +1124,13 @@ impl FeatureEngine for NowcastEngine {
             .cells
             .iter()
             .filter_map(|t| {
-                let lon = g.west
-                    + (f64::from(t.blob.centroid.0) / f64::from(g.width)) * (g.east - g.west);
-                let lat = g.north
-                    - (f64::from(t.blob.centroid.1) / f64::from(g.height)) * (g.north - g.south);
+                let (lon, lat, feature) = cell_feature(t, g, kx, ky, anchor);
                 if let Some(b) = &query.bbox {
                     if !b.contains(lon, lat) {
                         return None;
                     }
                 }
-                let mut props = std::collections::HashMap::new();
-                props.insert(
-                    "severity".into(),
-                    PropertyValue::String(t.severity.as_str().into()),
-                );
-                props.insert(
-                    "max_dbz".into(),
-                    PropertyValue::Float(f64::from(t.blob.max_value)),
-                );
-                props.insert(
-                    "area_km2".into(),
-                    PropertyValue::Float(t.blob.area as f64 * kx * ky),
-                );
-                props.insert("track_age".into(), PropertyValue::Integer(t.age as i64));
-                props.insert("deviant_mover".into(), PropertyValue::Bool(t.deviant()));
-                props.insert(
-                    "speed_ms".into(),
-                    t.speed_ms()
-                        .map(|v| PropertyValue::Float(f64::from(v)))
-                        .unwrap_or(PropertyValue::Null),
-                );
-                props.insert(
-                    "bearing_deg".into(),
-                    t.bearing_deg()
-                        .map(PropertyValue::Float)
-                        .unwrap_or(PropertyValue::Null),
-                );
-                props.insert(
-                    "observed".into(),
-                    PropertyValue::String(anchor.to_rfc3339()),
-                );
-                Some(Feature {
-                    id: t.id.to_string(),
-                    geometry: Arc::new(Geometry::Point { x: lon, y: lat }),
-                    properties: Arc::new(props),
-                })
+                Some(feature)
             })
             .collect();
         let number_matched = matched.len();
@@ -1141,14 +1157,19 @@ impl FeatureEngine for NowcastEngine {
     }
 
     fn get_feature(&self, feature_id: &str) -> Result<Feature, DataServerError> {
-        self.get_features(&FeatureQuery {
-            limit: usize::MAX,
-            ..Default::default()
-        })?
-        .features
-        .into_iter()
-        .find(|f| f.id == feature_id)
-        .ok_or_else(|| DataServerError::FeatureNotFound(feature_id.to_string()))
+        let state = self.state.load();
+        let not_found = || DataServerError::FeatureNotFound(feature_id.to_string());
+        let (&anchor, latest) = state.generations.iter().next_back().ok_or_else(not_found)?;
+        let id: u64 = feature_id.parse().map_err(|_| not_found())?;
+        let track = state
+            .cells
+            .iter()
+            .find(|t| t.id == id)
+            .ok_or_else(not_found)?;
+        let g = latest.geom;
+        let (kx, ky) =
+            crate::lonlat_grid_km_per_px([g.west, g.south, g.east, g.north], g.width, g.height);
+        Ok(cell_feature(track, g, kx, ky, anchor).2)
     }
 
     fn spatial_extent(&self) -> Option<[f64; 4]> {

--- a/crates/engine-nowcast/src/engine.rs
+++ b/crates/engine-nowcast/src/engine.rs
@@ -1172,6 +1172,15 @@ impl FeatureEngine for NowcastEngine {
         Ok(cell_feature(track, g, kx, ky, anchor).2)
     }
 
+    /// Bumps every generation, so any future consumer keying caches/ETags on
+    /// the feature snapshot (e.g. MVT serving of tracked cells) invalidates
+    /// correctly — cells are rebuilt per generation. Currently only the
+    /// plain Features path is wired, which doesn't read this; overriding
+    /// anyway removes the stale-tile trap before it can exist.
+    fn data_version(&self) -> u64 {
+        self.generations_total.load(Ordering::Relaxed)
+    }
+
     fn spatial_extent(&self) -> Option<[f64; 4]> {
         self.state.load().info.spatial_extent
     }

--- a/crates/engine-nowcast/src/engine.rs
+++ b/crates/engine-nowcast/src/engine.rs
@@ -1039,6 +1039,21 @@ impl FeatureEngine for NowcastEngine {
                 next_offset: None,
             });
         };
+        // Cells exist only at the latest analysis instant: a datetime
+        // filter that excludes the anchor matches nothing (engine-cap
+        // precedent for honoring `?datetime=`).
+        if let Some(dt) = &query.datetime {
+            let after_start = dt.start.is_none_or(|s| anchor >= s);
+            let before_end = dt.end.is_none_or(|e| anchor <= e);
+            if !(after_start && before_end) {
+                return Ok(FeaturePage {
+                    features: Vec::new(),
+                    number_matched: 0,
+                    number_returned: 0,
+                    next_offset: None,
+                });
+            }
+        }
         let g = latest.geom;
         let (kx, ky) =
             crate::lonlat_grid_km_per_px([g.west, g.south, g.east, g.north], g.width, g.height);
@@ -1108,6 +1123,12 @@ impl FeatureEngine for NowcastEngine {
             number_returned,
             next_offset,
         })
+    }
+
+    /// O(1) from the snapshot — the default would build every feature just
+    /// to count them, on every collection-metadata request.
+    fn feature_count(&self) -> usize {
+        self.state.load().cells.len()
     }
 
     fn get_feature(&self, feature_id: &str) -> Result<Feature, DataServerError> {

--- a/crates/engine-nowcast/src/engine.rs
+++ b/crates/engine-nowcast/src/engine.rs
@@ -399,8 +399,17 @@ impl NowcastEngine {
                         .next_back()
                         .map(|(&p, _)| (anchor - p).num_seconds() as f32)
                         .unwrap_or(generation.interval_secs);
+                    // Track continuity is only meaningful on an unchanged
+                    // grid: a source geometry change would silently
+                    // reinterpret previous pixel centroids on the new grid
+                    // (same class as the skill-scoring geometry guard), so
+                    // the track set resets and cells start as newborns.
+                    let previous_cells: &[CellTrack] = match old.generations.iter().next_back() {
+                        Some((_, prev)) if prev.geom == generation.geom => &old.cells,
+                        _ => &[],
+                    };
                     Arc::new(advance_tracks(
-                        &old.cells,
+                        previous_cells,
                         blobs,
                         PixelScale {
                             x: kx as f32,

--- a/crates/engine-nowcast/src/engine.rs
+++ b/crates/engine-nowcast/src/engine.rs
@@ -35,11 +35,15 @@ use tokio::sync::watch;
 use ds_core::config::NowcastConfig;
 use ds_core::datetime::parse_iso8601_duration;
 use ds_core::error::DataServerError;
+use ds_core::feature::{Feature, FeaturePage, FeatureQuery, Geometry, PropertyValue};
+use ds_core::feature_engine::FeatureEngine;
 use ds_core::map_engine::{MapEngine, OutputCrs, RasterInfo, RasterTile, RasterValues};
 use ds_core::resample::ProjectionGrid;
 
 use crate::advect::TrajectoryIntegrator;
+use crate::cells2d::{advance_tracks, CellTrack, CELL_MIN_AREA_PX, CELL_THRESHOLD_DBZ};
 use crate::motion::{estimate_motion_multi, MotionField, MotionOptions};
+use crate::objects::{segment_cells, PixelScale};
 use crate::Grid;
 
 /// Fastest cell motion the search window must cover (m/s). 40 m/s ≈ 144 km/h
@@ -148,6 +152,8 @@ struct NowcastState {
     generations: BTreeMap<DateTime<Utc>, Arc<Generation>>,
     /// Pre-built snapshot for the O(1) `raster_info()` contract.
     info: RasterInfo,
+    /// Tracked cells of the latest generation's analysis frame (#544).
+    cells: Arc<Vec<CellTrack>>,
 }
 
 pub struct NowcastEngine {
@@ -172,6 +178,8 @@ pub struct NowcastEngine {
     /// baseline. `u64::MAX` = not yet measured.
     lead_csi_permille: AtomicU64,
     lead_persistence_csi_permille: AtomicU64,
+    /// Monotonic id source for cell tracks (#544).
+    next_track_id: AtomicU64,
 }
 
 impl NowcastEngine {
@@ -248,6 +256,7 @@ impl NowcastEngine {
             state: ArcSwap::from_pointee(NowcastState {
                 generations: BTreeMap::new(),
                 info: empty_info(&source_info),
+                cells: Arc::new(Vec::new()),
             }),
             shutdown_tx,
             generations_total: AtomicU64::new(0),
@@ -257,6 +266,7 @@ impl NowcastEngine {
             lead_cap_warned: std::sync::atomic::AtomicBool::new(false),
             lead_csi_permille: AtomicU64::new(u64::MAX),
             lead_persistence_csi_permille: AtomicU64::new(u64::MAX),
+            next_track_id: AtomicU64::new(1),
         })
     }
 
@@ -365,8 +375,41 @@ impl NowcastEngine {
                     generations.remove(&oldest);
                 }
                 let info = build_info(&source_info, &generations);
-                self.state
-                    .store(Arc::new(NowcastState { generations, info }));
+                // Cell intelligence (#544): segment the fresh analysis frame
+                // and advance the track set against the ambient motion field.
+                let cells = {
+                    let generation = generations.get(&anchor).expect("just inserted");
+                    let g = &generation.geom;
+                    let analysis =
+                        frame_to_grid(&generation.frames[0], g.width as usize, g.height as usize);
+                    let blobs = segment_cells(&analysis, CELL_THRESHOLD_DBZ, CELL_MIN_AREA_PX);
+                    let (kx, ky) = crate::lonlat_grid_km_per_px(
+                        [g.west, g.south, g.east, g.north],
+                        g.width,
+                        g.height,
+                    );
+                    let interval_secs = generation
+                        .times
+                        .get(1)
+                        .map(|t| (*t - generation.times[0]).num_seconds() as f32)
+                        .unwrap_or(300.0);
+                    Arc::new(advance_tracks(
+                        &old.cells,
+                        blobs,
+                        PixelScale {
+                            x: kx as f32,
+                            y: ky as f32,
+                        },
+                        &generation.field,
+                        interval_secs,
+                        || self.next_track_id.fetch_add(1, Ordering::Relaxed),
+                    ))
+                };
+                self.state.store(Arc::new(NowcastState {
+                    generations,
+                    info,
+                    cells,
+                }));
                 self.generations_total.fetch_add(1, Ordering::Relaxed);
                 self.last_generation_ms.store(elapsed_ms, Ordering::Relaxed);
                 let lag = (Utc::now() - anchor).num_seconds().max(0) as u64;
@@ -973,5 +1016,114 @@ impl MapEngine for NowcastEngine {
         Self::select_generation(&state, reference_time)
             .map(|g| Some(g.reference_time))
             .unwrap_or(reference_time)
+    }
+}
+
+impl FeatureEngine for NowcastEngine {
+    /// Tracked cells of the latest analysis frame as Point features (#544).
+    fn get_features(&self, query: &FeatureQuery) -> Result<FeaturePage, DataServerError> {
+        let state = self.state.load();
+        let Some((&anchor, latest)) = state.generations.iter().next_back() else {
+            return Ok(FeaturePage {
+                features: Vec::new(),
+                number_matched: 0,
+                number_returned: 0,
+                next_offset: None,
+            });
+        };
+        let g = latest.geom;
+        let interval_secs = latest
+            .times
+            .get(1)
+            .map(|t| (*t - latest.times[0]).num_seconds() as f32)
+            .unwrap_or(300.0);
+        let (kx, ky) =
+            crate::lonlat_grid_km_per_px([g.west, g.south, g.east, g.north], g.width, g.height);
+        let matched: Vec<Feature> = state
+            .cells
+            .iter()
+            .filter_map(|t| {
+                let lon = g.west
+                    + (f64::from(t.blob.centroid.0) / f64::from(g.width)) * (g.east - g.west);
+                let lat = g.north
+                    - (f64::from(t.blob.centroid.1) / f64::from(g.height)) * (g.north - g.south);
+                if let Some(b) = &query.bbox {
+                    if !b.contains(lon, lat) {
+                        return None;
+                    }
+                }
+                let mut props = std::collections::HashMap::new();
+                props.insert(
+                    "severity".into(),
+                    PropertyValue::String(t.severity.as_str().into()),
+                );
+                props.insert(
+                    "max_dbz".into(),
+                    PropertyValue::Float(f64::from(t.blob.max_value)),
+                );
+                props.insert(
+                    "area_km2".into(),
+                    PropertyValue::Float(t.blob.area as f64 * kx * ky),
+                );
+                props.insert("track_age".into(), PropertyValue::Integer(t.age as i64));
+                props.insert("deviant_mover".into(), PropertyValue::Bool(t.deviant()));
+                props.insert(
+                    "speed_ms".into(),
+                    t.speed_ms(interval_secs)
+                        .map(|v| PropertyValue::Float(f64::from(v)))
+                        .unwrap_or(PropertyValue::Null),
+                );
+                props.insert(
+                    "bearing_deg".into(),
+                    t.bearing_deg()
+                        .map(PropertyValue::Float)
+                        .unwrap_or(PropertyValue::Null),
+                );
+                props.insert(
+                    "observed".into(),
+                    PropertyValue::String(anchor.to_rfc3339()),
+                );
+                Some(Feature {
+                    id: t.id.to_string(),
+                    geometry: Arc::new(Geometry::Point { x: lon, y: lat }),
+                    properties: Arc::new(props),
+                })
+            })
+            .collect();
+        let number_matched = matched.len();
+        let page: Vec<Feature> = matched
+            .into_iter()
+            .skip(query.offset)
+            .take(query.limit)
+            .collect();
+        let number_returned = page.len();
+        let next_offset = (query.offset + number_returned < number_matched)
+            .then(|| query.offset + number_returned);
+        Ok(FeaturePage {
+            features: page,
+            number_matched,
+            number_returned,
+            next_offset,
+        })
+    }
+
+    fn get_feature(&self, feature_id: &str) -> Result<Feature, DataServerError> {
+        self.get_features(&FeatureQuery {
+            limit: usize::MAX,
+            ..Default::default()
+        })?
+        .features
+        .into_iter()
+        .find(|f| f.id == feature_id)
+        .ok_or_else(|| DataServerError::FeatureNotFound(feature_id.to_string()))
+    }
+
+    fn spatial_extent(&self) -> Option<[f64; 4]> {
+        self.state.load().info.spatial_extent
+    }
+
+    fn temporal_extent(&self) -> Option<(DateTime<Utc>, DateTime<Utc>)> {
+        let state = self.state.load();
+        state.generations.iter().next_back().map(|(&a, _)| (a, a))
     }
 }

--- a/crates/engine-nowcast/src/lib.rs
+++ b/crates/engine-nowcast/src/lib.rs
@@ -21,6 +21,7 @@
 //!   timestamps.
 
 pub mod advect;
+pub mod cells2d;
 pub mod engine;
 pub mod motion;
 pub mod objects;

--- a/crates/engine-nowcast/tests/integration.rs
+++ b/crates/engine-nowcast/tests/integration.rs
@@ -514,3 +514,40 @@ fn dry_scene_leaves_both_skill_gauges_unset() {
         "a dry scene must leave the gauge pair unset"
     );
 }
+
+/// V2.2 (#544): after a generation, tracked cells serve as Point features
+/// with severity/motion/deviant properties; ids persist across generations.
+#[test]
+fn cell_features_are_served_and_tracks_persist() {
+    use ds_core::feature::{FeatureQuery, PropertyValue};
+    use ds_core::feature_engine::FeatureEngine;
+
+    let anchor1 = t0() + Duration::minutes(5);
+    let (source, engine) = build("PT30M", &[t0(), anchor1]);
+    engine.poll_once();
+    let page = engine.get_features(&FeatureQuery::default()).unwrap();
+    assert_eq!(page.number_matched, 1, "one disc, one cell");
+    let f = &page.features[0];
+    assert!(matches!(
+        f.properties.get("severity"),
+        Some(PropertyValue::String(s)) if s == "moderate"
+    ));
+    assert!(matches!(
+        f.properties.get("deviant_mover"),
+        Some(PropertyValue::Bool(false))
+    ));
+    let id1 = f.id.clone();
+
+    let anchor2 = anchor1 + Duration::minutes(5);
+    source.times.write().unwrap().push(anchor2);
+    engine.poll_once();
+    let page = engine.get_features(&FeatureQuery::default()).unwrap();
+    let f = &page.features[0];
+    assert_eq!(f.id, id1, "track id persists across generations");
+    assert!(matches!(
+        f.properties.get("track_age"),
+        Some(PropertyValue::Integer(2))
+    ));
+    assert!(engine.get_feature(&id1).is_ok());
+    assert!(engine.get_feature("9999").is_err());
+}

--- a/crates/engine-nowcast/tests/integration.rs
+++ b/crates/engine-nowcast/tests/integration.rs
@@ -550,4 +550,19 @@ fn cell_features_are_served_and_tracks_persist() {
     ));
     assert!(engine.get_feature(&id1).is_ok());
     assert!(engine.get_feature("9999").is_err());
+
+    // datetime filter: excluding the anchor matches nothing; including it
+    // matches; count accessor is O(1)-consistent with the page.
+    use ds_core::feature::DatetimeInterval;
+    let excl = engine
+        .get_features(&FeatureQuery {
+            datetime: Some(DatetimeInterval {
+                start: None,
+                end: Some(anchor2 - Duration::minutes(1)),
+            }),
+            ..Default::default()
+        })
+        .unwrap();
+    assert_eq!(excl.number_matched, 0);
+    assert_eq!(engine.feature_count(), 1);
 }

--- a/crates/engine-nowcast/tests/integration.rs
+++ b/crates/engine-nowcast/tests/integration.rs
@@ -566,3 +566,91 @@ fn cell_features_are_served_and_tracks_persist() {
     assert_eq!(excl.number_matched, 0);
     assert_eq!(engine.feature_count(), 1);
 }
+
+/// Geometry-change reset (#545 round 3/4): a source that changes its
+/// advertised extent mid-run must restart tracks as newborns instead of
+/// matching centroids reinterpreted on the new grid.
+#[test]
+fn geometry_change_resets_cell_tracks() {
+    struct MovableSource {
+        times: RwLock<Vec<DateTime<Utc>>>,
+        extent: RwLock<[f64; 4]>,
+    }
+    impl MapEngine for MovableSource {
+        fn get_raster_tile(
+            &self,
+            _bbox: [f64; 4],
+            width: u32,
+            height: u32,
+            time: Option<DateTime<Utc>>,
+            _output_crs: &OutputCrs,
+            _parameter: Option<&str>,
+            _z: Option<f64>,
+            _reference_time: Option<DateTime<Utc>>,
+        ) -> Result<RasterTile, DataServerError> {
+            Ok(RasterTile {
+                width,
+                height,
+                values: RasterValues::U8 {
+                    data: truth_frame(time.unwrap()),
+                    nodata: Some(NODATA),
+                    gain: 0.4,
+                    offset: -30.0,
+                },
+            })
+        }
+        fn raster_info(&self) -> RasterInfo {
+            RasterInfo {
+                native_crs: "CRS:84".into(),
+                spatial_extent: Some(*self.extent.read().unwrap()),
+                times: self.times.read().unwrap().clone(),
+                parameter: "reflectivity".into(),
+                unit: "dBZ".into(),
+                parameters: vec![],
+                vertical: None,
+                grid_size: Some([W, H]),
+                layer_subtitle: None,
+                reference_times: Vec::new(),
+            }
+        }
+    }
+    use ds_core::feature::{FeatureQuery, PropertyValue};
+    use ds_core::feature_engine::FeatureEngine;
+
+    let anchor1 = t0() + Duration::minutes(5);
+    let source = Arc::new(MovableSource {
+        times: RwLock::new(vec![t0(), anchor1]),
+        extent: RwLock::new(EXTENT),
+    });
+    let config = NowcastConfig {
+        source: "mock".into(),
+        horizon: "PT30M".into(),
+        step: None,
+        history_frames: 2,
+        poll_interval_secs: 30,
+        max_generations: 4,
+        max_pixels: 4_000_000,
+        min_echo: 10.0,
+    };
+    let engine =
+        NowcastEngine::new("mv-nowcast", "mock", source.clone(), &config).expect("engine builds");
+    engine.poll_once();
+
+    // Extent shifts (source footprint change) before the next frame.
+    *source.extent.write().unwrap() = [1.0, 51.0, 11.0, 61.0];
+    source
+        .times
+        .write()
+        .unwrap()
+        .push(anchor1 + Duration::minutes(5));
+    engine.poll_once();
+    let page = engine.get_features(&FeatureQuery::default()).unwrap();
+    assert_eq!(page.number_matched, 1);
+    assert!(
+        matches!(
+            page.features[0].properties.get("track_age"),
+            Some(PropertyValue::Integer(1))
+        ),
+        "track must restart as newborn after a geometry change"
+    );
+}

--- a/crates/server/src/admin.rs
+++ b/crates/server/src/admin.rs
@@ -967,7 +967,7 @@ pub fn load_collections(
             "odim-volume" => &["edr", "wms", "maps", "tiles", "3dtiles", "features"],
             "cap" => &["features", "wms", "maps", "tiles"],
             "postgis" => &["edr", "features", "tiles", "wms", "maps"],
-            "nowcast" => &["wms", "maps", "tiles"],
+            "nowcast" => &["wms", "maps", "tiles", "features"],
             _ => &[],
         };
         let unsupported: Vec<&str> = collection
@@ -2418,6 +2418,15 @@ pub fn load_collections(
                 build_styles(collection, &bundle_index),
             );
             info!("Collection '{}': wired to Tiles API", collection.id);
+        }
+
+        if collection.apis.contains(&"features".to_string()) {
+            feature_engines.insert(
+                collection.id.clone(),
+                engine.clone() as Arc<dyn ds_core::feature_engine::FeatureEngine>,
+            );
+            feature_collections.insert(collection.id.clone(), collection.clone());
+            info!("Collection '{}': wired to Features API", collection.id);
         }
 
         // A nowcast starts degraded: the first generation needs the source's

--- a/crates/server/src/admin.rs
+++ b/crates/server/src/admin.rs
@@ -4260,11 +4260,10 @@ mod tests {
 
     #[test]
     fn nowcast_wires_into_registries_and_boots_degraded() {
+        let mut nc = nowcast_test_collection("nc", "nowcast", Some("radar"));
+        nc.apis = vec!["wms".to_string(), "features".to_string()];
         let result = super::load_collections(
-            &[
-                tm35_source_collection("radar"),
-                nowcast_test_collection("nc", "nowcast", Some("radar")),
-            ],
+            &[tm35_source_collection("radar"), nc],
             &[],
             "http://x",
             false,
@@ -4272,6 +4271,10 @@ mod tests {
             super::ReusableCaches::default(),
         );
         assert!(result.wms_state.engines.contains_key("nc"));
+        assert!(
+            result.features_state.engines.contains_key("nc"),
+            "features API must be wired when listed in apis"
+        );
         assert_eq!(result.nowcast_engines.len(), 1);
         assert_eq!(result.nowcast_engines[0].source_id(), "radar");
         let h = health_of(&result, "nc");


### PR DESCRIPTION
Nowcasting v2 phase **V2.2 part 1** (#541). Closes #544.

Built on the verified 2D objects machinery from V2.1 — deliberately **not** on VoxelGrid attributes (beta/unverified/slow per owner's call); echo-top/VIL enrichment revisits once voxels are verified.

- **`cells2d`**: per-generation tracking of the analysis frame's 35 dBZ cells — anisotropic km matching, persistent track ids, age, velocity EMA; **TRT-lite severity** (max-dBZ steps 45/50/55 + area ≥ 50 km², documented heuristic that V2.4's tree model replaces); **deviant-mover flag** = sustained ≥ 5 m/s residual between track velocity and the ambient motion field sampled at the cell (the estimator-disagreement right-mover detector, also the future fusion signal).
- **`FeatureEngine` on the nowcast collection** (`apis += features`): tracked cells as GeoJSON Point features — `severity`, `max_dbz`, `area_km2`, `speed_ms`, `bearing_deg`, `deviant_mover`, `track_age`, `observed` — with bbox filtering and pagination.
- Lightning join (per-track flash counts + jump flag) is part 2: needs a ds-core event-source trait + engine-postgis impl + second-pass wiring.

Tests: severity monotonicity; a two-cell scenario where a small cell moves against the ambient flow of a dominant large cell — the counter-flow cell gets flagged (streak semantics), the with-flow cell doesn't, speeds/bearings verified; Features integration (id persistence across generations, properties, 404). 36 total green, clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)