### PR TITLE
fix(engine-nowcast): emit cell-feature values at meaningful precision

### DIFF
--- a/crates/engine-nowcast/src/engine.rs
+++ b/crates/engine-nowcast/src/engine.rs
@@ -1185,6 +1185,13 @@ impl MapEngine for NowcastEngine {
 /// Build one cell feature: lon/lat from the grid geometry plus the served
 /// property set. Shared by `get_features` and `get_feature` so the two
 /// paths cannot drift (and the by-id path needn't materialize every cell).
+/// Round to `places` decimals — serde's shortest-roundtrip float printing
+/// then emits the short form (`14.3`, not `14.300000000000001`).
+fn round_to(v: f64, places: i32) -> f64 {
+    let f = 10f64.powi(places);
+    (v * f).round() / f
+}
+
 fn cell_feature(
     t: &CellTrack,
     g: GridGeom,
@@ -1193,8 +1200,14 @@ fn cell_feature(
     anchor: DateTime<Utc>,
     lightning: bool,
 ) -> (f64, f64, Feature) {
+    // Emit each value at its MEANINGFUL precision, not the f64 bit depth:
+    // the working grid is ~500 m (5 lon/lat decimals ≈ 1 m), centroids
+    // jitter tenths of km², velocities tenths of m/s, bearings whole
+    // degrees. Raw f64s roughly double the GeoJSON payload for noise.
     let lon = g.west + (f64::from(t.blob.centroid.0) / f64::from(g.width)) * (g.east - g.west);
     let lat = g.north - (f64::from(t.blob.centroid.1) / f64::from(g.height)) * (g.north - g.south);
+    let lon = round_to(lon, 5);
+    let lat = round_to(lat, 5);
     let mut props = std::collections::HashMap::new();
     props.insert(
         "severity".into(),
@@ -1206,20 +1219,20 @@ fn cell_feature(
     );
     props.insert(
         "area_km2".into(),
-        PropertyValue::Float(t.blob.area as f64 * kx * ky),
+        PropertyValue::Float(round_to(t.blob.area as f64 * kx * ky, 1)),
     );
     props.insert("track_age".into(), PropertyValue::Integer(t.age as i64));
     props.insert("deviant_mover".into(), PropertyValue::Bool(t.deviant()));
     props.insert(
         "speed_ms".into(),
         t.speed_ms()
-            .map(|v| PropertyValue::Float(f64::from(v)))
+            .map(|v| PropertyValue::Float(round_to(f64::from(v), 1)))
             .unwrap_or(PropertyValue::Null),
     );
     props.insert(
         "bearing_deg".into(),
         t.bearing_deg()
-            .map(PropertyValue::Float)
+            .map(|b| PropertyValue::Float(round_to(b, 0) % 360.0))
             .unwrap_or(PropertyValue::Null),
     );
     props.insert(
@@ -1241,7 +1254,7 @@ fn cell_feature(
     props.insert(
         "intensity_trend_dbz_min".into(),
         if t.age >= 2 {
-            PropertyValue::Float(f64::from(t.intensity_tendency) * 60.0)
+            PropertyValue::Float(round_to(f64::from(t.intensity_tendency) * 60.0, 3))
         } else {
             PropertyValue::Null
         },
@@ -1259,7 +1272,7 @@ fn cell_feature(
         props.insert(
             "flash_rate_per_min".into(),
             t.flash_rate_per_min
-                .map(|r| PropertyValue::Float(f64::from(r)))
+                .map(|r| PropertyValue::Float(round_to(f64::from(r), 2)))
                 .unwrap_or(PropertyValue::Null),
         );
         props.insert(

--- a/crates/engine-nowcast/src/engine.rs
+++ b/crates/engine-nowcast/src/engine.rs
@@ -1182,9 +1182,6 @@ impl MapEngine for NowcastEngine {
     }
 }
 
-/// Build one cell feature: lon/lat from the grid geometry plus the served
-/// property set. Shared by `get_features` and `get_feature` so the two
-/// paths cannot drift (and the by-id path needn't materialize every cell).
 /// Round to `places` decimals — serde's shortest-roundtrip float printing
 /// then emits the short form (`14.3`, not `14.300000000000001`).
 fn round_to(v: f64, places: i32) -> f64 {
@@ -1192,6 +1189,9 @@ fn round_to(v: f64, places: i32) -> f64 {
     (v * f).round() / f
 }
 
+/// Build one cell feature: lon/lat from the grid geometry plus the served
+/// property set. Shared by `get_features` and `get_feature` so the two
+/// paths cannot drift (and the by-id path needn't materialize every cell).
 fn cell_feature(
     t: &CellTrack,
     g: GridGeom,
@@ -1215,7 +1215,9 @@ fn cell_feature(
     );
     props.insert(
         "max_dbz".into(),
-        PropertyValue::Float(f64::from(t.blob.max_value)),
+        // f32→f64 promotion of a gain-scaled byte prints noise for gains
+        // that aren't binary-exact (SMHI 0.4 ⇒ 36.400001525878906).
+        PropertyValue::Float(round_to(f64::from(t.blob.max_value), 1)),
     );
     props.insert(
         "area_km2".into(),

--- a/crates/engine-nowcast/tests/integration.rs
+++ b/crates/engine-nowcast/tests/integration.rs
@@ -748,6 +748,29 @@ fn cell_features_are_served_and_tracks_persist() {
     assert!(engine.get_feature(&id1).is_ok());
     assert!(engine.get_feature("9999").is_err());
 
+    // Precision contract: values are emitted at meaningful precision,
+    // not f64 bit depth (speed 0.1 m/s, bearing whole degrees in
+    // [0, 360), area 0.1 km², coordinates 1e-5 deg).
+    let frac_ok = |v: f64, f: f64| (v * f - (v * f).round()).abs() < 1e-9;
+    match f.properties.get("speed_ms") {
+        Some(PropertyValue::Float(v)) => assert!(frac_ok(*v, 10.0), "speed {v}"),
+        other => panic!("age-2 cell must report speed, got {other:?}"),
+    }
+    match f.properties.get("bearing_deg") {
+        Some(PropertyValue::Float(b)) => {
+            assert!(frac_ok(*b, 1.0) && (0.0..360.0).contains(b), "bearing {b}")
+        }
+        other => panic!("age-2 cell must report bearing, got {other:?}"),
+    }
+    match f.properties.get("area_km2") {
+        Some(PropertyValue::Float(a)) => assert!(frac_ok(*a, 10.0), "area {a}"),
+        other => panic!("missing area, got {other:?}"),
+    }
+    let ds_core::feature::Geometry::Point { x, y } = *f.geometry else {
+        panic!("cell geometry must be a Point");
+    };
+    assert!(frac_ok(x, 1e5) && frac_ok(y, 1e5), "coords {x},{y}");
+
     // History (#548): an interval before the latest snapshot selects the
     // OLDER retained snapshot (age-1 cells, observed at anchor1); an
     // interval before all snapshots matches nothing.


### PR DESCRIPTION
Live payloads carried full f64 bit depth — `"speed_ms": 11.172311782836914`, coordinates to 15 decimals — on a ~500 m working grid where none of it is signal. Values now round to their meaningful precision in `cell_feature`:

| property | precision | rationale |
|---|---|---|
| coordinates | 1e-5° (~1 m) | grid cell is ~500 m |
| `speed_ms` | 0.1 m/s | EMA'd centroid velocity jitters far above this |
| `bearing_deg` | whole degrees, normalized `[0, 360)` | arrow rendering; 359.6 → 0, not 360 |
| `area_km2` | 0.1 km² | one 500 m pixel = 0.4 km² |
| `intensity_trend_dbz_min` | 3 decimals | typical values ~0.03 |
| `flash_rate_per_min` | 2 decimals | |

serde's shortest-roundtrip float printing emits the short textual form after rounding. The precision contract is pinned in the features integration test (fractional checks + bearing range + Point coordinate precision). No API shape change — only value precision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Edrv5Cf4SosH4YmM9tBnEJ