### PR TITLE
feat(render): single StyleContext resolver, styles built once for WMS/Maps/Tiles/EDR

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1069,6 +1069,7 @@ dependencies = [
  "jpeg-encoder",
  "png",
  "quick_cache",
+ "toml",
  "webp",
 ]
 

--- a/crates/api-edr/src/handlers.rs
+++ b/crates/api-edr/src/handlers.rs
@@ -130,6 +130,12 @@ fn with_data_cache_control(
 pub struct EdrState {
     pub engines: HashMap<String, Arc<dyn EdrEngine>>,
     pub collections: HashMap<String, CollectionConfig>,
+    /// Resolved style maps per collection (same `StyleInfo` instances the
+    /// WMS/Maps/Tiles registries hold — resolved once by the server through
+    /// `ds_render::StyleContext`). The `f=png` cross-section plot uses the
+    /// collection's `default` style; raw `[wms]` config is never re-resolved
+    /// here.
+    pub styles: HashMap<String, HashMap<String, ds_render::StyleInfo>>,
     /// Static fallback base URL for absolute links (e.g. "https://api.example.com").
     /// Used as-is unless `trust_proxy_headers` resolves a per-request value.
     pub base_url: String,
@@ -1441,7 +1447,7 @@ pub async fn trajectory_query(
     State(state): State<AppState>,
 ) -> Result<impl IntoResponse, (StatusCode, Json<serde_json::Value>)> {
     let state = state.load_full();
-    let (engine, config) = lookup_collection(&state, &id)?;
+    let (engine, _config) = lookup_collection(&state, &id)?;
 
     // An engine that doesn't advertise `trajectory` has no cross-section
     // capability. Return 404 (the resource doesn't exist for this
@@ -1555,17 +1561,18 @@ pub async fn trajectory_query(
         }
         EdrFormat::Png => {
             // Render the cross-section as a colour-mapped heatmap using
-            // the collection's WMS colormap (or a data-scaled viridis
-            // fallback).
+            // the collection's resolved default style (or a data-scaled
+            // viridis fallback when the collection has none).
             // A failure here is an internal inconsistency (the engine
             // already returned a Section for this trajectory query), not
             // a client mistake — log it and return a generic 500 rather
             // than leaking the internal message in a 400.
-            let (heatmaps, colormap) = section_response_to_heatmaps(&result, config.wms.as_ref())
-                .map_err(|e| {
-                tracing::error!("Trajectory PNG section conversion error: {e}");
-                server_error()
-            })?;
+            let style = state.styles.get(&id).and_then(|m| m.get("default"));
+            let (heatmaps, colormap) =
+                section_response_to_heatmaps(&result, style).map_err(|e| {
+                    tracing::error!("Trajectory PNG section conversion error: {e}");
+                    server_error()
+                })?;
             let (w, h) = plot_dimensions(params.width, params.height);
             let png = render_heatmap(&heatmaps, colormap.as_ref(), w, h).map_err(|e| {
                 tracing::error!("Trajectory PNG render error: {e}");

--- a/crates/api-edr/src/plot_convert.rs
+++ b/crates/api-edr/src/plot_convert.rs
@@ -10,7 +10,6 @@
 
 use chrono::{DateTime, Utc};
 
-use ds_core::config::WmsConfig;
 use ds_core::error::DataServerError;
 use ds_core::model::{
     CoverageResponse, DomainDescription, ParameterDescription, QueryResult, VerticalCoord,
@@ -215,83 +214,16 @@ fn haversine_km(lon0: f64, lat0: f64, lon1: f64, lat1: f64) -> f64 {
     EARTH_RADIUS_M * c / 1000.0
 }
 
-/// Build the colormap (and its value range) for a cross-section PNG from
-/// the collection's optional `[wms]` style config. Mirrors the server's
-/// `build_colormap_from_wms_config` priority — inline `color_stops`, then
-/// a built-in `colormap` name, then a fallback — using only `ds_render`
-/// public APIs.
-///
-/// The fallback is viridis stretched to `data_range` (the finite min/max
-/// of the values being rendered) so a collection with no usable colormap
-/// config still produces a readable image rather than a flat one clamped
-/// to 0..1.
-fn section_colormap(
-    wms: Option<&WmsConfig>,
-    data_range: (f64, f64),
-) -> (Box<dyn ColorMap>, f64, f64) {
-    if let Some(w) = wms {
-        // Inline custom stops win.
-        if !w.color_stops.is_empty() {
-            let mut stops: Vec<ds_render::ColorStop> = w
-                .color_stops
-                .iter()
-                .filter_map(|s| {
-                    ds_render::parse_hex_color(&s.color)
-                        .ok()
-                        .map(|color| ds_render::ColorStop {
-                            value: s.value,
-                            color,
-                        })
-                })
-                .collect();
-            // Sort ascending by value: config stops may be authored
-            // highest-first (a natural radar-dBZ legend order), which
-            // would otherwise give `min > max` (reversed colour-bar
-            // labels) and a broken `LinearColorMap` bracket lookup.
-            stops.sort_by(|a, b| a.value.total_cmp(&b.value));
-            if !stops.is_empty() {
-                let min = w
-                    .min
-                    .unwrap_or_else(|| stops.first().map(|s| s.value).unwrap_or(0.0));
-                let max = w
-                    .max
-                    .unwrap_or_else(|| stops.last().map(|s| s.value).unwrap_or(1.0));
-                return (Box::new(ds_render::LinearColorMap::new(stops)), min, max);
-            }
-        }
-        // Then a named built-in.
-        if let Some(name) = w.colormap.as_deref() {
-            if let Some(palette) = ds_render::builtin_palette(name) {
-                let stops = &palette.stops;
-                let min = w
-                    .min
-                    .unwrap_or_else(|| stops.first().map(|s| s.value).unwrap_or(0.0));
-                let max = w
-                    .max
-                    .unwrap_or_else(|| stops.last().map(|s| s.value).unwrap_or(1.0));
-                return (
-                    Box::new(ds_render::LutColorMap::from_palette(palette, min, max)),
-                    min,
-                    max,
-                );
-            }
-        }
+/// Adapter: a shared Arc colormap behind the Box<dyn ColorMap> interface
+/// this module returns.
+struct ArcColorMap(std::sync::Arc<dyn ColorMap>);
+impl ColorMap for ArcColorMap {
+    fn color(&self, value: Option<f64>) -> [u8; 4] {
+        self.0.color(value)
     }
-    // Fallback: viridis stretched to the data's own finite range.
-    let (mut min, mut max) = data_range;
-    if !(min.is_finite() && max.is_finite()) || max <= min {
-        min = 0.0;
-        max = 1.0;
+    fn nodata_color(&self) -> [u8; 4] {
+        self.0.nodata_color()
     }
-    (
-        Box::new(ds_render::LutColorMap::from_builtin(
-            ds_render::BuiltinColormap::Viridis,
-            min,
-            max,
-        )),
-        min,
-        max,
-    )
 }
 
 /// Convert a cross-section (`Section`) coverage response into stacked
@@ -302,11 +234,13 @@ fn section_colormap(
 /// single snapshot, and the newest scan is the right default for radar
 /// imagery). The x axis is cumulative great-circle distance (km) along
 /// the path; the y axis is the vertical coordinate (height above antenna,
-/// m). All quantities share the collection colormap; for a correctly-
-/// scaled single panel, filter with `parameter-name`.
+/// m). All quantities share the collection's resolved `style` (the same
+/// `StyleInfo` the raster APIs render with); with no style, viridis is
+/// stretched to the data's own finite range. For a correctly-scaled
+/// single panel, filter with `parameter-name`.
 pub fn section_response_to_heatmaps(
     resp: &CoverageResponse,
-    wms: Option<&WmsConfig>,
+    style: Option<&ds_render::StyleInfo>,
 ) -> Result<(Vec<Heatmap>, Box<dyn ColorMap>), DataServerError> {
     let qr = match resp {
         CoverageResponse::Single(q) => q,
@@ -362,7 +296,27 @@ pub fn section_response_to_heatmaps(
         }
     }
 
-    let (colormap, vmin, vmax) = section_colormap(wms, (dmin, dmax));
+    let (colormap, vmin, vmax): (Box<dyn ColorMap>, f64, f64) = match style {
+        Some(s) => (Box::new(ArcColorMap(s.colormap.clone())), s.min, s.max),
+        None => {
+            // Fallback: viridis stretched to the data's own finite range so a
+            // collection with no style config still produces a readable image.
+            let (mut min, mut max) = (dmin, dmax);
+            if !(min.is_finite() && max.is_finite()) || max <= min {
+                min = 0.0;
+                max = 1.0;
+            }
+            (
+                Box::new(ds_render::LutColorMap::from_builtin(
+                    ds_render::BuiltinColormap::Viridis,
+                    min,
+                    max,
+                )),
+                min,
+                max,
+            )
+        }
+    };
 
     let y_label = axis_caption(z.kind.default_label(), z.kind.default_unit());
     let mut heatmaps = Vec::with_capacity(params.len());
@@ -644,30 +598,41 @@ mod tests {
         assert_eq!(hm.value_label, "dBZ");
     }
 
+    /// Build a resolved `StyleInfo` through the same `StyleContext` path the
+    /// server uses, so these tests pin the api-edr-facing contract.
+    fn resolved_style(spec: &ds_render::StyleSpec) -> ds_render::StyleInfo {
+        let ctx = ds_render::StyleContext::with_builtins();
+        let r = ctx.build_colormap(spec).unwrap();
+        ds_render::StyleInfo {
+            name: "default".into(),
+            title: "Default".into(),
+            colormap: r.colormap,
+            palette: r.palette,
+            min: r.min,
+            max: r.max,
+            parameter: None,
+        }
+    }
+
     #[test]
-    fn section_colormap_uses_builtin_when_configured() {
-        use ds_core::config::WmsConfig;
-        let wms = WmsConfig {
-            style_bundle: None,
-            colormap: Some("radar_dbz".into()),
-            color_stops: vec![],
+    fn section_style_uses_builtin_when_configured() {
+        let style = resolved_style(&ds_render::StyleSpec {
+            colormap: Some("radar_dbz"),
+            color_stops: &[],
             min: Some(-32.0),
             max: Some(95.0),
-            styles: vec![],
-            parameters: vec![],
-            rendered_cache_mb: 0,
-        };
+        });
         let qr = section("DBZH", "dBZ");
         let (heatmaps, _cmap) =
-            section_response_to_heatmaps(&CoverageResponse::Single(qr), Some(&wms)).unwrap();
-        // Config min/max drive the colour-bar bounds.
+            section_response_to_heatmaps(&CoverageResponse::Single(qr), Some(&style)).unwrap();
+        // Style min/max drive the colour-bar bounds.
         assert_eq!(heatmaps[0].value_min, -32.0);
         assert_eq!(heatmaps[0].value_max, 95.0);
     }
 
     #[test]
     fn section_colormap_falls_back_to_data_range() {
-        // No WMS config → viridis stretched to the data's finite range
+        // No resolved style → viridis stretched to the data's finite range
         // (5..25 in the fixture).
         let qr = section("DBZH", "dBZ");
         let (heatmaps, _cmap) =
@@ -684,37 +649,39 @@ mod tests {
 
     /// Descending-order `color_stops` (a natural radar-dBZ legend order)
     /// must still yield `value_min < value_max` — the colour bar would
-    /// otherwise label max→min top-to-bottom against the gradient.
+    /// otherwise label max→min top-to-bottom against the gradient. The stop
+    /// sorting itself now lives in `ds_render::StyleContext` (pinned there
+    /// by `inline_stops_win_over_name_and_sort_descending_input`); this
+    /// keeps the api-edr-level pin by resolving descending stops through
+    /// the same path a config would take.
     #[test]
-    fn section_colormap_sorts_descending_color_stops() {
-        use ds_core::config::{ColorStop, WmsConfig};
-        let wms = WmsConfig {
-            style_bundle: None,
+    fn section_style_from_descending_color_stops_sorts_range() {
+        use ds_core::config::ColorStop;
+        // Authored highest-value-first.
+        let stops = vec![
+            ColorStop {
+                value: 60.0,
+                color: "#ff0000".into(),
+            },
+            ColorStop {
+                value: 30.0,
+                color: "#00ff00".into(),
+            },
+            ColorStop {
+                value: 0.0,
+                color: "#0000ff".into(),
+            },
+        ];
+        let style = resolved_style(&ds_render::StyleSpec {
             colormap: None,
-            // Authored highest-value-first.
-            color_stops: vec![
-                ColorStop {
-                    value: 60.0,
-                    color: "#ff0000".into(),
-                },
-                ColorStop {
-                    value: 30.0,
-                    color: "#00ff00".into(),
-                },
-                ColorStop {
-                    value: 0.0,
-                    color: "#0000ff".into(),
-                },
-            ],
+            color_stops: &stops,
             min: None,
             max: None,
-            styles: vec![],
-            parameters: vec![],
-            rendered_cache_mb: 0,
-        };
+        });
+        assert!(style.min < style.max, "resolved style must sort the range");
         let qr = section("DBZH", "dBZ");
         let (heatmaps, _cmap) =
-            section_response_to_heatmaps(&CoverageResponse::Single(qr), Some(&wms)).unwrap();
+            section_response_to_heatmaps(&CoverageResponse::Single(qr), Some(&style)).unwrap();
         assert_eq!(heatmaps[0].value_min, 0.0, "min from the lowest stop");
         assert_eq!(heatmaps[0].value_max, 60.0, "max from the highest stop");
     }

--- a/crates/api-edr/tests/caching_tests.rs
+++ b/crates/api-edr/tests/caching_tests.rs
@@ -170,6 +170,7 @@ fn build_router() -> axum::Router {
     api_edr::router(Arc::new(ArcSwap::from_pointee(EdrState {
         engines,
         collections,
+        styles: HashMap::new(),
         base_url: String::new(),
         trust_proxy_headers: false,
     })))

--- a/crates/api-edr/tests/instances_tests.rs
+++ b/crates/api-edr/tests/instances_tests.rs
@@ -232,6 +232,7 @@ fn state() -> api_edr::handlers::AppState {
     Arc::new(ArcSwap::from_pointee(EdrState {
         engines,
         collections,
+        styles: HashMap::new(),
         base_url: String::new(),
         trust_proxy_headers: false,
     }))

--- a/crates/api-edr/tests/ogc_edr_api_tests.rs
+++ b/crates/api-edr/tests/ogc_edr_api_tests.rs
@@ -210,6 +210,7 @@ fn make_edr_state(engine: Arc<dyn EdrEngine>) -> Arc<ArcSwap<EdrState>> {
     Arc::new(ArcSwap::from_pointee(EdrState {
         engines,
         collections,
+        styles: HashMap::new(),
         base_url: String::new(),
         trust_proxy_headers: false,
     }))
@@ -246,6 +247,7 @@ mod proxy_headers {
         state.store(Arc::new(EdrState {
             engines: cur.engines.clone(),
             collections: cur.collections.clone(),
+            styles: cur.styles.clone(),
             base_url: base_url.to_string(),
             trust_proxy_headers,
         }));
@@ -1486,6 +1488,7 @@ mod metadata_extras {
         Arc::new(ArcSwap::from_pointee(EdrState {
             engines,
             collections,
+            styles: HashMap::new(),
             base_url: String::new(),
             trust_proxy_headers: false,
         }))

--- a/crates/api-edr/tests/performance_tests.rs
+++ b/crates/api-edr/tests/performance_tests.rs
@@ -183,6 +183,7 @@ fn make_edr_state(engine: Arc<dyn EdrEngine>) -> Arc<ArcSwap<EdrState>> {
     Arc::new(ArcSwap::from_pointee(EdrState {
         engines,
         collections,
+        styles: HashMap::new(),
         base_url: String::new(),
         trust_proxy_headers: false,
     }))

--- a/crates/api-edr/tests/png_plot_tests.rs
+++ b/crates/api-edr/tests/png_plot_tests.rs
@@ -177,6 +177,7 @@ fn router_with(engine: Arc<dyn EdrEngine>) -> axum::Router {
     api_edr::router(Arc::new(ArcSwap::from_pointee(EdrState {
         engines,
         collections,
+        styles: HashMap::new(),
         base_url: String::new(),
         trust_proxy_headers: false,
     })))

--- a/crates/api-edr/tests/security_tests.rs
+++ b/crates/api-edr/tests/security_tests.rs
@@ -123,6 +123,7 @@ fn make_edr_state(engine: Arc<dyn EdrEngine>) -> Arc<ArcSwap<EdrState>> {
     Arc::new(ArcSwap::from_pointee(EdrState {
         engines,
         collections,
+        styles: HashMap::new(),
         base_url: String::new(),
         trust_proxy_headers: false,
     }))

--- a/crates/api-edr/tests/spec_compliance_tests.rs
+++ b/crates/api-edr/tests/spec_compliance_tests.rs
@@ -138,6 +138,7 @@ fn make_edr_state(engine: Arc<dyn EdrEngine>) -> Arc<ArcSwap<EdrState>> {
     Arc::new(ArcSwap::from_pointee(EdrState {
         engines,
         collections,
+        styles: HashMap::new(),
         base_url: String::new(),
         trust_proxy_headers: false,
     }))

--- a/crates/api-maps/tests/integration.rs
+++ b/crates/api-maps/tests/integration.rs
@@ -155,6 +155,7 @@ fn build_router_with_engine(engine: Arc<dyn MapEngine>) -> axum::Router {
         StyleInfo {
             name: "default".to_string(),
             title: "Default".to_string(),
+            palette: ds_render::builtin_palette_arc("viridis").unwrap(),
             colormap: cmap,
             min: 0.0,
             max: 1.0,
@@ -216,6 +217,7 @@ fn build_router_with_apis(apis: Vec<String>) -> axum::Router {
         StyleInfo {
             name: "default".to_string(),
             title: "Default".to_string(),
+            palette: ds_render::builtin_palette_arc("viridis").unwrap(),
             colormap: cmap.clone(),
             min: 0.0,
             max: 1.0,
@@ -227,6 +229,7 @@ fn build_router_with_apis(apis: Vec<String>) -> axum::Router {
         StyleInfo {
             name: "grayscale".to_string(),
             title: "Grayscale".to_string(),
+            palette: ds_render::builtin_palette_arc("grayscale").unwrap(),
             colormap: Arc::new(LutColorMap::from_builtin(
                 BuiltinColormap::Grayscale,
                 0.0,
@@ -1289,6 +1292,7 @@ fn build_empty_router() -> axum::Router {
         StyleInfo {
             name: "default".to_string(),
             title: "Default".to_string(),
+            palette: ds_render::builtin_palette_arc("viridis").unwrap(),
             colormap: cmap,
             min: 0.0,
             max: 1.0,
@@ -1408,6 +1412,7 @@ fn build_multi_param_router() -> axum::Router {
         StyleInfo {
             name: "default".to_string(),
             title: "Default".to_string(),
+            palette: ds_render::builtin_palette_arc("viridis").unwrap(),
             colormap: cmap,
             min: 0.0,
             max: 1.0,

--- a/crates/api-tiles/tests/integration.rs
+++ b/crates/api-tiles/tests/integration.rs
@@ -153,6 +153,7 @@ fn build_router() -> axum::Router {
         StyleInfo {
             name: "default".to_string(),
             title: "Default".to_string(),
+            palette: ds_render::builtin_palette_arc("viridis").unwrap(),
             colormap: cmap.clone(),
             min: 0.0,
             max: 1.0,
@@ -164,6 +165,7 @@ fn build_router() -> axum::Router {
         StyleInfo {
             name: "grayscale".to_string(),
             title: "Grayscale".to_string(),
+            palette: ds_render::builtin_palette_arc("grayscale").unwrap(),
             colormap: Arc::new(LutColorMap::from_builtin(
                 BuiltinColormap::Grayscale,
                 0.0,
@@ -232,6 +234,7 @@ fn build_router_with_engine(engine: Arc<dyn MapEngine>) -> axum::Router {
         StyleInfo {
             name: "default".to_string(),
             title: "Default".to_string(),
+            palette: ds_render::builtin_palette_arc("viridis").unwrap(),
             colormap: cmap,
             min: 0.0,
             max: 1.0,
@@ -1054,6 +1057,7 @@ fn build_empty_router() -> axum::Router {
         StyleInfo {
             name: "default".to_string(),
             title: "Default".to_string(),
+            palette: ds_render::builtin_palette_arc("viridis").unwrap(),
             colormap: cmap,
             min: 0.0,
             max: 1.0,
@@ -1176,6 +1180,7 @@ fn build_multi_param_router() -> axum::Router {
         StyleInfo {
             name: "default".to_string(),
             title: "Default".to_string(),
+            palette: ds_render::builtin_palette_arc("viridis").unwrap(),
             colormap: cmap,
             min: 0.0,
             max: 1.0,

--- a/crates/api-wms/tests/integration.rs
+++ b/crates/api-wms/tests/integration.rs
@@ -109,6 +109,7 @@ fn build_empty_router() -> axum::Router {
         StyleInfo {
             name: "default".to_string(),
             title: "Default".to_string(),
+            palette: ds_render::builtin_palette_arc("viridis").unwrap(),
             colormap: cmap,
             min: 0.0,
             max: 1.0,
@@ -123,6 +124,7 @@ fn build_empty_router() -> axum::Router {
         StyleInfo {
             name: "radar_fmi".to_string(),
             title: "FMI Radar".to_string(),
+            palette: ds_render::builtin_palette_arc("radar_dbz").unwrap(),
             colormap: Arc::new(LutColorMap::from_builtin(
                 BuiltinColormap::RadarDbz,
                 -32.0,
@@ -285,6 +287,7 @@ fn build_failing_router() -> axum::Router {
         StyleInfo {
             name: "default".to_string(),
             title: "Default".to_string(),
+            palette: ds_render::builtin_palette_arc("viridis").unwrap(),
             colormap: cmap,
             min: 0.0,
             max: 1.0,
@@ -434,6 +437,7 @@ fn build_populated_router() -> axum::Router {
         StyleInfo {
             name: "default".to_string(),
             title: "Default".to_string(),
+            palette: ds_render::builtin_palette_arc("viridis").unwrap(),
             colormap: cmap,
             min: 0.0,
             max: 1.0,
@@ -800,6 +804,7 @@ fn build_counting_router(
         StyleInfo {
             name: "default".to_string(),
             title: "Default".to_string(),
+            palette: ds_render::builtin_palette_arc("viridis").unwrap(),
             colormap: cmap,
             min: 0.0,
             max: 1.0,
@@ -976,6 +981,7 @@ fn build_snapping_router(initial_times: &[&str]) -> SnappingRouter {
         StyleInfo {
             name: "default".to_string(),
             title: "Default".to_string(),
+            palette: ds_render::builtin_palette_arc("viridis").unwrap(),
             colormap: cmap,
             min: 0.0,
             max: 1.0,
@@ -1515,6 +1521,7 @@ fn build_forecast_router_with_engine(engine: Arc<dyn MapEngine>) -> axum::Router
         StyleInfo {
             name: "default".to_string(),
             title: "Default".to_string(),
+            palette: ds_render::builtin_palette_arc("viridis").unwrap(),
             colormap: cmap,
             min: 0.0,
             max: 1.0,
@@ -1974,6 +1981,7 @@ fn build_run_swap_router(initial_runs: &[&str]) -> RunSwapRouter {
         StyleInfo {
             name: "default".to_string(),
             title: "Default".to_string(),
+            palette: ds_render::builtin_palette_arc("viridis").unwrap(),
             colormap: cmap,
             min: 0.0,
             max: 1.0,
@@ -2158,6 +2166,7 @@ fn build_advancing_router() -> AdvancingFixture {
         StyleInfo {
             name: "default".to_string(),
             title: "Default".to_string(),
+            palette: ds_render::builtin_palette_arc("viridis").unwrap(),
             colormap: cmap,
             min: 0.0,
             max: 1.0,

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -3614,7 +3614,7 @@ colormap = "radar_dbz"
     fn wms_without_colormap_or_bundle_defaults_to_none() {
         // Verifies the Option<String> migration: omitting `colormap` no longer
         // forces a default at parse time — the default "viridis" is applied
-        // later by build_colormap_from_wms_config. Previously this field was a
+        // later by ds-render's StyleContext resolution. Previously this field was a
         // required String with a serde default.
         let tmp = TempDir::new().unwrap();
         let config_toml = r#"

--- a/crates/render/Cargo.toml
+++ b/crates/render/Cargo.toml
@@ -12,3 +12,6 @@ quick_cache = "0.6"
 ds-cache = { path = "../ds-cache" }
 bytes = "1"
 chrono = { version = "0.4", features = ["serde"] }
+
+[dev-dependencies]
+toml = "0.8"

--- a/crates/render/src/colormap.rs
+++ b/crates/render/src/colormap.rs
@@ -538,6 +538,41 @@ mod tests {
         assert_eq!(cmap.color(Some(200.0)), [255, 255, 255, 255]);
     }
 
+    /// Pin the enum↔table invariant: EVERY `BuiltinColormap` variant has a
+    /// non-empty row in the palette table (`builtin_stops` would panic
+    /// otherwise) and its `name()` resolves back to the variant through
+    /// `resolve_builtin`. A variant added without a table row — or a rename
+    /// on either side — fails here instead of panicking at style-build time.
+    #[test]
+    fn every_builtin_variant_round_trips_through_the_palette_table() {
+        let variants = [
+            BuiltinColormap::RadarDbz,
+            BuiltinColormap::RadarSmhi,
+            BuiltinColormap::RadarFmi,
+            BuiltinColormap::RadarBookbinder,
+            BuiltinColormap::Grayscale,
+            BuiltinColormap::Viridis,
+            BuiltinColormap::Temperature,
+            BuiltinColormap::Precipitation,
+            BuiltinColormap::PrecipitationRate,
+            BuiltinColormap::WindSpeed,
+            BuiltinColormap::CapSeverity,
+            BuiltinColormap::LightningAge,
+        ];
+        assert_eq!(variants.len(), 12, "the legacy shim covers 12 palettes");
+        for v in &variants {
+            let stops = builtin_stops(v);
+            assert!(!stops.is_empty(), "{} has no stops in the table", v.name());
+            let resolved = resolve_builtin(v.name())
+                .unwrap_or_else(|| panic!("{} does not resolve back to a variant", v.name()));
+            assert_eq!(
+                resolved.name(),
+                v.name(),
+                "resolve_builtin must map the name back to the same variant"
+            );
+        }
+    }
+
     #[test]
     fn test_cap_severity_ramp_resolves_and_colours_codes() {
         let builtin = resolve_builtin("cap_severity").expect("cap_severity is a builtin");

--- a/crates/render/src/lib.rs
+++ b/crates/render/src/lib.rs
@@ -7,6 +7,7 @@ pub mod metatile;
 pub mod palette;
 pub mod plot;
 pub mod rasterize;
+pub mod style;
 
 pub use colormap::{
     parse_hex_color, BuiltinColormap, ColorMap, ColorStop, IntegerLutColorMap, LinearColorMap,
@@ -15,10 +16,12 @@ pub use colormap::{
 pub use encode::{encode_jpeg, encode_png, encode_webp};
 pub use metatile::{render_metatiled, MetaTile, MetaTileStats, TileKeyPrefix, TilePixelCache};
 pub use palette::{
-    builtin_palette, builtin_palettes, Interpolation, Palette, PaletteInsert, PaletteRegistry,
+    builtin_palette, builtin_palette_arc, builtin_palettes, Interpolation, Palette, PaletteInsert,
+    PaletteRegistry,
 };
 pub use plot::{render_chart, render_heatmap, Heatmap, Panel, Series};
 pub use rasterize::{fill_polygon, Combine};
+pub use style::{ResolvedColormap, StyleContext, StyleSpec};
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -68,6 +71,11 @@ pub struct StyleInfo {
     pub name: String,
     pub title: String,
     pub colormap: Arc<dyn ColorMap>,
+    /// The palette the colormap was built from — stops, interpolation mode
+    /// and title, kept for machine-readable legends. `colormap` is the
+    /// render-ready (possibly integer-LUT-wrapped, possibly overlay-wrapped)
+    /// form of this palette sampled over `min..max`.
+    pub palette: Arc<Palette>,
     pub min: f64,
     pub max: f64,
     /// Data parameter to render. For multi-parameter engines, selects which

--- a/crates/render/src/palette.rs
+++ b/crates/render/src/palette.rs
@@ -433,6 +433,19 @@ pub fn builtin_names() -> &'static [&'static str] {
     NAMES.as_slice()
 }
 
+/// Arc-wrapped built-in lookup. The `Arc`s are process-global, so cloning
+/// one is refcount-cheap — this is the way to stamp a builtin into a
+/// [`crate::StyleInfo`] without copying stop data.
+pub fn builtin_palette_arc(name: &str) -> Option<Arc<Palette>> {
+    static ARCS: LazyLock<HashMap<&'static str, Arc<Palette>>> = LazyLock::new(|| {
+        BUILTIN_DEFS
+            .iter()
+            .map(|d| (d.name, Arc::new(materialize(d))))
+            .collect()
+    });
+    ARCS.get(name).cloned()
+}
+
 // ---------------------------------------------------------------------------
 // Registry
 // ---------------------------------------------------------------------------
@@ -460,11 +473,16 @@ pub struct PaletteRegistry {
 }
 
 impl PaletteRegistry {
-    /// A registry pre-populated with every built-in palette.
+    /// A registry pre-populated with every built-in palette (sharing the
+    /// process-global `Arc`s — no stop data is copied).
     pub fn with_builtins() -> Self {
         let map = builtin_palettes()
             .iter()
-            .map(|p| (p.name.clone(), Arc::new(p.clone())))
+            .map(|p| {
+                let arc = builtin_palette_arc(&p.name)
+                    .expect("builtin_palette_arc covers every table row");
+                (p.name.clone(), arc)
+            })
             .collect();
         Self {
             map,

--- a/crates/render/src/style.rs
+++ b/crates/render/src/style.rs
@@ -1,0 +1,569 @@
+//! The single config→style resolution path.
+//!
+//! Everything that turns `[wms]` config (inline fields, `[[wms.styles]]`,
+//! `[[wms.parameters]]`, style bundles) into render-ready [`StyleInfo`]
+//! maps goes through [`StyleContext`], so the WMS/Maps/Tiles registries and
+//! api-edr's `f=png` plots can never drift apart — they previously did:
+//! the server and api-edr each carried their own copy of this logic.
+//!
+//! Engine-specific concerns stay out: the ODIM CELLS overlay wrap is
+//! injected by the server through the `wrap` hook of
+//! [`StyleContext::parameter_layer_styles`] (#410 will move it onto an
+//! `OverlaySpec`).
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use ds_core::config::{CollectionConfig, StyleBundle, WmsParameterConfig};
+
+use crate::colormap::{ColorMap, IntegerLutColorMap, LinearColorMap, LutColorMap};
+use crate::palette::{Interpolation, Palette, PaletteRegistry};
+use crate::{parse_hex_color, ColorStop, StyleInfo};
+
+/// The style-affecting fields of one config block — `[wms]` inline fields,
+/// one `[[wms.styles]]` entry, a bundle default/extra, or one
+/// `[[wms.parameters]]` entry — reduced to a common shape.
+#[derive(Clone, Copy, Default)]
+pub struct StyleSpec<'a> {
+    pub colormap: Option<&'a str>,
+    pub color_stops: &'a [ds_core::config::ColorStop],
+    pub min: Option<f64>,
+    pub max: Option<f64>,
+}
+
+/// A resolved colormap: the render-ready (possibly integer-LUT-wrapped)
+/// colormap, the palette it was built from (stops for legends), and the
+/// effective value range.
+#[derive(Clone)]
+pub struct ResolvedColormap {
+    pub colormap: Arc<dyn ColorMap>,
+    pub palette: Arc<Palette>,
+    pub min: f64,
+    pub max: f64,
+}
+
+/// Resolver for config-declared styles against a palette registry.
+///
+/// Built once per config load (and per reload) by the server; api-edr
+/// consumes the resolved [`StyleInfo`] maps, never raw config.
+pub struct StyleContext {
+    registry: PaletteRegistry,
+}
+
+impl StyleContext {
+    pub fn new(registry: PaletteRegistry) -> Self {
+        Self { registry }
+    }
+
+    /// A context with only the built-in palettes (no user `[[colormaps]]`).
+    pub fn with_builtins() -> Self {
+        Self::new(PaletteRegistry::with_builtins())
+    }
+
+    pub fn registry(&self) -> &PaletteRegistry {
+        &self.registry
+    }
+
+    /// THE config→colormap path. Inline `color_stops` win; otherwise the
+    /// named palette is resolved from the registry — an unknown name is an
+    /// error (callers surface it at config load; a typo must not silently
+    /// render viridis). No name at all falls back to viridis. `min`/`max`
+    /// overrides default to the winning palette's first/last stop values.
+    pub fn build_colormap(&self, spec: &StyleSpec) -> Result<ResolvedColormap, String> {
+        // Inline custom stops take priority.
+        if !spec.color_stops.is_empty() {
+            let stops: Vec<ColorStop> = spec
+                .color_stops
+                .iter()
+                .filter_map(|s| {
+                    parse_hex_color(&s.color).ok().map(|color| ColorStop {
+                        value: s.value,
+                        color,
+                    })
+                })
+                .collect();
+            if !stops.is_empty() {
+                // Palette::new sorts ascending — config stops may be
+                // authored highest-first (the natural radar-dBZ legend
+                // order), which would otherwise break the bracket lookup.
+                let palette = Arc::new(Palette::new("custom", stops, Interpolation::Linear));
+                let (min, max) = range_for(&palette, spec.min, spec.max);
+                let colormap: Arc<dyn ColorMap> =
+                    Arc::new(LinearColorMap::new(palette.stops.clone()));
+                return Ok(ResolvedColormap {
+                    colormap: maybe_wrap_integer_lut(colormap, min, max),
+                    palette,
+                    min,
+                    max,
+                });
+            }
+            // Every stop failed to hex-parse: fall through to the named /
+            // default path (legacy behavior).
+        }
+
+        let name = spec.colormap.unwrap_or("viridis");
+        let palette = self
+            .registry
+            .get(name)
+            .ok_or_else(|| format!("unknown colormap '{name}'"))?;
+        let (min, max) = range_for(&palette, spec.min, spec.max);
+        let colormap: Arc<dyn ColorMap> = Arc::new(LutColorMap::from_palette(&palette, min, max));
+        Ok(ResolvedColormap {
+            colormap: maybe_wrap_integer_lut(colormap, min, max),
+            palette,
+            min,
+            max,
+        })
+    }
+
+    /// The collection-level default colormap: the bundle default when a
+    /// bundle is bound, else the inline `[wms]` fields.
+    pub fn collection_default(
+        &self,
+        collection: &CollectionConfig,
+        bundle: Option<&StyleBundle>,
+    ) -> Result<ResolvedColormap, String> {
+        if let Some(bundle) = bundle {
+            return self.build_colormap(&StyleSpec {
+                colormap: bundle.default.colormap.as_deref(),
+                color_stops: &bundle.default.color_stops,
+                min: bundle.default.min,
+                max: bundle.default.max,
+            });
+        }
+        let wms = collection.wms.as_ref();
+        self.build_colormap(&StyleSpec {
+            colormap: wms.and_then(|w| w.colormap.as_deref()),
+            color_stops: wms.map(|w| &w.color_stops[..]).unwrap_or(&[]),
+            min: wms.and_then(|w| w.min),
+            max: wms.and_then(|w| w.max),
+        })
+    }
+
+    /// All styles for a collection's base layer: `default` plus named
+    /// styles (bundle extras when a bundle is bound, else inline
+    /// `[[wms.styles]]`).
+    pub fn collection_styles(
+        &self,
+        collection: &CollectionConfig,
+        bundle: Option<&StyleBundle>,
+    ) -> Result<HashMap<String, StyleInfo>, String> {
+        let mut styles = HashMap::new();
+
+        let default = self.collection_default(collection, bundle)?;
+        styles.insert(
+            "default".to_string(),
+            StyleInfo {
+                name: "default".to_string(),
+                title: "Default".to_string(),
+                colormap: default.colormap,
+                palette: default.palette,
+                min: default.min,
+                max: default.max,
+                parameter: None,
+            },
+        );
+
+        if let Some(bundle) = bundle {
+            for extra in &bundle.extras {
+                let r = self.build_colormap(&StyleSpec {
+                    colormap: extra.colormap.as_deref(),
+                    color_stops: &extra.color_stops,
+                    min: extra.min,
+                    max: extra.max,
+                })?;
+                styles.insert(
+                    extra.name.clone(),
+                    StyleInfo {
+                        name: extra.name.clone(),
+                        title: extra.title.clone().unwrap_or_else(|| extra.name.clone()),
+                        colormap: r.colormap,
+                        palette: r.palette,
+                        min: r.min,
+                        max: r.max,
+                        parameter: extra.parameter.clone(),
+                    },
+                );
+            }
+        } else if let Some(wms_config) = &collection.wms {
+            for style_config in &wms_config.styles {
+                let r = self.build_colormap(&StyleSpec {
+                    colormap: style_config.colormap.as_deref(),
+                    color_stops: &style_config.color_stops,
+                    min: style_config.min,
+                    max: style_config.max,
+                })?;
+                styles.insert(
+                    style_config.name.clone(),
+                    StyleInfo {
+                        name: style_config.name.clone(),
+                        title: style_config
+                            .title
+                            .clone()
+                            .unwrap_or_else(|| style_config.name.clone()),
+                        colormap: r.colormap,
+                        palette: r.palette,
+                        min: r.min,
+                        max: r.max,
+                        parameter: style_config.parameter.clone(),
+                    },
+                );
+            }
+        }
+
+        Ok(styles)
+    }
+
+    /// Per-parameter layer style maps (`"{collection}/{param}"` keys) for
+    /// multi-parameter engines. Each parameter's default style uses its
+    /// `[[wms.parameters]]` entry when configured, else the collection
+    /// default; named styles are shared, except styles tagged with a
+    /// specific `parameter`, which are scoped to that layer only.
+    ///
+    /// `wrap` lets the caller decorate a parameter's colormaps (the server
+    /// wraps the ODIM CELLS overlay sentinel there — engine-specific logic
+    /// that must not live in this crate; #410). It is called with the
+    /// parameter short name and must return the (possibly wrapped) colormap.
+    #[allow(clippy::type_complexity)]
+    pub fn parameter_layer_styles(
+        &self,
+        collection: &CollectionConfig,
+        bundle: Option<&StyleBundle>,
+        param_names: &[(String, String)],
+        wrap: &dyn Fn(&str, Arc<dyn ColorMap>) -> Arc<dyn ColorMap>,
+    ) -> Result<HashMap<String, HashMap<String, StyleInfo>>, String> {
+        let mut out = HashMap::new();
+        let Some(wms_config) = &collection.wms else {
+            return Ok(out);
+        };
+
+        let shared_named_styles = self.collection_styles(collection, bundle)?;
+
+        // When a bundle is bound, inline per-parameter overrides are
+        // rejected by validation (bundles v2 will merge them instead).
+        let param_configs: HashMap<&str, &WmsParameterConfig> = wms_config
+            .parameters
+            .iter()
+            .map(|p| (p.name.as_str(), p))
+            .collect();
+
+        let fallback = self.collection_default(collection, bundle)?;
+
+        for (short_name, _title) in param_names {
+            let layer_key = format!("{}/{}", collection.id, short_name);
+            let mut layer_styles = HashMap::new();
+
+            let r = if let Some(pc) = param_configs.get(short_name.as_str()) {
+                self.build_colormap(&StyleSpec {
+                    colormap: pc.colormap.as_deref(),
+                    color_stops: &pc.color_stops,
+                    min: pc.min,
+                    max: pc.max,
+                })?
+            } else {
+                fallback.clone()
+            };
+
+            layer_styles.insert(
+                "default".to_string(),
+                StyleInfo {
+                    name: "default".to_string(),
+                    title: "Default".to_string(),
+                    colormap: wrap(short_name, r.colormap),
+                    palette: r.palette,
+                    min: r.min,
+                    max: r.max,
+                    parameter: Some(short_name.clone()),
+                },
+            );
+
+            for (name, style) in &shared_named_styles {
+                if name == "default" {
+                    continue;
+                }
+                if let Some(p) = style.parameter.as_deref() {
+                    if p != short_name {
+                        continue;
+                    }
+                }
+                layer_styles.insert(
+                    name.clone(),
+                    StyleInfo {
+                        colormap: wrap(short_name, style.colormap.clone()),
+                        ..style.clone()
+                    },
+                );
+            }
+
+            out.insert(layer_key, layer_styles);
+        }
+
+        Ok(out)
+    }
+}
+
+/// `min`/`max` overrides fall back to the palette's first/last stop values
+/// (and to 0..1 when the palette somehow has no stops), matching the
+/// legacy resolution exactly.
+fn range_for(
+    palette: &Palette,
+    min_override: Option<f64>,
+    max_override: Option<f64>,
+) -> (f64, f64) {
+    let min = min_override.unwrap_or_else(|| palette.stops.first().map(|s| s.value).unwrap_or(0.0));
+    let max = max_override.unwrap_or_else(|| palette.stops.last().map(|s| s.value).unwrap_or(1.0));
+    (min, max)
+}
+
+/// Wrap `cmap` in [`IntegerLutColorMap`] when the value range fits a small
+/// precomputed LUT (#207). Skipped for non-finite/inverted bounds, spans
+/// below 16 integer steps (≥1-unit-per-stop is too coarse for sub-unit
+/// gradients like viridis 0..1), or spans over the 65 536-entry cap.
+fn maybe_wrap_integer_lut(cmap: Arc<dyn ColorMap>, min: f64, max: f64) -> Arc<dyn ColorMap> {
+    if !min.is_finite() || !max.is_finite() {
+        return cmap;
+    }
+    let lo = min.floor() as i64;
+    let hi = max.ceil() as i64;
+    match hi.checked_sub(lo) {
+        Some(s) if (16..65_536).contains(&s) => {}
+        _ => return cmap,
+    }
+    match IntegerLutColorMap::from_colormap(cmap.as_ref(), lo, hi) {
+        Some(lut) => Arc::new(lut),
+        // Unreachable given the (16..65_536) gate above (max span 65 535 →
+        // range 65 536, which `from_colormap` accepts since its check is
+        // `range > MAX_INTEGER_LUT_SIZE`). Kept as a safe fallback for the
+        // day either bound is loosened.
+        None => cmap,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ds_core::config::ColorStop as ConfigColorStop;
+
+    fn spec_named(name: &str) -> StyleSpec<'_> {
+        StyleSpec {
+            colormap: Some(name),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn named_builtin_resolves_with_stop_range() {
+        let ctx = StyleContext::with_builtins();
+        let r = ctx.build_colormap(&spec_named("radar_dbz")).unwrap();
+        assert_eq!((r.min, r.max), (0.0, 70.0));
+        assert_eq!(r.palette.name, "radar_dbz");
+        // 0..70 spans ≥16 integer steps → integer-LUT wrapped, still
+        // colours like the raw palette at integer values.
+        assert_eq!(r.colormap.color(Some(35.0)), [255, 255, 0, 255]);
+    }
+
+    #[test]
+    fn no_name_defaults_to_viridis_0_1() {
+        let ctx = StyleContext::with_builtins();
+        let r = ctx.build_colormap(&StyleSpec::default()).unwrap();
+        assert_eq!(r.palette.name, "viridis");
+        assert_eq!((r.min, r.max), (0.0, 1.0));
+    }
+
+    #[test]
+    fn unknown_name_is_an_error() {
+        let ctx = StyleContext::with_builtins();
+        let Err(err) = ctx.build_colormap(&spec_named("virids")) else {
+            panic!("typo'd colormap name must not resolve");
+        };
+        assert!(err.contains("virids"), "error names the typo: {err}");
+    }
+
+    #[test]
+    fn inline_stops_win_over_name_and_sort_descending_input() {
+        let ctx = StyleContext::with_builtins();
+        let stops = vec![
+            ConfigColorStop {
+                value: 50.0,
+                color: "#FF0000".into(),
+            },
+            ConfigColorStop {
+                value: 0.0,
+                color: "#000000".into(),
+            },
+        ];
+        let r = ctx
+            .build_colormap(&StyleSpec {
+                colormap: Some("radar_dbz"),
+                color_stops: &stops,
+                min: None,
+                max: None,
+            })
+            .unwrap();
+        // Sorted ascending: range comes out 0..50, not 50..0.
+        assert_eq!((r.min, r.max), (0.0, 50.0));
+        assert_eq!(r.palette.stops[0].value, 0.0);
+        assert_eq!(r.colormap.color(Some(50.0)), [255, 0, 0, 255]);
+    }
+
+    #[test]
+    fn min_max_overrides_apply() {
+        let ctx = StyleContext::with_builtins();
+        let r = ctx
+            .build_colormap(&StyleSpec {
+                colormap: Some("viridis"),
+                color_stops: &[],
+                min: Some(200.0),
+                max: Some(300.0),
+            })
+            .unwrap();
+        assert_eq!((r.min, r.max), (200.0, 300.0));
+    }
+
+    // CollectionConfig is deserialized from TOML in production (per-file
+    // collection configs use exactly this shape); build test instances the
+    // same way rather than via a giant struct literal.
+    fn coll(wms_toml: &str) -> CollectionConfig {
+        let mut src = String::from("id = \"c1\"\ntitle = \"t\"\ndescription = \"d\"\n[wms]\n");
+        src.push_str(wms_toml);
+        toml::from_str(&src).expect("test collection config parses")
+    }
+
+    #[test]
+    fn collection_styles_default_and_named() {
+        let ctx = StyleContext::with_builtins();
+        let c = coll(
+            r#"
+            colormap = "radar_dbz"
+            [[wms.styles]]
+            name = "gray"
+            title = "Grayscale"
+            colormap = "grayscale"
+            min = 0.0
+            max = 70.0
+            "#,
+        );
+        let styles = ctx.collection_styles(&c, None).unwrap();
+        assert_eq!(styles.len(), 2);
+        assert_eq!(styles["default"].palette.name, "radar_dbz");
+        assert_eq!(styles["gray"].title, "Grayscale");
+        assert_eq!((styles["gray"].min, styles["gray"].max), (0.0, 70.0));
+    }
+
+    // --- maybe_wrap_integer_lut (#207) — moved here with the function from
+    // the server's admin.rs when style resolution was consolidated. ---
+
+    #[test]
+    fn integer_lut_wraps_when_range_fits_and_is_wide_enough() {
+        let src: Arc<dyn ColorMap> = Arc::new(LutColorMap::from_builtin(
+            crate::BuiltinColormap::RadarDbz,
+            -32.0,
+            95.0,
+        ));
+        let wrapped = maybe_wrap_integer_lut(src.clone(), -32.0, 95.0);
+        // It was replaced (no longer the same Arc).
+        assert!(
+            !Arc::ptr_eq(&src, &wrapped),
+            "expected wrap on the radar_dbz -32..95 range"
+        );
+        // Colour at integer values matches the source — the LUT just precomputes.
+        for v in [-32i64, -16, 0, 25, 50, 95] {
+            assert_eq!(
+                wrapped.color(Some(v as f64)),
+                src.color(Some(v as f64)),
+                "colour mismatch at v={v}"
+            );
+        }
+        // Out-of-range saturates to the boundary entry (not transparent),
+        // matching the float path's clamp — at integer endpoints we CAN
+        // compare to src by construction.
+        assert_eq!(wrapped.color(Some(-100.0)), src.color(Some(-32.0)));
+        assert_eq!(wrapped.color(Some(200.0)), src.color(Some(95.0)));
+        // (The non-integer rounding direction — round-nearest, not toward
+        // zero — is pinned in the IntegerLutColorMap tests where the
+        // colormap has distinct colours per integer. radar_dbz's low end is
+        // transparent so it can't distinguish the directions here.)
+    }
+
+    #[test]
+    fn integer_lut_skips_narrow_range() {
+        // viridis 0..1 → only 2 integer entries → truncation would collapse the
+        // gradient. Must NOT wrap.
+        let src: Arc<dyn ColorMap> = Arc::new(LutColorMap::from_builtin(
+            crate::BuiltinColormap::Viridis,
+            0.0,
+            1.0,
+        ));
+        let wrapped = maybe_wrap_integer_lut(src.clone(), 0.0, 1.0);
+        assert!(
+            Arc::ptr_eq(&src, &wrapped),
+            "expected no wrap for a narrow (<16-entry) range"
+        );
+    }
+
+    #[test]
+    fn integer_lut_skips_huge_range() {
+        // > 65 535 entries can't fit the integer LUT; fall back to the source.
+        let src: Arc<dyn ColorMap> = Arc::new(LutColorMap::from_builtin(
+            crate::BuiltinColormap::Viridis,
+            -100_000.0,
+            100_000.0,
+        ));
+        let wrapped = maybe_wrap_integer_lut(src.clone(), -100_000.0, 100_000.0);
+        assert!(
+            Arc::ptr_eq(&src, &wrapped),
+            "expected no wrap for an over-cap range"
+        );
+    }
+
+    #[test]
+    fn integer_lut_skips_non_finite_bounds() {
+        let src: Arc<dyn ColorMap> = Arc::new(LutColorMap::from_builtin(
+            crate::BuiltinColormap::Viridis,
+            0.0,
+            1.0,
+        ));
+        assert!(Arc::ptr_eq(
+            &src,
+            &maybe_wrap_integer_lut(src.clone(), f64::NAN, 1.0)
+        ));
+        assert!(Arc::ptr_eq(
+            &src,
+            &maybe_wrap_integer_lut(src.clone(), 0.0, f64::INFINITY)
+        ));
+    }
+
+    #[test]
+    fn parameter_layer_styles_use_param_config_and_wrap_hook() {
+        let ctx = StyleContext::with_builtins();
+        let c = coll(
+            r#"
+            colormap = "radar_dbz"
+            [[wms.parameters]]
+            name = "VRADH"
+            colormap = "radial_velocity"
+            "#,
+        );
+        let params = vec![
+            ("DBZH".to_string(), "Reflectivity".to_string()),
+            ("VRADH".to_string(), "Radial velocity".to_string()),
+        ];
+        let wrapped_for: std::cell::RefCell<Vec<String>> = std::cell::RefCell::new(Vec::new());
+        let maps = ctx
+            .parameter_layer_styles(&c, None, &params, &|short, cmap| {
+                wrapped_for.borrow_mut().push(short.to_string());
+                cmap
+            })
+            .unwrap();
+        let wrapped_for = wrapped_for.into_inner();
+        assert_eq!(maps.len(), 2);
+        assert_eq!(maps["c1/DBZH"]["default"].palette.name, "radar_dbz");
+        assert_eq!(maps["c1/VRADH"]["default"].palette.name, "radial_velocity");
+        assert_eq!(
+            maps["c1/VRADH"]["default"].parameter.as_deref(),
+            Some("VRADH")
+        );
+        assert!(wrapped_for.contains(&"DBZH".to_string()));
+        assert!(wrapped_for.contains(&"VRADH".to_string()));
+    }
+}

--- a/crates/server/src/admin.rs
+++ b/crates/server/src/admin.rs
@@ -898,8 +898,15 @@ pub fn load_collections(
 ) -> LoadResult {
     let bundle_index: HashMap<&str, &StyleBundle> =
         style_bundles.iter().map(|b| (b.id.as_str(), b)).collect();
+    // The single config→style resolution path (phase 2 of the styling
+    // revamp): every API's style map is resolved through one StyleContext,
+    // computed once per collection and shared via `styles_cache`.
+    let style_ctx = ds_render::StyleContext::with_builtins();
+    let mut styles_cache: HashMap<String, HashMap<String, HashMap<String, ds_render::StyleInfo>>> =
+        HashMap::new();
     let mut edr_engines: HashMap<String, Arc<dyn ds_core::edr_engine::EdrEngine>> = HashMap::new();
     let mut edr_collections: HashMap<String, CollectionConfig> = HashMap::new();
+    let mut edr_styles: HashMap<String, HashMap<String, ds_render::StyleInfo>> = HashMap::new();
     let mut feature_engines: HashMap<String, Arc<dyn ds_core::feature_engine::FeatureEngine>> =
         HashMap::new();
     let mut feature_collections: HashMap<String, CollectionConfig> = HashMap::new();
@@ -1186,6 +1193,13 @@ pub fn load_collections(
                         engine.clone() as Arc<dyn ds_core::edr_engine::EdrEngine>,
                     );
                     edr_collections.insert(collection.id.clone(), collection.clone());
+                    edr_styles.extend(collection_layer_styles(
+                        &style_ctx,
+                        &mut styles_cache,
+                        collection,
+                        &[],
+                        &bundle_index,
+                    ));
                 }
                 if collection.apis.contains(&"wms".to_string()) {
                     map_engines.insert(
@@ -1194,9 +1208,13 @@ pub fn load_collections(
                     );
                     map_collections.insert(collection.id.clone(), collection.clone());
 
-                    // Build styles from config
-                    let styles = build_styles(collection, &bundle_index);
-                    map_styles.insert(collection.id.clone(), styles);
+                    map_styles.extend(collection_layer_styles(
+                        &style_ctx,
+                        &mut styles_cache,
+                        collection,
+                        &[],
+                        &bundle_index,
+                    ));
 
                     info!("Collection '{}': wired to WMS API", collection.id);
                 }
@@ -1207,8 +1225,13 @@ pub fn load_collections(
                     );
                     maps_collections.insert(collection.id.clone(), collection.clone());
 
-                    let styles = build_styles(collection, &bundle_index);
-                    maps_styles.insert(collection.id.clone(), styles);
+                    maps_styles.extend(collection_layer_styles(
+                        &style_ctx,
+                        &mut styles_cache,
+                        collection,
+                        &[],
+                        &bundle_index,
+                    ));
 
                     info!("Collection '{}': wired to Maps API", collection.id);
                 }
@@ -1219,8 +1242,13 @@ pub fn load_collections(
                     );
                     tiles_collections.insert(collection.id.clone(), collection.clone());
 
-                    let styles = build_styles(collection, &bundle_index);
-                    tiles_styles.insert(collection.id.clone(), styles);
+                    tiles_styles.extend(collection_layer_styles(
+                        &style_ctx,
+                        &mut styles_cache,
+                        collection,
+                        &[],
+                        &bundle_index,
+                    ));
 
                     info!("Collection '{}': wired to Tiles API", collection.id);
                 }
@@ -1293,16 +1321,24 @@ pub fn load_collections(
 
                 querydata_engines.push(engine.clone());
 
+                // Get parameter list for per-parameter-layer styles
+                let raster_params =
+                    ds_core::map_engine::MapEngine::raster_info(engine.as_ref()).parameters;
+
                 if collection.apis.contains(&"edr".to_string()) {
                     edr_engines.insert(
                         collection.id.clone(),
                         engine.clone() as Arc<dyn ds_core::edr_engine::EdrEngine>,
                     );
                     edr_collections.insert(collection.id.clone(), collection.clone());
+                    edr_styles.extend(collection_layer_styles(
+                        &style_ctx,
+                        &mut styles_cache,
+                        collection,
+                        &raster_params,
+                        &bundle_index,
+                    ));
                 }
-                // Get parameter list for per-parameter-layer styles
-                let raster_params =
-                    ds_core::map_engine::MapEngine::raster_info(engine.as_ref()).parameters;
 
                 if collection.apis.contains(&"wms".to_string()) {
                     map_engines.insert(
@@ -1310,16 +1346,13 @@ pub fn load_collections(
                         engine.clone() as Arc<dyn ds_core::map_engine::MapEngine>,
                     );
                     map_collections.insert(collection.id.clone(), collection.clone());
-                    let styles = build_styles(collection, &bundle_index);
-                    map_styles.insert(collection.id.clone(), styles);
-                    if !raster_params.is_empty() {
-                        register_parameter_layer_styles(
-                            collection,
-                            &raster_params,
-                            &mut map_styles,
-                            &bundle_index,
-                        );
-                    }
+                    map_styles.extend(collection_layer_styles(
+                        &style_ctx,
+                        &mut styles_cache,
+                        collection,
+                        &raster_params,
+                        &bundle_index,
+                    ));
                     info!("Collection '{}': wired to WMS API", collection.id);
                 }
                 if collection.apis.contains(&"maps".to_string()) {
@@ -1328,16 +1361,13 @@ pub fn load_collections(
                         engine.clone() as Arc<dyn ds_core::map_engine::MapEngine>,
                     );
                     maps_collections.insert(collection.id.clone(), collection.clone());
-                    let styles = build_styles(collection, &bundle_index);
-                    maps_styles.insert(collection.id.clone(), styles);
-                    if !raster_params.is_empty() {
-                        register_parameter_layer_styles(
-                            collection,
-                            &raster_params,
-                            &mut maps_styles,
-                            &bundle_index,
-                        );
-                    }
+                    maps_styles.extend(collection_layer_styles(
+                        &style_ctx,
+                        &mut styles_cache,
+                        collection,
+                        &raster_params,
+                        &bundle_index,
+                    ));
                     info!("Collection '{}': wired to Maps API", collection.id);
                 }
                 if collection.apis.contains(&"tiles".to_string()) {
@@ -1346,16 +1376,13 @@ pub fn load_collections(
                         engine.clone() as Arc<dyn ds_core::map_engine::MapEngine>,
                     );
                     tiles_collections.insert(collection.id.clone(), collection.clone());
-                    let styles = build_styles(collection, &bundle_index);
-                    tiles_styles.insert(collection.id.clone(), styles);
-                    if !raster_params.is_empty() {
-                        register_parameter_layer_styles(
-                            collection,
-                            &raster_params,
-                            &mut tiles_styles,
-                            &bundle_index,
-                        );
-                    }
+                    tiles_styles.extend(collection_layer_styles(
+                        &style_ctx,
+                        &mut styles_cache,
+                        collection,
+                        &raster_params,
+                        &bundle_index,
+                    ));
                     info!("Collection '{}': wired to Tiles API", collection.id);
                 }
 
@@ -1422,16 +1449,24 @@ pub fn load_collections(
 
                 grib_engines.push(engine.clone());
 
+                // Get parameter list for per-parameter-layer styles
+                let raster_params =
+                    ds_core::map_engine::MapEngine::raster_info(engine.as_ref()).parameters;
+
                 if collection.apis.contains(&"edr".to_string()) {
                     edr_engines.insert(
                         collection.id.clone(),
                         engine.clone() as Arc<dyn ds_core::edr_engine::EdrEngine>,
                     );
                     edr_collections.insert(collection.id.clone(), collection.clone());
+                    edr_styles.extend(collection_layer_styles(
+                        &style_ctx,
+                        &mut styles_cache,
+                        collection,
+                        &raster_params,
+                        &bundle_index,
+                    ));
                 }
-                // Get parameter list for per-parameter-layer styles
-                let raster_params =
-                    ds_core::map_engine::MapEngine::raster_info(engine.as_ref()).parameters;
 
                 if collection.apis.contains(&"wms".to_string()) {
                     map_engines.insert(
@@ -1439,16 +1474,13 @@ pub fn load_collections(
                         engine.clone() as Arc<dyn ds_core::map_engine::MapEngine>,
                     );
                     map_collections.insert(collection.id.clone(), collection.clone());
-                    let styles = build_styles(collection, &bundle_index);
-                    map_styles.insert(collection.id.clone(), styles);
-                    if !raster_params.is_empty() {
-                        register_parameter_layer_styles(
-                            collection,
-                            &raster_params,
-                            &mut map_styles,
-                            &bundle_index,
-                        );
-                    }
+                    map_styles.extend(collection_layer_styles(
+                        &style_ctx,
+                        &mut styles_cache,
+                        collection,
+                        &raster_params,
+                        &bundle_index,
+                    ));
                     info!("Collection '{}': wired to WMS API", collection.id);
                 }
                 if collection.apis.contains(&"maps".to_string()) {
@@ -1457,16 +1489,13 @@ pub fn load_collections(
                         engine.clone() as Arc<dyn ds_core::map_engine::MapEngine>,
                     );
                     maps_collections.insert(collection.id.clone(), collection.clone());
-                    let styles = build_styles(collection, &bundle_index);
-                    maps_styles.insert(collection.id.clone(), styles);
-                    if !raster_params.is_empty() {
-                        register_parameter_layer_styles(
-                            collection,
-                            &raster_params,
-                            &mut maps_styles,
-                            &bundle_index,
-                        );
-                    }
+                    maps_styles.extend(collection_layer_styles(
+                        &style_ctx,
+                        &mut styles_cache,
+                        collection,
+                        &raster_params,
+                        &bundle_index,
+                    ));
                     info!("Collection '{}': wired to Maps API", collection.id);
                 }
                 if collection.apis.contains(&"tiles".to_string()) {
@@ -1475,16 +1504,13 @@ pub fn load_collections(
                         engine.clone() as Arc<dyn ds_core::map_engine::MapEngine>,
                     );
                     tiles_collections.insert(collection.id.clone(), collection.clone());
-                    let styles = build_styles(collection, &bundle_index);
-                    tiles_styles.insert(collection.id.clone(), styles);
-                    if !raster_params.is_empty() {
-                        register_parameter_layer_styles(
-                            collection,
-                            &raster_params,
-                            &mut tiles_styles,
-                            &bundle_index,
-                        );
-                    }
+                    tiles_styles.extend(collection_layer_styles(
+                        &style_ctx,
+                        &mut styles_cache,
+                        collection,
+                        &raster_params,
+                        &bundle_index,
+                    ));
                     info!("Collection '{}': wired to Tiles API", collection.id);
                 }
 
@@ -1552,19 +1578,26 @@ pub fn load_collections(
 
                 zarr_engines.push(engine.clone());
 
+                // Per-parameter-layer styles (one WMS/Maps/Tiles layer per Zarr
+                // variable).
+                let raster_params =
+                    ds_core::map_engine::MapEngine::raster_info(engine.as_ref()).parameters;
+
                 if collection.apis.contains(&"edr".to_string()) {
                     edr_engines.insert(
                         collection.id.clone(),
                         engine.clone() as Arc<dyn ds_core::edr_engine::EdrEngine>,
                     );
                     edr_collections.insert(collection.id.clone(), collection.clone());
+                    edr_styles.extend(collection_layer_styles(
+                        &style_ctx,
+                        &mut styles_cache,
+                        collection,
+                        &raster_params,
+                        &bundle_index,
+                    ));
                     info!("Collection '{}': wired to EDR API", collection.id);
                 }
-
-                // Per-parameter-layer styles (one WMS/Maps/Tiles layer per Zarr
-                // variable).
-                let raster_params =
-                    ds_core::map_engine::MapEngine::raster_info(engine.as_ref()).parameters;
 
                 if collection.apis.contains(&"wms".to_string()) {
                     map_engines.insert(
@@ -1572,16 +1605,13 @@ pub fn load_collections(
                         engine.clone() as Arc<dyn ds_core::map_engine::MapEngine>,
                     );
                     map_collections.insert(collection.id.clone(), collection.clone());
-                    let styles = build_styles(collection, &bundle_index);
-                    map_styles.insert(collection.id.clone(), styles);
-                    if !raster_params.is_empty() {
-                        register_parameter_layer_styles(
-                            collection,
-                            &raster_params,
-                            &mut map_styles,
-                            &bundle_index,
-                        );
-                    }
+                    map_styles.extend(collection_layer_styles(
+                        &style_ctx,
+                        &mut styles_cache,
+                        collection,
+                        &raster_params,
+                        &bundle_index,
+                    ));
                     info!("Collection '{}': wired to WMS API", collection.id);
                 }
                 if collection.apis.contains(&"maps".to_string()) {
@@ -1590,16 +1620,13 @@ pub fn load_collections(
                         engine.clone() as Arc<dyn ds_core::map_engine::MapEngine>,
                     );
                     maps_collections.insert(collection.id.clone(), collection.clone());
-                    let styles = build_styles(collection, &bundle_index);
-                    maps_styles.insert(collection.id.clone(), styles);
-                    if !raster_params.is_empty() {
-                        register_parameter_layer_styles(
-                            collection,
-                            &raster_params,
-                            &mut maps_styles,
-                            &bundle_index,
-                        );
-                    }
+                    maps_styles.extend(collection_layer_styles(
+                        &style_ctx,
+                        &mut styles_cache,
+                        collection,
+                        &raster_params,
+                        &bundle_index,
+                    ));
                     info!("Collection '{}': wired to Maps API", collection.id);
                 }
                 if collection.apis.contains(&"tiles".to_string()) {
@@ -1608,16 +1635,13 @@ pub fn load_collections(
                         engine.clone() as Arc<dyn ds_core::map_engine::MapEngine>,
                     );
                     tiles_collections.insert(collection.id.clone(), collection.clone());
-                    let styles = build_styles(collection, &bundle_index);
-                    tiles_styles.insert(collection.id.clone(), styles);
-                    if !raster_params.is_empty() {
-                        register_parameter_layer_styles(
-                            collection,
-                            &raster_params,
-                            &mut tiles_styles,
-                            &bundle_index,
-                        );
-                    }
+                    tiles_styles.extend(collection_layer_styles(
+                        &style_ctx,
+                        &mut styles_cache,
+                        collection,
+                        &raster_params,
+                        &bundle_index,
+                    ));
                     info!("Collection '{}': wired to Tiles API", collection.id);
                 }
 
@@ -1678,17 +1702,24 @@ pub fn load_collections(
 
                 odim_engines.push(engine.clone());
 
+                let raster_params =
+                    ds_core::map_engine::MapEngine::raster_info(engine.as_ref()).parameters;
+
                 if collection.apis.contains(&"edr".to_string()) {
                     edr_engines.insert(
                         collection.id.clone(),
                         engine.clone() as Arc<dyn ds_core::edr_engine::EdrEngine>,
                     );
                     edr_collections.insert(collection.id.clone(), collection.clone());
+                    edr_styles.extend(collection_layer_styles(
+                        &style_ctx,
+                        &mut styles_cache,
+                        collection,
+                        &raster_params,
+                        &bundle_index,
+                    ));
                     info!("Collection '{}': wired to EDR API", collection.id);
                 }
-
-                let raster_params =
-                    ds_core::map_engine::MapEngine::raster_info(engine.as_ref()).parameters;
 
                 if collection.apis.contains(&"wms".to_string()) {
                     map_engines.insert(
@@ -1696,16 +1727,13 @@ pub fn load_collections(
                         engine.clone() as Arc<dyn ds_core::map_engine::MapEngine>,
                     );
                     map_collections.insert(collection.id.clone(), collection.clone());
-                    let styles = build_styles(collection, &bundle_index);
-                    map_styles.insert(collection.id.clone(), styles);
-                    if !raster_params.is_empty() {
-                        register_parameter_layer_styles(
-                            collection,
-                            &raster_params,
-                            &mut map_styles,
-                            &bundle_index,
-                        );
-                    }
+                    map_styles.extend(collection_layer_styles(
+                        &style_ctx,
+                        &mut styles_cache,
+                        collection,
+                        &raster_params,
+                        &bundle_index,
+                    ));
                     info!("Collection '{}': wired to WMS API", collection.id);
                 }
                 if collection.apis.contains(&"maps".to_string()) {
@@ -1714,16 +1742,13 @@ pub fn load_collections(
                         engine.clone() as Arc<dyn ds_core::map_engine::MapEngine>,
                     );
                     maps_collections.insert(collection.id.clone(), collection.clone());
-                    let styles = build_styles(collection, &bundle_index);
-                    maps_styles.insert(collection.id.clone(), styles);
-                    if !raster_params.is_empty() {
-                        register_parameter_layer_styles(
-                            collection,
-                            &raster_params,
-                            &mut maps_styles,
-                            &bundle_index,
-                        );
-                    }
+                    maps_styles.extend(collection_layer_styles(
+                        &style_ctx,
+                        &mut styles_cache,
+                        collection,
+                        &raster_params,
+                        &bundle_index,
+                    ));
                     info!("Collection '{}': wired to Maps API", collection.id);
                 }
                 if collection.apis.contains(&"tiles".to_string()) {
@@ -1732,16 +1757,13 @@ pub fn load_collections(
                         engine.clone() as Arc<dyn ds_core::map_engine::MapEngine>,
                     );
                     tiles_collections.insert(collection.id.clone(), collection.clone());
-                    let styles = build_styles(collection, &bundle_index);
-                    tiles_styles.insert(collection.id.clone(), styles);
-                    if !raster_params.is_empty() {
-                        register_parameter_layer_styles(
-                            collection,
-                            &raster_params,
-                            &mut tiles_styles,
-                            &bundle_index,
-                        );
-                    }
+                    tiles_styles.extend(collection_layer_styles(
+                        &style_ctx,
+                        &mut styles_cache,
+                        collection,
+                        &raster_params,
+                        &bundle_index,
+                    ));
                     info!("Collection '{}': wired to Tiles API", collection.id);
                 }
 
@@ -1876,17 +1898,24 @@ pub fn load_collections(
                     site_cfg.description =
                         format!("{} (radar site {label} / {nod})", collection.description);
 
+                    // Per-site, multi-parameter: one layer per bare quantity.
+                    let raster_params =
+                        ds_core::map_engine::MapEngine::raster_info(view.as_ref()).parameters;
+
                     if collection.apis.contains(&"edr".to_string()) {
                         edr_engines.insert(
                             site_id.clone(),
                             view.clone() as Arc<dyn ds_core::edr_engine::EdrEngine>,
                         );
                         edr_collections.insert(site_id.clone(), site_cfg.clone());
+                        edr_styles.extend(collection_layer_styles(
+                            &style_ctx,
+                            &mut styles_cache,
+                            &site_cfg,
+                            &raster_params,
+                            &bundle_index,
+                        ));
                     }
-
-                    // Per-site, multi-parameter: one layer per bare quantity.
-                    let raster_params =
-                        ds_core::map_engine::MapEngine::raster_info(view.as_ref()).parameters;
 
                     if collection.apis.contains(&"wms".to_string()) {
                         map_engines.insert(
@@ -1894,16 +1923,13 @@ pub fn load_collections(
                             view.clone() as Arc<dyn ds_core::map_engine::MapEngine>,
                         );
                         map_collections.insert(site_id.clone(), site_cfg.clone());
-                        let styles = build_styles(&site_cfg, &bundle_index);
-                        map_styles.insert(site_id.clone(), styles);
-                        if !raster_params.is_empty() {
-                            register_parameter_layer_styles(
-                                &site_cfg,
-                                &raster_params,
-                                &mut map_styles,
-                                &bundle_index,
-                            );
-                        }
+                        map_styles.extend(collection_layer_styles(
+                            &style_ctx,
+                            &mut styles_cache,
+                            &site_cfg,
+                            &raster_params,
+                            &bundle_index,
+                        ));
                     }
                     if collection.apis.contains(&"maps".to_string()) {
                         maps_engines.insert(
@@ -1911,16 +1937,13 @@ pub fn load_collections(
                             view.clone() as Arc<dyn ds_core::map_engine::MapEngine>,
                         );
                         maps_collections.insert(site_id.clone(), site_cfg.clone());
-                        let styles = build_styles(&site_cfg, &bundle_index);
-                        maps_styles.insert(site_id.clone(), styles);
-                        if !raster_params.is_empty() {
-                            register_parameter_layer_styles(
-                                &site_cfg,
-                                &raster_params,
-                                &mut maps_styles,
-                                &bundle_index,
-                            );
-                        }
+                        maps_styles.extend(collection_layer_styles(
+                            &style_ctx,
+                            &mut styles_cache,
+                            &site_cfg,
+                            &raster_params,
+                            &bundle_index,
+                        ));
                     }
                     if collection.apis.contains(&"tiles".to_string()) {
                         tiles_engines.insert(
@@ -1928,16 +1951,13 @@ pub fn load_collections(
                             view.clone() as Arc<dyn ds_core::map_engine::MapEngine>,
                         );
                         tiles_collections.insert(site_id.clone(), site_cfg.clone());
-                        let styles = build_styles(&site_cfg, &bundle_index);
-                        tiles_styles.insert(site_id.clone(), styles);
-                        if !raster_params.is_empty() {
-                            register_parameter_layer_styles(
-                                &site_cfg,
-                                &raster_params,
-                                &mut tiles_styles,
-                                &bundle_index,
-                            );
-                        }
+                        tiles_styles.extend(collection_layer_styles(
+                            &style_ctx,
+                            &mut styles_cache,
+                            &site_cfg,
+                            &raster_params,
+                            &bundle_index,
+                        ));
                     }
                     if collection.apis.contains(&"3dtiles".to_string()) {
                         volume_engines.insert(
@@ -2075,10 +2095,13 @@ pub fn load_collections(
                         engine.clone() as Arc<dyn ds_core::map_engine::MapEngine>,
                     );
                     map_collections.insert(collection.id.clone(), collection.clone());
-                    map_styles.insert(
-                        collection.id.clone(),
-                        build_styles(collection, &bundle_index),
-                    );
+                    map_styles.extend(collection_layer_styles(
+                        &style_ctx,
+                        &mut styles_cache,
+                        collection,
+                        &[],
+                        &bundle_index,
+                    ));
                     info!("Collection '{}': wired to WMS API", collection.id);
                 }
                 if collection.apis.contains(&"maps".to_string()) {
@@ -2087,10 +2110,13 @@ pub fn load_collections(
                         engine.clone() as Arc<dyn ds_core::map_engine::MapEngine>,
                     );
                     maps_collections.insert(collection.id.clone(), collection.clone());
-                    maps_styles.insert(
-                        collection.id.clone(),
-                        build_styles(collection, &bundle_index),
-                    );
+                    maps_styles.extend(collection_layer_styles(
+                        &style_ctx,
+                        &mut styles_cache,
+                        collection,
+                        &[],
+                        &bundle_index,
+                    ));
                     info!("Collection '{}': wired to Maps API", collection.id);
                 }
                 if collection.apis.contains(&"tiles".to_string()) {
@@ -2099,10 +2125,13 @@ pub fn load_collections(
                         engine.clone() as Arc<dyn ds_core::map_engine::MapEngine>,
                     );
                     tiles_collections.insert(collection.id.clone(), collection.clone());
-                    tiles_styles.insert(
-                        collection.id.clone(),
-                        build_styles(collection, &bundle_index),
-                    );
+                    tiles_styles.extend(collection_layer_styles(
+                        &style_ctx,
+                        &mut styles_cache,
+                        collection,
+                        &[],
+                        &bundle_index,
+                    ));
                     info!("Collection '{}': wired to Tiles API", collection.id);
                 }
 
@@ -2244,12 +2273,26 @@ pub fn load_collections(
                     }
                 };
 
+                // The events shape has a raster surface (#504: the
+                // age-colored lightning layer) — wire the MapEngine into the
+                // raster APIs. Station shapes keep the MVT feature-tile
+                // path; config validation rejects wms/maps for them.
+                let is_events = validated.events().is_some();
                 if collection.apis.contains(&"edr".to_string()) {
                     edr_engines.insert(
                         collection.id.clone(),
                         engine.clone() as Arc<dyn ds_core::edr_engine::EdrEngine>,
                     );
                     edr_collections.insert(collection.id.clone(), collection.clone());
+                    if is_events {
+                        edr_styles.extend(collection_layer_styles(
+                            &style_ctx,
+                            &mut styles_cache,
+                            collection,
+                            &[],
+                            &bundle_index,
+                        ));
+                    }
                 }
                 if collection.apis.contains(&"features".to_string()) {
                     feature_engines.insert(
@@ -2258,19 +2301,19 @@ pub fn load_collections(
                     );
                     feature_collections.insert(collection.id.clone(), collection.clone());
                 }
-                // The events shape has a raster surface (#504: the
-                // age-colored lightning layer) — wire the MapEngine into the
-                // raster APIs. Station shapes keep the MVT feature-tile
-                // path; config validation rejects wms/maps for them.
-                let is_events = validated.events().is_some();
                 if collection.apis.contains(&"wms".to_string()) && is_events {
                     map_engines.insert(
                         collection.id.clone(),
                         engine.clone() as Arc<dyn ds_core::map_engine::MapEngine>,
                     );
                     map_collections.insert(collection.id.clone(), collection.clone());
-                    let styles = build_styles(collection, &bundle_index);
-                    map_styles.insert(collection.id.clone(), styles);
+                    map_styles.extend(collection_layer_styles(
+                        &style_ctx,
+                        &mut styles_cache,
+                        collection,
+                        &[],
+                        &bundle_index,
+                    ));
                     info!("Collection '{}': wired to WMS API", collection.id);
                 }
                 if collection.apis.contains(&"maps".to_string()) && is_events {
@@ -2279,8 +2322,13 @@ pub fn load_collections(
                         engine.clone() as Arc<dyn ds_core::map_engine::MapEngine>,
                     );
                     maps_collections.insert(collection.id.clone(), collection.clone());
-                    let styles = build_styles(collection, &bundle_index);
-                    maps_styles.insert(collection.id.clone(), styles);
+                    maps_styles.extend(collection_layer_styles(
+                        &style_ctx,
+                        &mut styles_cache,
+                        collection,
+                        &[],
+                        &bundle_index,
+                    ));
                     info!("Collection '{}': wired to Maps API", collection.id);
                 }
                 if collection.apis.contains(&"tiles".to_string()) {
@@ -2290,8 +2338,13 @@ pub fn load_collections(
                             engine.clone() as Arc<dyn ds_core::map_engine::MapEngine>,
                         );
                         tiles_collections.insert(collection.id.clone(), collection.clone());
-                        let styles = build_styles(collection, &bundle_index);
-                        tiles_styles.insert(collection.id.clone(), styles);
+                        tiles_styles.extend(collection_layer_styles(
+                            &style_ctx,
+                            &mut styles_cache,
+                            collection,
+                            &[],
+                            &bundle_index,
+                        ));
                         info!(
                             "Collection '{}': wired to Tiles API (raster)",
                             collection.id
@@ -2416,10 +2469,13 @@ pub fn load_collections(
                 engine.clone() as Arc<dyn ds_core::map_engine::MapEngine>,
             );
             map_collections.insert(collection.id.clone(), collection.clone());
-            map_styles.insert(
-                collection.id.clone(),
-                build_styles(collection, &bundle_index),
-            );
+            map_styles.extend(collection_layer_styles(
+                &style_ctx,
+                &mut styles_cache,
+                collection,
+                &[],
+                &bundle_index,
+            ));
             info!("Collection '{}': wired to WMS API", collection.id);
         }
         if collection.apis.contains(&"maps".to_string()) {
@@ -2428,10 +2484,13 @@ pub fn load_collections(
                 engine.clone() as Arc<dyn ds_core::map_engine::MapEngine>,
             );
             maps_collections.insert(collection.id.clone(), collection.clone());
-            maps_styles.insert(
-                collection.id.clone(),
-                build_styles(collection, &bundle_index),
-            );
+            maps_styles.extend(collection_layer_styles(
+                &style_ctx,
+                &mut styles_cache,
+                collection,
+                &[],
+                &bundle_index,
+            ));
             info!("Collection '{}': wired to Maps API", collection.id);
         }
         if collection.apis.contains(&"tiles".to_string()) {
@@ -2440,10 +2499,13 @@ pub fn load_collections(
                 engine.clone() as Arc<dyn ds_core::map_engine::MapEngine>,
             );
             tiles_collections.insert(collection.id.clone(), collection.clone());
-            tiles_styles.insert(
-                collection.id.clone(),
-                build_styles(collection, &bundle_index),
-            );
+            tiles_styles.extend(collection_layer_styles(
+                &style_ctx,
+                &mut styles_cache,
+                collection,
+                &[],
+                &bundle_index,
+            ));
             info!("Collection '{}': wired to Tiles API", collection.id);
         }
 
@@ -2530,6 +2592,7 @@ pub fn load_collections(
         edr_state: EdrState {
             engines: edr_engines,
             collections: edr_collections,
+            styles: edr_styles,
             base_url: base_url.to_string(),
             trust_proxy_headers,
         },
@@ -2594,82 +2657,89 @@ pub fn load_collections(
     }
 }
 
-/// Build all styles for a WMS-enabled collection (bundle if bound, inline otherwise).
-fn build_styles(
-    collection: &CollectionConfig,
-    bundles: &HashMap<&str, &StyleBundle>,
-) -> HashMap<String, ds_render::StyleInfo> {
-    build_styles_inner(collection, resolve_bundle(collection, bundles))
-}
-
-fn build_styles_inner(
-    collection: &CollectionConfig,
-    bundle: Option<&StyleBundle>,
-) -> HashMap<String, ds_render::StyleInfo> {
+/// Legacy-behavior fallback when style resolution fails despite config
+/// validation: a default-only style map on viridis 0..1.
+fn fallback_default_styles(ctx: &ds_render::StyleContext) -> HashMap<String, ds_render::StyleInfo> {
+    let r = ctx
+        .build_colormap(&ds_render::StyleSpec::default())
+        .expect("viridis is always registered");
     let mut styles = HashMap::new();
-
-    // Build default style (either from the bundle or from inline wms config)
-    let (default_colormap, default_min, default_max) =
-        build_collection_default_colormap(collection, bundle);
     styles.insert(
         "default".to_string(),
         ds_render::StyleInfo {
             name: "default".to_string(),
             title: "Default".to_string(),
-            colormap: default_colormap,
-            min: default_min,
-            max: default_max,
+            colormap: r.colormap,
+            palette: r.palette,
+            min: r.min,
+            max: r.max,
             parameter: None,
         },
     );
+    styles
+}
 
-    // Build additional named styles — prefer bundle extras when bound
-    if let Some(bundle) = bundle {
-        for extra in &bundle.extras {
-            let (colormap, min, max) = build_colormap_from_wms_config(
-                extra.colormap.as_deref(),
-                &extra.color_stops,
-                extra.min,
-                extra.max,
-            );
-            styles.insert(
-                extra.name.clone(),
-                ds_render::StyleInfo {
-                    name: extra.name.clone(),
-                    title: extra.title.clone().unwrap_or_else(|| extra.name.clone()),
-                    colormap,
-                    min,
-                    max,
-                    parameter: extra.parameter.clone(),
-                },
-            );
+/// Compute (once per collection) the full style-layer map: the collection
+/// key plus one "{id}/{param}" key per parameter, resolved through the
+/// shared StyleContext. Cached so the WMS, Maps and Tiles registries (and
+/// EDR) share identical StyleInfo instances instead of re-resolving per
+/// API (previously 3×). The ODIM CELLS overlay wrap is injected here —
+/// engine-specific logic that stays out of ds-render (#410).
+fn collection_layer_styles(
+    ctx: &ds_render::StyleContext,
+    cache: &mut HashMap<String, HashMap<String, HashMap<String, ds_render::StyleInfo>>>,
+    collection: &CollectionConfig,
+    param_names: &[(String, String)],
+    bundles: &HashMap<&str, &StyleBundle>,
+) -> HashMap<String, HashMap<String, ds_render::StyleInfo>> {
+    if let Some(hit) = cache.get(&collection.id) {
+        return hit.clone();
+    }
+    let bundle = resolve_bundle(collection, bundles);
+    // The derived storm-cell overlay (#367) paints cell outlines at their
+    // dBZ value and track trails at a reserved sentinel; wrap whatever
+    // colormap CELLS resolves to so the sentinel renders one neutral
+    // colour. Scoped to `odim-volume` — without the engine-type gate a
+    // non-ODIM collection with a band coincidentally named `CELLS` would
+    // get -9999.0 hijacked to grey (#410 removes this via an OverlaySpec).
+    let wrap = |short: &str, cmap: Arc<dyn ds_render::ColorMap>| -> Arc<dyn ds_render::ColorMap> {
+        if collection.engine_type == "odim-volume" && short == engine_odim::cells::CELLS_PARAMETER {
+            Arc::new(ds_render::OverlayColorMap::new(
+                cmap,
+                engine_odim::cells::CELLS_TRACK_SENTINEL,
+                engine_odim::cells::CELLS_TRACK_COLOR,
+            ))
+        } else {
+            cmap
         }
-    } else if let Some(wms_config) = &collection.wms {
-        for style_config in &wms_config.styles {
-            let (colormap, min, max) = build_colormap_from_wms_config(
-                style_config.colormap.as_deref(),
-                &style_config.color_stops,
-                style_config.min,
-                style_config.max,
+    };
+    let mut layers = HashMap::new();
+    match ctx.collection_styles(collection, bundle) {
+        Ok(styles) => {
+            layers.insert(collection.id.clone(), styles);
+        }
+        Err(e) => {
+            // Unknown colormap names are rejected at config validation
+            // (validate_style_colormaps); reaching this is a bug. Keep the
+            // legacy viridis fallback so the collection still renders.
+            tracing::error!(
+                "Collection '{}': style resolution failed ({e}); using viridis fallback",
+                collection.id
             );
-            styles.insert(
-                style_config.name.clone(),
-                ds_render::StyleInfo {
-                    name: style_config.name.clone(),
-                    title: style_config
-                        .title
-                        .clone()
-                        .unwrap_or_else(|| style_config.name.clone()),
-                    colormap,
-                    min,
-                    max,
-                    parameter: style_config.parameter.clone(),
-                },
-            );
+            layers.insert(collection.id.clone(), fallback_default_styles(ctx));
         }
     }
-
-    styles
+    if !param_names.is_empty() {
+        match ctx.parameter_layer_styles(collection, bundle, param_names, &wrap) {
+            Ok(maps) => layers.extend(maps),
+            Err(e) => tracing::error!(
+                "Collection '{}': parameter style resolution failed ({e})",
+                collection.id
+            ),
+        }
+    }
+    cache.insert(collection.id.clone(), layers.clone());
+    layers
 }
 
 /// Resolve a collection's bound bundle; None if unset (validation rejects unresolved refs).
@@ -2694,223 +2764,58 @@ fn resolve_bundle<'a>(
     }
 }
 
-/// Build the collection-level default colormap from the bundle or inline `[wms]` fields.
-fn build_collection_default_colormap(
-    collection: &CollectionConfig,
-    bundle: Option<&StyleBundle>,
-) -> (Arc<dyn ds_render::ColorMap>, f64, f64) {
-    if let Some(bundle) = bundle {
-        return build_colormap_from_wms_config(
-            bundle.default.colormap.as_deref(),
-            &bundle.default.color_stops,
-            bundle.default.min,
-            bundle.default.max,
-        );
-    }
-    build_colormap_from_wms_config(
-        collection.wms.as_ref().and_then(|w| w.colormap.as_deref()),
-        collection
-            .wms
-            .as_ref()
-            .map(|w| &w.color_stops[..])
-            .unwrap_or(&[]),
-        collection.wms.as_ref().and_then(|w| w.min),
-        collection.wms.as_ref().and_then(|w| w.max),
-    )
-}
-
-/// Register per-parameter-layer styles for multi-parameter engines.
-///
-/// For each parameter in `param_names`, creates a style set under the layer
-/// name `"collection-id/param-short-name"`. The default style uses the
-/// per-parameter colormap from `[[collections.wms.parameters]]` if configured,
-/// or falls back to the collection-level default. Named styles are shared
-/// across all parameter layers.
-fn register_parameter_layer_styles(
-    collection: &CollectionConfig,
-    param_names: &[(String, String)],
-    style_map: &mut HashMap<String, HashMap<String, ds_render::StyleInfo>>,
-    bundles: &HashMap<&str, &StyleBundle>,
-) {
-    let wms_config = match &collection.wms {
-        Some(c) => c,
-        None => return,
+/// Reject unknown `colormap = "..."` names at config load. A typo'd name
+/// previously fell back to viridis silently — the config "worked" but
+/// rendered wrong. Runs against the same palette registry the styles are
+/// built from (built-ins today; [[colormaps]] entries join in a later
+/// phase).
+pub fn validate_style_colormaps(
+    collections: &[CollectionConfig],
+    style_bundles: &[StyleBundle],
+) -> Result<(), ds_core::error::DataServerError> {
+    let registry = ds_render::PaletteRegistry::with_builtins();
+    let check = |owner: &str, name: Option<&str>| -> Result<(), ds_core::error::DataServerError> {
+        if let Some(n) = name {
+            if !registry.contains(n) {
+                return Err(ds_core::error::DataServerError::Config(format!(
+                    "{owner}: unknown colormap '{n}' (built-ins: {})",
+                    ds_render::palette::builtin_names().join(", ")
+                )));
+            }
+        }
+        Ok(())
     };
-
-    let bundle = resolve_bundle(collection, bundles);
-    let shared_named_styles = build_styles_inner(collection, bundle);
-
-    // When a bundle is bound, inline per-parameter overrides are rejected by validation.
-    let param_configs: HashMap<&str, &ds_core::config::WmsParameterConfig> = wms_config
-        .parameters
-        .iter()
-        .map(|p| (p.name.as_str(), p))
-        .collect();
-
-    let (fallback_colormap, fallback_min, fallback_max) =
-        build_collection_default_colormap(collection, bundle);
-
-    for (short_name, _title) in param_names {
-        let layer_key = format!("{}/{}", collection.id, short_name);
-        let mut layer_styles = HashMap::new();
-
-        // The derived storm-cell overlay (#367) paints cell outlines/markers
-        // at their dBZ value and track trails at a reserved sentinel; wrap
-        // whatever colormap it resolves to so the sentinel renders one neutral
-        // colour (distinct from the dBZ-coloured outlines) regardless of the
-        // base colormap (inherited or overridden). Scoped to `odim-volume` —
-        // this generic helper runs for every engine, and only the ODIM PVOL
-        // engine produces a CELLS overlay; without the engine-type gate a
-        // non-ODIM collection with a band coincidentally named `CELLS` would
-        // get `-9999.0` hijacked to grey (#410 will remove the engine-specific
-        // branch entirely via an `OverlaySpec` on `StyleInfo`).
-        let is_cells = collection.engine_type == "odim-volume"
-            && short_name == engine_odim::cells::CELLS_PARAMETER;
-        let wrap_cells = |cmap: Arc<dyn ds_render::ColorMap>| -> Arc<dyn ds_render::ColorMap> {
-            if is_cells {
-                Arc::new(ds_render::OverlayColorMap::new(
-                    cmap,
-                    engine_odim::cells::CELLS_TRACK_SENTINEL,
-                    engine_odim::cells::CELLS_TRACK_COLOR,
-                ))
-            } else {
-                cmap
-            }
-        };
-
-        // Build this parameter's default style
-        let (colormap, min, max) = if let Some(pc) = param_configs.get(short_name.as_str()) {
-            build_colormap_from_wms_config(pc.colormap.as_deref(), &pc.color_stops, pc.min, pc.max)
-        } else {
-            (fallback_colormap.clone(), fallback_min, fallback_max)
-        };
-
-        layer_styles.insert(
-            "default".to_string(),
-            ds_render::StyleInfo {
-                name: "default".to_string(),
-                title: "Default".to_string(),
-                colormap: wrap_cells(colormap),
-                min,
-                max,
-                parameter: Some(short_name.clone()),
-            },
-        );
-
-        // Add shared named styles (excluding "default" which we just built).
-        // Styles tagged with a specific `parameter` are scoped to that layer only —
-        // otherwise a bundle extra with `parameter = "wind_speed"` would leak into
-        // every parameter layer's style map.
-        for (name, style) in &shared_named_styles {
-            if name == "default" {
-                continue;
-            }
-            if let Some(p) = style.parameter.as_deref() {
-                if p != short_name {
-                    continue;
-                }
-            }
-            // A CELLS-scoped named style still needs the trail sentinel handled.
-            if is_cells {
-                layer_styles.insert(
-                    name.clone(),
-                    ds_render::StyleInfo {
-                        colormap: wrap_cells(style.colormap.clone()),
-                        ..style.clone()
-                    },
-                );
-            } else {
-                layer_styles.insert(name.clone(), style.clone());
-            }
-        }
-
-        style_map.insert(layer_key, layer_styles);
-    }
-}
-
-/// Wrap `cmap` in [`ds_render::IntegerLutColorMap`] when the value range fits
-/// a small precomputed LUT (#207). Skipped for non-finite/inverted bounds,
-/// spans below 16 integer steps (≥1-unit-per-stop is too coarse for sub-unit
-/// gradients like viridis 0..1), or spans over the 65 536-entry cap.
-fn maybe_wrap_integer_lut(
-    cmap: Arc<dyn ds_render::ColorMap>,
-    min: f64,
-    max: f64,
-) -> Arc<dyn ds_render::ColorMap> {
-    if !min.is_finite() || !max.is_finite() {
-        return cmap;
-    }
-    let lo = min.floor() as i64;
-    let hi = max.ceil() as i64;
-    let span = match hi.checked_sub(lo) {
-        Some(s) if (16..65_536).contains(&s) => s,
-        _ => return cmap,
-    };
-    match ds_render::IntegerLutColorMap::from_colormap(cmap.as_ref(), lo, hi) {
-        Some(lut) => {
-            tracing::debug!(
-                "Wired IntegerLutColorMap [{lo}..{hi}] ({} entries) for colorize",
-                span + 1
-            );
-            Arc::new(lut)
-        }
-        // Currently unreachable given the (16..65_536) gate above (max span 65 535
-        // → range 65 536, which `from_colormap` accepts since its check is
-        // `range > MAX_INTEGER_LUT_SIZE`). Kept as a safe fallback for the day
-        // either bound is loosened.
-        None => cmap,
-    }
-}
-
-/// Build a colormap and value range from WMS config fields.
-fn build_colormap_from_wms_config(
-    colormap_name: Option<&str>,
-    color_stops: &[ds_core::config::ColorStop],
-    min_override: Option<f64>,
-    max_override: Option<f64>,
-) -> (Arc<dyn ds_render::ColorMap>, f64, f64) {
-    // Custom color stops take priority
-    if !color_stops.is_empty() {
-        let stops: Vec<ds_render::ColorStop> = color_stops
-            .iter()
-            .filter_map(|s| {
-                ds_render::parse_hex_color(&s.color)
-                    .ok()
-                    .map(|c| ds_render::ColorStop {
-                        value: s.value,
-                        color: c,
-                    })
-            })
-            .collect();
-        if !stops.is_empty() {
-            let min = min_override.unwrap_or_else(|| stops.first().map(|s| s.value).unwrap_or(0.0));
-            let max = max_override.unwrap_or_else(|| stops.last().map(|s| s.value).unwrap_or(1.0));
-            let cmap: Arc<dyn ds_render::ColorMap> =
-                Arc::new(ds_render::LinearColorMap::new(stops));
-            return (maybe_wrap_integer_lut(cmap, min, max), min, max);
+    for b in style_bundles {
+        check(
+            &format!("style_bundle '{}'", b.id),
+            b.default.colormap.as_deref(),
+        )?;
+        for e in &b.extras {
+            check(
+                &format!("style_bundle '{}' extra '{}'", b.id, e.name),
+                e.colormap.as_deref(),
+            )?;
         }
     }
-
-    // Fall back to built-in colormap name
-    let name = colormap_name.unwrap_or("viridis");
-    if let Some(palette) = ds_render::builtin_palette(name) {
-        let stops = &palette.stops;
-        let min = min_override.unwrap_or_else(|| stops.first().map(|s| s.value).unwrap_or(0.0));
-        let max = max_override.unwrap_or_else(|| stops.last().map(|s| s.value).unwrap_or(1.0));
-        let cmap: Arc<dyn ds_render::ColorMap> =
-            Arc::new(ds_render::LutColorMap::from_palette(palette, min, max));
-        return (maybe_wrap_integer_lut(cmap, min, max), min, max);
+    for c in collections {
+        if let Some(w) = &c.wms {
+            let owner = format!("collection '{}'", c.id);
+            check(&owner, w.colormap.as_deref())?;
+            for s in &w.styles {
+                check(
+                    &format!("{owner} style '{}'", s.name),
+                    s.colormap.as_deref(),
+                )?;
+            }
+            for p in &w.parameters {
+                check(
+                    &format!("{owner} parameter '{}'", p.name),
+                    p.colormap.as_deref(),
+                )?;
+            }
+        }
     }
-
-    // Default: viridis 0..1
-    let min = min_override.unwrap_or(0.0);
-    let max = max_override.unwrap_or(1.0);
-    let cmap: Arc<dyn ds_render::ColorMap> = Arc::new(ds_render::LutColorMap::from_builtin(
-        ds_render::BuiltinColormap::Viridis,
-        min,
-        max,
-    ));
-    (maybe_wrap_integer_lut(cmap, min, max), min, max)
+    Ok(())
 }
 
 /// Update the health gauges from the current health vector.
@@ -3057,6 +2962,13 @@ pub(crate) fn do_reload(state: &AdminState) -> Result<ReloadOutcome, ReloadError
     for warning in &config_warnings {
         tracing::warn!("{warning}");
     }
+
+    // Same colormap-name validation as startup: an unknown name rejects the
+    // reload and keeps the old registry serving.
+    validate_style_colormaps(&config.collections, &config.style_bundles).map_err(|e| {
+        tracing::error!("Reload failed: {e}");
+        ReloadError::ConfigRead(format!("{e}"))
+    })?;
 
     let base_url = config.server.base_url();
 
@@ -4157,10 +4069,23 @@ pub async fn request_logging_middleware(
 
 #[cfg(test)]
 mod tests {
-    use super::{build_styles, classify_route, is_safe_request_id, maybe_wrap_integer_lut};
+    use super::{classify_route, collection_layer_styles, is_safe_request_id};
     use ds_core::config::{CollectionConfig, StyleBundle};
     use std::collections::HashMap;
     use std::sync::Arc;
+
+    /// Resolve a collection's full style-layer map through a fresh
+    /// [`ds_render::StyleContext`] + empty cache — the test-side stand-in for
+    /// the per-load resolution `load_collections` performs.
+    fn layer_styles(
+        collection: &CollectionConfig,
+        param_names: &[(String, String)],
+        bundles: &HashMap<&str, &StyleBundle>,
+    ) -> HashMap<String, HashMap<String, ds_render::StyleInfo>> {
+        let ctx = ds_render::StyleContext::with_builtins();
+        let mut cache = HashMap::new();
+        collection_layer_styles(&ctx, &mut cache, collection, param_names, bundles)
+    }
 
     // --- nowcast second-pass wiring (#522) ---
 
@@ -4424,87 +4349,8 @@ mod tests {
         );
     }
 
-    // --- maybe_wrap_integer_lut (#207) ---
-
-    #[test]
-    fn integer_lut_wraps_when_range_fits_and_is_wide_enough() {
-        let src: Arc<dyn ds_render::ColorMap> = Arc::new(ds_render::LutColorMap::from_builtin(
-            ds_render::BuiltinColormap::RadarDbz,
-            -32.0,
-            95.0,
-        ));
-        let wrapped = maybe_wrap_integer_lut(src.clone(), -32.0, 95.0);
-        // It was replaced (no longer the same Arc).
-        assert!(
-            !Arc::ptr_eq(&src, &wrapped),
-            "expected wrap on the radar_dbz -32..95 range"
-        );
-        // Colour at integer values matches the source — the LUT just precomputes.
-        for v in [-32i64, -16, 0, 25, 50, 95] {
-            assert_eq!(
-                wrapped.color(Some(v as f64)),
-                src.color(Some(v as f64)),
-                "colour mismatch at v={v}"
-            );
-        }
-        // Out-of-range saturates to the boundary entry (not transparent),
-        // matching the float path's clamp — at integer endpoints we CAN
-        // compare to src by construction.
-        assert_eq!(wrapped.color(Some(-100.0)), src.color(Some(-32.0)));
-        assert_eq!(wrapped.color(Some(200.0)), src.color(Some(95.0)));
-        // (The non-integer rounding direction — round-nearest, not toward
-        // zero — is pinned in ds-render's IntegerLutColorMap tests where the
-        // colormap has distinct colours per integer. radar_dbz's low end is
-        // transparent so it can't distinguish the directions here.)
-    }
-
-    #[test]
-    fn integer_lut_skips_narrow_range() {
-        // viridis 0..1 → only 2 integer entries → truncation would collapse the
-        // gradient. Must NOT wrap.
-        let src: Arc<dyn ds_render::ColorMap> = Arc::new(ds_render::LutColorMap::from_builtin(
-            ds_render::BuiltinColormap::Viridis,
-            0.0,
-            1.0,
-        ));
-        let wrapped = maybe_wrap_integer_lut(src.clone(), 0.0, 1.0);
-        assert!(
-            Arc::ptr_eq(&src, &wrapped),
-            "expected no wrap for a narrow (<16-entry) range"
-        );
-    }
-
-    #[test]
-    fn integer_lut_skips_huge_range() {
-        // > 65 535 entries can't fit the integer LUT; fall back to the source.
-        let src: Arc<dyn ds_render::ColorMap> = Arc::new(ds_render::LutColorMap::from_builtin(
-            ds_render::BuiltinColormap::Viridis,
-            -100_000.0,
-            100_000.0,
-        ));
-        let wrapped = maybe_wrap_integer_lut(src.clone(), -100_000.0, 100_000.0);
-        assert!(
-            Arc::ptr_eq(&src, &wrapped),
-            "expected no wrap for an over-cap range"
-        );
-    }
-
-    #[test]
-    fn integer_lut_skips_non_finite_bounds() {
-        let src: Arc<dyn ds_render::ColorMap> = Arc::new(ds_render::LutColorMap::from_builtin(
-            ds_render::BuiltinColormap::Viridis,
-            0.0,
-            1.0,
-        ));
-        assert!(Arc::ptr_eq(
-            &src,
-            &maybe_wrap_integer_lut(src.clone(), f64::NAN, 1.0)
-        ));
-        assert!(Arc::ptr_eq(
-            &src,
-            &maybe_wrap_integer_lut(src.clone(), 0.0, f64::INFINITY)
-        ));
-    }
+    // (The maybe_wrap_integer_lut (#207) unit tests moved with the function
+    // into ds-render — see crates/render/src/style.rs.)
 
     #[test]
     fn accepts_typical_uuid() {
@@ -4608,7 +4454,7 @@ mod tests {
     }
 
     #[test]
-    fn build_styles_expands_bundle_into_default_plus_extras() {
+    fn collection_styles_expand_bundle_into_default_plus_extras() {
         let collection: CollectionConfig = toml::from_str(
             r#"
 id = "radar-dwd"
@@ -4652,7 +4498,9 @@ colormap = "radar_fmi"
         let index: HashMap<&str, &StyleBundle> =
             bundles.iter().map(|b| (b.id.as_str(), b)).collect();
 
-        let styles = build_styles(&collection, &index);
+        let layers = layer_styles(&collection, &[], &index);
+        assert_eq!(layers.len(), 1, "no params → collection layer only");
+        let styles = &layers["radar-dwd"];
         assert_eq!(styles.len(), 3, "default + 2 extras expected");
         assert!(styles.contains_key("default"));
         assert_eq!(styles["default"].name, "default");
@@ -4663,7 +4511,7 @@ colormap = "radar_fmi"
     }
 
     #[test]
-    fn build_styles_falls_back_to_inline_when_no_bundle_referenced() {
+    fn collection_styles_fall_back_to_inline_when_no_bundle_referenced() {
         let collection: CollectionConfig = toml::from_str(
             r#"
 id = "radar-fmi"
@@ -4690,15 +4538,20 @@ colormap = "grayscale"
 
         let index: HashMap<&str, &StyleBundle> = HashMap::new();
 
-        let styles = build_styles(&collection, &index);
+        let styles = &layer_styles(&collection, &[], &index)["radar-fmi"];
         assert_eq!(styles.len(), 2);
         assert!(styles.contains_key("default"));
+        assert_eq!(
+            (styles["default"].min, styles["default"].max),
+            (0.0, 70.0),
+            "default min/max come from the radar_dbz stops"
+        );
         assert!(styles.contains_key("alt"));
         assert_eq!(styles["alt"].title, "Alt");
     }
 
     #[test]
-    fn build_styles_falls_back_when_bundle_ref_unknown() {
+    fn collection_styles_fall_back_when_bundle_ref_unknown() {
         // Exercises the defensive path in resolve_bundle: validate() normally
         // rejects unresolved refs, but if a caller skips validation the
         // collection must still load with the inline default (viridis) rather
@@ -4723,18 +4576,20 @@ style_bundle = "does_not_exist"
         .unwrap();
 
         let index: HashMap<&str, &StyleBundle> = HashMap::new();
-        let styles = build_styles(&collection, &index);
+        let styles = &layer_styles(&collection, &[], &index)["radar-x"];
 
         // Only the default; no extras; the bundle was silently skipped.
         assert_eq!(styles.len(), 1);
         assert!(styles.contains_key("default"));
+        assert_eq!(styles["default"].palette.name, "viridis");
+        assert_eq!((styles["default"].min, styles["default"].max), (0.0, 1.0));
     }
 
     #[test]
-    fn build_styles_parameter_tagged_extras_stay_in_map() {
-        // build_styles itself returns every extra — scoping by parameter
-        // happens downstream in register_parameter_layer_styles. This test
-        // locks the current behaviour so the bundle surface stays stable.
+    fn collection_styles_parameter_tagged_extras_stay_in_collection_map() {
+        // The collection-level map returns every extra — scoping by
+        // parameter happens in the per-parameter layer maps. This locks the
+        // bundle surface stable AND pins the scoping outcome.
         let collection: CollectionConfig = toml::from_str(
             r#"
 id = "multi"
@@ -4772,10 +4627,159 @@ colormap = "grayscale"
         let bundles = [bundle];
         let index: HashMap<&str, &StyleBundle> =
             bundles.iter().map(|b| (b.id.as_str(), b)).collect();
-        let styles = build_styles(&collection, &index);
+        let params = vec![
+            ("wind_speed".to_string(), "Wind speed".to_string()),
+            ("t2m".to_string(), "Temperature".to_string()),
+        ];
+        let layers = layer_styles(&collection, &params, &index);
 
+        let styles = &layers["multi"];
         assert_eq!(styles.len(), 3);
         assert_eq!(styles["wind_only"].parameter.as_deref(), Some("wind_speed"));
         assert!(styles["global"].parameter.is_none());
+
+        // Parameter scoping: the tagged extra only reaches its own layer;
+        // the untagged extra reaches every layer.
+        let wind = &layers["multi/wind_speed"];
+        assert!(wind.contains_key("wind_only"));
+        assert!(wind.contains_key("global"));
+        let t2m = &layers["multi/t2m"];
+        assert!(!t2m.contains_key("wind_only"));
+        assert!(t2m.contains_key("global"));
+    }
+
+    #[test]
+    fn odim_volume_cells_layer_gets_track_overlay_wrap() {
+        // The derived storm-cell overlay (#367): for an odim-volume
+        // collection, the CELLS parameter layer's colormaps must render the
+        // reserved track sentinel as the fixed neutral colour.
+        let collection: CollectionConfig = toml::from_str(
+            r#"
+id = "pvol-fivih"
+title = "Vihti"
+description = "Vihti PVOL"
+engine_type = "odim-volume"
+
+[odim]
+
+[wms]
+colormap = "radar_dbz"
+"#,
+        )
+        .unwrap();
+        let index: HashMap<&str, &StyleBundle> = HashMap::new();
+        let params = vec![(
+            engine_odim::cells::CELLS_PARAMETER.to_string(),
+            "Storm cells".to_string(),
+        )];
+        let layers = layer_styles(&collection, &params, &index);
+        let cells_default = &layers["pvol-fivih/CELLS"]["default"];
+        assert_eq!(
+            cells_default
+                .colormap
+                .color(Some(engine_odim::cells::CELLS_TRACK_SENTINEL)),
+            engine_odim::cells::CELLS_TRACK_COLOR,
+            "CELLS layer must render the track sentinel as the overlay colour"
+        );
+
+        // A non-ODIM collection with a band coincidentally named CELLS must
+        // NOT get the overlay wrap (#410 gate).
+        let plain: CollectionConfig = toml::from_str(
+            r#"
+id = "qd"
+title = "QD"
+description = "QD"
+engine_type = "querydata"
+
+[querydata]
+
+[wms]
+colormap = "radar_dbz"
+"#,
+        )
+        .unwrap();
+        let layers = layer_styles(&plain, &params, &index);
+        let cells_default = &layers["qd/CELLS"]["default"];
+        assert_ne!(
+            cells_default
+                .colormap
+                .color(Some(engine_odim::cells::CELLS_TRACK_SENTINEL)),
+            engine_odim::cells::CELLS_TRACK_COLOR,
+            "non-ODIM engines must not hijack the sentinel value"
+        );
+    }
+
+    #[test]
+    fn edr_state_gets_the_same_resolved_styles() {
+        // Task-level wiring pin: a wms+edr collection's resolved styles land
+        // in the EDR state (the f=png trajectory plot consumes them).
+        let mut c = tm35_source_collection("radar");
+        c.apis = vec!["edr".to_string(), "wms".to_string()];
+        let result = super::load_collections(
+            &[c],
+            &[],
+            "http://x",
+            false,
+            0,
+            super::ReusableCaches::default(),
+        );
+        let edr = &result.edr_state.styles["radar"];
+        let wms = &result.wms_state.styles["radar"];
+        assert!(edr.contains_key("default"));
+        assert_eq!(edr.len(), wms.len(), "EDR and WMS share one resolution");
+        assert_eq!(edr["default"].min, wms["default"].min);
+        assert_eq!(edr["default"].max, wms["default"].max);
+    }
+
+    #[test]
+    fn validate_style_colormaps_rejects_unknown_names() {
+        // A typo'd colormap name is a config error at load, not a silent
+        // viridis fallback.
+        let bad: CollectionConfig = toml::from_str(
+            r#"
+id = "radar"
+title = "R"
+description = "R"
+engine_type = "geotiff"
+
+[geotiff]
+filename_template = "radar_%Y%m%dT%H%MZ.tif"
+parameter = "reflectivity"
+unit = "dBZ"
+data_path = "/tmp"
+
+[wms]
+colormap = "virids"
+"#,
+        )
+        .unwrap();
+        let err = super::validate_style_colormaps(std::slice::from_ref(&bad), &[])
+            .expect_err("typo'd colormap must be rejected");
+        let msg = format!("{err}");
+        assert!(msg.contains("virids"), "error names the typo: {msg}");
+        assert!(msg.contains("radar"), "error names the collection: {msg}");
+
+        // A valid name (and no wms at all) passes.
+        let mut ok = bad.clone();
+        ok.wms.as_mut().unwrap().colormap = Some("radar_dbz".into());
+        super::validate_style_colormaps(std::slice::from_ref(&ok), &[]).expect("valid name passes");
+
+        // A bundle extra with an unknown name is rejected too.
+        let bundle: StyleBundle = toml::from_str(
+            r#"
+id = "b"
+
+[default]
+colormap = "viridis"
+
+[[extras]]
+name = "x"
+colormap = "no_such_map"
+"#,
+        )
+        .unwrap();
+        let err = super::validate_style_colormaps(&[], std::slice::from_ref(&bundle))
+            .expect_err("unknown bundle extra colormap must be rejected");
+        assert!(format!("{err}").contains("no_such_map"));
     }
 }

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -329,6 +329,13 @@ async fn main() {
         tracing::warn!("{warning}");
     }
 
+    // Reject unknown colormap names up front — a typo'd `colormap = "..."`
+    // must fail startup, not silently render viridis.
+    if let Err(e) = admin::validate_style_colormaps(&config.collections, &config.style_bundles) {
+        tracing::error!("Invalid style configuration: {e}");
+        std::process::exit(1);
+    }
+
     // Auto-discover collections from any --auto-collections directories (#411)
     // and merge them with the config-file collections. The merged set goes
     // through the same validate() as TOML collections (so duplicate ids across

--- a/crates/server/src/preview.rs
+++ b/crates/server/src/preview.rs
@@ -909,6 +909,7 @@ mod tests {
         api_edr::handlers::EdrState {
             engines: HashMap::new(),
             collections: HashMap::new(),
+            styles: HashMap::new(),
             base_url: String::new(),
             trust_proxy_headers: false,
         }
@@ -1512,6 +1513,7 @@ mod tests {
             ds_render::StyleInfo {
                 name: "default".to_string(),
                 title: "Default".to_string(),
+                palette: ds_render::builtin_palette_arc("viridis").unwrap(),
                 colormap: Arc::new(ds_render::LutColorMap::from_builtin(
                     ds_render::BuiltinColormap::Viridis,
                     0.0,
@@ -2137,6 +2139,7 @@ mod tests {
             ds_render::StyleInfo {
                 name: "rainbow".to_string(),
                 title: "Rainbow".to_string(),
+                palette: ds_render::builtin_palette_arc("viridis").unwrap(),
                 colormap: Arc::new(ds_render::LutColorMap::from_builtin(
                     ds_render::BuiltinColormap::Viridis,
                     0.0,

--- a/crates/server/tests/middleware.rs
+++ b/crates/server/tests/middleware.rs
@@ -101,6 +101,7 @@ fn make_styles() -> HashMap<String, StyleInfo> {
         StyleInfo {
             name: "default".to_string(),
             title: "Default".to_string(),
+            palette: ds_render::builtin_palette_arc("viridis").unwrap(),
             colormap: Arc::new(LutColorMap::from_builtin(
                 BuiltinColormap::Viridis,
                 0.0,


### PR DESCRIPTION
## Summary

Phase 2 of the styling revamp (stacked on #558). One resolver — `ds_render::StyleContext` — now owns every config→colormap decision; the server and api-edr consume resolved `StyleInfo`, never raw config.

- **New `crates/render/src/style.rs`**: `StyleSpec` / `ResolvedColormap` / `StyleContext::{build_colormap, collection_default, collection_styles, parameter_layer_styles}`. The integer-LUT wrap (#207) moved in. Engine-specific CELLS overlay is injected by the server through a wrap hook (stays out of ds-render; #410 groundwork).
- **admin.rs**: the six legacy style builders are deleted; per-collection style maps are computed once (cached) and shared across the WMS/Maps/Tiles registries — previously the same styles were re-resolved 3× per collection.
- **`StyleInfo.palette`**: the resolved `Arc<Palette>` (stops + interpolation) is kept beside the baked colormap — groundwork for machine-readable legend JSON (next phases).
- **EDR fix**: `EdrState` gets the same resolved styles; `f=png` cross-sections color via the resolved default style. Bundle-bound collections previously fell back to data-range viridis in EDR plots because `plot_convert` re-implemented resolution without bundle support — that duplicate (`section_colormap`) is deleted.
- **Stricter config**: unknown `colormap = "..."` names now fail config load/reload (`validate_style_colormaps`) instead of silently rendering viridis. Inline `color_stops` are sorted ascending on every path (previously EDR-only; unsorted stops broke the WMS gradient bracket lookup).

## Behavior

Pixel parity verified end-to-end: booted this branch and `main` against the same local fixtures and byte-compared five artifacts — bundle default (EPSG:4326 direct path), bundle extra style (EPSG:3857 meta-tile path), ODIM PVOL per-parameter inline stops (DBZH), PVOL fallback parameter (VRAD), and GetLegendGraphic. **All byte-identical.**

Intentional changes only:
1. Unknown colormap name → config error (was silent viridis). Deployments should grep configs for typos before upgrading.
2. EDR f=png on styled/bundled collections now matches WMS colors (was viridis-on-data-range).
3. Unsorted inline stops now resolve as if sorted (was broken rendering).

## Test plan

- New resolver unit tests in style.rs (precedence, unknown-name error, stop sorting, min/max overrides, parameter layers + wrap hook) plus the #207 integer-LUT tests moved from admin.rs, assertions unchanged.
- admin tests ported to the resolver (CELLS overlay pin, parameter-scoped extras, EDR/WMS shared-resolution pin, `validate_style_colormaps` cases).
- `cargo clippy --all-targets -- -D warnings` clean; full suites green: ds-render, server, api-edr, api-wms, api-maps, api-tiles (717 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VWyrJy1FVeinRS8UsSZKrU