### PR TITLE
feat(nowcast): per-cell lightning join — flash rate + Schultz jump flag

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -403,6 +403,8 @@ apis = ["wms", "maps", "tiles"]
 source = "radar"        # collection id to extrapolate
 horizon = "PT2H"        # how far into the future (default PT2H)
 # step = "PT5M"         # timestep spacing (default: source cadence)
+# lightning_source = "lightning"  # events-shape postgis collection: per-cell
+                                  # flash_count/rate + lightning_jump (#549)
 
 [collections.wms]
 colormap = "radar_dbz"

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -220,6 +220,13 @@ pub struct NowcastConfig {
     /// object-harness gate has passed for that source.
     #[serde(default)]
     pub growth_decay: bool,
+    /// Collection id of a point-event collection (engine-postgis `events`
+    /// shape, e.g. lightning strikes) to join onto tracked cells as
+    /// per-cell flash counts/rates and a lightning-jump flag (#549). Must
+    /// exist in the same config; a missing or non-event collection fails
+    /// this collection at load.
+    #[serde(default)]
+    pub lightning_source: Option<String>,
 }
 
 fn default_nowcast_horizon() -> String {

--- a/crates/core/src/events.rs
+++ b/crates/core/src/events.rs
@@ -1,0 +1,41 @@
+//! Point-event sources (#549): lightning strikes and similar timestamped
+//! point observations, joinable onto other engines' domain objects (e.g.
+//! nowcast cell tracks). Framework-free like the rest of ds-core — the
+//! trait is the seam that lets engine-nowcast consume engine-postgis
+//! events without depending on it.
+
+use chrono::{DateTime, Utc};
+
+use crate::error::DataServerError;
+
+/// One point event in WGS84.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct EventPoint {
+    pub time: DateTime<Utc>,
+    pub lon: f64,
+    pub lat: f64,
+}
+
+/// A source of recent point events.
+///
+/// Contract:
+/// - `recent_events` returns every event in the HALF-OPEN window
+///   `(start, end]` across the source's whole extent, ascending by time,
+///   capped at `limit` — when capped, the NEWEST events are kept (the cap
+///   is a safety valve; callers treat `len() == limit` as possible
+///   truncation and may log it).
+/// - One bounded call per consumer cycle (e.g. per nowcast generation),
+///   never per object — implementations may hit a database.
+/// - Implementations are sync bridges over async I/O in practice
+///   (engine-postgis): call this from a MULTI-THREAD runtime worker (the
+///   background poll runtime), never from `spawn_blocking` and never from
+///   a request-handler task — the same rules as `ds-storage`
+///   (root CLAUDE.md rule 7).
+pub trait EventSource: Send + Sync {
+    fn recent_events(
+        &self,
+        start: DateTime<Utc>,
+        end: DateTime<Utc>,
+        limit: usize,
+    ) -> Result<Vec<EventPoint>, DataServerError>;
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -4,6 +4,7 @@ pub mod config;
 pub mod datetime;
 pub mod edr_engine;
 pub mod error;
+pub mod events;
 pub mod feature;
 pub mod feature_engine;
 pub mod geo;

--- a/crates/engine-nowcast/CLAUDE.md
+++ b/crates/engine-nowcast/CLAUDE.md
@@ -103,8 +103,21 @@ follow-up (full frames only for the latest generation) is scoped in #523.
   never forecast) ⇒ 0 features. The collection's temporal extent
   advertises the retained span; by-id GET serves the latest snapshot's
   version of a track.
-- Lightning join (flash counts/jump per track) is part 2 — needs a ds-core
-  event-source trait + engine-postgis impl.
+- **Lightning join (#549, part 2):** `[collections.nowcast]
+  lightning_source = "<id>"` names an events-shape engine-postgis
+  collection in the same config (wired second-pass via the
+  `ds_core::events::EventSource` trait — engine-nowcast never depends on
+  engine-postgis; a missing/non-events id FAILS the collection at load).
+  Each generation makes ONE bounded window fetch `(prev anchor, anchor]`
+  on the poll runtime (the postgis sync bridge is legal there and only
+  there), bins strikes onto cells via the label map (unlabeled strikes
+  fall back to the nearest centroid within `LIGHTNING_JOIN_RADIUS_KM`),
+  and updates per-track flash stats + the Schultz-style 2σ jump flag
+  (`MIN_JUMP_RATE_PER_MIN` floor — revisit against Nordic storm data if
+  jumps never fire). Feature properties `flash_count` /
+  `flash_rate_per_min` / `lightning_jump` exist ONLY when a source is
+  wired; null means "join skipped this generation" (source error — the
+  generation itself never fails), 0 means measured-quiet.
 
 ## Gotchas
 

--- a/crates/engine-nowcast/src/cells2d.rs
+++ b/crates/engine-nowcast/src/cells2d.rs
@@ -309,6 +309,13 @@ pub fn advance_tracks(
 /// The jump flag is the Schultz-style detector: the window's rate exceeds
 /// the track's recent baseline mean by 2σ, with ≥ 2 baseline rates and the
 /// [`MIN_JUMP_RATE_PER_MIN`] absolute floor.
+///
+/// The radius fallback is a deliberate brute-force O(unmatched strikes ×
+/// tracks) scan: the worst real Nordic window (~10⁴ strikes × ~150 cells)
+/// is ~10⁶ distance checks once per generation on the background runtime
+/// — milliseconds. Even the MAX_JOIN_STRIKES cap × the 255-track label
+/// ceiling stays in the tens of ms. A spatial index earns its complexity
+/// only if either bound grows by orders of magnitude.
 pub fn apply_lightning(
     tracks: &mut [CellTrack],
     strikes_px: &[(f32, f32)],

--- a/crates/engine-nowcast/src/cells2d.rs
+++ b/crates/engine-nowcast/src/cells2d.rs
@@ -38,6 +38,19 @@ pub const DEVIANT_STREAK: u32 = 2;
 /// Per-second clamp on a cell's measured intensity tendency (±2 dBZ per
 /// 5-minute interval at the usual cadence).
 pub const MAX_CELL_TENDENCY_PER_S: f32 = 2.0 / 300.0;
+/// Lightning join (#549): a strike outside every cell footprint joins the
+/// nearest cell centroid within this many km (anvil and adjacent flashes
+/// belong to the storm even when they miss the 35 dBZ contour).
+pub const LIGHTNING_JOIN_RADIUS_KM: f32 = 10.0;
+/// Per-generation flash-rate history depth for the jump baseline
+/// (6 generations ≈ 30 min at 5-min cadence — the scale of the Schultz
+/// lightning-jump verification window).
+pub const FLASH_HISTORY_LEN: usize = 6;
+/// Absolute flash-rate floor (flashes/min) for the jump flag — the
+/// published Schultz operational threshold. Suppresses 2σ triggers on
+/// near-zero baselines, where a single extra strike is "2σ". Revisit
+/// against live Nordic storm data if jumps never fire.
+pub const MIN_JUMP_RATE_PER_MIN: f32 = 10.0;
 
 /// TRT-lite severity rank from 2D attributes (documented heuristic v1).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -105,6 +118,18 @@ pub struct CellTrack {
     /// per-pixel motion-residual contamination that poisoned field-level
     /// profiles. 0.0 until the second observation.
     pub intensity_tendency: f32,
+    /// Lightning join (#549): strikes attributed to this cell over the
+    /// last inter-generation window. `None` = no event source configured,
+    /// or the join was skipped this generation (source error).
+    pub flash_count: Option<u32>,
+    /// The same window's strikes per minute.
+    pub flash_rate_per_min: Option<f32>,
+    /// Recent per-generation flash rates (ascending age, newest LAST,
+    /// ≤ [`FLASH_HISTORY_LEN`]) — the jump detector's baseline, carried
+    /// across generations by the track id.
+    pub flash_history: Vec<f32>,
+    /// Schultz-style 2σ lightning jump fired this generation.
+    pub lightning_jump: bool,
 }
 
 impl CellTrack {
@@ -205,6 +230,10 @@ pub fn advance_tracks(
                     severity,
                     growing: None,
                     intensity_tendency: 0.0,
+                    flash_count: None,
+                    flash_rate_per_min: None,
+                    flash_history: Vec::new(),
+                    lightning_jump: false,
                 },
                 Some(pi) => {
                     let prev = &previous[pi];
@@ -252,11 +281,89 @@ pub fn advance_tracks(
                             0
                         },
                         severity,
+                        // The join (apply_lightning) fills this generation's
+                        // stats after matching; the baseline history rides
+                        // the track.
+                        flash_count: None,
+                        flash_rate_per_min: None,
+                        flash_history: prev.flash_history.clone(),
+                        lightning_jump: false,
                     }
                 }
             }
         })
         .collect()
+}
+
+/// Join one generation's lightning strikes onto the tracked cells (#549)
+/// and update each track's flash statistics and jump flag.
+///
+/// `strikes_px` are strike positions in WORKING-GRID pixel coordinates —
+/// the caller projects lon/lat and drops off-grid strikes. `labels` is the
+/// analysis label map on the same grid (`0` background, `k+1` ⇔
+/// `tracks[k]`, the `segment_cells_labeled` contract — `advance_tracks`
+/// returns tracks in blob order, which preserves it). A strike lands on
+/// its footprint's cell when labeled, else on the nearest cell centroid
+/// within [`LIGHTNING_JOIN_RADIUS_KM`] (anisotropic km), else nowhere.
+///
+/// The jump flag is the Schultz-style detector: the window's rate exceeds
+/// the track's recent baseline mean by 2σ, with ≥ 2 baseline rates and the
+/// [`MIN_JUMP_RATE_PER_MIN`] absolute floor.
+pub fn apply_lightning(
+    tracks: &mut [CellTrack],
+    strikes_px: &[(f32, f32)],
+    labels: &[u32],
+    width: usize,
+    scale: PixelScale,
+    window_secs: f32,
+) {
+    let mut counts = vec![0u32; tracks.len()];
+    for &(sx, sy) in strikes_px {
+        // In-grid by contract; `as usize` saturates negatives to 0 and
+        // `labels.get` bounds the rest.
+        let idx = (sy as usize) * width + sx as usize;
+        let label = labels.get(idx).copied().unwrap_or(0) as usize;
+        if (1..=tracks.len()).contains(&label) {
+            counts[label - 1] += 1;
+            continue;
+        }
+        let gate2 = LIGHTNING_JOIN_RADIUS_KM * LIGHTNING_JOIN_RADIUS_KM;
+        let mut best: Option<(usize, f32)> = None;
+        for (k, t) in tracks.iter().enumerate() {
+            let dx = (sx - t.blob.centroid.0) * scale.x;
+            let dy = (sy - t.blob.centroid.1) * scale.y;
+            let d2 = dx * dx + dy * dy;
+            if d2 <= gate2 && best.is_none_or(|(_, b)| d2 < b) {
+                best = Some((k, d2));
+            }
+        }
+        if let Some((k, _)) = best {
+            counts[k] += 1;
+        }
+    }
+
+    let window_min = (window_secs / 60.0).max(f32::EPSILON);
+    for (t, &n) in tracks.iter_mut().zip(&counts) {
+        let rate = n as f32 / window_min;
+        let jump = t.flash_history.len() >= 2 && rate >= MIN_JUMP_RATE_PER_MIN && {
+            let count = t.flash_history.len() as f32;
+            let mean = t.flash_history.iter().sum::<f32>() / count;
+            let var = t
+                .flash_history
+                .iter()
+                .map(|r| (r - mean).powi(2))
+                .sum::<f32>()
+                / count;
+            rate > mean + 2.0 * var.sqrt()
+        };
+        t.flash_count = Some(n);
+        t.flash_rate_per_min = Some(rate);
+        t.lightning_jump = jump;
+        t.flash_history.push(rate);
+        if t.flash_history.len() > FLASH_HISTORY_LEN {
+            t.flash_history.remove(0);
+        }
+    }
 }
 
 #[cfg(test)]
@@ -265,6 +372,96 @@ mod tests {
     use crate::motion::{estimate_motion, MotionField, MotionOptions};
     use crate::objects::segment_cells;
     use crate::Grid;
+
+    fn bare_track(id: u64, cx: f32, cy: f32) -> CellTrack {
+        CellTrack {
+            id,
+            blob: CellBlob {
+                centroid: (cx, cy),
+                area: 10,
+                volume: 400.0,
+                max_value: 40.0,
+            },
+            age: 1,
+            velocity_kms: None,
+            deviant_streak: 0,
+            severity: Severity::Weak,
+            growing: None,
+            intensity_tendency: 0.0,
+            flash_count: None,
+            flash_rate_per_min: None,
+            flash_history: Vec::new(),
+            lightning_jump: false,
+        }
+    }
+
+    #[test]
+    fn lightning_attributes_by_label_then_radius_and_ignores_far_strikes() {
+        // 40×20 grid at 1 km/px. Track 1 has a labeled footprint around
+        // (3,3); track 2 sits at (30,10) with no labeled pixels (its
+        // strikes must come via the radius fallback).
+        let (w, h) = (40usize, 20usize);
+        let mut labels = vec![0u32; w * h];
+        for y in 2..5 {
+            for x in 2..5 {
+                labels[y * w + x] = 1;
+            }
+        }
+        let mut tracks = vec![bare_track(1, 3.0, 3.0), bare_track(2, 30.0, 10.0)];
+        let scale = PixelScale { x: 1.0, y: 1.0 };
+        let strikes = [
+            (3.5, 3.5),   // labeled footprint → track 1
+            (30.0, 10.0), // unlabeled px → nearest centroid (track 2, 0 km)
+            (30.0, 2.0),  // 8 km north of track 2 — inside the 10 km gate
+            (39.5, 19.5), // ~13.4 km from track 2 — outside the gate, dropped
+        ];
+        apply_lightning(&mut tracks, &strikes, &labels, w, scale, 300.0);
+        assert_eq!(tracks[0].flash_count, Some(1));
+        assert_eq!(tracks[1].flash_count, Some(2));
+        let r0 = tracks[0].flash_rate_per_min.unwrap();
+        let r1 = tracks[1].flash_rate_per_min.unwrap();
+        assert!(
+            (r0 - 0.2).abs() < 1e-6,
+            "1 strike / 5 min = 0.2/min, got {r0}"
+        );
+        assert!((r1 - 0.4).abs() < 1e-6);
+        assert!(!tracks[0].lightning_jump, "no baseline yet");
+        assert_eq!(tracks[0].flash_history.len(), 1);
+    }
+
+    #[test]
+    fn lightning_jump_needs_baseline_floor_and_two_sigma() {
+        let (w, h) = (10usize, 10usize);
+        let labels = vec![0u32; w * h];
+        let scale = PixelScale { x: 1.0, y: 1.0 };
+        let strike = (5.0f32, 5.0f32); // radius-joins the only track
+        let mut tracks = vec![bare_track(1, 5.0, 5.0)];
+
+        // A burst with NO baseline never jumps (history < 2). Fresh track:
+        // a burst entering the history would raise the later 2σ bar (the
+        // detector deliberately distrusts cells that JUST burst).
+        let burst: Vec<(f32, f32)> = vec![strike; 60]; // 12 fl/min
+        apply_lightning(&mut tracks, &burst, &labels, w, scale, 300.0);
+        assert!(!tracks[0].lightning_jump, "no jump without a baseline");
+
+        // Quiet-baseline track: quiet, quiet, sub-floor uptick (4 fl/min
+        // < the 10 fl/min floor — no jump, baseline [0,0,4]), then a real
+        // burst: 12 ≥ floor and > mean+2σ ≈ 5.1 ⇒ jump.
+        let mut tracks = vec![bare_track(2, 5.0, 5.0)];
+        apply_lightning(&mut tracks, &[], &labels, w, scale, 300.0);
+        apply_lightning(&mut tracks, &[], &labels, w, scale, 300.0);
+        let uptick: Vec<(f32, f32)> = vec![strike; 20]; // 4 fl/min < floor
+        apply_lightning(&mut tracks, &uptick, &labels, w, scale, 300.0);
+        assert!(!tracks[0].lightning_jump, "below the absolute floor");
+        apply_lightning(&mut tracks, &burst, &labels, w, scale, 300.0);
+        assert!(tracks[0].lightning_jump, "burst over quiet baseline");
+
+        // History stays bounded.
+        for _ in 0..10 {
+            apply_lightning(&mut tracks, &[], &labels, w, scale, 300.0);
+        }
+        assert!(tracks[0].flash_history.len() <= FLASH_HISTORY_LEN);
+    }
 
     #[test]
     fn counter_flow_cell_matches_via_raw_position_pass() {
@@ -288,6 +485,10 @@ mod tests {
             severity: Severity::Weak,
             growing: None,
             intensity_tendency: 0.0,
+            flash_count: None,
+            flash_rate_per_min: None,
+            flash_history: Vec::new(),
+            lightning_jump: false,
         }];
         // Uniform 30 px/interval eastward flow; at 1 km/px the compensated
         // hypothesis lands 30 km from the stationary successor — outside

--- a/crates/engine-nowcast/src/engine.rs
+++ b/crates/engine-nowcast/src/engine.rs
@@ -702,7 +702,7 @@ impl NowcastEngine {
                     if events.len() >= MAX_JOIN_STRIKES {
                         tracing::warn!(
                             collection = %self.collection_id,
-                            "lightning window hit the {MAX_JOIN_STRIKES}-row cap;                              flash counts may undercount this generation"
+                            "lightning window hit the {MAX_JOIN_STRIKES}-row cap; flash counts may undercount this generation"
                         );
                     }
                     let strikes_px: Vec<(f32, f32)> = events
@@ -1264,7 +1264,14 @@ fn cell_feature(
         );
         props.insert(
             "lightning_jump".into(),
-            PropertyValue::Bool(t.lightning_jump),
+            // Same tri-state as the counts: a skipped join is "unknown",
+            // not "no jump" — flash_count doubles as the joined-this-
+            // generation marker.
+            if t.flash_count.is_some() {
+                PropertyValue::Bool(t.lightning_jump)
+            } else {
+                PropertyValue::Null
+            },
         );
     }
     (

--- a/crates/engine-nowcast/src/engine.rs
+++ b/crates/engine-nowcast/src/engine.rs
@@ -41,7 +41,9 @@ use ds_core::map_engine::{MapEngine, OutputCrs, RasterInfo, RasterTile, RasterVa
 use ds_core::resample::ProjectionGrid;
 
 use crate::advect::TrajectoryIntegrator;
-use crate::cells2d::{advance_tracks, CellTrack, CELL_MIN_AREA_PX, CELL_THRESHOLD_DBZ};
+use crate::cells2d::{
+    advance_tracks, apply_lightning, CellTrack, CELL_MIN_AREA_PX, CELL_THRESHOLD_DBZ,
+};
 use crate::motion::{estimate_motion_multi, MotionField, MotionOptions};
 use crate::objects::{segment_cells_labeled, PixelScale};
 use crate::tendency::EFOLD_INTERVALS;
@@ -71,6 +73,11 @@ const MAX_LEADS: usize = 96;
 /// Hard cap on `history_frames`: each is one sequential blocking source
 /// fetch per generation, and pair-averaging saturates after a few pairs.
 const MAX_HISTORY_FRAMES: usize = 8;
+/// Row cap on the per-generation lightning fetch (#549) — a safety valve
+/// mirroring engine-postgis's own window cap; an extreme Nordic storm day
+/// peaks around 10⁴ strikes per 5-minute window, well under it. Hitting
+/// the cap logs possible truncation instead of failing the generation.
+const MAX_JOIN_STRIKES: usize = 200_000;
 
 /// Parsed, validated engine configuration.
 struct EngineCfg {
@@ -200,6 +207,9 @@ pub struct NowcastEngine {
     lead_persistence_csi_permille: AtomicU64,
     /// Monotonic id source for cell tracks (#544).
     next_track_id: AtomicU64,
+    /// Optional point-event source joined onto tracked cells per
+    /// generation (#549) — lightning, wired by the server's second pass.
+    lightning: Option<Arc<dyn ds_core::events::EventSource>>,
 }
 
 impl NowcastEngine {
@@ -288,6 +298,7 @@ impl NowcastEngine {
             lead_csi_permille: AtomicU64::new(u64::MAX),
             lead_persistence_csi_permille: AtomicU64::new(u64::MAX),
             next_track_id: AtomicU64::new(1),
+            lightning: None,
         })
     }
 
@@ -342,6 +353,15 @@ impl NowcastEngine {
     /// Signal the poll loop to exit (server reload/shutdown).
     pub fn shutdown(&self) {
         let _ = self.shutdown_tx.send(());
+    }
+
+    /// Attach a point-event source whose strikes are joined onto tracked
+    /// cells each generation (#549). Called by the server's second-pass
+    /// wiring before the engine is shared; the Feature layer only emits
+    /// the flash properties when a source is attached.
+    pub fn with_lightning_source(mut self, source: Arc<dyn ds_core::events::EventSource>) -> Self {
+        self.lightning = Some(source);
+        self
     }
 
     /// Poll the source for a new frame; spawn on the BACKGROUND runtime only.
@@ -660,7 +680,7 @@ impl NowcastEngine {
             Some((_, prev)) if prev.geom == geom => &prev.cells,
             _ => &[],
         };
-        let cells = Arc::new(advance_tracks(
+        let mut cells = advance_tracks(
             previous_cells,
             blobs,
             scale,
@@ -668,7 +688,49 @@ impl NowcastEngine {
             displacement_secs,
             interval.num_seconds() as f32,
             || self.next_track_id.fetch_add(1, Ordering::Relaxed),
-        ));
+        );
+        // Lightning join (#549): one bounded event fetch per generation
+        // (we are ON the background poll runtime — the EventSource sync
+        // bridge is legal here, root rule 7), binned onto cells via the
+        // label map. A source error degrades to "no flash data this
+        // generation" (fields stay None), never a failed generation.
+        if let Some(source) = &self.lightning {
+            let window_secs = displacement_secs.max(1.0);
+            let start = anchor - Duration::seconds(window_secs as i64);
+            match source.recent_events(start, anchor, MAX_JOIN_STRIKES) {
+                Ok(events) => {
+                    if events.len() >= MAX_JOIN_STRIKES {
+                        tracing::warn!(
+                            collection = %self.collection_id,
+                            "lightning window hit the {MAX_JOIN_STRIKES}-row cap;                              flash counts may undercount this generation"
+                        );
+                    }
+                    let strikes_px: Vec<(f32, f32)> = events
+                        .iter()
+                        .filter_map(|e| geom.frac_px(e.lon, e.lat))
+                        .map(|(x, y)| (x as f32, y as f32))
+                        .collect();
+                    apply_lightning(
+                        &mut cells,
+                        &strikes_px,
+                        &labels,
+                        geom.width as usize,
+                        scale,
+                        window_secs,
+                    );
+                    tracing::debug!(
+                        collection = %self.collection_id,
+                        strikes = strikes_px.len(),
+                        "lightning join complete"
+                    );
+                }
+                Err(e) => tracing::warn!(
+                    collection = %self.collection_id,
+                    "lightning join skipped this generation: {e}"
+                ),
+            }
+        }
+        let cells = Arc::new(cells);
 
         // Per-pixel LABEL map + per-cell tendency table (#546 iteration 1
         // pivot): each pixel of tracked cell L gets L's OWN EMA'd intensity
@@ -1129,6 +1191,7 @@ fn cell_feature(
     kx: f64,
     ky: f64,
     anchor: DateTime<Utc>,
+    lightning: bool,
 ) -> (f64, f64, Feature) {
     let lon = g.west + (f64::from(t.blob.centroid.0) / f64::from(g.width)) * (g.east - g.west);
     let lat = g.north - (f64::from(t.blob.centroid.1) / f64::from(g.height)) * (g.north - g.south);
@@ -1183,6 +1246,27 @@ fn cell_feature(
             PropertyValue::Null
         },
     );
+    // Flash properties exist only when a lightning source is wired —
+    // absent means "not measured", null means "join skipped this
+    // generation" (source error), values mean measured (0 = quiet cell).
+    if lightning {
+        props.insert(
+            "flash_count".into(),
+            t.flash_count
+                .map(|n| PropertyValue::Integer(i64::from(n)))
+                .unwrap_or(PropertyValue::Null),
+        );
+        props.insert(
+            "flash_rate_per_min".into(),
+            t.flash_rate_per_min
+                .map(|r| PropertyValue::Float(f64::from(r)))
+                .unwrap_or(PropertyValue::Null),
+        );
+        props.insert(
+            "lightning_jump".into(),
+            PropertyValue::Bool(t.lightning_jump),
+        );
+    }
     (
         lon,
         lat,
@@ -1227,7 +1311,8 @@ impl FeatureEngine for NowcastEngine {
             .cells
             .iter()
             .filter_map(|t| {
-                let (lon, lat, feature) = cell_feature(t, g, kx, ky, anchor);
+                let (lon, lat, feature) =
+                    cell_feature(t, g, kx, ky, anchor, self.lightning.is_some());
                 if let Some(b) = &query.bbox {
                     if !b.contains(lon, lat) {
                         return None;
@@ -1279,7 +1364,7 @@ impl FeatureEngine for NowcastEngine {
         let g = snapshot.geom;
         let (kx, ky) =
             crate::lonlat_grid_km_per_px([g.west, g.south, g.east, g.north], g.width, g.height);
-        Ok(cell_feature(track, g, kx, ky, snapshot.anchor).2)
+        Ok(cell_feature(track, g, kx, ky, snapshot.anchor, self.lightning.is_some()).2)
     }
 
     /// Bumps every generation, so any future consumer keying caches/ETags on

--- a/crates/engine-nowcast/tests/integration.rs
+++ b/crates/engine-nowcast/tests/integration.rs
@@ -189,6 +189,103 @@ fn lightning_join_exposes_flash_properties() {
     assert!(!page.features[0].properties.contains_key("lightning_jump"));
 }
 
+/// A failing event source degrades to null flash fields for that
+/// generation — the generation itself, and the properties' presence,
+/// survive (#549 contract: present-but-null = "join skipped").
+#[test]
+fn lightning_source_error_degrades_to_null_fields() {
+    use ds_core::events::{EventPoint, EventSource};
+    use ds_core::feature::{FeatureQuery, PropertyValue};
+    use ds_core::feature_engine::FeatureEngine;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    struct FlakyStrikes {
+        fail: AtomicBool,
+    }
+    impl EventSource for FlakyStrikes {
+        fn recent_events(
+            &self,
+            _start: DateTime<Utc>,
+            end: DateTime<Utc>,
+            _limit: usize,
+        ) -> Result<Vec<EventPoint>, ds_core::error::DataServerError> {
+            if self.fail.load(Ordering::Relaxed) {
+                return Err(ds_core::error::DataServerError::Engine(
+                    "lightning db unreachable".into(),
+                ));
+            }
+            let (cx, cy) = disc_center(end);
+            let lon = EXTENT[0] + cx / f64::from(W) * (EXTENT[2] - EXTENT[0]);
+            let lat = EXTENT[3] - cy / f64::from(H) * (EXTENT[3] - EXTENT[1]);
+            Ok(vec![
+                EventPoint {
+                    time: end,
+                    lon,
+                    lat
+                };
+                10
+            ])
+        }
+    }
+
+    let anchor1 = t0() + Duration::minutes(5);
+    let source = Arc::new(MockSource {
+        times: RwLock::new(vec![t0(), anchor1]),
+    });
+    let config = NowcastConfig {
+        source: "mock".into(),
+        horizon: "PT30M".into(),
+        step: None,
+        history_frames: 2,
+        poll_interval_secs: 30,
+        max_generations: 4,
+        max_pixels: 4_000_000,
+        min_echo: 10.0,
+        growth_decay: false,
+        lightning_source: Some("mock-lightning".into()),
+    };
+    let strikes = Arc::new(FlakyStrikes {
+        fail: AtomicBool::new(false),
+    });
+    let engine = NowcastEngine::new("flaky-nowcast", "mock", source.clone(), &config)
+        .expect("engine builds")
+        .with_lightning_source(strikes.clone());
+
+    // Healthy generation: measured values.
+    engine.poll_once();
+    let page = engine.get_features(&FeatureQuery::default()).unwrap();
+    assert!(matches!(
+        page.features[0].properties.get("flash_count"),
+        Some(PropertyValue::Integer(10))
+    ));
+
+    // Source down for the next generation: it still completes, the track
+    // persists, and every flash field reads null — including the jump
+    // flag (unknown ≠ false).
+    strikes.fail.store(true, Ordering::Relaxed);
+    let anchor2 = anchor1 + Duration::minutes(5);
+    source.times.write().unwrap().push(anchor2);
+    engine.poll_once();
+    let page = engine.get_features(&FeatureQuery::default()).unwrap();
+    let f = &page.features[0];
+    assert!(matches!(
+        f.properties.get("track_age"),
+        Some(PropertyValue::Integer(2))
+    ));
+    assert!(matches!(
+        f.properties.get("flash_count"),
+        Some(PropertyValue::Null)
+    ));
+    assert!(matches!(
+        f.properties.get("flash_rate_per_min"),
+        Some(PropertyValue::Null)
+    ));
+    assert!(matches!(
+        f.properties.get("lightning_jump"),
+        Some(PropertyValue::Null)
+    ));
+}
+
 fn build(horizon: &str, source_times: &[DateTime<Utc>]) -> (Arc<MockSource>, NowcastEngine) {
     build_with_history(horizon, source_times, 2)
 }

--- a/crates/engine-nowcast/tests/integration.rs
+++ b/crates/engine-nowcast/tests/integration.rs
@@ -97,6 +97,98 @@ impl MapEngine for MockSource {
     }
 }
 
+/// Lightning join (#549): a mock event source dropping a fixed burst on
+/// the disc each window must surface flash properties on the cell —
+/// and an engine WITHOUT a source must not emit them at all.
+#[test]
+fn lightning_join_exposes_flash_properties() {
+    use ds_core::events::{EventPoint, EventSource};
+    use ds_core::feature::{FeatureQuery, PropertyValue};
+    use ds_core::feature_engine::FeatureEngine;
+
+    struct DiscStrikes;
+    impl EventSource for DiscStrikes {
+        fn recent_events(
+            &self,
+            _start: DateTime<Utc>,
+            end: DateTime<Utc>,
+            _limit: usize,
+        ) -> Result<Vec<EventPoint>, ds_core::error::DataServerError> {
+            // disc_center is in grid PIXELS; strikes arrive in WGS84.
+            let (cx, cy) = disc_center(end);
+            let lon = EXTENT[0] + cx / f64::from(W) * (EXTENT[2] - EXTENT[0]);
+            let lat = EXTENT[3] - cy / f64::from(H) * (EXTENT[3] - EXTENT[1]);
+            Ok(vec![
+                EventPoint {
+                    time: end,
+                    lon,
+                    lat
+                };
+                30
+            ])
+        }
+    }
+
+    let anchor1 = t0() + Duration::minutes(5);
+    let source = Arc::new(MockSource {
+        times: RwLock::new(vec![t0(), anchor1]),
+    });
+    let config = NowcastConfig {
+        source: "mock".into(),
+        horizon: "PT30M".into(),
+        step: None,
+        history_frames: 2,
+        poll_interval_secs: 30,
+        max_generations: 4,
+        max_pixels: 4_000_000,
+        min_echo: 10.0,
+        growth_decay: false,
+        lightning_source: Some("mock-lightning".into()),
+    };
+    let engine = NowcastEngine::new("lj-nowcast", "mock", source.clone(), &config)
+        .expect("engine builds")
+        .with_lightning_source(Arc::new(DiscStrikes));
+    engine.poll_once();
+    let page = engine.get_features(&FeatureQuery::default()).unwrap();
+    let f = &page.features[0];
+    assert!(matches!(
+        f.properties.get("flash_count"),
+        Some(PropertyValue::Integer(30))
+    ));
+    // 30 strikes over the 5-min window = 6 flashes/min — measured, but
+    // under the 10/min jump floor: never a jump, even with a baseline.
+    assert!(matches!(
+        f.properties.get("flash_rate_per_min"),
+        Some(PropertyValue::Float(r)) if (r - 6.0).abs() < 1e-6
+    ));
+    assert!(matches!(
+        f.properties.get("lightning_jump"),
+        Some(PropertyValue::Bool(false))
+    ));
+
+    let anchor2 = anchor1 + Duration::minutes(5);
+    source.times.write().unwrap().push(anchor2);
+    engine.poll_once();
+    let page = engine.get_features(&FeatureQuery::default()).unwrap();
+    let f = &page.features[0];
+    assert!(matches!(
+        f.properties.get("flash_count"),
+        Some(PropertyValue::Integer(30))
+    ));
+    assert!(matches!(
+        f.properties.get("lightning_jump"),
+        Some(PropertyValue::Bool(false))
+    ));
+
+    // No source wired ⇒ the flash properties do not exist (absent, not
+    // null — "not measured" is a different statement than "no strikes").
+    let (_s2, plain) = build("PT30M", &[t0(), anchor1]);
+    plain.poll_once();
+    let page = plain.get_features(&FeatureQuery::default()).unwrap();
+    assert!(!page.features[0].properties.contains_key("flash_count"));
+    assert!(!page.features[0].properties.contains_key("lightning_jump"));
+}
+
 fn build(horizon: &str, source_times: &[DateTime<Utc>]) -> (Arc<MockSource>, NowcastEngine) {
     build_with_history(horizon, source_times, 2)
 }
@@ -119,6 +211,7 @@ fn build_with_history(
         max_pixels: 4_000_000,
         min_echo: 10.0,
         growth_decay: false,
+        lightning_source: None,
     };
     let engine =
         NowcastEngine::new("mock-nowcast", "mock", source.clone(), &config).expect("engine builds");
@@ -340,6 +433,7 @@ fn excessive_lead_count_is_rejected_at_construction() {
         max_pixels: 4_000_000,
         min_echo: 10.0,
         growth_decay: false,
+        lightning_source: None,
     };
     let err = NowcastEngine::new("mock-nowcast", "mock", source, &config)
         .err()
@@ -381,6 +475,7 @@ fn oversized_history_frames_is_rejected() {
         max_pixels: 4_000_000,
         min_echo: 10.0,
         growth_decay: false,
+        lightning_source: None,
     };
     let err = NowcastEngine::new("mock-nowcast", "mock", source, &config)
         .err()
@@ -501,6 +596,7 @@ fn dry_scene_leaves_both_skill_gauges_unset() {
         max_pixels: 4_000_000,
         min_echo: 10.0,
         growth_decay: false,
+        lightning_source: None,
     };
     let engine =
         NowcastEngine::new("dry-nowcast", "mock", source.clone(), &config).expect("engine builds");
@@ -651,6 +747,7 @@ fn geometry_change_resets_cell_tracks() {
         max_pixels: 4_000_000,
         min_echo: 10.0,
         growth_decay: false,
+        lightning_source: None,
     };
     let engine =
         NowcastEngine::new("mv-nowcast", "mock", source.clone(), &config).expect("engine builds");
@@ -743,6 +840,7 @@ fn growth_decay_dims_decaying_echo() {
             max_pixels: 4_000_000,
             min_echo: 10.0,
             growth_decay,
+            lightning_source: None,
         };
         let engine = NowcastEngine::new("fade", "mock", source.clone(), &config).expect("builds");
         engine.poll_once();

--- a/crates/engine-postgis/src/engine.rs
+++ b/crates/engine-postgis/src/engine.rs
@@ -29,9 +29,9 @@ use crate::config::PostgisEngineConfig;
 use crate::health::{Health, HealthSnapshot, HealthStatus};
 use crate::metadata::{CollectionMeta, MetadataCache};
 use crate::query::{
-    build_events_area, build_location, build_position, build_stations_in_polygon, params_as_refs,
-    BuiltQuery, DEFAULT_POSITION_RADIUS_M, MAX_AREA_QUERIES, MAX_OBSERVATION_ROWS,
-    MAX_RESPONSE_VALUES, MAX_STATIONS_IN_POLYGON,
+    build_events_area, build_events_window, build_location, build_position,
+    build_stations_in_polygon, params_as_refs, BuiltQuery, DEFAULT_POSITION_RADIUS_M,
+    MAX_AREA_QUERIES, MAX_OBSERVATION_ROWS, MAX_RESPONSE_VALUES, MAX_STATIONS_IN_POLYGON,
 };
 use crate::schema::{EventsShape, ObservationSchema};
 
@@ -309,6 +309,54 @@ impl PostgisEngine {
             &key_refs,
             events,
         )))
+    }
+}
+
+// ─── EventSource (#549): recent point events for cross-engine joins ─────────
+
+impl ds_core::events::EventSource for PostgisEngine {
+    /// Events-shape window fetch for consumers in OTHER engines (the
+    /// nowcast per-cell lightning join): the half-open window `(start,
+    /// end]` across the whole table extent, ascending by time, NEWEST kept
+    /// when `limit` truncates. Reuses the #504 window SQL and the engine's
+    /// sync bridge — the ds-storage calling rules apply (multi-thread
+    /// runtime worker only; the background poll runtime qualifies).
+    fn recent_events(
+        &self,
+        start: DateTime<Utc>,
+        end: DateTime<Utc>,
+        limit: usize,
+    ) -> Result<Vec<ds_core::events::EventPoint>, DataServerError> {
+        let Some(shape) = self.config.events() else {
+            return Err(DataServerError::Engine(
+                "recent_events requires an events-shape postgis collection".into(),
+            ));
+        };
+        let built = build_events_window(shape, (start, end), limit)
+            .map_err(|e| DataServerError::Engine(format!("build_events_window: {e}")))?;
+        let rows = run_single_query_sync(&self.pool, built)?;
+        let mut out = Vec::with_capacity(rows.len());
+        for row in &rows {
+            let time: DateTime<Utc> = row
+                .try_get("time")
+                .map_err(|e| DataServerError::Engine(format!("decode event time: {e}")))?;
+            let lon: Option<f64> = row
+                .try_get("lon")
+                .map_err(|e| DataServerError::Engine(format!("decode event lon: {e}")))?;
+            let lat: Option<f64> = row
+                .try_get("lat")
+                .map_err(|e| DataServerError::Engine(format!("decode event lat: {e}")))?;
+            // Degenerate geometries (ST_X of POINT EMPTY) skip the event,
+            // mirroring the EDR decode path.
+            let (Some(lon), Some(lat)) = (lon, lat) else {
+                continue;
+            };
+            out.push(ds_core::events::EventPoint { time, lon, lat });
+        }
+        // Window SQL orders newest-first (so truncation keeps the newest);
+        // the trait contract is ascending.
+        out.reverse();
+        Ok(out)
     }
 }
 

--- a/crates/server/src/admin.rs
+++ b/crates/server/src/admin.rs
@@ -936,6 +936,10 @@ pub fn load_collections(
     let mut cap_engines: Vec<Arc<engine_cap::CapEngine>> = Vec::new();
     let mut postgis_engines: Vec<Arc<engine_postgis::PostgisEngine>> = Vec::new();
     let mut nowcast_engines: Vec<Arc<engine_nowcast::NowcastEngine>> = Vec::new();
+    // Point-event sources (#549): events-shape postgis collections, keyed
+    // by collection id — the nowcast second pass looks up its
+    // `lightning_source` here.
+    let mut event_sources: HashMap<String, Arc<dyn ds_core::events::EventSource>> = HashMap::new();
     // Derived collections wire in a second pass, after every base engine
     // exists (#522). Collected here during the main loop.
     let mut nowcast_pending: Vec<&CollectionConfig> = Vec::new();
@@ -2195,6 +2199,12 @@ pub fn load_collections(
                     validated.clone(),
                     pool,
                 ));
+                if validated.events().is_some() {
+                    event_sources.insert(
+                        collection.id.clone(),
+                        engine.clone() as Arc<dyn ds_core::events::EventSource>,
+                    );
+                }
 
                 // Bootstrap metadata synchronously. Failure ⇒ degraded status;
                 // the engine still gets wired in so requests can retry once
@@ -2375,12 +2385,28 @@ pub fn load_collections(
             source.clone(),
             nowcast_config,
         ) {
-            Ok(e) => Arc::new(e),
+            Ok(e) => e,
             Err(e) => {
                 fail(format!("failed to initialize nowcast engine: {e}"));
                 continue;
             }
         };
+        // Lightning join (#549): a named source must exist and be an
+        // events-shape postgis collection in the same config — failing the
+        // collection beats silently serving cells without flash data.
+        let engine = match nowcast_config.lightning_source.as_deref() {
+            Some(src_id) => match event_sources.get(src_id) {
+                Some(events) => engine.with_lightning_source(events.clone()),
+                None => {
+                    fail(format!(
+                        "lightning_source '{src_id}' not found or not an events-shape                          postgis collection (it must be defined in the same config)"
+                    ));
+                    continue;
+                }
+            },
+            None => engine,
+        };
+        let engine = Arc::new(engine);
         nowcast_engines.push(engine.clone());
 
         if collection.apis.contains(&"wms".to_string()) {
@@ -4170,6 +4196,7 @@ mod tests {
                 max_pixels: 500_000,
                 min_echo: 10.0,
                 growth_decay: false,
+                lightning_source: None,
             }),
             preview: None,
         }

--- a/crates/server/src/admin.rs
+++ b/crates/server/src/admin.rs
@@ -4262,6 +4262,38 @@ mod tests {
     }
 
     #[test]
+    fn nowcast_missing_lightning_source_fails_that_collection() {
+        // The #549 safety property: a lightning_source that names no
+        // events-shape collection fails the nowcast collection at load —
+        // never silently serving cells without flash data. (A station-
+        // shape postgis collection takes the same path: it is never
+        // entered into the event-source registry, so the lookup misses.)
+        let mut nc = nowcast_test_collection("nc", "nowcast", Some("radar"));
+        nc.nowcast.as_mut().unwrap().lightning_source = Some("no-such-lightning".into());
+        let result = super::load_collections(
+            &[tm35_source_collection("radar"), nc],
+            &[],
+            "http://x",
+            false,
+            0,
+            super::ReusableCaches::default(),
+        );
+        let h = health_of(&result, "nc");
+        assert_eq!(h.status, super::CollectionStatus::Failed);
+        assert!(
+            h.error
+                .as_deref()
+                .unwrap_or("")
+                .contains("lightning_source"),
+            "error should name the missing lightning source: {:?}",
+            h.error
+        );
+        assert!(!result.wms_state.engines.contains_key("nc"));
+        // The base collection is unaffected.
+        assert!(result.wms_state.engines.contains_key("radar"));
+    }
+
+    #[test]
     fn nowcast_of_nowcast_is_rejected() {
         let result = super::load_collections(
             &[

--- a/crates/server/src/admin.rs
+++ b/crates/server/src/admin.rs
@@ -2399,7 +2399,8 @@ pub fn load_collections(
                 Some(events) => engine.with_lightning_source(events.clone()),
                 None => {
                     fail(format!(
-                        "lightning_source '{src_id}' not found or not an events-shape                          postgis collection (it must be defined in the same config)"
+                        "lightning_source '{src_id}' not found or not an events-shape postgis \
+                         collection (it must be defined in the same config)"
                     ));
                     continue;
                 }


### PR DESCRIPTION
Closes #549 (V2.2 part 2, epic #541).

## What

Tracked nowcast cells gain live lightning intelligence: per-cell `flash_count`, `flash_rate_per_min`, and a Schultz-style 2σ `lightning_jump` flag, joined from an engine-postgis events-shape collection (the lightning strike DB) once per generation.

## How

- **ds-core `events` module** — `EventPoint {time, lon, lat}` + `EventSource` trait: half-open `(start, end]` window, ascending, newest-kept truncation, one bounded call per consumer cycle. Framework-free; engine-nowcast never depends on engine-postgis.
- **engine-postgis** — `impl EventSource for PostgisEngine` (events shape only), reusing the #504 `build_events_window` SQL and the engine's sync bridge. The ds-storage calling rules apply and hold: the only caller is the nowcast poll loop on the multi-thread background runtime.
- **server** — `event_sources` registry populated from events-shape postgis collections; the nowcast second pass resolves `[collections.nowcast] lightning_source = "<id>"` from it. Missing/non-events id ⇒ the nowcast collection FAILS at load (no silent no-flash serving).
- **engine-nowcast** — strikes project to the working grid and bin by the analysis label map (`segment_cells_labeled` contract); unlabeled strikes join the nearest cell centroid within `LIGHTNING_JOIN_RADIUS_KM = 10` (anisotropic km); beyond that they're dropped. Rates feed a per-track 6-generation history; jump = rate > baseline mean + 2σ, with the published 10 fl/min Schultz floor (documented for re-tuning against Nordic storm data). Source errors degrade to a warning + null flash fields for that generation — the generation itself never fails.

## Property semantics

Absent = no source wired ("not measured"). Null = join skipped this generation (source error). `0` / `false` = measured and quiet.

## Testing

- Unit: label-then-radius attribution with an out-of-gate strike dropped; jump detector needs ≥2 baseline rates, respects the absolute floor, fires on a burst over a quiet baseline, history bounded.
- Integration: mock event source dropping a 30-strike burst on the moving disc — properties present with correct values across two generations; a source-less engine emits no flash properties at all.
- `cargo test --workspace`: 69 suites green. fmt + clippy `-D warnings` clean on ds-core, engine-nowcast, engine-postgis, server.

## Prod enable (after deploy)

Add to `fmi-radar-nowcast.toml`: `lightning_source = "<lightning collection id>"` under `[nowcast]`. Live smoke deferred to prod (the strike DB only exists there) — same pattern as v2.2 part 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Edrv5Cf4SosH4YmM9tBnEJ