### PR TITLE
feat(engine-nowcast): growth/decay profile mechanism (off by default — scene-wide gate failed)

### DIFF
--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -215,6 +215,11 @@ pub struct NowcastConfig {
     /// field.
     #[serde(default = "default_nowcast_min_echo")]
     pub min_echo: f64,
+    /// Apply intensity-based growth/decay profiles along the leads (#546,
+    /// NowPrecip-2 lineage). Default off — flip per collection once the
+    /// object-harness gate has passed for that source.
+    #[serde(default)]
+    pub growth_decay: bool,
 }
 
 fn default_nowcast_horizon() -> String {

--- a/crates/engine-nowcast/examples/skill_spike.rs
+++ b/crates/engine-nowcast/examples/skill_spike.rs
@@ -26,6 +26,7 @@ use engine_nowcast::objects::{
     ObjectScores, PixelScale,
 };
 use engine_nowcast::skill::{score, Contingency};
+use engine_nowcast::tendency::GrowthProfile;
 use engine_nowcast::{advect::advect, Grid};
 
 /// Keep the working grid at most this many pixels (halve dims until it fits).
@@ -46,6 +47,7 @@ struct Args {
     object_threshold: f32,
     min_area: usize,
     gate_km: f64,
+    growth_decay: bool,
 }
 
 fn parse_args() -> Result<Args, String> {
@@ -64,6 +66,7 @@ fn parse_args() -> Result<Args, String> {
         object_threshold: 35.0,
         min_area: 5,
         gate_km: 20.0,
+        growth_decay: false,
     };
     let mut it = std::env::args().skip(1);
     while let Some(flag) = it.next() {
@@ -138,6 +141,7 @@ fn parse_args() -> Result<Args, String> {
                     .parse()
                     .map_err(|e: std::num::ParseFloatError| e.to_string())?
             }
+            "--growth-decay" => args.growth_decay = true,
             other => return Err(format!("unknown flag {other}")),
         }
     }
@@ -379,9 +383,23 @@ fn main() -> ExitCode {
         // then chained forward through observed-track matches per lead.
         let mut classes = classify_growth(&obs_cells[i - 1], &obs_cells[i], scale, gate_km);
 
+        // Growth/decay profile for this anchor (#546): advect the previous
+        // frame one interval, measure per-band tendencies vs the anchor.
+        let profile = args.growth_decay.then(|| {
+            let advected_prev = advect(&frames[i - 1], &field, 1.0, args.substeps);
+            GrowthProfile::measure(&advected_prev, &frames[i], args.min_echo)
+        });
+
         for lead in 1..=(frames.len() - 1 - i) {
             let started = Instant::now();
-            let forecast = advect(&frames[i], &field, lead as f32, args.substeps);
+            let mut forecast = advect(&frames[i], &field, lead as f32, args.substeps);
+            if let Some(p) = &profile {
+                for v in forecast.data.iter_mut() {
+                    if v.is_finite() {
+                        *v = p.apply(*v, lead as f32);
+                    }
+                }
+            }
             let advect_ms = started.elapsed().as_millis();
             println!("  lead +{lead}: advection {advect_ms}ms");
             for (k, &thr) in args.thresholds.iter().enumerate() {

--- a/crates/engine-nowcast/src/engine.rs
+++ b/crates/engine-nowcast/src/engine.rs
@@ -44,6 +44,7 @@ use crate::advect::TrajectoryIntegrator;
 use crate::cells2d::{advance_tracks, CellTrack, CELL_MIN_AREA_PX, CELL_THRESHOLD_DBZ};
 use crate::motion::{estimate_motion_multi, MotionField, MotionOptions};
 use crate::objects::{segment_cells, PixelScale};
+use crate::tendency::{GrowthProfile, PROFILE_EMA_ALPHA};
 use crate::Grid;
 
 /// Fastest cell motion the search window must cover (m/s). 40 m/s ≈ 144 km/h
@@ -81,6 +82,7 @@ struct EngineCfg {
     max_generations: usize,
     max_pixels: usize,
     min_echo: f32,
+    growth_decay: bool,
 }
 
 /// The regular WGS84 grid every stored frame lives on.
@@ -146,6 +148,9 @@ struct Generation {
     field: MotionField,
     /// Source interval (s) the field's vectors span.
     interval_secs: f32,
+    /// Per-band growth/decay profile (measured + EMA'd) — the history for
+    /// the NEXT generation (#546).
+    profile: GrowthProfile,
 }
 
 /// Atomically swapped engine state.
@@ -254,6 +259,7 @@ impl NowcastEngine {
                 max_generations: config.max_generations.max(1),
                 max_pixels: config.max_pixels.clamp(65_536, 16_000_000),
                 min_echo: config.min_echo as f32,
+                growth_decay: config.growth_decay,
             },
             state: ArcSwap::from_pointee(NowcastState {
                 generations: BTreeMap::new(),
@@ -648,6 +654,23 @@ impl NowcastEngine {
             }
         }
 
+        // Growth/decay profile (#546): advect the previous frame one
+        // interval and measure per-band tendencies against the analysis in
+        // the Lagrangian frame; EMA with the previous generation's profile.
+        // Measured even when application is disabled, so flipping the config
+        // on starts from a warmed profile.
+        let mut profile = {
+            let prev_f32 = &motion_frames[motion_frames.len() - 2].1;
+            let advected_prev = crate::advect::advect(prev_f32, &field, 1.0, SUBSTEPS);
+            GrowthProfile::measure(&advected_prev, analysis_f32, self.cfg.min_echo)
+        };
+        {
+            let state = self.state.load();
+            if let Some((_, latest)) = state.generations.iter().next_back() {
+                profile.blend_with_previous(&latest.profile, PROFILE_EMA_ALPHA);
+            }
+        }
+
         // Lead schedule. An explicit step was validated against MAX_LEADS at
         // construction; the source-cadence default can still exceed it (a
         // fast-cadence source under a long horizon), so make the truncation
@@ -688,19 +711,53 @@ impl NowcastEngine {
         for i in 1..=k {
             let lead_time = anchor + step * (i as i32);
             trajectories.advance(delta, SUBSTEPS);
+            let lead_intervals = delta * i as f32;
             let frame = match &frames[0] {
                 FrameData::U8 {
                     data,
                     nodata,
                     gain,
                     offset,
-                } => FrameData::U8 {
-                    data: trajectories.sample_u8(data, *nodata),
-                    nodata: *nodata,
-                    gain: *gain,
-                    offset: *offset,
-                },
-                FrameData::F32(_) => FrameData::F32(trajectories.sample(analysis_f32).data),
+                } => {
+                    let mut sampled = trajectories.sample_u8(data, *nodata);
+                    if self.cfg.growth_decay {
+                        for raw in sampled.iter_mut() {
+                            if *raw == *nodata {
+                                continue;
+                            }
+                            let v = (f64::from(*raw) * *gain + *offset) as f32;
+                            let adjusted = profile.apply(v, lead_intervals);
+                            if adjusted != v {
+                                let mut r = ((f64::from(adjusted) - *offset) / *gain)
+                                    .round()
+                                    .clamp(0.0, 255.0)
+                                    as u8;
+                                if r == *nodata {
+                                    // Never collide with the nodata byte.
+                                    r = r.saturating_sub(1);
+                                }
+                                *raw = r;
+                            }
+                        }
+                    }
+                    FrameData::U8 {
+                        data: sampled,
+                        nodata: *nodata,
+                        gain: *gain,
+                        offset: *offset,
+                    }
+                }
+                FrameData::F32(_) => {
+                    let mut sampled = trajectories.sample(analysis_f32).data;
+                    if self.cfg.growth_decay {
+                        for v in sampled.iter_mut() {
+                            if v.is_finite() {
+                                *v = profile.apply(*v, lead_intervals);
+                            }
+                        }
+                    }
+                    FrameData::F32(sampled)
+                }
             };
             times.push(lead_time);
             frames.push(frame);
@@ -714,6 +771,7 @@ impl NowcastEngine {
             geom,
             field,
             interval_secs: interval.num_seconds() as f32,
+            profile,
         })
     }
 

--- a/crates/engine-nowcast/src/engine.rs
+++ b/crates/engine-nowcast/src/engine.rs
@@ -733,8 +733,11 @@ impl NowcastEngine {
                                     .clamp(0.0, 255.0)
                                     as u8;
                                 if r == *nodata {
-                                    // Never collide with the nodata byte.
-                                    r = r.saturating_sub(1);
+                                    // Never collide with the nodata byte —
+                                    // step AWAY from it in whichever
+                                    // direction exists (nodata = 0 sources
+                                    // can't step down).
+                                    r = if r == 0 { 1 } else { r - 1 };
                                 }
                                 *raw = r;
                             }

--- a/crates/engine-nowcast/src/lib.rs
+++ b/crates/engine-nowcast/src/lib.rs
@@ -26,6 +26,7 @@ pub mod engine;
 pub mod motion;
 pub mod objects;
 pub mod skill;
+pub mod tendency;
 
 pub use engine::NowcastEngine;
 

--- a/crates/engine-nowcast/src/tendency.rs
+++ b/crates/engine-nowcast/src/tendency.rs
@@ -77,8 +77,9 @@ impl GrowthProfile {
                 continue;
             }
             if let Some(b) = profile.band(a) {
-                // Treat sub-base actuals as the base floor so decay out of
-                // the band is measured rather than skipped.
+                // Floor sub-base actuals one band BELOW base (not at base
+                // itself) so decay out of the lowest band still registers
+                // as roughly one band's worth of loss instead of zero.
                 sums[b] += f64::from(o.max(base - BAND_WIDTH) - a);
                 counts[b] += 1;
             }

--- a/crates/engine-nowcast/src/tendency.rs
+++ b/crates/engine-nowcast/src/tendency.rs
@@ -1,0 +1,200 @@
+//! Intensity-based growth/decay profiles (#546, v2.3) — the NowPrecip-2
+//! lineage (Sideris et al., QJRMS 2026): classical, per-intensity-band
+//! tendencies measured in the Lagrangian (storm-following) frame.
+//!
+//! Measurement: advect the previous frame one interval along the motion
+//! field, compare with the actual frame — the per-band mean difference is
+//! growth/decay net of motion. Application: adjust each advected value by
+//! its band's tendency integrated over the lead with an e-folding damping,
+//! so short leads evolve and long leads relax toward pure advection
+//! instead of running away. This attacks pure advection's biggest lie:
+//! cells never die.
+
+use crate::Grid;
+
+/// Intensity band width (physical units, dBZ for radar).
+pub const BAND_WIDTH: f32 = 2.0;
+/// Number of bands above the profile base (covers base .. base+64 dBZ).
+pub const N_BANDS: usize = 32;
+/// Minimum pixels in a band for its tendency to be trusted; sparser bands
+/// keep tendency 0 (pure advection).
+pub const MIN_BAND_SAMPLES: u32 = 200;
+/// Per-interval tendency clamp — a band never brightens/dims faster than
+/// this, keeping one noisy scene from painting extremes.
+pub const MAX_TENDENCY: f32 = 2.0;
+/// e-folding of the applied tendency, in source intervals (3 × 5 min =
+/// 15 min): `delta(lead) = tendency × efold × (1 − exp(−lead/efold))`.
+///
+/// GATE STATUS (#546, 2026-07-25): scene-wide profiles FAILED the V2.1
+/// harness on the stratiform SMHI hindcast — worse than pure advection at
+/// every lead/threshold (e.g. +60 min/20 dBZ CSI 0.305 vs 0.339; a 45-min
+/// e-fold was far worse still, 0.118). The mechanism therefore ships
+/// OFF by default (`growth_decay = false`) pending localization
+/// (NowPrecip 2 applies profiles regionally, not scene-wide) or the
+/// learned route (V2.5). Do not enable in prod until a gate run passes.
+pub const EFOLD_INTERVALS: f32 = 3.0;
+/// Cross-generation EMA weight for the new profile (same spirit as the
+/// motion-field EMA — damps single-scene noise).
+pub const PROFILE_EMA_ALPHA: f32 = 0.6;
+
+/// Per-band mean intensity tendency (physical units per source interval).
+#[derive(Debug, Clone)]
+pub struct GrowthProfile {
+    /// Band 0 starts here (typically `min_echo`).
+    pub base: f32,
+    pub tendency: [f32; N_BANDS],
+}
+
+impl GrowthProfile {
+    pub fn zero(base: f32) -> Self {
+        Self {
+            base,
+            tendency: [0.0; N_BANDS],
+        }
+    }
+
+    #[inline]
+    fn band(&self, value: f32) -> Option<usize> {
+        if !value.is_finite() || value < self.base {
+            return None;
+        }
+        let b = ((value - self.base) / BAND_WIDTH) as usize;
+        Some(b.min(N_BANDS - 1))
+    }
+
+    /// Measure the profile from an advected-previous vs actual frame pair
+    /// (both on the same grid). Pixels are binned by the ADVECTED value —
+    /// the same key later used at application time — and each band's mean
+    /// `(actual − advected)` becomes its tendency, clamped to
+    /// [`MAX_TENDENCY`]. Bands with fewer than [`MIN_BAND_SAMPLES`] pixels
+    /// stay 0.
+    pub fn measure(advected_prev: &Grid, actual: &Grid, base: f32) -> Self {
+        let mut sums = [0f64; N_BANDS];
+        let mut counts = [0u32; N_BANDS];
+        let profile = Self::zero(base);
+        for (&a, &o) in advected_prev.data.iter().zip(&actual.data) {
+            if !a.is_finite() || !o.is_finite() {
+                continue;
+            }
+            if let Some(b) = profile.band(a) {
+                // Treat sub-base actuals as the base floor so decay out of
+                // the band is measured rather than skipped.
+                sums[b] += f64::from(o.max(base - BAND_WIDTH) - a);
+                counts[b] += 1;
+            }
+        }
+        let mut tendency = [0f32; N_BANDS];
+        let mut measured = [false; N_BANDS];
+        for b in 0..N_BANDS {
+            if counts[b] >= MIN_BAND_SAMPLES {
+                tendency[b] =
+                    ((sums[b] / f64::from(counts[b])) as f32).clamp(-MAX_TENDENCY, MAX_TENDENCY);
+                measured[b] = true;
+            }
+        }
+        // Fill unmeasured bands from the nearest measured neighbour (≤ 2
+        // bands away): measurement keys by the PREVIOUS value, application
+        // by the CURRENT one — in an evolving scene those routinely sit in
+        // adjacent bands, and an unmeasured hole there would silently
+        // disable the profile exactly where it matters.
+        let filled = tendency;
+        for b in 0..N_BANDS {
+            if measured[b] {
+                continue;
+            }
+            for d in 1..=2usize {
+                let lower = b.checked_sub(d).filter(|&i| measured[i]);
+                let upper = (b + d < N_BANDS && measured[b + d]).then_some(b + d);
+                if let Some(src) = lower.or(upper) {
+                    tendency[b] = filled[src];
+                    break;
+                }
+            }
+        }
+        Self { base, tendency }
+    }
+
+    /// Cross-generation EMA: `self = alpha·self + (1−alpha)·prev`. No-op on
+    /// a base mismatch (config change).
+    pub fn blend_with_previous(&mut self, prev: &GrowthProfile, alpha: f32) {
+        if (self.base - prev.base).abs() > f32::EPSILON {
+            return;
+        }
+        for (t, p) in self.tendency.iter_mut().zip(&prev.tendency) {
+            *t = alpha * *t + (1.0 - alpha) * p;
+        }
+    }
+
+    /// Adjusted value at `lead` intervals: the band tendency integrated
+    /// under e-folding damping. Values below the base (or nodata) pass
+    /// through untouched.
+    #[inline]
+    pub fn apply(&self, value: f32, lead: f32) -> f32 {
+        if self.band(value).is_none() {
+            return value;
+        }
+        // Linear interpolation between band centres removes the
+        // discretization cliff at band boundaries.
+        let f = ((value - self.base) / BAND_WIDTH - 0.5).clamp(0.0, (N_BANDS - 1) as f32 - 1e-3);
+        let (lo, frac) = (f as usize, f.fract());
+        let hi = (lo + 1).min(N_BANDS - 1);
+        let t = self.tendency[lo] * (1.0 - frac) + self.tendency[hi] * frac;
+        value + t * EFOLD_INTERVALS * (1.0 - (-lead / EFOLD_INTERVALS).exp())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn flat(w: usize, h: usize, v: f32) -> Grid {
+        Grid::new(w, h, vec![v; w * h])
+    }
+
+    #[test]
+    fn measures_uniform_decay_and_applies_with_efold() {
+        // Advected says 40 dBZ everywhere; reality is 38.5 → tendency −1.5.
+        let advected = flat(200, 200, 40.0);
+        let actual = flat(200, 200, 38.5);
+        let p = GrowthProfile::measure(&advected, &actual, 10.0);
+        let b = ((40.0 - 10.0) / BAND_WIDTH) as usize;
+        assert!((p.tendency[b] + 1.5).abs() < 1e-3);
+
+        // Lead 1 ≈ raw tendency; long leads saturate at tendency × efold.
+        let v1 = p.apply(40.0, 1.0);
+        assert!(
+            (v1 - (40.0 - 1.5 * EFOLD_INTERVALS * (1.0 - (-1.0f32 / EFOLD_INTERVALS).exp()))).abs()
+                < 1e-3
+        );
+        let v_inf = p.apply(40.0, 1000.0);
+        assert!((v_inf - (40.0 - 1.5 * EFOLD_INTERVALS)).abs() < 1e-2);
+        assert!(v1 > v_inf, "damped integral is monotone in lead");
+        // Below-base values untouched.
+        assert_eq!(p.apply(5.0, 3.0), 5.0);
+    }
+
+    #[test]
+    fn sparse_bands_and_clamps_stay_conservative() {
+        // Tiny frame: under MIN_BAND_SAMPLES → tendency 0.
+        let p = GrowthProfile::measure(&flat(10, 10, 40.0), &flat(10, 10, 20.0), 10.0);
+        assert!(p.tendency.iter().all(|&t| t == 0.0));
+        // Huge change clamps to MAX_TENDENCY.
+        let p = GrowthProfile::measure(&flat(200, 200, 40.0), &flat(200, 200, 10.0), 10.0);
+        let b = ((40.0 - 10.0) / BAND_WIDTH) as usize;
+        assert_eq!(p.tendency[b], -MAX_TENDENCY);
+    }
+
+    #[test]
+    fn ema_blends_and_skips_base_mismatch() {
+        let mut a = GrowthProfile::zero(10.0);
+        a.tendency[3] = 1.0;
+        let mut b = GrowthProfile::zero(10.0);
+        b.tendency[3] = -1.0;
+        a.blend_with_previous(&b, 0.6);
+        assert!((a.tendency[3] - 0.2).abs() < 1e-6);
+        let c = GrowthProfile::zero(20.0);
+        let before = a.tendency[3];
+        a.blend_with_previous(&c, 0.6);
+        assert_eq!(a.tendency[3], before);
+    }
+}

--- a/crates/engine-nowcast/tests/integration.rs
+++ b/crates/engine-nowcast/tests/integration.rs
@@ -118,6 +118,7 @@ fn build_with_history(
         max_generations: 4,
         max_pixels: 4_000_000,
         min_echo: 10.0,
+        growth_decay: false,
     };
     let engine =
         NowcastEngine::new("mock-nowcast", "mock", source.clone(), &config).expect("engine builds");
@@ -338,6 +339,7 @@ fn excessive_lead_count_is_rejected_at_construction() {
         max_generations: 4,
         max_pixels: 4_000_000,
         min_echo: 10.0,
+        growth_decay: false,
     };
     let err = NowcastEngine::new("mock-nowcast", "mock", source, &config)
         .err()
@@ -378,6 +380,7 @@ fn oversized_history_frames_is_rejected() {
         max_generations: 4,
         max_pixels: 4_000_000,
         min_echo: 10.0,
+        growth_decay: false,
     };
     let err = NowcastEngine::new("mock-nowcast", "mock", source, &config)
         .err()
@@ -497,6 +500,7 @@ fn dry_scene_leaves_both_skill_gauges_unset() {
         max_generations: 4,
         max_pixels: 4_000_000,
         min_echo: 10.0,
+        growth_decay: false,
     };
     let engine =
         NowcastEngine::new("dry-nowcast", "mock", source.clone(), &config).expect("engine builds");
@@ -631,6 +635,7 @@ fn geometry_change_resets_cell_tracks() {
         max_generations: 4,
         max_pixels: 4_000_000,
         min_echo: 10.0,
+        growth_decay: false,
     };
     let engine =
         NowcastEngine::new("mv-nowcast", "mock", source.clone(), &config).expect("engine builds");
@@ -652,5 +657,90 @@ fn geometry_change_resets_cell_tracks() {
             Some(PropertyValue::Integer(1))
         ),
         "track must restart as newborn after a geometry change"
+    );
+}
+
+/// Growth/decay application (#546): a source whose echo fades every frame
+/// must produce dimmer lead frames than pure advection when enabled.
+#[test]
+fn growth_decay_dims_decaying_echo() {
+    struct FadingSource {
+        times: RwLock<Vec<DateTime<Utc>>>,
+    }
+    impl MapEngine for FadingSource {
+        fn get_raster_tile(
+            &self,
+            _bbox: [f64; 4],
+            width: u32,
+            height: u32,
+            time: Option<DateTime<Utc>>,
+            _output_crs: &OutputCrs,
+            _parameter: Option<&str>,
+            _z: Option<f64>,
+            _reference_time: Option<DateTime<Utc>>,
+        ) -> Result<RasterTile, DataServerError> {
+            // Static disc fading 1 dBZ (2.5 raw) per 5-min frame.
+            let t = time.unwrap();
+            let steps = ((t - t0()).num_seconds() / 300) as f64;
+            let raw_val = (175.0 - 2.5 * steps).max(100.0) as u8;
+            let data: Vec<u8> = truth_frame(t0())
+                .into_iter()
+                .map(|r| if r == ECHO_RAW { raw_val } else { r })
+                .collect();
+            Ok(RasterTile {
+                width,
+                height,
+                values: RasterValues::U8 {
+                    data,
+                    nodata: Some(NODATA),
+                    gain: 0.4,
+                    offset: -30.0,
+                },
+            })
+        }
+        fn raster_info(&self) -> RasterInfo {
+            RasterInfo {
+                native_crs: "CRS:84".into(),
+                spatial_extent: Some(EXTENT),
+                times: self.times.read().unwrap().clone(),
+                parameter: "reflectivity".into(),
+                unit: "dBZ".into(),
+                parameters: vec![],
+                vertical: None,
+                grid_size: Some([W, H]),
+                layer_subtitle: None,
+                reference_times: Vec::new(),
+            }
+        }
+    }
+    let run = |growth_decay: bool| -> f32 {
+        let anchor = t0() + Duration::minutes(5);
+        let source = Arc::new(FadingSource {
+            times: RwLock::new(vec![t0(), anchor]),
+        });
+        let config = NowcastConfig {
+            source: "mock".into(),
+            horizon: "PT1H".into(),
+            step: None,
+            history_frames: 2,
+            poll_interval_secs: 30,
+            max_generations: 4,
+            max_pixels: 4_000_000,
+            min_echo: 10.0,
+            growth_decay,
+        };
+        let engine = NowcastEngine::new("fade", "mock", source, &config).expect("builds");
+        engine.poll_once();
+        let raw = render_raw(&engine, anchor + Duration::minutes(30));
+        raw.iter()
+            .filter(|&&r| r != NODATA && r > 0)
+            .map(|&r| r as f32 * 0.4 - 30.0)
+            .fold(f32::MIN, f32::max)
+    };
+    let plain = run(false);
+    let adjusted = run(true);
+    assert!(
+        adjusted < plain - 1.0,
+        "growth/decay must dim a fading echo at +30 min: {adjusted} vs {plain}"
     );
 }

--- a/crates/server/src/admin.rs
+++ b/crates/server/src/admin.rs
@@ -4169,6 +4169,7 @@ mod tests {
                 max_generations: 2,
                 max_pixels: 500_000,
                 min_echo: 10.0,
+                growth_decay: false,
             }),
             preview: None,
         }


### PR DESCRIPTION
Part of #541 phase V2.3 / #546 — **does not close #546**: the mechanism lands, the quality gate did not pass, and the flag defaults off.

## What landed

`tendency::GrowthProfile` — the NowPrecip-2-lineage classical method: per-intensity-band tendencies measured in the Lagrangian frame (previous frame advected one interval vs the actual anchor), sparse-band fill from nearest measured neighbours + band-centre interpolation at apply time (measurement keys by the previous value, application by the current one — adjacent-band holes would silently disable the profile), cross-generation EMA, e-folding damped integration along leads. Wired behind `[collections.nowcast] growth_decay` (**default `false`**); measured every generation even when off, so enabling starts from a warmed profile. `skill_spike` gains `--growth-decay` for A/B gating.

## Honest gate result (the V2.1 harness doing its job)

SMHI 25-frame stratiform hindcast, pixel CSI at 20 dBZ vs **pure advection**:

| lead | advection | GD (45-min e-fold) | GD (15-min e-fold) |
|---|---|---|---|
| +5 min | 0.676 | 0.651 | 0.654 |
| +30 min | 0.448 | 0.322 | 0.401 |
| +60 min | 0.339 | 0.118 | 0.305 |
| +115 min | 0.263 | 0.029 | 0.240 |

Scene-wide profiles lose at **every** lead/threshold: the scene-mean tendency in widespread stratiform is mildly negative, and integrating it drains the entire field below threshold rather than decaying the cells that are actually dying. This matches why NowPrecip 2 embeds its profiles in a *localization* architecture (regional profiles), not scene-wide ones. Gate status is documented on `EFOLD_INTERVALS` and in #546, which stays open for the iteration: localized/per-region profiles, growth-class-conditioned application, or the learned Lagrangian residual (V2.5).

41 tests green (new: measurement/e-fold math, sparse-fill + clamps, EMA, and an engine-level fading-source test proving application works end to end); clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)