### PR TITLE
fix(engines): emit feature-property timestamps at seconds precision with Z suffix

### DIFF
--- a/crates/engine-cap/src/catalog.rs
+++ b/crates/engine-cap/src/catalog.rs
@@ -550,7 +550,10 @@ fn str_list(items: &[String]) -> PropertyValue {
 
 fn insert_time(p: &mut HashMap<String, PropertyValue>, key: &str, t: Option<DateTime<Utc>>) {
     if let Some(t) = t {
-        p.insert(key.to_string(), PropertyValue::String(t.to_rfc3339()));
+        p.insert(
+            key.to_string(),
+            PropertyValue::String(t.to_rfc3339_opts(chrono::SecondsFormat::Secs, true)),
+        );
     }
 }
 

--- a/crates/engine-nowcast/src/engine.rs
+++ b/crates/engine-nowcast/src/engine.rs
@@ -1239,7 +1239,7 @@ fn cell_feature(
     );
     props.insert(
         "observed".into(),
-        PropertyValue::String(anchor.to_rfc3339()),
+        PropertyValue::String(anchor.to_rfc3339_opts(chrono::SecondsFormat::Secs, true)),
     );
     // Lifecycle as DATA, not field modification: three gate runs showed
     // tendency extrapolation loses to pure advection (#546), but the

--- a/crates/engine-odim/src/volume_engine.rs
+++ b/crates/engine-odim/src/volume_engine.rs
@@ -3247,7 +3247,9 @@ impl PolarVolumeEngine {
             "latest_volume_time".into(),
             meta.times
                 .last()
-                .map(|t| PropertyValue::String(t.to_rfc3339()))
+                .map(|t| {
+                    PropertyValue::String(t.to_rfc3339_opts(chrono::SecondsFormat::Secs, true))
+                })
                 .unwrap_or(PropertyValue::Null),
         );
         props.insert(


### PR DESCRIPTION
Completes the timestamp-format sweep started in #556, across the Features-served property surface:

- **engine-cap** — every alert time property (`onset`, `effective`, `expires`, …) via the shared `insert_time` helper
- **engine-nowcast** — the tracked-cell `observed` anchor time
- **engine-odim** — the PVOL site inventory's `latest_volume_time`

All now serialize as `2026-08-01T20:26:39Z` instead of chrono's default `2026-08-01T20:26:39.123456+00:00`. Grepped the remaining Features-serving engines (postgis, csv, geojson) — no other `to_rfc3339()` property emissions exist; the rest of the hits are log lines and test assertions, untouched.

Caching-neutral in the #555 sense: these are data-derived times (deterministic per response), so ETags remain stable — the bytes just change once at deploy.

`cargo fmt`/`clippy -D warnings` clean; all engine-cap/engine-nowcast/engine-odim suites pass (276 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)