### PR TITLE
fix(api-features): emit items timeStamp at seconds precision with Z suffix

### DIFF
--- a/crates/api-features/src/handlers.rs
+++ b/crates/api-features/src/handlers.rs
@@ -733,7 +733,11 @@ pub async fn items(
             .expect("GeoJSON Value serializes")
             .as_bytes(),
     );
-    doc["timeStamp"] = json!(Utc::now().to_rfc3339());
+    // Seconds precision with a `Z` suffix (2026-08-01T20:26:39Z) — sub-second
+    // precision is noise for a response-generation stamp, and `Z` matches the
+    // temporal-extent formatting elsewhere. Caching-neutral: the ETag above is
+    // computed with `timeStamp` blanked.
+    doc["timeStamp"] = json!(Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true));
 
     let mut resp = GeoJsonResponse(doc).into_response();
     resp.headers_mut().insert(


### PR DESCRIPTION
Re-applies a local formatting tweak that predated #555 (the caching-headers PR rewrote the surrounding `items` code).

The GeoJSON `timeStamp` in `/collections/{id}/items` responses now serializes as `2026-08-01T20:26:39Z` instead of chrono's default `2026-08-01T20:26:39.123456+00:00` — sub-second precision is noise for a response-generation stamp, and the `Z` form matches the temporal formatting used elsewhere.

Caching-neutral: the items ETag introduced in #555 is deliberately computed with `timeStamp` blanked, so this cannot affect revalidation. `cargo fmt`/`clippy -D warnings` clean; all api-features suites pass (94 tests incl. the caching tests, whose timeStamp assertions are format-agnostic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)