### PR TITLE
feat(api): Cache-Control + ETag/If-None-Match on EDR and Features responses

### DIFF
--- a/crates/api-3dtiles/src/handlers.rs
+++ b/crates/api-3dtiles/src/handlers.rs
@@ -24,6 +24,9 @@ use bytes::Bytes;
 use chrono::{DateTime, SecondsFormat, Utc};
 use ds_core::config::CollectionConfig;
 use ds_core::geo::geodetic_to_ecef;
+// Strong content-derived ETag; shared with api-edr/api-features so the
+// implementations cannot drift (#499).
+use ds_core::http_cache::etag_of;
 use ds_core::volume::VolumeEngine;
 use ds_render::{BuiltinColormap, ColorMap, ColorStop, LutColorMap};
 use serde::Deserialize;
@@ -394,20 +397,6 @@ fn parse_datetime(s: &str) -> Result<DateTime<Utc>, Tiles3dError> {
         .map_err(|_| Tiles3dError::BadRequest(format!("invalid datetime: {s:?}")))
 }
 
-/// Strong content-derived ETag — quoted hex with no `W/` prefix (the bytes are
-/// exact, so byte-equal responses are equivalent per RFC 7232 §2.1). FNV-1a
-/// 64-bit — stable across Rust versions and instances (unlike `DefaultHasher`),
-/// so a toolchain upgrade or a mixed-version fleet doesn't silently invalidate
-/// ETags.
-fn etag_of(bytes: &[u8]) -> String {
-    let mut h: u64 = 0xcbf2_9ce4_8422_2325;
-    for &b in bytes {
-        h ^= b as u64;
-        h = h.wrapping_mul(0x0000_0100_0000_01b3);
-    }
-    format!("\"{h:016x}\"")
-}
-
 /// The `Cache-Control` for a response: content pinned to an **exactly
 /// advertised** volume time is an archived volume that never changes, so let
 /// browsers hold it for a day without revalidating (`immutable`) — exactly the
@@ -453,7 +442,7 @@ fn binary_response(
     let not_modified = headers
         .get(header::IF_NONE_MATCH)
         .and_then(|h| h.to_str().ok())
-        .is_some_and(|v| v == "*" || v.split(',').any(|t| t.trim() == etag));
+        .is_some_and(|v| ds_core::http_cache::if_none_match_matches(v, etag));
     if not_modified {
         return (
             StatusCode::NOT_MODIFIED,

--- a/crates/api-edr/CLAUDE.md
+++ b/crates/api-edr/CLAUDE.md
@@ -64,3 +64,27 @@ owns the instance-id string form:
   → 404 (an empty PointSeries would fail schema validation).
 - When adding endpoints or params, update `api_definition()` in
   `src/handlers.rs` (OpenAPI).
+
+## Caching headers (#499)
+
+Every 200 carries `Cache-Control` + a strong content-derived ETag, and a
+matching `If-None-Match` short-circuits to 304 — added by the
+`caching::conditional_get` middleware wrapping the whole router (an
+intentional near-twin of `api-features/src/caching.rs`; the pure pieces are
+shared via `ds_core::http_cache`). Policy:
+
+- Default (metadata, "latest"/open-ended queries): `public, max-age=60`.
+- *Settled* data queries — closed `datetime` interval whose end is ≥1 h in
+  the past — get `public, max-age=86400` via `with_data_cache_control` in the
+  data-query handlers. Never `immutable`: observations back-fill and rolling
+  retention prunes, so the response can still change; expiry + ETag
+  revalidation bounds the staleness to a day.
+- A 304 still recomputes the query (no content cache at this layer — EDR
+  query keys barely repeat, #202); it saves the transfer, and `max-age`
+  saves the request.
+
+A new handler needs no caching code unless its 200 body embeds a per-request
+value (a generation timestamp, a random id): a body-hash ETag then never
+matches, so precompute the ETag over the body with that field blanked and
+set the `ETag` header yourself — the middleware honours it (see the
+Features `items` handler).

--- a/crates/api-edr/src/caching.rs
+++ b/crates/api-edr/src/caching.rs
@@ -1,0 +1,82 @@
+//! Response-caching middleware: `Cache-Control` + ETag / `If-None-Match`
+//! conditional GET for every 200 this router serves (#499).
+//!
+//! The pure pieces (hashing, matching, policy strings) live in
+//! [`ds_core::http_cache`]; this file is only the axum glue. It is an
+//! intentional near-twin of `api-features/src/caching.rs` — ds-core is
+//! framework-free, so the middleware itself cannot be shared. Keep the two
+//! in sync.
+//!
+//! A 304 here still recomputes the query server-side (there is no content
+//! cache at this layer — EDR query keys barely repeat, #202); what it saves
+//! is the response transfer, and `Cache-Control` saves the request entirely
+//! within the freshness window.
+
+use axum::body::Body;
+use axum::extract::Request;
+use axum::http::{header, HeaderValue, StatusCode};
+use axum::middleware::Next;
+use axum::response::{IntoResponse, Response};
+
+use ds_core::http_cache::{etag_of, if_none_match_matches, CACHE_CONTROL_SHORT};
+
+/// Middleware wrapping every route: buffer the (already in-memory) body of a
+/// 200, default `Cache-Control` to the short policy when the handler didn't
+/// set one, attach a strong content-derived ETag (honouring one the handler
+/// precomputed), and short-circuit a matching `If-None-Match` to 304.
+pub async fn conditional_get(req: Request, next: Next) -> Response {
+    // Owned copy so it survives the request being consumed by `next`.
+    let if_none_match = req
+        .headers()
+        .get(header::IF_NONE_MATCH)
+        .and_then(|v| v.to_str().ok())
+        .map(str::to_owned);
+    let resp = next.run(req).await;
+    if resp.status() != StatusCode::OK {
+        return resp;
+    }
+    let (mut parts, body) = resp.into_parts();
+    // Every 200 body in this crate is a fully buffered String/Vec (serde_json
+    // output or an encoded PNG), so this await is a cheap move, not a
+    // streaming hazard.
+    let bytes = match axum::body::to_bytes(body, usize::MAX).await {
+        Ok(bytes) => bytes,
+        Err(e) => {
+            tracing::error!("failed to buffer response body for ETag: {e}");
+            return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+        }
+    };
+    if !parts.headers.contains_key(header::CACHE_CONTROL) {
+        parts.headers.insert(
+            header::CACHE_CONTROL,
+            HeaderValue::from_static(CACHE_CONTROL_SHORT),
+        );
+    }
+    let etag = match parts
+        .headers
+        .get(header::ETAG)
+        .and_then(|v| v.to_str().ok())
+    {
+        Some(precomputed) => precomputed.to_owned(),
+        None => {
+            let etag = etag_of(&bytes);
+            parts.headers.insert(
+                header::ETAG,
+                HeaderValue::from_str(&etag).expect("quoted-hex etag is a valid header value"),
+            );
+            etag
+        }
+    };
+    if if_none_match
+        .as_deref()
+        .is_some_and(|inm| if_none_match_matches(inm, &etag))
+    {
+        // Keep the 200's headers (RFC 7232 §4.1 wants Cache-Control/ETag/Vary
+        // repeated) but drop the payload-specific ones along with the body.
+        parts.status = StatusCode::NOT_MODIFIED;
+        parts.headers.remove(header::CONTENT_TYPE);
+        parts.headers.remove(header::CONTENT_LENGTH);
+        return Response::from_parts(parts, Body::empty());
+    }
+    Response::from_parts(parts, Body::from(bytes))
+}

--- a/crates/api-edr/src/handlers.rs
+++ b/crates/api-edr/src/handlers.rs
@@ -98,6 +98,33 @@ fn with_vary(mut resp: Response) -> Response {
     resp
 }
 
+/// Attach the data-query `Cache-Control` policy (#499) to a success response:
+/// a settled window (closed `datetime` interval entirely in the past) gets the
+/// long policy, everything else the short one. `datetime` is the parsed
+/// request interval; the `parse_datetime_interval` open-bound sentinels
+/// (`MIN_UTC`/`MAX_UTC`) map back to "open" for
+/// [`ds_core::http_cache::data_cache_control`]. Metadata endpoints don't call
+/// this — they fall through to the middleware's short default
+/// (`caching::conditional_get`).
+fn with_data_cache_control(
+    mut resp: Response,
+    datetime: Option<(chrono::DateTime<chrono::Utc>, chrono::DateTime<chrono::Utc>)>,
+) -> Response {
+    let (start, end) = match datetime {
+        Some((s, e)) => (
+            (s != chrono::DateTime::<chrono::Utc>::MIN_UTC).then_some(s),
+            (e != chrono::DateTime::<chrono::Utc>::MAX_UTC).then_some(e),
+        ),
+        None => (None, None),
+    };
+    let cc = ds_core::http_cache::data_cache_control(start, end, chrono::Utc::now());
+    resp.headers_mut().insert(
+        header::CACHE_CONTROL,
+        axum::http::HeaderValue::from_static(cc),
+    );
+    resp
+}
+
 /// Shared state for the EDR API: a registry of collection engines + metadata.
 #[derive(Clone)]
 pub struct EdrState {
@@ -1177,6 +1204,7 @@ pub async fn location_query(
 
     let format = parse_edr_format(params.f.as_deref()).map_err(|e| bad_request(&e))?;
     render_coverage_response(result, format, params.width, params.height)
+        .map(|r| with_data_cache_control(r, datetime))
 }
 
 pub async fn position_query(
@@ -1272,7 +1300,8 @@ async fn run_position_query(
                 reference_time,
             )
             .map_err(|e| map_engine_error(&e))?;
-        return render_coverage_response(result, format, params.width, params.height);
+        return render_coverage_response(result, format, params.width, params.height)
+            .map(|r| with_data_cache_control(r, datetime));
     }
 
     // MULTIPOINT — fan out one query per point and flatten every point's
@@ -1300,6 +1329,7 @@ async fn run_position_query(
         params.width,
         params.height,
     )
+    .map(|r| with_data_cache_control(r, datetime))
 }
 
 pub async fn area_query(
@@ -1395,9 +1425,13 @@ async fn run_area_query(
         tracing::error!("Area CoverageJSON serialise error: {e}");
         server_error()
     })?;
-    Ok((
-        [(header::CONTENT_TYPE, "application/prs.coverage+json")],
-        body,
+    Ok(with_data_cache_control(
+        (
+            [(header::CONTENT_TYPE, "application/prs.coverage+json")],
+            body,
+        )
+            .into_response(),
+        datetime,
     ))
 }
 
@@ -1510,11 +1544,14 @@ pub async fn trajectory_query(
                 tracing::error!("Trajectory CoverageJSON serialise error: {e}");
                 server_error()
             })?;
-            Ok((
-                [(header::CONTENT_TYPE, "application/prs.coverage+json")],
-                body,
-            )
-                .into_response())
+            Ok(with_data_cache_control(
+                (
+                    [(header::CONTENT_TYPE, "application/prs.coverage+json")],
+                    body,
+                )
+                    .into_response(),
+                datetime,
+            ))
         }
         EdrFormat::Png => {
             // Render the cross-section as a colour-mapped heatmap using
@@ -1534,7 +1571,10 @@ pub async fn trajectory_query(
                 tracing::error!("Trajectory PNG render error: {e}");
                 server_error()
             })?;
-            Ok(([(header::CONTENT_TYPE, "image/png")], png).into_response())
+            Ok(with_data_cache_control(
+                ([(header::CONTENT_TYPE, "image/png")], png).into_response(),
+                datetime,
+            ))
         }
     }
 }
@@ -1632,8 +1672,15 @@ fn build_collection_metadata(
         extent.insert("vertical".to_string(), json!(vertical_obj));
     }
 
-    let parameter_names: serde_json::Map<String, serde_json::Value> = param_descs
-        .iter()
+    // Sorted iteration: serde_json's workspace-enabled `preserve_order` makes
+    // insertion order the wire order, and `get_parameter_descriptions` builds
+    // a fresh HashMap per call — unsorted, byte-identical requests would
+    // serialize differently and the content-derived ETag would never
+    // revalidate (#499).
+    let mut sorted_descs: Vec<_> = param_descs.iter().collect();
+    sorted_descs.sort_by_key(|(name, _)| *name);
+    let parameter_names: serde_json::Map<String, serde_json::Value> = sorted_descs
+        .into_iter()
         .map(|(name, desc)| {
             let mut param = json!({
                 "type": "Parameter",

--- a/crates/api-edr/src/lib.rs
+++ b/crates/api-edr/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod caching;
 pub mod handlers;
 pub mod params;
 pub(crate) mod plot_convert;
@@ -42,5 +43,7 @@ pub fn router(state: AppState) -> Router {
             "/collections/{id}/instances/{instanceId}/area",
             get(handlers::instance_area_query),
         )
+        // Cache-Control + ETag/If-None-Match on every 200 (#499).
+        .layer(axum::middleware::from_fn(caching::conditional_get))
         .with_state(state)
 }

--- a/crates/api-edr/src/response.rs
+++ b/crates/api-edr/src/response.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use ds_core::model::{CoverageResponse, DomainDescription, Location, QueryResult, VerticalCoord};
 use serde_json::{json, Map, Number, Value};
 
@@ -129,9 +131,21 @@ fn build_ndarray(ndarray: &ds_core::model::NdArray) -> Value {
     Value::Object(obj)
 }
 
+/// Iterate a per-query `HashMap` in sorted key order. This workspace's
+/// serde_json is built with `preserve_order` (pulled in by zarrs), so
+/// insertion order IS the wire order — and a fresh `HashMap`'s iteration
+/// order differs per instance. Without sorting, byte-identical queries would
+/// serialize in different key orders and the content-derived ETag would
+/// never revalidate (#499).
+fn sorted<V>(map: &HashMap<String, V>) -> Vec<(&String, &V)> {
+    let mut entries: Vec<_> = map.iter().collect();
+    entries.sort_by_key(|(name, _)| *name);
+    entries
+}
+
 fn build_parameters(result: &QueryResult) -> Map<String, Value> {
     let mut parameters = Map::with_capacity(result.parameters.len());
-    for (name, desc) in &result.parameters {
+    for (name, desc) in sorted(&result.parameters) {
         parameters.insert(
             name.clone(),
             build_parameter(&desc.label, &desc.unit, &desc.observed_property),
@@ -142,7 +156,7 @@ fn build_parameters(result: &QueryResult) -> Map<String, Value> {
 
 fn build_ranges(result: &QueryResult) -> Map<String, Value> {
     let mut ranges = Map::with_capacity(result.ranges.len());
-    for (name, ndarray) in &result.ranges {
+    for (name, ndarray) in sorted(&result.ranges) {
         ranges.insert(name.clone(), build_ndarray(ndarray));
     }
     ranges

--- a/crates/api-edr/tests/caching_tests.rs
+++ b/crates/api-edr/tests/caching_tests.rs
@@ -1,0 +1,318 @@
+//! Cache-Control + ETag / If-None-Match behavior (#499).
+//!
+//! Every 200 must carry an explicit `Cache-Control` (short for metadata and
+//! "latest" queries, long for settled past windows) and a strong ETag that
+//! answers `If-None-Match` with 304.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use arc_swap::ArcSwap;
+use axum::body::Body;
+use axum::http::{header, Request, StatusCode};
+use chrono::{DateTime, Utc};
+use http_body_util::BodyExt;
+use tower::ServiceExt;
+
+use api_edr::handlers::EdrState;
+use ds_core::config::CollectionConfig;
+use ds_core::edr_engine::EdrEngine;
+use ds_core::error::DataServerError;
+use ds_core::model::*;
+
+struct MockEngine;
+
+impl MockEngine {
+    fn sample_query_result() -> QueryResult {
+        let times: Vec<DateTime<Utc>> = (0..3)
+            .map(|h| {
+                format!("2024-01-01T{h:02}:00:00Z")
+                    .parse::<DateTime<Utc>>()
+                    .unwrap()
+            })
+            .collect();
+        // Several parameters in fresh-per-query HashMaps: with serde_json's
+        // workspace-enabled `preserve_order`, unsorted map serialization
+        // would emit a different key order per request — the revalidation
+        // tests below would then fail, guarding the sorted-serialization fix.
+        let mut parameters = HashMap::new();
+        let mut ranges = HashMap::new();
+        for name in [
+            "temperature",
+            "humidity",
+            "pressure",
+            "wind_speed",
+            "dewpoint",
+            "visibility",
+        ] {
+            parameters.insert(
+                name.to_string(),
+                ParameterDescription {
+                    label: name.into(),
+                    unit: "degC".into(),
+                    observed_property: name.into(),
+                },
+            );
+            ranges.insert(
+                name.to_string(),
+                NdArray {
+                    shape: vec![3],
+                    axis_names: vec!["t".into()],
+                    values: vec![Some(-2.5), Some(-2.8), None],
+                },
+            );
+        }
+        QueryResult {
+            domain: DomainDescription::PointSeries {
+                x: 24.9384,
+                y: 60.1699,
+                t: times,
+                z: None,
+            },
+            parameters,
+            ranges,
+        }
+    }
+}
+
+impl EdrEngine for MockEngine {
+    fn get_locations(&self) -> Result<Vec<Location>, DataServerError> {
+        Ok(vec![Location {
+            id: "helsinki".into(),
+            label: "Helsinki".into(),
+            latitude: 60.1699,
+            longitude: 24.9384,
+        }])
+    }
+
+    fn query_location(
+        &self,
+        _location_id: &str,
+        _datetime: Option<(DateTime<Utc>, DateTime<Utc>)>,
+        _parameters: Option<&[String]>,
+        _z: Option<&[f64]>,
+        _reference_time: Option<DateTime<Utc>>,
+    ) -> Result<CoverageResponse, DataServerError> {
+        Ok(CoverageResponse::Single(Self::sample_query_result()))
+    }
+
+    fn query_position(
+        &self,
+        _coords: &str,
+        _datetime: Option<(DateTime<Utc>, DateTime<Utc>)>,
+        _parameters: Option<&[String]>,
+        _z: Option<&[f64]>,
+        _reference_time: Option<DateTime<Utc>>,
+    ) -> Result<CoverageResponse, DataServerError> {
+        Ok(CoverageResponse::Single(Self::sample_query_result()))
+    }
+
+    fn get_parameters(&self) -> Vec<String> {
+        // Six parameters so the /collections metadata path (default
+        // `get_parameter_descriptions` → fresh HashMap) also exercises the
+        // sorted serialization guarded by the revalidation tests.
+        [
+            "temperature",
+            "humidity",
+            "pressure",
+            "wind_speed",
+            "dewpoint",
+            "visibility",
+        ]
+        .map(String::from)
+        .to_vec()
+    }
+
+    fn get_temporal_extent(&self) -> Option<(DateTime<Utc>, DateTime<Utc>)> {
+        Some((
+            "2024-01-01T00:00:00Z".parse().unwrap(),
+            "2024-01-01T23:00:00Z".parse().unwrap(),
+        ))
+    }
+
+    fn get_spatial_extent(&self) -> Option<[f64; 4]> {
+        Some([23.7610, 60.1699, 24.9384, 61.4978])
+    }
+
+    fn supported_query_types(&self) -> Vec<String> {
+        vec!["locations".to_string(), "position".to_string()]
+    }
+}
+
+fn build_router() -> axum::Router {
+    let engine: Arc<dyn EdrEngine> = Arc::new(MockEngine);
+    let mut engines: HashMap<String, Arc<dyn EdrEngine>> = HashMap::new();
+    let mut collections = HashMap::new();
+    engines.insert("weather".to_string(), engine);
+    collections.insert(
+        "weather".to_string(),
+        CollectionConfig {
+            id: "weather".to_string(),
+            title: "Weather".to_string(),
+            description: "Test collection".to_string(),
+            data_path: None,
+            apis: vec!["edr".to_string()],
+            engine_type: "csv".to_string(),
+            keywords: Vec::new(),
+            license: None,
+            geotiff: None,
+            querydata: None,
+            wms: None,
+            grib: None,
+            zarr: None,
+            odim: None,
+            cap: None,
+            postgis: None,
+            nowcast: None,
+            preview: None,
+        },
+    );
+    api_edr::router(Arc::new(ArcSwap::from_pointee(EdrState {
+        engines,
+        collections,
+        base_url: String::new(),
+        trust_proxy_headers: false,
+    })))
+}
+
+async fn get_response(uri: &str, if_none_match: Option<&str>) -> axum::response::Response {
+    let mut req = Request::builder().uri(uri);
+    if let Some(inm) = if_none_match {
+        req = req.header(header::IF_NONE_MATCH, inm);
+    }
+    build_router()
+        .oneshot(req.body(Body::empty()).unwrap())
+        .await
+        .unwrap()
+}
+
+fn header_str(resp: &axum::response::Response, name: header::HeaderName) -> Option<&str> {
+    resp.headers().get(name).and_then(|v| v.to_str().ok())
+}
+
+/// A closed interval comfortably in the past relative to the test run.
+const SETTLED_WINDOW: &str = "2024-01-01T00:00:00Z/2024-01-01T06:00:00Z";
+
+#[tokio::test]
+async fn metadata_endpoints_carry_short_cache_control_and_etag() {
+    for uri in [
+        "/",
+        "/conformance",
+        "/collections",
+        "/collections/weather",
+        "/collections/weather/locations",
+        "/api",
+    ] {
+        let resp = get_response(uri, None).await;
+        assert_eq!(resp.status(), StatusCode::OK, "{uri}");
+        assert_eq!(
+            header_str(&resp, header::CACHE_CONTROL),
+            Some("public, max-age=60"),
+            "{uri}"
+        );
+        let etag = header_str(&resp, header::ETAG)
+            .expect("etag present")
+            .to_owned();
+        assert!(
+            etag.starts_with('"') && etag.ends_with('"'),
+            "{uri}: {etag}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn if_none_match_revalidates_to_304() {
+    let first = get_response("/collections", None).await;
+    let etag = header_str(&first, header::ETAG).unwrap().to_owned();
+
+    let second = get_response("/collections", Some(&etag)).await;
+    assert_eq!(second.status(), StatusCode::NOT_MODIFIED);
+    // RFC 7232 §4.1: the 304 repeats ETag/Cache-Control (and Vary, which the
+    // content-negotiated metadata endpoints set).
+    assert_eq!(header_str(&second, header::ETAG), Some(etag.as_str()));
+    assert_eq!(
+        header_str(&second, header::CACHE_CONTROL),
+        Some("public, max-age=60")
+    );
+    assert_eq!(header_str(&second, header::VARY), Some("accept"));
+    let body = second.into_body().collect().await.unwrap().to_bytes();
+    assert!(body.is_empty());
+
+    // A non-matching tag still gets the full 200.
+    let third = get_response("/collections", Some("\"deadbeefdeadbeef\"")).await;
+    assert_eq!(third.status(), StatusCode::OK);
+    let body = third.into_body().collect().await.unwrap().to_bytes();
+    assert!(!body.is_empty());
+}
+
+#[tokio::test]
+async fn coverage_query_revalidates_to_304() {
+    let uri = format!(
+        "/collections/weather/position?coords=POINT(24.94%2060.17)&datetime={SETTLED_WINDOW}"
+    );
+    let first = get_response(&uri, None).await;
+    assert_eq!(first.status(), StatusCode::OK);
+    let etag = header_str(&first, header::ETAG).unwrap().to_owned();
+
+    let second = get_response(&uri, Some(&etag)).await;
+    assert_eq!(second.status(), StatusCode::NOT_MODIFIED);
+    let body = second.into_body().collect().await.unwrap().to_bytes();
+    assert!(body.is_empty());
+}
+
+#[tokio::test]
+async fn settled_past_window_gets_long_cache_control() {
+    for uri in [
+        format!(
+            "/collections/weather/position?coords=POINT(24.94%2060.17)&datetime={SETTLED_WINDOW}"
+        ),
+        format!("/collections/weather/locations/helsinki?datetime={SETTLED_WINDOW}"),
+        // An instant in the past is settled too.
+        "/collections/weather/position?coords=POINT(24.94%2060.17)&datetime=2024-01-01T03:00:00Z"
+            .to_string(),
+    ] {
+        let resp = get_response(&uri, None).await;
+        assert_eq!(resp.status(), StatusCode::OK, "{uri}");
+        assert_eq!(
+            header_str(&resp, header::CACHE_CONTROL),
+            Some("public, max-age=86400"),
+            "{uri}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn open_latest_or_future_windows_get_short_cache_control() {
+    let now_plus_day =
+        (Utc::now() + chrono::Duration::days(1)).to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
+    for uri in [
+        // No datetime — "latest".
+        "/collections/weather/position?coords=POINT(24.94%2060.17)".to_string(),
+        // Open start: retention keeps changing the answer.
+        "/collections/weather/position?coords=POINT(24.94%2060.17)&datetime=../2024-01-01T06:00:00Z"
+            .to_string(),
+        // Open end.
+        "/collections/weather/position?coords=POINT(24.94%2060.17)&datetime=2024-01-01T00:00:00Z/.."
+            .to_string(),
+        // Closed window that isn't settled yet.
+        format!(
+            "/collections/weather/position?coords=POINT(24.94%2060.17)&datetime=2024-01-01T00:00:00Z/{now_plus_day}"
+        ),
+    ] {
+        let resp = get_response(&uri, None).await;
+        assert_eq!(resp.status(), StatusCode::OK, "{uri}");
+        assert_eq!(
+            header_str(&resp, header::CACHE_CONTROL),
+            Some("public, max-age=60"),
+            "{uri}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn error_responses_are_left_alone() {
+    let resp = get_response("/collections/nope", None).await;
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    assert!(resp.headers().get(header::ETAG).is_none());
+    assert!(resp.headers().get(header::CACHE_CONTROL).is_none());
+}

--- a/crates/api-features/src/caching.rs
+++ b/crates/api-features/src/caching.rs
@@ -1,0 +1,80 @@
+//! Response-caching middleware: `Cache-Control` + ETag / `If-None-Match`
+//! conditional GET for every 200 this router serves (#499).
+//!
+//! The pure pieces (hashing, matching, policy strings) live in
+//! [`ds_core::http_cache`]; this file is only the axum glue. It is an
+//! intentional near-twin of `api-edr/src/caching.rs` — ds-core is
+//! framework-free, so the middleware itself cannot be shared. Keep the two
+//! in sync.
+//!
+//! The `items` handler precomputes its ETag over the body with the
+//! per-request `timeStamp` excluded (a body hash here would never match) —
+//! the middleware honours a handler-set ETag instead of hashing.
+
+use axum::body::Body;
+use axum::extract::Request;
+use axum::http::{header, HeaderValue, StatusCode};
+use axum::middleware::Next;
+use axum::response::{IntoResponse, Response};
+
+use ds_core::http_cache::{etag_of, if_none_match_matches, CACHE_CONTROL_SHORT};
+
+/// Middleware wrapping every route: buffer the (already in-memory) body of a
+/// 200, default `Cache-Control` to the short policy when the handler didn't
+/// set one, attach a strong content-derived ETag (honouring one the handler
+/// precomputed), and short-circuit a matching `If-None-Match` to 304.
+pub async fn conditional_get(req: Request, next: Next) -> Response {
+    // Owned copy so it survives the request being consumed by `next`.
+    let if_none_match = req
+        .headers()
+        .get(header::IF_NONE_MATCH)
+        .and_then(|v| v.to_str().ok())
+        .map(str::to_owned);
+    let resp = next.run(req).await;
+    if resp.status() != StatusCode::OK {
+        return resp;
+    }
+    let (mut parts, body) = resp.into_parts();
+    // Every 200 body in this crate is a fully buffered String/Vec (serde_json
+    // output), so this await is a cheap move, not a streaming hazard.
+    let bytes = match axum::body::to_bytes(body, usize::MAX).await {
+        Ok(bytes) => bytes,
+        Err(e) => {
+            tracing::error!("failed to buffer response body for ETag: {e}");
+            return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+        }
+    };
+    if !parts.headers.contains_key(header::CACHE_CONTROL) {
+        parts.headers.insert(
+            header::CACHE_CONTROL,
+            HeaderValue::from_static(CACHE_CONTROL_SHORT),
+        );
+    }
+    let etag = match parts
+        .headers
+        .get(header::ETAG)
+        .and_then(|v| v.to_str().ok())
+    {
+        Some(precomputed) => precomputed.to_owned(),
+        None => {
+            let etag = etag_of(&bytes);
+            parts.headers.insert(
+                header::ETAG,
+                HeaderValue::from_str(&etag).expect("quoted-hex etag is a valid header value"),
+            );
+            etag
+        }
+    };
+    if if_none_match
+        .as_deref()
+        .is_some_and(|inm| if_none_match_matches(inm, &etag))
+    {
+        // Keep the 200's headers (RFC 7232 §4.1 wants Cache-Control/ETag/Vary
+        // repeated) but drop the payload-specific ones along with the body.
+        parts.status = StatusCode::NOT_MODIFIED;
+        parts.headers.remove(header::CONTENT_TYPE);
+        parts.headers.remove(header::CONTENT_LENGTH);
+        return Response::from_parts(parts, Body::empty());
+    }
+    Response::from_parts(parts, Body::from(bytes))
+}

--- a/crates/api-features/src/handlers.rs
+++ b/crates/api-features/src/handlers.rs
@@ -691,6 +691,16 @@ pub async fn items(
     let limit = params.limit.unwrap_or(DEFAULT_LIMIT).clamp(1, MAX_LIMIT);
     let offset = params.offset.unwrap_or(0);
 
+    // Cache-Control policy (#499): a settled window (closed datetime interval
+    // entirely in the past) gets the long policy, everything else the short
+    // one — captured before `datetime` moves into the query.
+    let (window_start, window_end) = datetime
+        .as_ref()
+        .map(|d| (d.start, d.end))
+        .unwrap_or((None, None));
+    let cache_control =
+        ds_core::http_cache::data_cache_control(window_start, window_end, Utc::now());
+
     let query = FeatureQuery {
         bbox,
         limit,
@@ -705,15 +715,36 @@ pub async fn items(
         )
     })?;
 
-    let timestamp = Utc::now().to_rfc3339();
-    Ok(GeoJsonResponse(feature_page_to_geojson(
+    // Hash the ETag over the document with an empty `timeStamp` placeholder:
+    // the field is the response *generation* time, so a hash over the final
+    // body would change on every request and `If-None-Match` would never
+    // match. The `caching::conditional_get` middleware honours this
+    // precomputed ETag instead of hashing the body.
+    let mut doc = feature_page_to_geojson(
         &page,
         &id,
         limit,
         offset,
-        &timestamp,
+        "",
         &request_base_url(&state, &headers),
-    )))
+    );
+    let etag = ds_core::http_cache::etag_of(
+        serde_json::to_string(&doc)
+            .expect("GeoJSON Value serializes")
+            .as_bytes(),
+    );
+    doc["timeStamp"] = json!(Utc::now().to_rfc3339());
+
+    let mut resp = GeoJsonResponse(doc).into_response();
+    resp.headers_mut().insert(
+        header::ETAG,
+        HeaderValue::from_str(&etag).expect("quoted-hex etag is a valid header value"),
+    );
+    resp.headers_mut().insert(
+        header::CACHE_CONTROL,
+        HeaderValue::from_static(cache_control),
+    );
+    Ok(resp)
 }
 
 pub async fn item(

--- a/crates/api-features/src/lib.rs
+++ b/crates/api-features/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod caching;
 pub mod handlers;
 pub mod params;
 pub mod response;
@@ -17,5 +18,7 @@ pub fn router(state: AppState) -> Router {
         .route("/collections/{id}", get(handlers::collection))
         .route("/collections/{id}/items", get(handlers::items))
         .route("/collections/{id}/items/{feature_id}", get(handlers::item))
+        // Cache-Control + ETag/If-None-Match on every 200 (#499).
+        .layer(axum::middleware::from_fn(caching::conditional_get))
         .with_state(state)
 }

--- a/crates/api-features/src/response.rs
+++ b/crates/api-features/src/response.rs
@@ -55,9 +55,15 @@ fn geometry_to_json(g: &Geometry) -> Value {
 }
 
 pub fn feature_to_geojson(feature: &Feature, collection_id: &str, base_url: &str) -> Value {
-    let properties: serde_json::Map<String, Value> = feature
-        .properties
-        .iter()
+    // Sorted iteration: serde_json's workspace-enabled `preserve_order` makes
+    // insertion order the wire order, and engines build each feature's
+    // property HashMap fresh per request — unsorted, byte-identical requests
+    // would serialize differently and the content-derived ETag would never
+    // revalidate (#499).
+    let mut entries: Vec<_> = feature.properties.iter().collect();
+    entries.sort_by_key(|(k, _)| *k);
+    let properties: serde_json::Map<String, Value> = entries
+        .into_iter()
         .map(|(k, v)| (k.clone(), property_value_to_json(v)))
         .collect();
 

--- a/crates/api-features/tests/caching_tests.rs
+++ b/crates/api-features/tests/caching_tests.rs
@@ -1,0 +1,230 @@
+//! Cache-Control + ETag / If-None-Match behavior (#499).
+//!
+//! Items responses carry a per-request `timeStamp`, so their ETag is
+//! precomputed over the document with the timestamp excluded — otherwise
+//! revalidation could never match. The other endpoints hash the body as-is.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use arc_swap::ArcSwap;
+use axum::body::Body;
+use axum::http::{header, Request, StatusCode};
+use http_body_util::BodyExt;
+use serde_json::{json, Value};
+use tower::ServiceExt;
+
+use api_features::handlers::FeaturesState;
+use ds_core::config::CollectionConfig;
+use ds_core::error::DataServerError;
+use ds_core::feature::*;
+use ds_core::feature_engine::FeatureEngine;
+
+struct MockFeatureEngine {
+    features: Vec<Feature>,
+}
+
+impl MockFeatureEngine {
+    fn new() -> Self {
+        Self {
+            features: vec![Feature {
+                id: "helsinki".into(),
+                geometry: Geometry::Point {
+                    x: 24.9384,
+                    y: 60.1699,
+                }
+                .into(),
+                properties: {
+                    // Several properties in a fresh-per-request HashMap: with
+                    // serde_json's workspace-enabled `preserve_order`,
+                    // unsorted map serialization would emit a different key
+                    // order per request — the ETag/304 tests below would then
+                    // fail, guarding the sorted-serialization fix.
+                    let mut m = HashMap::new();
+                    for (k, v) in [
+                        ("name", "Helsinki"),
+                        ("country", "FI"),
+                        ("region", "Uusimaa"),
+                        ("timezone", "Europe/Helsinki"),
+                        ("kind", "capital"),
+                        ("status", "active"),
+                    ] {
+                        m.insert(k.into(), PropertyValue::String(v.into()));
+                    }
+                    m.into()
+                },
+            }],
+        }
+    }
+}
+
+impl FeatureEngine for MockFeatureEngine {
+    fn get_features(&self, query: &FeatureQuery) -> Result<FeaturePage, DataServerError> {
+        let features: Vec<Feature> = self.features.iter().take(query.limit).cloned().collect();
+        Ok(FeaturePage {
+            number_matched: self.features.len(),
+            number_returned: features.len(),
+            features,
+            next_offset: None,
+        })
+    }
+
+    fn get_feature(&self, feature_id: &str) -> Result<Feature, DataServerError> {
+        self.features
+            .iter()
+            .find(|f| f.id == feature_id)
+            .cloned()
+            .ok_or_else(|| DataServerError::FeatureNotFound(feature_id.into()))
+    }
+
+    fn feature_count(&self) -> usize {
+        self.features.len()
+    }
+
+    fn spatial_extent(&self) -> Option<[f64; 4]> {
+        Some([23.7610, 60.1699, 24.9384, 61.4978])
+    }
+}
+
+fn build_router() -> axum::Router {
+    let engine: Arc<dyn FeatureEngine> = Arc::new(MockFeatureEngine::new());
+    let mut engines: HashMap<String, Arc<dyn FeatureEngine>> = HashMap::new();
+    let mut collections = HashMap::new();
+    engines.insert("cities".to_string(), engine);
+    collections.insert(
+        "cities".to_string(),
+        CollectionConfig {
+            id: "cities".to_string(),
+            title: "Cities".to_string(),
+            description: "Test collection".to_string(),
+            data_path: None,
+            apis: vec!["features".to_string()],
+            engine_type: "geojson".to_string(),
+            keywords: Vec::new(),
+            license: None,
+            geotiff: None,
+            querydata: None,
+            wms: None,
+            grib: None,
+            zarr: None,
+            odim: None,
+            cap: None,
+            postgis: None,
+            nowcast: None,
+            preview: None,
+        },
+    );
+    api_features::router(Arc::new(ArcSwap::from_pointee(FeaturesState {
+        engines,
+        collections,
+        base_url: String::new(),
+        trust_proxy_headers: false,
+    })))
+}
+
+async fn get_response(uri: &str, if_none_match: Option<&str>) -> axum::response::Response {
+    let mut req = Request::builder().uri(uri);
+    if let Some(inm) = if_none_match {
+        req = req.header(header::IF_NONE_MATCH, inm);
+    }
+    build_router()
+        .oneshot(req.body(Body::empty()).unwrap())
+        .await
+        .unwrap()
+}
+
+fn header_str(resp: &axum::response::Response, name: header::HeaderName) -> Option<&str> {
+    resp.headers().get(name).and_then(|v| v.to_str().ok())
+}
+
+#[tokio::test]
+async fn metadata_endpoints_carry_short_cache_control_and_etag() {
+    for uri in ["/", "/conformance", "/collections", "/collections/cities"] {
+        let resp = get_response(uri, None).await;
+        assert_eq!(resp.status(), StatusCode::OK, "{uri}");
+        assert_eq!(
+            header_str(&resp, header::CACHE_CONTROL),
+            Some("public, max-age=60"),
+            "{uri}"
+        );
+        assert!(header_str(&resp, header::ETAG).is_some(), "{uri}");
+    }
+}
+
+#[tokio::test]
+async fn items_etag_excludes_the_response_timestamp() {
+    let resp = get_response("/collections/cities/items", None).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let etag = header_str(&resp, header::ETAG).unwrap().to_owned();
+    let body = resp.into_body().collect().await.unwrap().to_bytes();
+
+    // The advertised ETag must equal the hash of the document with the
+    // per-request timeStamp blanked — proving revalidation is immune to the
+    // generation time (and that the middleware honoured the precomputed tag).
+    let mut doc: Value = serde_json::from_slice(&body).unwrap();
+    assert!(doc["timeStamp"].as_str().is_some_and(|t| !t.is_empty()));
+    doc["timeStamp"] = json!("");
+    let recomputed = ds_core::http_cache::etag_of(serde_json::to_string(&doc).unwrap().as_bytes());
+    assert_eq!(etag, recomputed);
+
+    // And it revalidates: a second request (new timeStamp) still 304s.
+    let second = get_response("/collections/cities/items", Some(&etag)).await;
+    assert_eq!(second.status(), StatusCode::NOT_MODIFIED);
+    let body = second.into_body().collect().await.unwrap().to_bytes();
+    assert!(body.is_empty());
+}
+
+#[tokio::test]
+async fn items_cache_control_follows_the_datetime_window() {
+    // Settled: closed interval entirely in the past.
+    let resp = get_response(
+        "/collections/cities/items?datetime=2024-01-01T00:00:00Z/2024-01-01T06:00:00Z",
+        None,
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(
+        header_str(&resp, header::CACHE_CONTROL),
+        Some("public, max-age=86400")
+    );
+
+    // Open-ended or absent windows stay short.
+    for uri in [
+        "/collections/cities/items",
+        "/collections/cities/items?datetime=../2024-01-01T06:00:00Z",
+        "/collections/cities/items?datetime=2024-01-01T00:00:00Z/..",
+    ] {
+        let resp = get_response(uri, None).await;
+        assert_eq!(resp.status(), StatusCode::OK, "{uri}");
+        assert_eq!(
+            header_str(&resp, header::CACHE_CONTROL),
+            Some("public, max-age=60"),
+            "{uri}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn single_feature_revalidates_to_304() {
+    let first = get_response("/collections/cities/items/helsinki", None).await;
+    assert_eq!(first.status(), StatusCode::OK);
+    assert_eq!(
+        header_str(&first, header::CACHE_CONTROL),
+        Some("public, max-age=60")
+    );
+    let etag = header_str(&first, header::ETAG).unwrap().to_owned();
+
+    let second = get_response("/collections/cities/items/helsinki", Some(&etag)).await;
+    assert_eq!(second.status(), StatusCode::NOT_MODIFIED);
+    assert_eq!(header_str(&second, header::ETAG), Some(etag.as_str()));
+    let body = second.into_body().collect().await.unwrap().to_bytes();
+    assert!(body.is_empty());
+}
+
+#[tokio::test]
+async fn error_responses_are_left_alone() {
+    let resp = get_response("/collections/cities/items/nope", None).await;
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    assert!(resp.headers().get(header::ETAG).is_none());
+    assert!(resp.headers().get(header::CACHE_CONTROL).is_none());
+}

--- a/crates/core/src/http_cache.rs
+++ b/crates/core/src/http_cache.rs
@@ -1,0 +1,177 @@
+//! HTTP response-caching primitives shared by the API crates (#499).
+//!
+//! ds-core is framework-free, so this module holds only the pure pieces —
+//! ETag computation, `If-None-Match` matching, and the `Cache-Control`
+//! policy strings. The thin axum glue (a response middleware that buffers
+//! the body, stamps these headers, and answers conditional requests with
+//! 304) lives per API crate in `src/caching.rs` (api-edr, api-features);
+//! api-3dtiles calls these helpers directly from its content path.
+
+use chrono::{DateTime, Duration, Utc};
+
+/// `Cache-Control` for "latest" / open-ended data queries and metadata
+/// endpoints: they change on every data arrival, so a short window that
+/// coalesces refresh loops (matching the WMS and 3D Tiles "latest" policy).
+pub const CACHE_CONTROL_SHORT: &str = "public, max-age=60";
+
+/// `Cache-Control` for a *settled* data query (see [`data_cache_control`]):
+/// the answer is about the past and can be held for a day.
+///
+/// Deliberately NOT `immutable`: unlike a 3D Tiles volume pinned to an
+/// exactly-advertised timestep, the API layer cannot know whether the
+/// engine's window can still change — late-arriving observations back-fill,
+/// and rolling retention prunes. After expiry the client revalidates with
+/// `If-None-Match`, so a stale window self-heals within a day.
+pub const CACHE_CONTROL_SETTLED: &str = "public, max-age=86400";
+
+/// How far in the past a query window's end must be before the response is
+/// considered settled. Sized for late-arriving observations: real-time obs
+/// typically land within minutes; an hour covers the common stragglers.
+/// (Later QC revisions are accepted staleness — capped by the one-day
+/// `max-age` in [`CACHE_CONTROL_SETTLED`].)
+fn settled_horizon() -> Duration {
+    Duration::hours(1)
+}
+
+/// Select the `Cache-Control` policy for a data-query response from its
+/// `datetime` selection. `start`/`end` are the requested interval bounds with
+/// open (`..`) bounds mapped to `None` by the caller; an instant is
+/// `start == end`.
+///
+/// *Settled* — a **closed** interval whose end is at least
+/// [`settled_horizon`] before `now` — gets the long policy: the response
+/// describes the past and byte-identical refetches dominate. Everything else
+/// (no datetime, open bounds, windows touching now or the future) gets the
+/// short policy, because "latest" answers change as data arrives. An open
+/// *start* is not settled even with a past end: the response then includes
+/// the oldest retained data, which rolling retention keeps changing.
+pub fn data_cache_control(
+    start: Option<DateTime<Utc>>,
+    end: Option<DateTime<Utc>>,
+    now: DateTime<Utc>,
+) -> &'static str {
+    let settled =
+        start.is_some() && end.is_some_and(|e| now.signed_duration_since(e) >= settled_horizon());
+    if settled {
+        CACHE_CONTROL_SETTLED
+    } else {
+        CACHE_CONTROL_SHORT
+    }
+}
+
+/// Strong content-derived ETag — quoted hex with no `W/` prefix (the bytes
+/// are exact, so byte-equal responses are equivalent per RFC 7232 §2.1).
+/// FNV-1a 64-bit — stable across Rust versions and instances (unlike
+/// `DefaultHasher`), so a toolchain upgrade or a mixed-version fleet doesn't
+/// silently invalidate ETags.
+pub fn etag_of(bytes: &[u8]) -> String {
+    let mut h: u64 = 0xcbf2_9ce4_8422_2325;
+    for &b in bytes {
+        h ^= b as u64;
+        h = h.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    format!("\"{h:016x}\"")
+}
+
+/// Whether an `If-None-Match` header value matches `etag` (as produced by
+/// [`etag_of`]). RFC 7232 §3.2: the value may be `*` or a comma-separated
+/// list of entity tags.
+pub fn if_none_match_matches(header_value: &str, etag: &str) -> bool {
+    header_value == "*" || header_value.split(',').any(|t| t.trim() == etag)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn t(s: &str) -> DateTime<Utc> {
+        s.parse().unwrap()
+    }
+
+    #[test]
+    fn etag_is_stable_and_quoted() {
+        let a = etag_of(b"hello");
+        assert_eq!(a, etag_of(b"hello"));
+        assert!(a.starts_with('"') && a.ends_with('"'));
+        // Pinned value: FNV-1a 64 of "hello". A change here means every
+        // deployed client's cache silently invalidates — deliberate only.
+        assert_eq!(a, "\"a430d84680aabd0b\"");
+        assert_ne!(a, etag_of(b"hello2"));
+    }
+
+    #[test]
+    fn if_none_match_forms() {
+        let e = etag_of(b"x");
+        assert!(if_none_match_matches(&e, &e));
+        assert!(if_none_match_matches("*", &e));
+        assert!(if_none_match_matches(&format!("\"other\", {e}"), &e));
+        assert!(!if_none_match_matches("\"other\"", &e));
+        // The quotes are part of the tag: a bare hex token must not match.
+        assert!(!if_none_match_matches(e.trim_matches('"'), &e));
+    }
+
+    #[test]
+    fn closed_past_interval_is_settled() {
+        let now = t("2026-08-01T12:00:00Z");
+        assert_eq!(
+            data_cache_control(
+                Some(t("2026-08-01T06:00:00Z")),
+                Some(t("2026-08-01T08:00:00Z")),
+                now
+            ),
+            CACHE_CONTROL_SETTLED
+        );
+        // An instant (start == end) counts too.
+        assert_eq!(
+            data_cache_control(
+                Some(t("2026-08-01T08:00:00Z")),
+                Some(t("2026-08-01T08:00:00Z")),
+                now
+            ),
+            CACHE_CONTROL_SETTLED
+        );
+    }
+
+    #[test]
+    fn recent_open_or_absent_windows_are_short() {
+        let now = t("2026-08-01T12:00:00Z");
+        // No datetime at all ("latest").
+        assert_eq!(data_cache_control(None, None, now), CACHE_CONTROL_SHORT);
+        // End inside the settled horizon.
+        assert_eq!(
+            data_cache_control(
+                Some(t("2026-08-01T10:00:00Z")),
+                Some(t("2026-08-01T11:30:00Z")),
+                now
+            ),
+            CACHE_CONTROL_SHORT
+        );
+        // Exactly on the horizon boundary is settled (>=).
+        assert_eq!(
+            data_cache_control(
+                Some(t("2026-08-01T10:00:00Z")),
+                Some(t("2026-08-01T11:00:00Z")),
+                now
+            ),
+            CACHE_CONTROL_SETTLED
+        );
+        // Open start (`../end`): retention keeps changing the answer.
+        assert_eq!(
+            data_cache_control(None, Some(t("2026-08-01T08:00:00Z")), now),
+            CACHE_CONTROL_SHORT
+        );
+        // Open end (`start/..`) and future windows.
+        assert_eq!(
+            data_cache_control(Some(t("2026-08-01T06:00:00Z")), None, now),
+            CACHE_CONTROL_SHORT
+        );
+        assert_eq!(
+            data_cache_control(
+                Some(t("2026-08-02T00:00:00Z")),
+                Some(t("2026-08-02T06:00:00Z")),
+                now
+            ),
+            CACHE_CONTROL_SHORT
+        );
+    }
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -9,6 +9,7 @@ pub mod feature;
 pub mod feature_engine;
 pub mod geo;
 pub mod html;
+pub mod http_cache;
 pub mod instances;
 pub mod map_engine;
 pub mod model;


### PR DESCRIPTION
Closes #499.

api-edr and api-features responses carried no caching headers at all — every raster API (WMS/Maps/Tiles/3D Tiles) sets them. Polling and animation clients re-fetched byte-identical CoverageJSON/GeoJSON on every refresh (an `fmi-obs` area query is ~0.3 s of N sequential DB queries server-side), proxies could cache nothing, and there was no cheap revalidation.

## What this does

**Policy** (mirroring `api-3dtiles`; handler-level only, no engine changes):

| Response | Cache-Control |
|---|---|
| Metadata (landing, conformance, `/collections`, collection detail, `/locations`, instances, `/api`) | `public, max-age=60` |
| Data queries — "latest", open-ended (`..`), or windows touching now/future | `public, max-age=60` |
| Data queries — *settled*: closed `datetime` interval ending ≥ 1 h in the past | `public, max-age=86400` |

- Never `immutable`: unlike a 3D Tiles volume pinned to an exactly-advertised timestep, the API layer can't know whether a window can still change (obs back-fill, rolling retention). Expiry + ETag revalidation bounds staleness to a day. The 1 h settled horizon covers common late-arriving observations.
- Every 200 gets a strong content-derived (FNV-1a) ETag; a matching `If-None-Match` (incl. `*` and comma lists per RFC 7232 §3.2) short-circuits to **304** with `ETag`/`Cache-Control`/`Vary` repeated.
- A 304 still recomputes the query server-side (no content cache at this layer — EDR query keys barely repeat, #202); it saves the transfer, and `max-age` saves the request entirely.

## Implementation

- **`ds_core::http_cache`** (new, framework-free): `etag_of` (FNV-1a, moved from api-3dtiles), `if_none_match_matches`, the two policy strings, `data_cache_control(start, end, now)`.
- **`caching::conditional_get`** middleware in api-edr and api-features (intentional near-twins; ds-core can't hold axum glue). Handlers only add code when the policy differs from the default (settled upgrade) or the body embeds a per-request value.
- **Features `items`**: ETag precomputed over the body with the per-request `timeStamp` blanked — a plain body hash would never match. The middleware honours handler-set ETags.
- **api-3dtiles** now reuses the ds-core helpers (deletes its local copies).

## Determinism fix the smoke test caught

This workspace's serde_json is built with `preserve_order` (pulled in by zarrs), so JSON key order = insertion order = **fresh-per-request `HashMap` iteration order**. Identical queries serialized with different key orders, so ETags never revalidated (three different ETags for the same request live). Fixed by sorted iteration at the serialization boundaries: CoverageJSON `parameters`/`ranges`, collection `parameter_names`, and feature `properties`. The new caching tests use 6-key maps so any regression re-breaks the 304 tests loudly.

## Testing

- New `caching_tests.rs` in both crates (policy per window shape, 304 revalidation incl. non-matching tag, timeStamp-excluded items ETag, errors untouched) + ds-core unit tests (pinned FNV vector, RFC 7232 forms, horizon boundary).
- Full suites green: api-edr (incl. 27 CoverageJSON schema validations — Critical Rule 12), api-features, api-3dtiles, ds-core. `cargo fmt` + `clippy --all-targets -D warnings` clean.
- End-to-end smoke against a live server (CSV weather collection, EDR + Features): settled window → `max-age=86400`, latest → `60`, repeated requests → identical ETags, `If-None-Match` → `304`, items ETag stable across seconds despite `timeStamp`, metadata short policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)