### PR TITLE
feat(server): user-defined colormaps — [[colormaps]], colormaps_dir, cpt/GDAL/SLD import

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -337,6 +337,28 @@ port = 8000
 # collections_dir = "collections.d"     # optional, directory of per-collection .toml files
 # watch_collections_dir = true          # optional, auto-reload on collections_dir changes (default false)
 # watch_debounce_ms = 500               # optional, coalesce-window for the watcher (default 500)
+# colormaps_dir = "colormaps.d"  # optional, directory of palette files loaded as
+                                 # named colormaps (name = file stem). Formats:
+                                 # .toml (ColormapDef), GMT .cpt, GDAL color-relief
+                                 # .txt/.clr, SLD .sld (ColorMap). Re-read on reload;
+                                 # missing dir = hard error; other extensions skipped.
+
+# Optional named colormaps. Like [[style_bundles]], MUST live in top-level
+# config.toml (rejected in per-collection files). Registered next to the
+# built-ins; the name works anywhere a built-in colormap name does ([wms]
+# colormap, styles, parameters, bundle defaults/extras). A user colormap may
+# shadow a built-in name (replaces it deployment-wide, logged WARN);
+# duplicate user names are a config error. Unknown colormap name references
+# anywhere in config are a LOAD ERROR (no silent viridis fallback).
+[[colormaps]]
+name = "radar_nssl2"
+title = "NSSL Reflectivity 2"
+# interpolation = "step"        # "linear" (default) | "step" (discrete classes)
+# nodata_color = "#00000000"    # optional
+color_stops = [
+  { value = 5.0,  color = "#414141" },
+  { value = 60.0, color = "#FF0000" },
+]
 
 # Optional shared WMS style bundles. MUST live in top-level config.toml —
 # a [[style_bundles]] block inside a collections_dir file is silently

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4076,6 +4076,7 @@ dependencies = [
  "http-body-util",
  "notify",
  "prometheus",
+ "quick-xml 0.37.5",
  "rust-embed",
  "serde",
  "serde_json",

--- a/README.md
+++ b/README.md
@@ -352,6 +352,7 @@ colormap = "radar_dbz"          # built-in colormap (or use color_stops for cust
 | `port` | yes | — | Bind port |
 | `base_url` | no | `http://{host}:{port}` | External base URL for absolute links (set when behind a reverse proxy) |
 | `collections_dir` | no | — | Directory of per-collection `.toml` config files (see [Per-File Collection Configs](#per-file-collection-configs)) |
+| `colormaps_dir` | no | — | Directory of palette files loaded as named colormaps (one per file, name = file stem). Formats: `.toml` (colormap fields), GMT `.cpt`, GDAL color-relief `.txt`/`.clr`, SLD `.sld` (ColorMap). Resolved relative to the config file's directory; re-read on reload. Missing directory is a hard error; other extensions are skipped (`.disabled` works). |
 | `watch_collections_dir` | no | `false` | Auto-reload when files in `collections_dir` are added, changed, or removed. Debounced; runs on the background runtime. See trust-model note in [Per-File Collection Configs](#per-file-collection-configs). |
 | `watch_debounce_ms` | no | `500` | Coalesce-window in milliseconds for the filesystem watcher (only used when `watch_collections_dir = true`). |
 | `metatile_cache_mb` | no | `1024` | Size (MB) of the global Web Mercator meta-tile cache. Server-wide, not per-collection. `0` disables meta-tiling (EPSG:3857 GetMap reverts to a direct render; reload-reversible). Consumed by WMS today; Maps/Tiles will share it when meta-tiling extends to them. |
@@ -1232,6 +1233,28 @@ Styles live under each collection's `[wms]` block — Maps and Tiles read the sa
 | `cloud_cover` | White overlay with increasing opacity | 0–100 % |
 | `cap_severity` | CAP alert severity codes, grey/green/yellow/orange/red | 0–4 |
 | `lightning_age` | Lightning strike age, near-white → orange → dark violet | 0–60 min |
+
+**Named custom colormaps** — define once, reference anywhere a built-in
+name works (`[wms] colormap`, `[[wms.styles]]`, `[[wms.parameters]]`, style
+bundles). Only in top-level `config.toml` (like `[[style_bundles]]`), or as
+files in `colormaps_dir`:
+
+```toml
+[[colormaps]]
+name = "radar_house"
+title = "House Radar Style"
+# interpolation = "step"      # "linear" (default) | "step" (discrete classes)
+# nodata_color = "#00000000"  # optional
+color_stops = [
+  { value = 5.0,  color = "#414141" },
+  { value = 60.0, color = "#FF0000" },
+]
+```
+
+A user colormap may shadow a built-in name (replacing it server-wide; logged
+as a warning). Duplicate user names and unknown `colormap = "..."`
+references anywhere in config are load errors — a typo fails startup/reload
+instead of silently rendering viridis.
 
 **Custom color stops** override the built-in colormap:
 

--- a/colormaps.d/pressure_wide.toml
+++ b/colormaps.d/pressure_wide.toml
@@ -1,0 +1,9 @@
+# Example named colormap as a colormaps_dir file. `name` defaults to the
+# file stem ("pressure_wide").
+title = "MSLP wide range"
+color_stops = [
+  { value = 930.0,  color = "#3B0F70" },
+  { value = 980.0,  color = "#3060D0" },
+  { value = 1013.0, color = "#DCDCD2" },
+  { value = 1050.0, color = "#B01E1E" },
+]

--- a/colormaps.d/radar_nssl2.cpt
+++ b/colormaps.d/radar_nssl2.cpt
@@ -1,0 +1,9 @@
+# NSSL-inspired reflectivity ramp (example palette for colormaps_dir).
+# Format: GMT color palette table — z0 R G B z1 R G B per segment.
+5   65  65  65   15  100 100 100
+15  65  182 255  25  30  110 235
+25  60  200 60   35  255 230 0
+35  255 160 0    45  235 50  20
+45  200 0   90   55  145 20  145
+55  235 120 235  70  255 255 255
+N 0 0 0

--- a/config.toml
+++ b/config.toml
@@ -2,6 +2,9 @@
 host = "127.0.0.1"
 port = 8000
 collections_dir = "collections.d"
+# Named colormaps loaded from palette files (.toml / .cpt / .txt / .clr /
+# .sld), one per file, name = file stem. See colormaps.d/ for examples.
+colormaps_dir = "colormaps.d"
 # Derive each request's absolute link base from reverse-proxy headers
 # (Forwarded / X-Forwarded-*). Default false; enable only behind a trusted proxy.
 # trust_proxy_headers = true

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -8,6 +8,12 @@ pub struct ServerConfig {
     /// Shared style bundles referenced by collections via `[wms] style_bundle`.
     #[serde(default)]
     pub style_bundles: Vec<StyleBundle>,
+    /// Named, reusable colormaps (`[[colormaps]]`). Registered alongside the
+    /// built-ins; referencable anywhere a built-in colormap name is accepted
+    /// (`[wms] colormap`, styles, parameters, bundle defaults/extras). Only
+    /// allowed in the top-level config.toml, like `[[style_bundles]]`.
+    #[serde(default)]
+    pub colormaps: Vec<ColormapDef>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -25,6 +31,13 @@ pub struct ServerSettings {
     /// Resolved relative to the parent directory of the main config file.
     /// Each file defines one collection using `CollectionConfig` fields directly.
     pub collections_dir: Option<String>,
+    /// Directory of palette files loaded as named colormaps (one palette per
+    /// file, name = file stem). Supported: `.toml` (`ColormapDef` fields),
+    /// GMT `.cpt`, GDAL color-relief `.txt`/`.clr`, SLD `.sld` (ColorMap).
+    /// Resolved relative to the parent directory of the main config file,
+    /// like `collections_dir`. Re-read on reload.
+    #[serde(default)]
+    pub colormaps_dir: Option<String>,
     /// Size in MB of the global Web Mercator meta-tile (decoded-RGBA) cache
     /// (#202). A single server-wide cache, not per-collection. Currently
     /// consumed only by the WMS GetMap path; api-maps/api-tiles still render
@@ -85,6 +98,7 @@ impl ServerConfig {
                 base_url: None,
                 admin_token: None,
                 collections_dir: None,
+                colormaps_dir: None,
                 metatile_cache_mb: default_metatile_cache_mb(),
                 watch_collections_dir: false,
                 watch_debounce_ms: default_watch_debounce_ms(),
@@ -92,6 +106,7 @@ impl ServerConfig {
             },
             collections: Vec::new(),
             style_bundles: Vec::new(),
+            colormaps: Vec::new(),
         }
     }
 }
@@ -453,6 +468,90 @@ pub struct StyleBundleExtra {
     pub min: Option<f64>,
     pub max: Option<f64>,
     pub parameter: Option<String>,
+}
+
+/// A named, reusable colormap (`[[colormaps]]` in the top-level config, or
+/// one `.toml` file in `colormaps_dir`). Registered next to the built-in
+/// palettes; the name is then valid anywhere a built-in name is accepted.
+/// A user colormap may shadow a built-in name (replacing it deployment-wide,
+/// logged as a warning); duplicate user names are a config error.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ColormapDef {
+    /// Registry name referenced by `colormap = "<name>"`. In a
+    /// `colormaps_dir` file this may be omitted — it defaults to the file
+    /// stem (a mismatch logs a warning, mirroring per-collection files).
+    #[serde(default)]
+    pub name: Option<String>,
+    /// Human-readable title (legends/UI).
+    pub title: Option<String>,
+    /// `"linear"` (default) — gradient between stops — or `"step"` —
+    /// discrete classes, each value taking the highest stop at or below it.
+    #[serde(default)]
+    pub interpolation: Option<String>,
+    /// The palette stops (`#RRGGBB` / `#RRGGBBAA`), at least one required.
+    #[serde(default)]
+    pub color_stops: Vec<ColorStop>,
+    /// Optional color for nodata pixels (default fully transparent).
+    pub nodata_color: Option<String>,
+}
+
+impl ColormapDef {
+    /// Validate one definition. `owner` names the source (config.toml index
+    /// or a colormaps_dir filename) in error messages; `name` is the
+    /// resolved registry name.
+    pub fn validate(&self, owner: &str, name: &str) -> Result<(), crate::error::DataServerError> {
+        if name.is_empty() {
+            return Err(crate::error::DataServerError::Config(format!(
+                "{owner}: colormap has an empty name"
+            )));
+        }
+        match self.interpolation.as_deref() {
+            None | Some("linear") | Some("step") => {}
+            Some(other) => {
+                return Err(crate::error::DataServerError::Config(format!(
+                    "{owner}: colormap '{name}': interpolation must be \
+                     \"linear\" or \"step\", got \"{other}\""
+                )));
+            }
+        }
+        if self.color_stops.is_empty() {
+            return Err(crate::error::DataServerError::Config(format!(
+                "{owner}: colormap '{name}' has no color_stops"
+            )));
+        }
+        for stop in &self.color_stops {
+            if !stop.value.is_finite() {
+                return Err(crate::error::DataServerError::Config(format!(
+                    "{owner}: colormap '{name}': non-finite stop value"
+                )));
+            }
+            validate_hex_color(&stop.color).map_err(|e| {
+                crate::error::DataServerError::Config(format!("{owner}: colormap '{name}': {e}"))
+            })?;
+        }
+        if let Some(nd) = &self.nodata_color {
+            validate_hex_color(nd).map_err(|e| {
+                crate::error::DataServerError::Config(format!(
+                    "{owner}: colormap '{name}': nodata_color: {e}"
+                ))
+            })?;
+        }
+        Ok(())
+    }
+}
+
+/// Minimal `#RRGGBB` / `#RRGGBBAA` shape check. The authoritative parser
+/// lives in ds-render (which depends on this crate, so it can't be called
+/// from here); this catches typos at config load with a clear message.
+fn validate_hex_color(s: &str) -> Result<(), String> {
+    let digits = s.strip_prefix('#').unwrap_or(s);
+    if (digits.len() == 6 || digits.len() == 8) && digits.chars().all(|c| c.is_ascii_hexdigit()) {
+        Ok(())
+    } else {
+        Err(format!(
+            "invalid hex color '{s}' (expected #RRGGBB or #RRGGBBAA)"
+        ))
+    }
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -1915,13 +2014,19 @@ impl ServerConfig {
             let raw: toml::Table = toml::from_str(&content).map_err(|e| {
                 crate::error::DataServerError::Config(format!("Failed to parse {filename}: {e}"))
             })?;
-            // style_bundles must live in config.toml; serde silently drops
-            // them on CollectionConfig, which makes the later "not defined"
-            // error confusing.
+            // style_bundles and colormaps must live in config.toml; serde
+            // silently drops them on CollectionConfig, which makes the later
+            // "not defined" / "unknown colormap" error confusing.
             if raw.contains_key("style_bundles") {
                 return Err(crate::error::DataServerError::Config(format!(
                     "{filename}: [[style_bundles]] is not allowed in per-collection files — \
                      move the block to the top-level config.toml"
+                )));
+            }
+            if raw.contains_key("colormaps") {
+                return Err(crate::error::DataServerError::Config(format!(
+                    "{filename}: [[colormaps]] is not allowed in per-collection files — \
+                     move the block to the top-level config.toml (or a colormaps_dir file)"
                 )));
             }
             let collection: CollectionConfig = raw.try_into().map_err(|e| {
@@ -1945,6 +2050,27 @@ impl ServerConfig {
 
     /// Validate configuration for common errors before starting the server.
     pub fn validate(&self) -> Result<(), crate::error::DataServerError> {
+        // Validate [[colormaps]]: each definition well-formed, names present
+        // and unique. (Whether a name shadows a built-in is decided by the
+        // server layer, which owns the palette registry.)
+        let mut colormap_names: std::collections::HashSet<&str> = std::collections::HashSet::new();
+        for (i, def) in self.colormaps.iter().enumerate() {
+            let owner = format!("[[colormaps]] entry {}", i + 1);
+            let name = def.name.as_deref().unwrap_or("");
+            if def.name.is_none() {
+                return Err(crate::error::DataServerError::Config(format!(
+                    "{owner}: 'name' is required in config.toml colormaps \
+                     (it is only optional in colormaps_dir files)"
+                )));
+            }
+            def.validate(&owner, name)?;
+            if !colormap_names.insert(name) {
+                return Err(crate::error::DataServerError::Config(format!(
+                    "Duplicate colormap name '{name}' in [[colormaps]]"
+                )));
+            }
+        }
+
         // Check for duplicate style_bundle IDs + validate each bundle's extras.
         let mut bundle_ids: std::collections::HashSet<&str> = std::collections::HashSet::new();
         for bundle in &self.style_bundles {

--- a/crates/render/src/lib.rs
+++ b/crates/render/src/lib.rs
@@ -5,6 +5,7 @@ mod encode;
 pub(crate) mod font;
 pub mod metatile;
 pub mod palette;
+pub mod palette_formats;
 pub mod plot;
 pub mod rasterize;
 pub mod style;
@@ -19,6 +20,7 @@ pub use palette::{
     builtin_palette, builtin_palette_arc, builtin_palettes, Interpolation, Palette, PaletteInsert,
     PaletteRegistry,
 };
+pub use palette_formats::{parse_cpt, parse_gdal_txt};
 pub use plot::{render_chart, render_heatmap, Heatmap, Panel, Series};
 pub use rasterize::{fill_polygon, Combine};
 pub use style::{ResolvedColormap, StyleContext, StyleSpec};

--- a/crates/render/src/palette_formats.rs
+++ b/crates/render/src/palette_formats.rs
@@ -1,0 +1,849 @@
+//! Parsers for external palette file formats — GMT color palette tables
+//! (`.cpt`) and GDAL color-relief / `.clr` text files.
+//!
+//! Both convert into the crate's [`Palette`] model, so a user-supplied file
+//! is indistinguishable from a built-in palette once loaded into a
+//! [`crate::PaletteRegistry`]. Hand-rolled (no serde, no regex) to keep
+//! `ds-render` framework-free.
+//!
+//! What is deliberately NOT supported, since neither affects the rendered
+//! result we can represent: GMT per-color transparency (`r/g/b@50`), CMYK
+//! color models, and GDAL percentage entries (which need the raster's value
+//! range, unavailable at parse time — they produce an explicit error).
+
+use crate::colormap::{parse_hex_color, ColorStop};
+use crate::palette::{Interpolation, Palette};
+
+// ---------------------------------------------------------------------------
+// GMT color palette tables (.cpt)
+// ---------------------------------------------------------------------------
+
+/// Color model a `.cpt` file's triplets are expressed in, taken from its
+/// `# COLOR_MODEL = ...` header comment (default RGB).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ColorModel {
+    Rgb,
+    Hsv,
+}
+
+/// One `z0 color0 z1 color1` row of a `.cpt`.
+struct Segment {
+    z0: f64,
+    c0: [u8; 4],
+    z1: f64,
+    c1: [u8; 4],
+}
+
+/// Parse a GMT color palette table into a [`Palette`] named `name`.
+///
+/// Segment lines are `z0 color0 z1 color1`, where each color is an `R G B`
+/// triplet (whitespace- or slash-separated), a `#RRGGBB` / `#RRGGBBAA` hex
+/// literal, or a single 0–255 gray value. Under `# COLOR_MODEL = HSV` (or
+/// `+HSV`) triplets are read as hue/saturation/value and converted.
+///
+/// Boundaries shared by adjacent segments collapse into one stop; a genuine
+/// discontinuity (same `z`, different color) is kept as two stops at that
+/// value, which [`crate::LinearColorMap`] renders as a hard edge. A file
+/// whose every segment is a single flat color (`color0 == color1`) is a
+/// class table and yields [`Interpolation::Step`].
+///
+/// `B` (background) and `F` (foreground) lines are ignored; `N` sets
+/// [`Palette::nodata_color`]. Trailing `;label` annotations and GMT's
+/// `L`/`U`/`B` annotation flags are tolerated.
+pub fn parse_cpt(name: &str, text: &str) -> Result<Palette, String> {
+    // Pre-pass: the color model governs how every segment is read, so pick
+    // it up before parsing any of them regardless of where it appears.
+    let model = detect_color_model(text);
+
+    let mut segments: Vec<Segment> = Vec::new();
+    let mut nodata_color: Option<[u8; 4]> = None;
+
+    for (idx, raw) in text.lines().enumerate() {
+        let lineno = idx + 1;
+        let trimmed = raw.trim();
+        // A '#' only opens a comment at the start of a line — mid-line it
+        // introduces a hex color.
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+        // GMT allows a trailing ';Label' annotation on any row.
+        let line = trimmed.split(';').next().unwrap_or("").trim();
+        if line.is_empty() {
+            continue;
+        }
+        let mut tokens: Vec<&str> = line.split_whitespace().collect();
+
+        // B/F/N rows: background, foreground, nodata.
+        if let Some(&first) = tokens.first() {
+            if first.len() == 1 {
+                match first.to_ascii_uppercase().as_str() {
+                    "B" | "F" => continue,
+                    "N" => {
+                        nodata_color = Some(parse_cpt_color(&tokens[1..], model, lineno, trimmed)?);
+                        continue;
+                    }
+                    _ => {}
+                }
+            }
+        }
+
+        // An annotation flag (L/U/B) may trail the second color; drop it
+        // before the token count decides the layout. Guarded on length so a
+        // 4-token row's color can never be mistaken for a flag.
+        if tokens.len() >= 5
+            && tokens
+                .last()
+                .is_some_and(|t| matches!(t.to_ascii_uppercase().as_str(), "L" | "U" | "B"))
+        {
+            tokens.pop();
+        }
+
+        // Colors are 1 or 3 tokens each, so the row is 4, 6 or 8 tokens. At
+        // 6 the split is ambiguous by count alone — the shape of the first
+        // color token resolves it.
+        let (c0_len, c1_len) = match tokens.len() {
+            4 => (1usize, 1usize),
+            8 => (3, 3),
+            6 => {
+                if is_compound_color(tokens[1]) {
+                    (1, 3)
+                } else {
+                    (3, 1)
+                }
+            }
+            n => {
+                return Err(cpt_err(
+                    lineno,
+                    trimmed,
+                    &format!("expected 'z0 color0 z1 color1' (4, 6 or 8 tokens), found {n}"),
+                ))
+            }
+        };
+
+        let z0 = parse_cpt_z(tokens[0], lineno, trimmed)?;
+        let c0 = parse_cpt_color(&tokens[1..1 + c0_len], model, lineno, trimmed)?;
+        let z1 = parse_cpt_z(tokens[1 + c0_len], lineno, trimmed)?;
+        let c1 = parse_cpt_color(
+            &tokens[2 + c0_len..2 + c0_len + c1_len],
+            model,
+            lineno,
+            trimmed,
+        )?;
+        segments.push(Segment { z0, c0, z1, c1 });
+    }
+
+    if segments.is_empty() {
+        return Err("no color segments found in .cpt".to_string());
+    }
+
+    // Sort by lower bound first so boundary de-duplication only ever fires
+    // between genuinely adjacent segments, and a descending-order file
+    // produces the same stop sequence as its ascending twin.
+    segments.sort_by(|a, b| a.z0.total_cmp(&b.z0));
+
+    // A table whose every segment is one flat color is a class table, not a
+    // ramp: one stop per lower bound, closed by the final upper bound.
+    let discrete = segments.iter().all(|s| s.c0 == s.c1);
+    let stops = if discrete {
+        let mut stops: Vec<ColorStop> = segments
+            .iter()
+            .map(|s| ColorStop {
+                value: s.z0,
+                color: s.c0,
+            })
+            .collect();
+        let last = &segments[segments.len() - 1];
+        stops.push(ColorStop {
+            value: last.z1,
+            color: last.c1,
+        });
+        stops
+    } else {
+        let mut stops: Vec<ColorStop> = Vec::with_capacity(segments.len() * 2);
+        for seg in &segments {
+            let lower = ColorStop {
+                value: seg.z0,
+                color: seg.c0,
+            };
+            // Skip the lower stop only when the previous segment already
+            // ended exactly there with the same color; an equal value with a
+            // different color is a discontinuity and both stops are kept.
+            if stops.last() != Some(&lower) {
+                stops.push(lower);
+            }
+            stops.push(ColorStop {
+                value: seg.z1,
+                color: seg.c1,
+            });
+        }
+        stops
+    };
+
+    let mut palette = Palette::new(
+        name,
+        stops,
+        if discrete {
+            Interpolation::Step
+        } else {
+            Interpolation::Linear
+        },
+    );
+    palette.nodata_color = nodata_color;
+    Ok(palette)
+}
+
+/// Scan header comments for `COLOR_MODEL = HSV` / `+HSV`. Anything else
+/// (including an absent directive) is RGB.
+fn detect_color_model(text: &str) -> ColorModel {
+    for line in text.lines() {
+        let trimmed = line.trim();
+        let Some(comment) = trimmed.strip_prefix('#') else {
+            continue;
+        };
+        let upper = comment.to_ascii_uppercase();
+        if !upper.contains("COLOR_MODEL") {
+            continue;
+        }
+        let Some((_, value)) = upper.split_once('=') else {
+            continue;
+        };
+        // GMT 5 writes '+HSV' to request hue-wise interpolation; the '+' does
+        // not change how the components are read.
+        if value.trim().trim_start_matches('+') == "HSV" {
+            return ColorModel::Hsv;
+        }
+    }
+    ColorModel::Rgb
+}
+
+/// Whether a token carries a whole color on its own (hex, or a `/`- or
+/// `-`-separated triplet) rather than being one component of three. A
+/// leading `-` is a negative number, not a separator.
+fn is_compound_color(token: &str) -> bool {
+    token.starts_with('#')
+        || token.contains('/')
+        || (token.contains('-') && !token.starts_with('-'))
+}
+
+fn cpt_err(lineno: usize, line: &str, msg: &str) -> String {
+    format!("line {lineno}: {msg}: '{line}'")
+}
+
+fn parse_cpt_z(token: &str, lineno: usize, line: &str) -> Result<f64, String> {
+    token
+        .parse::<f64>()
+        .map_err(|_| cpt_err(lineno, line, &format!("invalid z value '{token}'")))
+}
+
+/// Parse a `.cpt` color from either 1 token (hex, packed triplet, or gray)
+/// or 3 tokens (one component each), in the file's color model.
+fn parse_cpt_color(
+    tokens: &[&str],
+    model: ColorModel,
+    lineno: usize,
+    line: &str,
+) -> Result<[u8; 4], String> {
+    match tokens {
+        [single] => {
+            if single.starts_with('#') {
+                return parse_hex_color(single)
+                    .map_err(|e| cpt_err(lineno, line, &format!("invalid color '{single}': {e}")));
+            }
+            let sep = if single.contains('/') {
+                Some('/')
+            } else if is_compound_color(single) {
+                Some('-')
+            } else {
+                None
+            };
+            if let Some(sep) = sep {
+                let parts: Vec<&str> = single.split(sep).collect();
+                if parts.len() != 3 {
+                    return Err(cpt_err(
+                        lineno,
+                        line,
+                        &format!("expected 3 color components in '{single}'"),
+                    ));
+                }
+                return triplet(&parts, model, lineno, line);
+            }
+            // A lone number is a gray level, in either color model.
+            let g = component(single, 0.0, 255.0, lineno, line)?;
+            let g = g.round() as u8;
+            Ok([g, g, g, 255])
+        }
+        [_, _, _] => triplet(tokens, model, lineno, line),
+        other => Err(cpt_err(
+            lineno,
+            line,
+            &format!("expected 1 or 3 color tokens, found {}", other.len()),
+        )),
+    }
+}
+
+/// Convert three component tokens to RGBA under the given color model.
+fn triplet(
+    parts: &[&str],
+    model: ColorModel,
+    lineno: usize,
+    line: &str,
+) -> Result<[u8; 4], String> {
+    match model {
+        ColorModel::Rgb => {
+            let r = component(parts[0], 0.0, 255.0, lineno, line)?;
+            let g = component(parts[1], 0.0, 255.0, lineno, line)?;
+            let b = component(parts[2], 0.0, 255.0, lineno, line)?;
+            Ok([r.round() as u8, g.round() as u8, b.round() as u8, 255])
+        }
+        ColorModel::Hsv => {
+            let h = component(parts[0], 0.0, 360.0, lineno, line)?;
+            let s = component(parts[1], 0.0, 1.0, lineno, line)?;
+            let v = component(parts[2], 0.0, 1.0, lineno, line)?;
+            let [r, g, b] = hsv_to_rgb(h, s, v);
+            Ok([r, g, b, 255])
+        }
+    }
+}
+
+/// Parse one color component and range-check it.
+fn component(token: &str, min: f64, max: f64, lineno: usize, line: &str) -> Result<f64, String> {
+    let v: f64 = token
+        .parse()
+        .map_err(|_| cpt_err(lineno, line, &format!("invalid color component '{token}'")))?;
+    if !(min..=max).contains(&v) {
+        return Err(cpt_err(
+            lineno,
+            line,
+            &format!("color component '{token}' out of range {min}..{max}"),
+        ));
+    }
+    Ok(v)
+}
+
+/// HSV → RGB (hue in degrees, saturation and value in 0..1).
+fn hsv_to_rgb(h: f64, s: f64, v: f64) -> [u8; 3] {
+    let c = v * s;
+    // 360° wraps back to 0 so the sector index below stays in 0..=5.
+    let hp = h.rem_euclid(360.0) / 60.0;
+    let x = c * (1.0 - (hp % 2.0 - 1.0).abs());
+    let (r, g, b) = match hp as u32 {
+        0 => (c, x, 0.0),
+        1 => (x, c, 0.0),
+        2 => (0.0, c, x),
+        3 => (0.0, x, c),
+        4 => (x, 0.0, c),
+        _ => (c, 0.0, x),
+    };
+    let m = v - c;
+    let to_u8 = |ch: f64| ((ch + m) * 255.0).round().clamp(0.0, 255.0) as u8;
+    [to_u8(r), to_u8(g), to_u8(b)]
+}
+
+// ---------------------------------------------------------------------------
+// GDAL color-relief / .clr text files
+// ---------------------------------------------------------------------------
+
+/// Parse a GDAL color-relief text file (as accepted by `gdaldem
+/// color-relief`, also the `.clr` form) into a [`Palette`] named `name`.
+///
+/// Each line is `value R G B [A]` (alpha defaults to opaque), where the
+/// fields may be separated by whitespace, commas or colons. The color may
+/// instead be one of GDAL's named colors (white, black, red, green, blue,
+/// yellow, magenta, cyan, gray/grey). An `nv` line sets
+/// [`Palette::nodata_color`]. `#` comments and blank lines are ignored.
+///
+/// Percentage entries (`50%`) are rejected: resolving them needs the
+/// raster's value range, which a palette file has no access to.
+pub fn parse_gdal_txt(name: &str, text: &str) -> Result<Palette, String> {
+    let mut stops: Vec<ColorStop> = Vec::new();
+    let mut nodata_color: Option<[u8; 4]> = None;
+
+    for (idx, raw) in text.lines().enumerate() {
+        let lineno = idx + 1;
+        let trimmed = raw.trim();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+        let tokens: Vec<&str> = trimmed
+            .split(|c: char| c.is_whitespace() || c == ',' || c == ':')
+            .filter(|t| !t.is_empty())
+            .collect();
+        // A line of nothing but separators carries no fields at all.
+        let Some(&head) = tokens.first() else {
+            return Err(cpt_err(lineno, trimmed, "expected 'value R G B [A]'"));
+        };
+
+        if head.ends_with('%') {
+            return Err(cpt_err(
+                lineno,
+                trimmed,
+                &format!("percentage entry '{head}' is not supported; only absolute values are"),
+            ));
+        }
+
+        let color = parse_gdal_color(&tokens[1..], lineno, trimmed)?;
+        if head.eq_ignore_ascii_case("nv") {
+            nodata_color = Some(color);
+            continue;
+        }
+        let value = tokens[0]
+            .parse::<f64>()
+            .map_err(|_| cpt_err(lineno, trimmed, &format!("invalid value '{head}'")))?;
+        stops.push(ColorStop { value, color });
+    }
+
+    if stops.is_empty() {
+        return Err("no color entries found in GDAL color file".to_string());
+    }
+
+    // GDAL color-relief interpolates between entries by default.
+    let mut palette = Palette::new(name, stops, Interpolation::Linear);
+    palette.nodata_color = nodata_color;
+    Ok(palette)
+}
+
+/// GDAL's named color set, lower-cased.
+fn named_color(name: &str) -> Option<[u8; 4]> {
+    let rgb = match name.to_ascii_lowercase().as_str() {
+        "white" => [255, 255, 255],
+        "black" => [0, 0, 0],
+        "red" => [255, 0, 0],
+        "green" => [0, 255, 0],
+        "blue" => [0, 0, 255],
+        "yellow" => [255, 255, 0],
+        "magenta" => [255, 0, 255],
+        "cyan" => [0, 255, 255],
+        "gray" | "grey" => [128, 128, 128],
+        _ => return None,
+    };
+    Some([rgb[0], rgb[1], rgb[2], 255])
+}
+
+/// Parse the color field of a GDAL line: `R G B [A]`, or a named color with
+/// an optional alpha.
+fn parse_gdal_color(tokens: &[&str], lineno: usize, line: &str) -> Result<[u8; 4], String> {
+    let numeric = |t: &str| t.parse::<f64>().is_ok();
+    match tokens {
+        [name] | [name, _] if !numeric(name) => {
+            let mut color = named_color(name)
+                .ok_or_else(|| cpt_err(lineno, line, &format!("unknown color name '{name}'")))?;
+            if let [_, alpha] = tokens {
+                color[3] = component(alpha, 0.0, 255.0, lineno, line)?.round() as u8;
+            }
+            Ok(color)
+        }
+        [r, g, b] | [r, g, b, _] => {
+            let a = match tokens {
+                [_, _, _, alpha] => component(alpha, 0.0, 255.0, lineno, line)?.round() as u8,
+                _ => 255,
+            };
+            Ok([
+                component(r, 0.0, 255.0, lineno, line)?.round() as u8,
+                component(g, 0.0, 255.0, lineno, line)?.round() as u8,
+                component(b, 0.0, 255.0, lineno, line)?.round() as u8,
+                a,
+            ])
+        }
+        other => Err(cpt_err(
+            lineno,
+            line,
+            &format!(
+                "expected 'value R G B [A]' or 'value <color-name>', found {} color token(s)",
+                other.len()
+            ),
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `(value, color)` view of a palette's stops, for compact assertions.
+    fn stops_of(p: &Palette) -> Vec<(f64, [u8; 4])> {
+        p.stops.iter().map(|s| (s.value, s.color)).collect()
+    }
+
+    // -- .cpt ---------------------------------------------------------------
+
+    #[test]
+    fn cpt_continuous_ramp_dedupes_shared_boundary() {
+        let text = "\
+# a two-segment ramp
+0   0 0 255   10   0 255 0
+10  0 255 0   20   255 0 0
+";
+        let p = parse_cpt("ramp", text).unwrap();
+        assert_eq!(p.name, "ramp");
+        assert_eq!(p.title, None);
+        assert_eq!(p.interpolation, Interpolation::Linear);
+        assert_eq!(
+            stops_of(&p),
+            vec![
+                (0.0, [0, 0, 255, 255]),
+                (10.0, [0, 255, 0, 255]),
+                (20.0, [255, 0, 0, 255]),
+            ],
+            "the shared 10 boundary must collapse to one stop"
+        );
+        assert_eq!(p.default_range(), Some((0.0, 20.0)));
+        assert_eq!(p.nodata_color, None);
+    }
+
+    #[test]
+    fn cpt_discontinuity_keeps_both_stops() {
+        // Segment 1 ramps up to cyan at 10, segment 2 restarts at red — a
+        // hard edge, kept as two stops at the same value so the zero-width
+        // bracket renders as a jump rather than a blend.
+        let text = "\
+0   0 0 255    10  0 255 255
+10  255 0 0    20  255 255 0
+";
+        let p = parse_cpt("edge", text).unwrap();
+        assert_eq!(p.interpolation, Interpolation::Linear);
+        assert_eq!(
+            stops_of(&p),
+            vec![
+                (0.0, [0, 0, 255, 255]),
+                (10.0, [0, 255, 255, 255]),
+                (10.0, [255, 0, 0, 255]),
+                (20.0, [255, 255, 0, 255]),
+            ],
+            "both sides of the discontinuity must be present, lower side first"
+        );
+    }
+
+    #[test]
+    fn cpt_discrete_classes_become_step_interpolation() {
+        let text = "\
+0   128 128 128   10  128 128 128
+10  0 255 0       20  0 255 0
+20  255 0 0       30  255 0 0
+";
+        let p = parse_cpt("classes", text).unwrap();
+        assert_eq!(p.interpolation, Interpolation::Step);
+        assert_eq!(
+            stops_of(&p),
+            vec![
+                (0.0, [128, 128, 128, 255]),
+                (10.0, [0, 255, 0, 255]),
+                (20.0, [255, 0, 0, 255]),
+                (30.0, [255, 0, 0, 255]),
+            ],
+            "one stop per class lower bound, closed by the last upper bound"
+        );
+        // Step semantics: a value inside a class takes that class's color.
+        assert_eq!(p.sample(5.0), [128, 128, 128, 255]);
+        assert_eq!(p.sample(15.0), [0, 255, 0, 255]);
+        assert_eq!(p.sample(25.0), [255, 0, 0, 255]);
+    }
+
+    #[test]
+    fn cpt_hsv_color_model_converts_to_rgb() {
+        let text = "\
+# COLOR_MODEL = HSV
+0   0 1 1     10   120 1 1
+10  120 1 1   20   240 1 1
+";
+        let p = parse_cpt("hsv", text).unwrap();
+        assert_eq!(
+            stops_of(&p),
+            vec![
+                (0.0, [255, 0, 0, 255]),  // h=0   → red
+                (10.0, [0, 255, 0, 255]), // h=120 → green
+                (20.0, [0, 0, 255, 255]), // h=240 → blue
+            ]
+        );
+    }
+
+    #[test]
+    fn cpt_hsv_accepts_plus_prefix_and_packed_triplets() {
+        // GMT 5 writes '+HSV'; the packed 'h-s-v' single-token form is also
+        // valid there.
+        let text = "\
+# COLOR_MODEL = +HSV
+0  60-1-1  10  180-0.5-1
+";
+        let p = parse_cpt("hsv2", text).unwrap();
+        assert_eq!(
+            stops_of(&p),
+            vec![
+                (0.0, [255, 255, 0, 255]),    // h=60  s=1   → yellow
+                (10.0, [128, 255, 255, 255]), // h=180 s=0.5 → pale cyan
+            ]
+        );
+    }
+
+    #[test]
+    fn cpt_slash_separated_and_hex_and_gray_colors() {
+        let slash = parse_cpt("slash", "0 255/0/0 10 0/0/255\n").unwrap();
+        assert_eq!(
+            stops_of(&slash),
+            vec![(0.0, [255, 0, 0, 255]), (10.0, [0, 0, 255, 255])]
+        );
+
+        let hex = parse_cpt("hex", "0 #ff0000 10 #0000ff80\n").unwrap();
+        assert_eq!(
+            stops_of(&hex),
+            vec![(0.0, [255, 0, 0, 255]), (10.0, [0, 0, 255, 128])]
+        );
+
+        let gray = parse_cpt("gray", "0 0 10 255\n").unwrap();
+        assert_eq!(
+            stops_of(&gray),
+            vec![(0.0, [0, 0, 0, 255]), (10.0, [255, 255, 255, 255])]
+        );
+
+        // Mixed widths on one row (6 tokens) resolve by the shape of the
+        // first color token, in both orders.
+        let mixed = parse_cpt("mixed", "0 255/0/0 10 0 0 255\n").unwrap();
+        assert_eq!(
+            stops_of(&mixed),
+            vec![(0.0, [255, 0, 0, 255]), (10.0, [0, 0, 255, 255])]
+        );
+        let mixed = parse_cpt("mixed", "0 255 0 0 10 0/0/255\n").unwrap();
+        assert_eq!(
+            stops_of(&mixed),
+            vec![(0.0, [255, 0, 0, 255]), (10.0, [0, 0, 255, 255])]
+        );
+    }
+
+    #[test]
+    fn cpt_nodata_line_sets_nodata_color_and_bf_are_ignored() {
+        let text = "\
+0 0 0 255 10 255 0 0
+B 0 0 0
+F 255 255 255
+N 128 128 128
+";
+        let p = parse_cpt("nd", text).unwrap();
+        assert_eq!(p.nodata_color, Some([128, 128, 128, 255]));
+        assert_eq!(p.stops.len(), 2, "B/F rows must not become stops");
+
+        // Hex form of N is accepted too.
+        let p = parse_cpt("nd", "0 0 0 255 10 255 0 0\nN #7f7f7f\n").unwrap();
+        assert_eq!(p.nodata_color, Some([127, 127, 127, 255]));
+    }
+
+    #[test]
+    fn cpt_tolerates_labels_and_annotation_flags() {
+        let text = "\
+0   0 0 255   10  0 255 0  ; low
+10  0 255 0   20  255 0 0  L
+";
+        let p = parse_cpt("annot", text).unwrap();
+        assert_eq!(
+            stops_of(&p),
+            vec![
+                (0.0, [0, 0, 255, 255]),
+                (10.0, [0, 255, 0, 255]),
+                (20.0, [255, 0, 0, 255]),
+            ]
+        );
+    }
+
+    #[test]
+    fn cpt_descending_file_yields_ascending_stops() {
+        let text = "\
+20  255 0 0   30  255 255 255
+10  0 255 0   20  255 0 0
+0   0 0 255   10  0 255 0
+";
+        let p = parse_cpt("desc", text).unwrap();
+        assert_eq!(
+            stops_of(&p),
+            vec![
+                (0.0, [0, 0, 255, 255]),
+                (10.0, [0, 255, 0, 255]),
+                (20.0, [255, 0, 0, 255]),
+                (30.0, [255, 255, 255, 255]),
+            ],
+            "stops sort ascending and boundaries still de-duplicate"
+        );
+        assert!(p.stops.windows(2).all(|w| w[0].value <= w[1].value));
+    }
+
+    #[test]
+    fn cpt_malformed_lines_report_line_number_and_content() {
+        // Wrong token count.
+        let err = parse_cpt("bad", "0 0 0 255 10 255 0 0\n0 255 10\n").unwrap_err();
+        assert!(err.starts_with("line 2:"), "got: {err}");
+        assert!(err.contains("0 255 10"), "got: {err}");
+
+        // Unparsable z.
+        let err = parse_cpt("bad", "# header\nxx 0 0 255 10 255 0 0\n").unwrap_err();
+        assert!(err.starts_with("line 2:"), "got: {err}");
+        assert!(err.contains("invalid z value 'xx'"), "got: {err}");
+
+        // Unparsable color component.
+        let err = parse_cpt("bad", "0 0 0 blue 10 255 0 0\n").unwrap_err();
+        assert!(err.starts_with("line 1:"), "got: {err}");
+        assert!(err.contains("'blue'"), "got: {err}");
+
+        // Out-of-range component.
+        let err = parse_cpt("bad", "0 0 0 300 10 255 0 0\n").unwrap_err();
+        assert!(err.contains("out of range"), "got: {err}");
+
+        // Out-of-range HSV hue.
+        let err = parse_cpt("bad", "# COLOR_MODEL = HSV\n0 400 1 1 10 0 1 1\n").unwrap_err();
+        assert!(
+            err.starts_with("line 2:") && err.contains("out of range"),
+            "got: {err}"
+        );
+
+        // Nothing usable at all.
+        let err = parse_cpt("empty", "# just a comment\n\n").unwrap_err();
+        assert!(err.contains("no color segments"), "got: {err}");
+    }
+
+    #[test]
+    fn hsv_to_rgb_pins_primaries_and_neutrals() {
+        assert_eq!(hsv_to_rgb(0.0, 1.0, 1.0), [255, 0, 0]);
+        assert_eq!(hsv_to_rgb(120.0, 1.0, 1.0), [0, 255, 0]);
+        assert_eq!(hsv_to_rgb(240.0, 1.0, 1.0), [0, 0, 255]);
+        assert_eq!(hsv_to_rgb(360.0, 1.0, 1.0), [255, 0, 0], "360 wraps to 0");
+        assert_eq!(hsv_to_rgb(0.0, 0.0, 1.0), [255, 255, 255], "s=0 → white");
+        assert_eq!(hsv_to_rgb(200.0, 1.0, 0.0), [0, 0, 0], "v=0 → black");
+        assert_eq!(hsv_to_rgb(0.0, 0.0, 0.5), [128, 128, 128]);
+    }
+
+    // -- GDAL color-relief --------------------------------------------------
+
+    #[test]
+    fn gdal_basic_ramp_with_optional_alpha() {
+        let text = "\
+# elevation ramp
+0    0 0 255
+500  0 255 0 128
+1000 255 0 0
+";
+        let p = parse_gdal_txt("relief", text).unwrap();
+        assert_eq!(p.name, "relief");
+        assert_eq!(p.interpolation, Interpolation::Linear);
+        assert_eq!(
+            stops_of(&p),
+            vec![
+                (0.0, [0, 0, 255, 255]),
+                (500.0, [0, 255, 0, 128]),
+                (1000.0, [255, 0, 0, 255]),
+            ]
+        );
+        assert_eq!(p.nodata_color, None);
+        assert_eq!(p.default_range(), Some((0.0, 1000.0)));
+    }
+
+    #[test]
+    fn gdal_nv_line_sets_nodata_color() {
+        let text = "\
+nv 0 0 0 0
+0  0 0 255
+10 255 0 0
+";
+        let p = parse_gdal_txt("nd", text).unwrap();
+        assert_eq!(p.nodata_color, Some([0, 0, 0, 0]));
+        assert_eq!(p.stops.len(), 2, "the nv row must not become a stop");
+
+        // Named color and a 3-component form both work for nv.
+        let p = parse_gdal_txt("nd", "nv black\n0 white\n").unwrap();
+        assert_eq!(p.nodata_color, Some([0, 0, 0, 255]));
+    }
+
+    #[test]
+    fn gdal_named_colors() {
+        let text = "\
+0    black
+100  RED
+200  green
+300  blue
+400  yellow
+500  magenta
+600  cyan
+700  gray
+800  grey
+900  white
+";
+        let p = parse_gdal_txt("named", text).unwrap();
+        assert_eq!(
+            stops_of(&p),
+            vec![
+                (0.0, [0, 0, 0, 255]),
+                (100.0, [255, 0, 0, 255]),
+                (200.0, [0, 255, 0, 255]),
+                (300.0, [0, 0, 255, 255]),
+                (400.0, [255, 255, 0, 255]),
+                (500.0, [255, 0, 255, 255]),
+                (600.0, [0, 255, 255, 255]),
+                (700.0, [128, 128, 128, 255]),
+                (800.0, [128, 128, 128, 255]),
+                (900.0, [255, 255, 255, 255]),
+            ],
+            "names are case-insensitive"
+        );
+    }
+
+    #[test]
+    fn gdal_unknown_named_color_is_an_error() {
+        let err = parse_gdal_txt("bad", "0 white\n100 chartreuse\n").unwrap_err();
+        assert!(err.starts_with("line 2:"), "got: {err}");
+        assert!(err.contains("chartreuse"), "got: {err}");
+    }
+
+    #[test]
+    fn gdal_percentage_entries_are_rejected_with_a_clear_message() {
+        let err = parse_gdal_txt("pct", "0 0 0 255\n50% 255 0 0\n").unwrap_err();
+        assert!(err.starts_with("line 2:"), "got: {err}");
+        assert!(
+            err.contains("absolute values"),
+            "the error must point at the absolute-value requirement: {err}"
+        );
+        assert!(err.contains("50%"), "got: {err}");
+    }
+
+    #[test]
+    fn gdal_accepts_comma_and_colon_separators() {
+        let p = parse_gdal_txt("sep", "0,0,0,255\n10:255:0:0\n").unwrap();
+        assert_eq!(
+            stops_of(&p),
+            vec![(0.0, [0, 0, 255, 255]), (10.0, [255, 0, 0, 255])]
+        );
+    }
+
+    #[test]
+    fn gdal_descending_file_yields_ascending_stops() {
+        let text = "\
+1000 255 0 0
+500  0 255 0
+0    0 0 255
+";
+        let p = parse_gdal_txt("desc", text).unwrap();
+        assert_eq!(
+            stops_of(&p),
+            vec![
+                (0.0, [0, 0, 255, 255]),
+                (500.0, [0, 255, 0, 255]),
+                (1000.0, [255, 0, 0, 255]),
+            ]
+        );
+        assert!(p.stops.windows(2).all(|w| w[0].value <= w[1].value));
+    }
+
+    #[test]
+    fn gdal_malformed_lines_report_line_number_and_content() {
+        // Too few color tokens.
+        let err = parse_gdal_txt("bad", "0 0 0 255\n10 255 0\n").unwrap_err();
+        assert!(err.starts_with("line 2:"), "got: {err}");
+        assert!(err.contains("10 255 0"), "got: {err}");
+
+        // Unparsable value.
+        let err = parse_gdal_txt("bad", "abc 255 0 0\n").unwrap_err();
+        assert!(err.contains("invalid value 'abc'"), "got: {err}");
+
+        // Out-of-range component.
+        let err = parse_gdal_txt("bad", "0 0 0 300\n").unwrap_err();
+        assert!(err.contains("out of range"), "got: {err}");
+
+        // Nothing usable at all.
+        let err = parse_gdal_txt("empty", "# only comments\n\n   \n").unwrap_err();
+        assert!(err.contains("no color entries"), "got: {err}");
+    }
+}

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 icechunk = ["engine-zarr/icechunk"]
 
 [dependencies]
+toml = "0.8"
 ds-core = { path = "../core" }
 engine-csv = { path = "../engine-csv" }
 engine-geojson = { path = "../engine-geojson" }
@@ -36,6 +37,7 @@ http-body = "1"
 notify = "8"
 rust-embed = { version = "8", features = ["include-exclude"] }
 prometheus = "0.13"
+quick-xml = "0.37"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["full"] }

--- a/crates/server/src/admin.rs
+++ b/crates/server/src/admin.rs
@@ -848,6 +848,15 @@ pub struct ServerState {
     /// Bearer token for admin endpoint authentication.
     /// If None, admin endpoints are disabled (return 403).
     pub admin_token: Option<String>,
+    /// Fingerprint of all style-affecting config (colormaps, bundles,
+    /// per-collection [wms] blocks, colormaps_dir file bytes) at the last
+    /// successful load. A reload whose fingerprint differs drops the
+    /// rendered/meta-tile caches instead of reusing them — their keys carry
+    /// no style content, so reusing them would serve the OLD colors for
+    /// every already-cached tile (as verified live: edit palette → reload →
+    /// X-Cache: HIT with stale pixels). A spurious watcher reload leaves
+    /// the fingerprint unchanged and keeps the warm caches (#202).
+    pub style_fingerprint: std::sync::atomic::AtomicU64,
 }
 
 pub type AdminState = Arc<ServerState>;
@@ -889,6 +898,7 @@ pub struct ReusableCaches {
 }
 
 pub fn load_collections(
+    style_ctx: &ds_render::StyleContext,
     collections: &[CollectionConfig],
     style_bundles: &[StyleBundle],
     base_url: &str,
@@ -899,9 +909,9 @@ pub fn load_collections(
     let bundle_index: HashMap<&str, &StyleBundle> =
         style_bundles.iter().map(|b| (b.id.as_str(), b)).collect();
     // The single config→style resolution path (phase 2 of the styling
-    // revamp): every API's style map is resolved through one StyleContext,
-    // computed once per collection and shared via `styles_cache`.
-    let style_ctx = ds_render::StyleContext::with_builtins();
+    // revamp): every API's style map is resolved through the caller's
+    // StyleContext (built-ins + user [[colormaps]]), computed once per
+    // collection and shared via `styles_cache`.
     let mut styles_cache: HashMap<String, HashMap<String, HashMap<String, ds_render::StyleInfo>>> =
         HashMap::new();
     let mut edr_engines: HashMap<String, Arc<dyn ds_core::edr_engine::EdrEngine>> = HashMap::new();
@@ -1194,7 +1204,7 @@ pub fn load_collections(
                     );
                     edr_collections.insert(collection.id.clone(), collection.clone());
                     edr_styles.extend(collection_layer_styles(
-                        &style_ctx,
+                        style_ctx,
                         &mut styles_cache,
                         collection,
                         &[],
@@ -1209,7 +1219,7 @@ pub fn load_collections(
                     map_collections.insert(collection.id.clone(), collection.clone());
 
                     map_styles.extend(collection_layer_styles(
-                        &style_ctx,
+                        style_ctx,
                         &mut styles_cache,
                         collection,
                         &[],
@@ -1226,7 +1236,7 @@ pub fn load_collections(
                     maps_collections.insert(collection.id.clone(), collection.clone());
 
                     maps_styles.extend(collection_layer_styles(
-                        &style_ctx,
+                        style_ctx,
                         &mut styles_cache,
                         collection,
                         &[],
@@ -1243,7 +1253,7 @@ pub fn load_collections(
                     tiles_collections.insert(collection.id.clone(), collection.clone());
 
                     tiles_styles.extend(collection_layer_styles(
-                        &style_ctx,
+                        style_ctx,
                         &mut styles_cache,
                         collection,
                         &[],
@@ -1332,7 +1342,7 @@ pub fn load_collections(
                     );
                     edr_collections.insert(collection.id.clone(), collection.clone());
                     edr_styles.extend(collection_layer_styles(
-                        &style_ctx,
+                        style_ctx,
                         &mut styles_cache,
                         collection,
                         &raster_params,
@@ -1347,7 +1357,7 @@ pub fn load_collections(
                     );
                     map_collections.insert(collection.id.clone(), collection.clone());
                     map_styles.extend(collection_layer_styles(
-                        &style_ctx,
+                        style_ctx,
                         &mut styles_cache,
                         collection,
                         &raster_params,
@@ -1362,7 +1372,7 @@ pub fn load_collections(
                     );
                     maps_collections.insert(collection.id.clone(), collection.clone());
                     maps_styles.extend(collection_layer_styles(
-                        &style_ctx,
+                        style_ctx,
                         &mut styles_cache,
                         collection,
                         &raster_params,
@@ -1377,7 +1387,7 @@ pub fn load_collections(
                     );
                     tiles_collections.insert(collection.id.clone(), collection.clone());
                     tiles_styles.extend(collection_layer_styles(
-                        &style_ctx,
+                        style_ctx,
                         &mut styles_cache,
                         collection,
                         &raster_params,
@@ -1460,7 +1470,7 @@ pub fn load_collections(
                     );
                     edr_collections.insert(collection.id.clone(), collection.clone());
                     edr_styles.extend(collection_layer_styles(
-                        &style_ctx,
+                        style_ctx,
                         &mut styles_cache,
                         collection,
                         &raster_params,
@@ -1475,7 +1485,7 @@ pub fn load_collections(
                     );
                     map_collections.insert(collection.id.clone(), collection.clone());
                     map_styles.extend(collection_layer_styles(
-                        &style_ctx,
+                        style_ctx,
                         &mut styles_cache,
                         collection,
                         &raster_params,
@@ -1490,7 +1500,7 @@ pub fn load_collections(
                     );
                     maps_collections.insert(collection.id.clone(), collection.clone());
                     maps_styles.extend(collection_layer_styles(
-                        &style_ctx,
+                        style_ctx,
                         &mut styles_cache,
                         collection,
                         &raster_params,
@@ -1505,7 +1515,7 @@ pub fn load_collections(
                     );
                     tiles_collections.insert(collection.id.clone(), collection.clone());
                     tiles_styles.extend(collection_layer_styles(
-                        &style_ctx,
+                        style_ctx,
                         &mut styles_cache,
                         collection,
                         &raster_params,
@@ -1590,7 +1600,7 @@ pub fn load_collections(
                     );
                     edr_collections.insert(collection.id.clone(), collection.clone());
                     edr_styles.extend(collection_layer_styles(
-                        &style_ctx,
+                        style_ctx,
                         &mut styles_cache,
                         collection,
                         &raster_params,
@@ -1606,7 +1616,7 @@ pub fn load_collections(
                     );
                     map_collections.insert(collection.id.clone(), collection.clone());
                     map_styles.extend(collection_layer_styles(
-                        &style_ctx,
+                        style_ctx,
                         &mut styles_cache,
                         collection,
                         &raster_params,
@@ -1621,7 +1631,7 @@ pub fn load_collections(
                     );
                     maps_collections.insert(collection.id.clone(), collection.clone());
                     maps_styles.extend(collection_layer_styles(
-                        &style_ctx,
+                        style_ctx,
                         &mut styles_cache,
                         collection,
                         &raster_params,
@@ -1636,7 +1646,7 @@ pub fn load_collections(
                     );
                     tiles_collections.insert(collection.id.clone(), collection.clone());
                     tiles_styles.extend(collection_layer_styles(
-                        &style_ctx,
+                        style_ctx,
                         &mut styles_cache,
                         collection,
                         &raster_params,
@@ -1712,7 +1722,7 @@ pub fn load_collections(
                     );
                     edr_collections.insert(collection.id.clone(), collection.clone());
                     edr_styles.extend(collection_layer_styles(
-                        &style_ctx,
+                        style_ctx,
                         &mut styles_cache,
                         collection,
                         &raster_params,
@@ -1728,7 +1738,7 @@ pub fn load_collections(
                     );
                     map_collections.insert(collection.id.clone(), collection.clone());
                     map_styles.extend(collection_layer_styles(
-                        &style_ctx,
+                        style_ctx,
                         &mut styles_cache,
                         collection,
                         &raster_params,
@@ -1743,7 +1753,7 @@ pub fn load_collections(
                     );
                     maps_collections.insert(collection.id.clone(), collection.clone());
                     maps_styles.extend(collection_layer_styles(
-                        &style_ctx,
+                        style_ctx,
                         &mut styles_cache,
                         collection,
                         &raster_params,
@@ -1758,7 +1768,7 @@ pub fn load_collections(
                     );
                     tiles_collections.insert(collection.id.clone(), collection.clone());
                     tiles_styles.extend(collection_layer_styles(
-                        &style_ctx,
+                        style_ctx,
                         &mut styles_cache,
                         collection,
                         &raster_params,
@@ -1909,7 +1919,7 @@ pub fn load_collections(
                         );
                         edr_collections.insert(site_id.clone(), site_cfg.clone());
                         edr_styles.extend(collection_layer_styles(
-                            &style_ctx,
+                            style_ctx,
                             &mut styles_cache,
                             &site_cfg,
                             &raster_params,
@@ -1924,7 +1934,7 @@ pub fn load_collections(
                         );
                         map_collections.insert(site_id.clone(), site_cfg.clone());
                         map_styles.extend(collection_layer_styles(
-                            &style_ctx,
+                            style_ctx,
                             &mut styles_cache,
                             &site_cfg,
                             &raster_params,
@@ -1938,7 +1948,7 @@ pub fn load_collections(
                         );
                         maps_collections.insert(site_id.clone(), site_cfg.clone());
                         maps_styles.extend(collection_layer_styles(
-                            &style_ctx,
+                            style_ctx,
                             &mut styles_cache,
                             &site_cfg,
                             &raster_params,
@@ -1952,7 +1962,7 @@ pub fn load_collections(
                         );
                         tiles_collections.insert(site_id.clone(), site_cfg.clone());
                         tiles_styles.extend(collection_layer_styles(
-                            &style_ctx,
+                            style_ctx,
                             &mut styles_cache,
                             &site_cfg,
                             &raster_params,
@@ -2096,7 +2106,7 @@ pub fn load_collections(
                     );
                     map_collections.insert(collection.id.clone(), collection.clone());
                     map_styles.extend(collection_layer_styles(
-                        &style_ctx,
+                        style_ctx,
                         &mut styles_cache,
                         collection,
                         &[],
@@ -2111,7 +2121,7 @@ pub fn load_collections(
                     );
                     maps_collections.insert(collection.id.clone(), collection.clone());
                     maps_styles.extend(collection_layer_styles(
-                        &style_ctx,
+                        style_ctx,
                         &mut styles_cache,
                         collection,
                         &[],
@@ -2126,7 +2136,7 @@ pub fn load_collections(
                     );
                     tiles_collections.insert(collection.id.clone(), collection.clone());
                     tiles_styles.extend(collection_layer_styles(
-                        &style_ctx,
+                        style_ctx,
                         &mut styles_cache,
                         collection,
                         &[],
@@ -2286,7 +2296,7 @@ pub fn load_collections(
                     edr_collections.insert(collection.id.clone(), collection.clone());
                     if is_events {
                         edr_styles.extend(collection_layer_styles(
-                            &style_ctx,
+                            style_ctx,
                             &mut styles_cache,
                             collection,
                             &[],
@@ -2308,7 +2318,7 @@ pub fn load_collections(
                     );
                     map_collections.insert(collection.id.clone(), collection.clone());
                     map_styles.extend(collection_layer_styles(
-                        &style_ctx,
+                        style_ctx,
                         &mut styles_cache,
                         collection,
                         &[],
@@ -2323,7 +2333,7 @@ pub fn load_collections(
                     );
                     maps_collections.insert(collection.id.clone(), collection.clone());
                     maps_styles.extend(collection_layer_styles(
-                        &style_ctx,
+                        style_ctx,
                         &mut styles_cache,
                         collection,
                         &[],
@@ -2339,7 +2349,7 @@ pub fn load_collections(
                         );
                         tiles_collections.insert(collection.id.clone(), collection.clone());
                         tiles_styles.extend(collection_layer_styles(
-                            &style_ctx,
+                            style_ctx,
                             &mut styles_cache,
                             collection,
                             &[],
@@ -2470,7 +2480,7 @@ pub fn load_collections(
             );
             map_collections.insert(collection.id.clone(), collection.clone());
             map_styles.extend(collection_layer_styles(
-                &style_ctx,
+                style_ctx,
                 &mut styles_cache,
                 collection,
                 &[],
@@ -2485,7 +2495,7 @@ pub fn load_collections(
             );
             maps_collections.insert(collection.id.clone(), collection.clone());
             maps_styles.extend(collection_layer_styles(
-                &style_ctx,
+                style_ctx,
                 &mut styles_cache,
                 collection,
                 &[],
@@ -2500,7 +2510,7 @@ pub fn load_collections(
             );
             tiles_collections.insert(collection.id.clone(), collection.clone());
             tiles_styles.extend(collection_layer_styles(
-                &style_ctx,
+                style_ctx,
                 &mut styles_cache,
                 collection,
                 &[],
@@ -2772,14 +2782,14 @@ fn resolve_bundle<'a>(
 pub fn validate_style_colormaps(
     collections: &[CollectionConfig],
     style_bundles: &[StyleBundle],
+    registry: &ds_render::PaletteRegistry,
 ) -> Result<(), ds_core::error::DataServerError> {
-    let registry = ds_render::PaletteRegistry::with_builtins();
     let check = |owner: &str, name: Option<&str>| -> Result<(), ds_core::error::DataServerError> {
         if let Some(n) = name {
             if !registry.contains(n) {
                 return Err(ds_core::error::DataServerError::Config(format!(
-                    "{owner}: unknown colormap '{n}' (built-ins: {})",
-                    ds_render::palette::builtin_names().join(", ")
+                    "{owner}: unknown colormap '{n}' (available: {})",
+                    registry.names().join(", ")
                 )));
             }
         }
@@ -2963,12 +2973,28 @@ pub(crate) fn do_reload(state: &AdminState) -> Result<ReloadOutcome, ReloadError
         tracing::warn!("{warning}");
     }
 
-    // Same colormap-name validation as startup: an unknown name rejects the
-    // reload and keeps the old registry serving.
-    validate_style_colormaps(&config.collections, &config.style_bundles).map_err(|e| {
+    // Rebuild the palette registry (built-ins + [[colormaps]] +
+    // colormaps_dir) and run the same colormap-name validation as startup:
+    // an unknown name or a broken palette file rejects the reload and keeps
+    // the old registry serving.
+    let config_dir = std::path::Path::new(&state.config_path)
+        .parent()
+        .map(std::path::Path::to_path_buf);
+    let palette_registry = crate::colormaps::build_palette_registry(&config, config_dir.as_deref())
+        .map_err(|e| {
+            tracing::error!("Reload failed: {e}");
+            ReloadError::ConfigRead(format!("{e}"))
+        })?;
+    validate_style_colormaps(
+        &config.collections,
+        &config.style_bundles,
+        &palette_registry,
+    )
+    .map_err(|e| {
         tracing::error!("Reload failed: {e}");
         ReloadError::ConfigRead(format!("{e}"))
     })?;
+    let style_ctx = ds_render::StyleContext::new(palette_registry);
 
     let base_url = config.server.base_url();
 
@@ -2982,15 +3008,30 @@ pub(crate) fn do_reload(state: &AdminState) -> Result<ReloadOutcome, ReloadError
     // cache instead of rebuilding it empty — a spurious `collections_dir`
     // watcher event must not dump a multi-GB meta-tile cache. `load_collections`
     // reuses each one iff its configured size is unchanged.
+    //
+    // EXCEPT when style-affecting config changed (palettes, bundles, [wms]
+    // blocks, colormaps_dir files): the rendered / meta-tile keys carry no
+    // style content, so reusing those caches would keep serving the OLD
+    // colors as X-Cache HITs. The (style-independent) vector-tile cache is
+    // always safe to reuse.
+    let new_style_fp = crate::colormaps::style_config_fingerprint(&config, config_dir.as_deref());
+    let styles_changed = state
+        .style_fingerprint
+        .load(std::sync::atomic::Ordering::Relaxed)
+        != new_style_fp;
+    if styles_changed {
+        info!("Style configuration changed — dropping rendered and meta-tile caches");
+    }
     let reuse = {
         let wms = state.wms.load();
         ReusableCaches {
-            rendered: Some(wms.rendered_cache.clone()),
-            tile: Some(wms.tile_cache.clone()),
+            rendered: (!styles_changed).then(|| wms.rendered_cache.clone()),
+            tile: (!styles_changed).then(|| wms.tile_cache.clone()),
             vector: Some(state.tiles.load().vector_tile_cache.clone()),
         }
     };
     let mut result = load_collections(
+        &style_ctx,
         &config.collections,
         &config.style_bundles,
         &base_url,
@@ -3029,6 +3070,12 @@ pub(crate) fn do_reload(state: &AdminState) -> Result<ReloadOutcome, ReloadError
             configured: config.collections.len(),
         });
     }
+
+    // Reload accepted: remember the style fingerprint so the NEXT reload
+    // can tell whether style config changed again.
+    state
+        .style_fingerprint
+        .store(new_style_fp, std::sync::atomic::Ordering::Relaxed);
 
     // Surface a vanished per-site radar in `/health`. A site that was
     // `Ready` in the live registry but is absent from the new scan (its
@@ -4169,6 +4216,7 @@ mod tests {
     #[test]
     fn nowcast_unknown_source_fails_that_collection_only() {
         let result = super::load_collections(
+            &ds_render::StyleContext::with_builtins(),
             &[nowcast_test_collection("nc", "nowcast", Some("no-such"))],
             &[],
             "http://x",
@@ -4196,6 +4244,7 @@ mod tests {
         let mut nc = nowcast_test_collection("nc", "nowcast", Some("radar"));
         nc.nowcast.as_mut().unwrap().lightning_source = Some("no-such-lightning".into());
         let result = super::load_collections(
+            &ds_render::StyleContext::with_builtins(),
             &[tm35_source_collection("radar"), nc],
             &[],
             "http://x",
@@ -4221,6 +4270,7 @@ mod tests {
     #[test]
     fn nowcast_of_nowcast_is_rejected() {
         let result = super::load_collections(
+            &ds_render::StyleContext::with_builtins(),
             &[
                 tm35_source_collection("radar"),
                 nowcast_test_collection("nc1", "nowcast", Some("radar")),
@@ -4249,6 +4299,7 @@ mod tests {
         let mut nc = nowcast_test_collection("nc", "nowcast", Some("radar"));
         nc.apis = vec!["wms".to_string(), "features".to_string()];
         let result = super::load_collections(
+            &ds_render::StyleContext::with_builtins(),
             &[tm35_source_collection("radar"), nc],
             &[],
             "http://x",
@@ -4282,6 +4333,7 @@ mod tests {
         // Startup-equivalent: fresh caches (empty collections is fine — the
         // render caches are built unconditionally).
         let first = super::load_collections(
+            &ds_render::StyleContext::with_builtins(),
             &[],
             &[],
             "http://x",
@@ -4296,6 +4348,7 @@ mod tests {
         // Reload with the SAME meta-tile size → every cache is reused (same
         // `Arc`), so a warm cache survives a reload instead of being dumped.
         let second = super::load_collections(
+            &ds_render::StyleContext::with_builtins(),
             &[],
             &[],
             "http://x",
@@ -4324,6 +4377,7 @@ mod tests {
         // differently-sized cache can't be reused); the unchanged rendered/
         // vector caches are still reused.
         let third = super::load_collections(
+            &ds_render::StyleContext::with_builtins(),
             &[],
             &[],
             "http://x",
@@ -4716,6 +4770,7 @@ colormap = "radar_dbz"
         let mut c = tm35_source_collection("radar");
         c.apis = vec!["edr".to_string(), "wms".to_string()];
         let result = super::load_collections(
+            &ds_render::StyleContext::with_builtins(),
             &[c],
             &[],
             "http://x",
@@ -4753,8 +4808,12 @@ colormap = "virids"
 "#,
         )
         .unwrap();
-        let err = super::validate_style_colormaps(std::slice::from_ref(&bad), &[])
-            .expect_err("typo'd colormap must be rejected");
+        let err = super::validate_style_colormaps(
+            std::slice::from_ref(&bad),
+            &[],
+            &ds_render::PaletteRegistry::with_builtins(),
+        )
+        .expect_err("typo'd colormap must be rejected");
         let msg = format!("{err}");
         assert!(msg.contains("virids"), "error names the typo: {msg}");
         assert!(msg.contains("radar"), "error names the collection: {msg}");
@@ -4762,7 +4821,12 @@ colormap = "virids"
         // A valid name (and no wms at all) passes.
         let mut ok = bad.clone();
         ok.wms.as_mut().unwrap().colormap = Some("radar_dbz".into());
-        super::validate_style_colormaps(std::slice::from_ref(&ok), &[]).expect("valid name passes");
+        super::validate_style_colormaps(
+            std::slice::from_ref(&ok),
+            &[],
+            &ds_render::PaletteRegistry::with_builtins(),
+        )
+        .expect("valid name passes");
 
         // A bundle extra with an unknown name is rejected too.
         let bundle: StyleBundle = toml::from_str(
@@ -4778,8 +4842,12 @@ colormap = "no_such_map"
 "#,
         )
         .unwrap();
-        let err = super::validate_style_colormaps(&[], std::slice::from_ref(&bundle))
-            .expect_err("unknown bundle extra colormap must be rejected");
+        let err = super::validate_style_colormaps(
+            &[],
+            std::slice::from_ref(&bundle),
+            &ds_render::PaletteRegistry::with_builtins(),
+        )
+        .expect_err("unknown bundle extra colormap must be rejected");
         assert!(format!("{err}").contains("no_such_map"));
     }
 }

--- a/crates/server/src/colormaps.rs
+++ b/crates/server/src/colormaps.rs
@@ -1,0 +1,332 @@
+//! Palette registry construction: built-ins + `[[colormaps]]` +
+//! `colormaps_dir` files.
+//!
+//! Built once per config load (startup and every reload) and handed to
+//! `ds_render::StyleContext`, so user-defined colormaps are referencable
+//! anywhere a built-in name is accepted. Duplicate user names are a config
+//! error; a user palette shadowing a built-in name is allowed and logged as
+//! a warning (it deliberately restyles that name deployment-wide).
+
+use std::path::{Path, PathBuf};
+
+use ds_core::config::{ColormapDef, ServerConfig};
+use ds_core::error::DataServerError;
+use ds_render::{Interpolation, Palette, PaletteInsert, PaletteRegistry};
+
+/// Build the palette registry for a config: built-ins, then `[[colormaps]]`
+/// entries, then `colormaps_dir` files (sorted by filename). `config_dir` is
+/// the parent directory of the main config file — a relative
+/// `colormaps_dir` resolves against it, mirroring `collections_dir`.
+pub fn build_palette_registry(
+    config: &ServerConfig,
+    config_dir: Option<&Path>,
+) -> Result<PaletteRegistry, DataServerError> {
+    let mut registry = PaletteRegistry::with_builtins();
+
+    for (i, def) in config.colormaps.iter().enumerate() {
+        let owner = format!("[[colormaps]] entry {}", i + 1);
+        // `ServerConfig::validate()` requires `name` for config.toml entries.
+        let name = def.name.clone().unwrap_or_default();
+        let palette = def_to_palette(&owner, &name, def)?;
+        insert_logged(&mut registry, palette, &owner)?;
+    }
+
+    if let Some(dir) = &config.server.colormaps_dir {
+        let dir_path = resolve_dir(dir, config_dir);
+        load_colormaps_dir(&mut registry, &dir_path)?;
+    }
+
+    Ok(registry)
+}
+
+/// Convert a validated [`ColormapDef`] into a [`Palette`].
+fn def_to_palette(owner: &str, name: &str, def: &ColormapDef) -> Result<Palette, DataServerError> {
+    let interpolation = match def.interpolation.as_deref() {
+        Some("step") => Interpolation::Step,
+        _ => Interpolation::Linear,
+    };
+    let mut stops = Vec::with_capacity(def.color_stops.len());
+    for stop in &def.color_stops {
+        let color = ds_render::parse_hex_color(&stop.color)
+            .map_err(|e| DataServerError::Config(format!("{owner}: colormap '{name}': {e}")))?;
+        stops.push(ds_render::ColorStop {
+            value: stop.value,
+            color,
+        });
+    }
+    let mut palette = Palette::new(name, stops, interpolation);
+    palette.title = def.title.clone();
+    if let Some(nd) = &def.nodata_color {
+        let color = ds_render::parse_hex_color(nd).map_err(|e| {
+            DataServerError::Config(format!("{owner}: colormap '{name}': nodata_color: {e}"))
+        })?;
+        palette.nodata_color = Some(color);
+    }
+    Ok(palette)
+}
+
+fn resolve_dir(dir: &str, config_dir: Option<&Path>) -> PathBuf {
+    let p = Path::new(dir);
+    if p.is_relative() {
+        if let Some(base) = config_dir {
+            return base.join(p);
+        }
+    }
+    p.to_path_buf()
+}
+
+/// Load every palette file in `dir` (non-recursive, sorted by filename).
+/// Extensions: `.toml` (ColormapDef), `.cpt` (GMT), `.txt`/`.clr` (GDAL
+/// color-relief), `.sld` (SLD ColorMap). Other extensions are skipped, so
+/// `.disabled` works like it does for collections. A missing directory is a
+/// hard error (a typo'd path must not silently load nothing); an empty one
+/// logs a warning.
+fn load_colormaps_dir(registry: &mut PaletteRegistry, dir: &Path) -> Result<(), DataServerError> {
+    let entries = std::fs::read_dir(dir).map_err(|e| {
+        DataServerError::Config(format!(
+            "colormaps_dir '{}' cannot be read: {e}",
+            dir.display()
+        ))
+    })?;
+    let mut files: Vec<PathBuf> = entries
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| p.is_file())
+        .collect();
+    files.sort();
+
+    let mut loaded = 0usize;
+    for path in &files {
+        let filename = path.file_name().unwrap_or_default().to_string_lossy();
+        let stem = path.file_stem().unwrap_or_default().to_string_lossy();
+        let ext = path
+            .extension()
+            .unwrap_or_default()
+            .to_string_lossy()
+            .to_ascii_lowercase();
+        let parse = |what: &str, r: Result<Palette, String>| -> Result<Palette, DataServerError> {
+            r.map_err(|e| {
+                DataServerError::Config(format!("colormaps_dir {filename} ({what}): {e}"))
+            })
+        };
+        let palette = match ext.as_str() {
+            "toml" => {
+                let text = read(path)?;
+                let def: ColormapDef = toml::from_str(&text).map_err(|e| {
+                    DataServerError::Config(format!("colormaps_dir {filename}: {e}"))
+                })?;
+                let name = def.name.clone().unwrap_or_else(|| stem.to_string());
+                if def.name.is_some() && name != stem {
+                    tracing::warn!(
+                        "colormaps_dir {filename}: filename stem '{stem}' differs from \
+                         colormap name '{name}'"
+                    );
+                }
+                def.validate(&format!("colormaps_dir {filename}"), &name)?;
+                def_to_palette(&format!("colormaps_dir {filename}"), &name, &def)?
+            }
+            "cpt" => parse("GMT cpt", ds_render::parse_cpt(&stem, &read(path)?))?,
+            "txt" | "clr" => parse(
+                "GDAL color-relief",
+                ds_render::parse_gdal_txt(&stem, &read(path)?),
+            )?,
+            "sld" => parse(
+                "SLD ColorMap",
+                crate::sld::parse_sld_colormap(&stem, &read(path)?),
+            )?,
+            _ => continue,
+        };
+        insert_logged(registry, palette, &format!("colormaps_dir {filename}"))?;
+        loaded += 1;
+    }
+
+    if loaded == 0 {
+        tracing::warn!(
+            "colormaps_dir '{}' contains no palette files (.toml/.cpt/.txt/.clr/.sld)",
+            dir.display()
+        );
+    } else {
+        tracing::info!("Loaded {loaded} colormap(s) from '{}'", dir.display());
+    }
+    Ok(())
+}
+
+/// Fingerprint of everything that can change how styles resolve: the
+/// `[[colormaps]]` definitions, style bundles, per-collection `[wms]`
+/// blocks, and the raw bytes of every `colormaps_dir` palette file (sorted
+/// by name). Compared across reloads to decide whether the rendered /
+/// meta-tile caches can be reused — their keys carry no style content, so
+/// reusing them across a style change serves stale colors. Only ever
+/// compared within one process (previous load vs reload), so `Debug`
+/// formatting and `DefaultHasher` are acceptable serializations.
+pub fn style_config_fingerprint(config: &ServerConfig, config_dir: Option<&Path>) -> u64 {
+    use std::hash::{Hash, Hasher};
+    let mut h = std::collections::hash_map::DefaultHasher::new();
+    format!("{:?}", config.colormaps).hash(&mut h);
+    format!("{:?}", config.style_bundles).hash(&mut h);
+    for c in &config.collections {
+        c.id.hash(&mut h);
+        format!("{:?}", c.wms).hash(&mut h);
+    }
+    if let Some(dir) = &config.server.colormaps_dir {
+        let dir_path = resolve_dir(dir, config_dir);
+        if let Ok(entries) = std::fs::read_dir(&dir_path) {
+            let mut files: Vec<PathBuf> = entries
+                .filter_map(|e| e.ok())
+                .map(|e| e.path())
+                .filter(|p| p.is_file())
+                .collect();
+            files.sort();
+            for f in &files {
+                f.file_name().unwrap_or_default().hash(&mut h);
+                std::fs::read(f).unwrap_or_default().hash(&mut h);
+            }
+        }
+    }
+    h.finish()
+}
+
+fn read(path: &Path) -> Result<String, DataServerError> {
+    std::fs::read_to_string(path)
+        .map_err(|e| DataServerError::Config(format!("Failed to read {}: {e}", path.display())))
+}
+
+fn insert_logged(
+    registry: &mut PaletteRegistry,
+    palette: Palette,
+    owner: &str,
+) -> Result<(), DataServerError> {
+    let name = palette.name.clone();
+    match registry.insert(palette) {
+        Ok(PaletteInsert::Added) => Ok(()),
+        Ok(PaletteInsert::ShadowedBuiltin) => {
+            tracing::warn!(
+                "{owner}: colormap '{name}' shadows the built-in palette of the same \
+                 name — every collection using '{name}' now renders with the custom palette"
+            );
+            Ok(())
+        }
+        Err(e) => Err(DataServerError::Config(format!("{owner}: {e}"))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config_with(colormaps_toml: &str) -> ServerConfig {
+        let src = format!("[server]\nhost = \"127.0.0.1\"\nport = 8000\n{colormaps_toml}");
+        toml::from_str(&src).expect("test config parses")
+    }
+
+    #[test]
+    fn config_colormaps_register_and_resolve() {
+        let config = config_with(
+            r##"
+            [[colormaps]]
+            name = "house"
+            title = "House Style"
+            interpolation = "step"
+            color_stops = [
+                { value = 0.0, color = "#00000000" },
+                { value = 10.0, color = "#FF0000" },
+            ]
+            nodata_color = "#01020304"
+            "##,
+        );
+        config.validate().expect("valid config");
+        let reg = build_palette_registry(&config, None).unwrap();
+        let p = reg.get("house").expect("registered");
+        assert_eq!(p.title.as_deref(), Some("House Style"));
+        assert_eq!(p.interpolation, Interpolation::Step);
+        assert_eq!(p.stops.len(), 2);
+        assert_eq!(p.nodata_color, Some([1, 2, 3, 4]));
+        // Built-ins still present.
+        assert!(reg.get("radar_dbz").is_some());
+    }
+
+    #[test]
+    fn duplicate_config_colormap_is_error() {
+        let config = config_with(
+            r##"
+            [[colormaps]]
+            name = "dup"
+            color_stops = [ { value = 0.0, color = "#000000" } ]
+            [[colormaps]]
+            name = "dup"
+            color_stops = [ { value = 0.0, color = "#FFFFFF" } ]
+            "##,
+        );
+        // Caught in ds-core validate() already…
+        assert!(config.validate().is_err());
+        // …and defense-in-depth at registry build.
+        assert!(build_palette_registry(&config, None).is_err());
+    }
+
+    #[test]
+    fn shadowing_builtin_is_allowed() {
+        let config = config_with(
+            r##"
+            [[colormaps]]
+            name = "temperature"
+            color_stops = [
+                { value = 0.0, color = "#000000" },
+                { value = 1.0, color = "#FFFFFF" },
+            ]
+            "##,
+        );
+        config.validate().expect("shadowing validates");
+        let reg = build_palette_registry(&config, None).unwrap();
+        // The user palette wins.
+        assert_eq!(reg.get("temperature").unwrap().stops.len(), 2);
+    }
+
+    #[test]
+    fn colormaps_dir_loads_by_extension_and_missing_dir_errors() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("ramp.toml"),
+            r##"
+            color_stops = [
+                { value = 0.0, color = "#000000" },
+                { value = 5.0, color = "#FFFFFF" },
+            ]
+            "##,
+        )
+        .unwrap();
+        std::fs::write(dir.path().join("ignored.disabled"), "junk").unwrap();
+        std::fs::write(
+            dir.path().join("relief.txt"),
+            "0 0 0 0\n100 255 255 255\nnv 0 0 0 0\n",
+        )
+        .unwrap();
+
+        let mut config = config_with("");
+        config.server.colormaps_dir = Some(dir.path().to_string_lossy().to_string());
+        let reg = build_palette_registry(&config, None).unwrap();
+        // .toml name defaults to the file stem.
+        assert!(reg.get("ramp").is_some());
+        assert!(reg.get("relief").is_some());
+        assert_eq!(reg.get("relief").unwrap().nodata_color, Some([0, 0, 0, 0]));
+
+        let mut missing = config_with("");
+        missing.server.colormaps_dir = Some("/nonexistent/colormaps.d".to_string());
+        assert!(build_palette_registry(&missing, None).is_err());
+    }
+
+    #[test]
+    fn relative_dir_resolves_against_config_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let sub = dir.path().join("colormaps.d");
+        std::fs::create_dir(&sub).unwrap();
+        std::fs::write(
+            sub.join("x.toml"),
+            r##"color_stops = [ { value = 0.0, color = "#000000" } ]"##,
+        )
+        .unwrap();
+        let mut config = config_with("");
+        config.server.colormaps_dir = Some("colormaps.d".to_string());
+        let reg = build_palette_registry(&config, Some(dir.path())).unwrap();
+        assert!(reg.get("x").is_some());
+    }
+}

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -1,6 +1,8 @@
 mod admin;
 mod auto;
+mod colormaps;
 mod preview;
+mod sld;
 mod watcher;
 
 use std::sync::{Arc, OnceLock, RwLock};
@@ -329,12 +331,28 @@ async fn main() {
         tracing::warn!("{warning}");
     }
 
-    // Reject unknown colormap names up front — a typo'd `colormap = "..."`
-    // must fail startup, not silently render viridis.
-    if let Err(e) = admin::validate_style_colormaps(&config.collections, &config.style_bundles) {
+    // Build the palette registry (built-ins + [[colormaps]] + colormaps_dir)
+    // and reject unknown colormap names up front — a typo'd `colormap = "..."`
+    // or a broken palette file must fail startup, not silently render viridis.
+    let config_dir = std::path::Path::new(&config_path)
+        .parent()
+        .map(std::path::Path::to_path_buf);
+    let palette_registry = match colormaps::build_palette_registry(&config, config_dir.as_deref()) {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::error!("Invalid colormap configuration: {e}");
+            std::process::exit(1);
+        }
+    };
+    if let Err(e) = admin::validate_style_colormaps(
+        &config.collections,
+        &config.style_bundles,
+        &palette_registry,
+    ) {
         tracing::error!("Invalid style configuration: {e}");
         std::process::exit(1);
     }
+    let style_ctx = ds_render::StyleContext::new(palette_registry);
 
     // Auto-discover collections from any --auto-collections directories (#411)
     // and merge them with the config-file collections. The merged set goes
@@ -442,6 +460,7 @@ async fn main() {
     info!("Socket bound to {addr} — loading collections, not yet serving");
 
     let result = admin::load_collections(
+        &style_ctx,
         &config.collections,
         &config.style_bundles,
         &base_url,
@@ -618,6 +637,10 @@ async fn main() {
         nowcast_engines: RwLock::new(result.nowcast_engines),
         reload_lock: tokio::sync::Mutex::new(()),
         admin_token,
+        style_fingerprint: std::sync::atomic::AtomicU64::new(colormaps::style_config_fingerprint(
+            &config,
+            config_dir.as_deref(),
+        )),
     });
 
     // Start the collections_dir watcher (issue #318) if enabled. Best-effort:

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -344,16 +344,6 @@ async fn main() {
             std::process::exit(1);
         }
     };
-    if let Err(e) = admin::validate_style_colormaps(
-        &config.collections,
-        &config.style_bundles,
-        &palette_registry,
-    ) {
-        tracing::error!("Invalid style configuration: {e}");
-        std::process::exit(1);
-    }
-    let style_ctx = ds_render::StyleContext::new(palette_registry);
-
     // Auto-discover collections from any --auto-collections directories (#411)
     // and merge them with the config-file collections. The merged set goes
     // through the same validate() as TOML collections (so duplicate ids across
@@ -371,6 +361,19 @@ async fn main() {
             std::process::exit(1);
         }
     }
+
+    // Colormap-name validation runs AFTER the auto-collections merge so every
+    // collection source is checked uniformly (auto configs carry no [wms]
+    // block today, but the ordering must not silently exempt them).
+    if let Err(e) = admin::validate_style_colormaps(
+        &config.collections,
+        &config.style_bundles,
+        &palette_registry,
+    ) {
+        tracing::error!("Invalid style configuration: {e}");
+        std::process::exit(1);
+    }
+    let style_ctx = ds_render::StyleContext::new(palette_registry);
 
     // Apply --collections filter if provided. Unknown IDs are a hard error —
     // typing `--collections noa-gfs` should not silently load nothing.

--- a/crates/server/src/preview.rs
+++ b/crates/server/src/preview.rs
@@ -998,6 +998,7 @@ mod tests {
             nowcast_engines: RwLock::new(Vec::new()),
             reload_lock: tokio::sync::Mutex::new(()),
             admin_token: None,
+            style_fingerprint: std::sync::atomic::AtomicU64::new(0),
         })
     }
 

--- a/crates/server/src/sld.rs
+++ b/crates/server/src/sld.rs
@@ -1,0 +1,501 @@
+//! OGC SLD `RasterSymbolizer/ColorMap` → [`ds_render::Palette`].
+//!
+//! Lets a deployment reuse the SLD files it already ships to GeoServer/
+//! MapServer as MeteoCore colormaps. Parsing is a small streaming pass over
+//! `quick-xml` events matching **local** element names, so the sld:/se:/
+//! default-namespace spellings of the same document all parse identically
+//! (the same approach `engine-cap`'s CAP parser takes).
+//!
+//! Only the SLD 1.0 `ColorMapEntry` form is supported — the SE 1.1
+//! `Categorize`/`Interpolate` functions are not. The first `ColorMap`
+//! element in the document wins; anything after it is not read.
+//!
+//! Security: this is XML *reading*. `quick-xml` resolves only the five
+//! predefined entities, so a `<!ENTITY xxe SYSTEM "file:///…">` internal
+//! subset is never expanded — an escape referencing it fails the attribute
+//! parse instead. Nothing here unwraps on document content.
+
+use quick_xml::events::{BytesStart, Event};
+use quick_xml::Reader;
+
+use ds_render::{parse_hex_color, ColorStop, Interpolation, Palette};
+
+/// Parse the first `ColorMap` in an SLD document into a named palette.
+///
+/// `name` becomes the palette's registry key. The result has no title, is
+/// not normalized, and carries no explicit nodata color — an SLD ColorMap
+/// expresses none of those.
+pub fn parse_sld_colormap(name: &str, xml: &str) -> Result<Palette, String> {
+    let mut reader = Reader::from_str(xml);
+
+    let mut color_map: Option<ColorMap> = None;
+
+    loop {
+        let event = reader
+            .read_event()
+            .map_err(|e| format!("malformed XML at byte {}: {e}", reader.buffer_position()))?;
+
+        match event {
+            Event::Start(e) => match color_map.as_mut() {
+                Some(cm) => {
+                    if is_local(e.local_name().as_ref(), b"ColorMapEntry") {
+                        cm.push_entry(&e)?;
+                    }
+                    cm.depth += 1;
+                }
+                None => {
+                    if is_local(e.local_name().as_ref(), b"ColorMap") {
+                        color_map = Some(ColorMap::open(&e)?);
+                    }
+                }
+            },
+            Event::Empty(e) => match color_map.as_mut() {
+                Some(cm) => {
+                    if is_local(e.local_name().as_ref(), b"ColorMapEntry") {
+                        cm.push_entry(&e)?;
+                    }
+                }
+                None => {
+                    if is_local(e.local_name().as_ref(), b"ColorMap") {
+                        // Self-closing <ColorMap/>: opens and closes at once.
+                        return ColorMap::open(&e)?.finish(name);
+                    }
+                }
+            },
+            Event::End(e) => {
+                let closes_color_map = color_map.as_mut().is_some_and(|cm| {
+                    if cm.depth == 0 && is_local(e.local_name().as_ref(), b"ColorMap") {
+                        true
+                    } else {
+                        cm.depth = cm.depth.saturating_sub(1);
+                        false
+                    }
+                });
+                if closes_color_map {
+                    if let Some(cm) = color_map.take() {
+                        return cm.finish(name);
+                    }
+                }
+            }
+            Event::Eof => break,
+            _ => {}
+        }
+    }
+
+    match color_map {
+        // Truncated document: the ColorMap never closed, but its entries are
+        // all we needed.
+        Some(cm) => cm.finish(name),
+        None => Err("no ColorMap element found".to_string()),
+    }
+}
+
+/// A `ColorMap` element being read.
+struct ColorMap {
+    interpolation: Interpolation,
+    stops: Vec<ColorStop>,
+    /// Entry counter, for error messages — counts every `ColorMapEntry`
+    /// seen, including the one that failed.
+    entry_index: usize,
+    /// Open-element nesting below the `ColorMap`, so a nested `</…>` is not
+    /// mistaken for the `ColorMap`'s own end tag.
+    depth: usize,
+}
+
+impl ColorMap {
+    fn open(e: &BytesStart) -> Result<Self, String> {
+        let interpolation = match attribute(e, b"type")?.as_deref().map(str::trim) {
+            // SLD 1.0 §11.4.3: "ramp" is the default.
+            None | Some("ramp") => Interpolation::Linear,
+            Some("intervals") | Some("values") => Interpolation::Step,
+            Some(other) => {
+                return Err(format!(
+                    "unsupported ColorMap type '{other}' (expected ramp, intervals or values)"
+                ))
+            }
+        };
+        Ok(Self {
+            interpolation,
+            stops: Vec::new(),
+            entry_index: 0,
+            depth: 0,
+        })
+    }
+
+    fn push_entry(&mut self, e: &BytesStart) -> Result<(), String> {
+        let index = self.entry_index;
+        self.entry_index += 1;
+        let at = |msg: String| format!("ColorMapEntry[{index}]: {msg}");
+
+        let color = attribute(e, b"color")
+            .map_err(at)?
+            .ok_or_else(|| at("missing required attribute 'color'".to_string()))?;
+        let mut color = parse_hex_color(color.trim())
+            .map_err(|err| at(format!("invalid color '{color}': {err}")))?;
+
+        let quantity = attribute(e, b"quantity")
+            .map_err(at)?
+            .ok_or_else(|| at("missing required attribute 'quantity'".to_string()))?;
+        let value: f64 = quantity
+            .trim()
+            .parse()
+            .map_err(|_| at(format!("invalid quantity '{quantity}'")))?;
+        if !value.is_finite() {
+            return Err(at(format!("quantity '{quantity}' is not a finite number")));
+        }
+
+        if let Some(opacity) = attribute(e, b"opacity").map_err(at)? {
+            let factor: f64 = opacity
+                .trim()
+                .parse()
+                .map_err(|_| at(format!("invalid opacity '{opacity}'")))?;
+            if !(0.0..=1.0).contains(&factor) {
+                return Err(at(format!("opacity '{opacity}' is outside 0..1")));
+            }
+            // Scales the color's alpha, which is 255 for the "#RRGGBB" form
+            // SLD specifies — so this is the spec's round(opacity * 255).
+            color[3] = (factor * f64::from(color[3])).round() as u8;
+        }
+
+        self.stops.push(ColorStop { value, color });
+        Ok(())
+    }
+
+    fn finish(self, name: &str) -> Result<Palette, String> {
+        if self.stops.is_empty() {
+            return Err(
+                "ColorMap has no ColorMapEntry children — only the SLD 1.0 ColorMapEntry \
+                 form is supported, not the SE 1.1 Categorize/Interpolate functions"
+                    .to_string(),
+            );
+        }
+        Ok(Palette::new(name, self.stops, self.interpolation))
+    }
+}
+
+/// Compare an element's local name (namespace prefix already stripped by
+/// `local_name()`) against an expected name.
+fn is_local(local: &[u8], expected: &[u8]) -> bool {
+    local == expected
+}
+
+/// The value of an unprefixed attribute by local name, if present.
+///
+/// `xmlns` declarations are skipped: `xmlns:color` would otherwise have the
+/// local name `color`.
+fn attribute(e: &BytesStart, want: &[u8]) -> Result<Option<String>, String> {
+    for attr in e.attributes() {
+        let attr = attr.map_err(|err| format!("malformed attribute: {err}"))?;
+        let (local, prefix) = attr.key.decompose();
+        if attr.key.as_ref() == b"xmlns" || prefix.is_some_and(|p| p.as_ref() == b"xmlns") {
+            continue;
+        }
+        if local.as_ref() == want {
+            let name = String::from_utf8_lossy(want);
+            let value = attr
+                .unescape_value()
+                .map_err(|err| format!("attribute '{name}' has an unusable value: {err}"))?;
+            return Ok(Some(value.into_owned()));
+        }
+    }
+    Ok(None)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// GeoServer's usual export shape: SLD 1.0, `sld:` prefixes everywhere,
+    /// no `type` attribute, entries as empty elements.
+    const GEOSERVER_SLD: &str = r##"<?xml version="1.0" encoding="UTF-8"?>
+<sld:StyledLayerDescriptor xmlns:sld="http://www.opengis.net/sld"
+                           xmlns:ogc="http://www.opengis.net/ogc"
+                           version="1.0.0">
+  <sld:NamedLayer>
+    <sld:Name>radar</sld:Name>
+    <sld:UserStyle>
+      <sld:FeatureTypeStyle>
+        <sld:Rule>
+          <sld:RasterSymbolizer>
+            <sld:Opacity>1.0</sld:Opacity>
+            <sld:ColorMap>
+              <sld:ColorMapEntry color="#000000" quantity="-32" opacity="0" label="no echo"/>
+              <sld:ColorMapEntry color="#0080FF" quantity="5" label="5 dBZ"/>
+              <sld:ColorMapEntry color="#00C800" quantity="25" label="25 dBZ"/>
+              <sld:ColorMapEntry color="#FF0000" quantity="50" label="50 dBZ"/>
+            </sld:ColorMap>
+          </sld:RasterSymbolizer>
+        </sld:Rule>
+      </sld:FeatureTypeStyle>
+    </sld:UserStyle>
+  </sld:NamedLayer>
+</sld:StyledLayerDescriptor>"##;
+
+    #[test]
+    fn geoserver_sld_ramp_is_linear_with_pinned_stops() {
+        let p = parse_sld_colormap("radar_house", GEOSERVER_SLD).unwrap();
+
+        assert_eq!(p.name, "radar_house");
+        assert_eq!(p.title, None);
+        assert!(!p.normalized);
+        assert_eq!(p.nodata_color, None);
+        assert_eq!(p.interpolation, Interpolation::Linear);
+
+        assert_eq!(p.stops.len(), 4);
+        assert_eq!(p.stops[0].value, -32.0);
+        assert_eq!(p.stops[0].color, [0, 0, 0, 0]);
+        assert_eq!(p.stops[1].value, 5.0);
+        assert_eq!(p.stops[1].color, [0, 128, 255, 255]);
+        assert_eq!(p.stops[2].value, 25.0);
+        assert_eq!(p.stops[2].color, [0, 200, 0, 255]);
+        assert_eq!(p.stops[3].value, 50.0);
+        assert_eq!(p.stops[3].color, [255, 0, 0, 255]);
+        assert_eq!(p.default_range(), Some((-32.0, 50.0)));
+    }
+
+    #[test]
+    fn intervals_and_values_types_are_step() {
+        let xml = |t: &str| {
+            format!(
+                r##"<StyledLayerDescriptor><ColorMap type="{t}">
+                     <ColorMapEntry color="#000000" quantity="0"/>
+                     <ColorMapEntry color="#FFFFFF" quantity="10"/>
+                   </ColorMap></StyledLayerDescriptor>"##
+            )
+        };
+        for t in ["intervals", "values"] {
+            let p = parse_sld_colormap("c", &xml(t)).unwrap();
+            assert_eq!(p.interpolation, Interpolation::Step, "type={t}");
+            assert_eq!(p.stops.len(), 2);
+        }
+        let ramp = parse_sld_colormap("c", &xml("ramp")).unwrap();
+        assert_eq!(ramp.interpolation, Interpolation::Linear);
+        assert!(parse_sld_colormap("c", &xml("categorize")).is_err());
+    }
+
+    #[test]
+    fn opacity_scales_alpha() {
+        let xml = r##"<ColorMap>
+            <ColorMapEntry color="#112233" quantity="0" opacity="0"/>
+            <ColorMapEntry color="#112233" quantity="1" opacity="0.5"/>
+            <ColorMapEntry color="#112233" quantity="2" opacity="1.0"/>
+            <ColorMapEntry color="#112233" quantity="3"/>
+            <ColorMapEntry color="#11223380" quantity="4" opacity="0.5"/>
+        </ColorMap>"##;
+        let p = parse_sld_colormap("c", xml).unwrap();
+        assert_eq!(p.stops[0].color, [17, 34, 51, 0]);
+        assert_eq!(p.stops[1].color, [17, 34, 51, 128]);
+        assert_eq!(p.stops[2].color, [17, 34, 51, 255]);
+        assert_eq!(p.stops[3].color, [17, 34, 51, 255]);
+        // "#RRGGBBAA" is outside SLD, but scaling stays sane: 128 * 0.5.
+        assert_eq!(p.stops[4].color, [17, 34, 51, 64]);
+
+        assert!(parse_sld_colormap(
+            "c",
+            r##"<ColorMap><ColorMapEntry color="#112233" quantity="0" opacity="1.5"/></ColorMap>"##
+        )
+        .is_err());
+        assert!(parse_sld_colormap(
+            "c",
+            r##"<ColorMap><ColorMapEntry color="#112233" quantity="0" opacity="-0.1"/></ColorMap>"##
+        )
+        .is_err());
+        assert!(parse_sld_colormap(
+            "c",
+            r##"<ColorMap><ColorMapEntry color="#112233" quantity="0" opacity="半"/></ColorMap>"##
+        )
+        .is_err());
+    }
+
+    /// The same document with a default namespace and `se:` prefixes must
+    /// parse to exactly the same palette — element matching is on local
+    /// names only.
+    #[test]
+    fn namespace_spellings_agree() {
+        let default_ns = r##"<?xml version="1.0" encoding="UTF-8"?>
+<StyledLayerDescriptor xmlns="http://www.opengis.net/sld" version="1.0.0">
+  <NamedLayer><UserStyle><FeatureTypeStyle><Rule><RasterSymbolizer>
+    <ColorMap>
+      <ColorMapEntry color="#000000" quantity="-32" opacity="0" label="no echo"/>
+      <ColorMapEntry color="#0080FF" quantity="5" label="5 dBZ"/>
+      <ColorMapEntry color="#00C800" quantity="25" label="25 dBZ"/>
+      <ColorMapEntry color="#FF0000" quantity="50" label="50 dBZ"/>
+    </ColorMap>
+  </RasterSymbolizer></Rule></FeatureTypeStyle></UserStyle></NamedLayer>
+</StyledLayerDescriptor>"##;
+        let se_ns = r##"<sld:StyledLayerDescriptor xmlns:sld="http://www.opengis.net/sld"
+                                                  xmlns:se="http://www.opengis.net/se">
+  <se:RasterSymbolizer><se:ColorMap>
+    <se:ColorMapEntry color="#000000" quantity="-32" opacity="0"/>
+    <se:ColorMapEntry color="#0080FF" quantity="5"/>
+    <se:ColorMapEntry color="#00C800" quantity="25"/>
+    <se:ColorMapEntry color="#FF0000" quantity="50"/>
+  </se:ColorMap></se:RasterSymbolizer>
+</sld:StyledLayerDescriptor>"##;
+
+        let reference = parse_sld_colormap("c", GEOSERVER_SLD).unwrap();
+        for xml in [default_ns, se_ns] {
+            let p = parse_sld_colormap("c", xml).unwrap();
+            assert_eq!(p.interpolation, reference.interpolation);
+            assert_eq!(p.stops.len(), reference.stops.len());
+            for (got, want) in p.stops.iter().zip(&reference.stops) {
+                assert_eq!(got.value, want.value);
+                assert_eq!(got.color, want.color);
+            }
+        }
+    }
+
+    #[test]
+    fn descending_entries_come_out_ascending() {
+        let xml = r##"<ColorMap>
+            <ColorMapEntry color="#FF0000" quantity="50"/>
+            <ColorMapEntry color="#00FF00" quantity="25"/>
+            <ColorMapEntry color="#0000FF" quantity="-5.5"/>
+        </ColorMap>"##;
+        let p = parse_sld_colormap("c", xml).unwrap();
+        let values: Vec<f64> = p.stops.iter().map(|s| s.value).collect();
+        assert_eq!(values, vec![-5.5, 25.0, 50.0]);
+        assert_eq!(p.stops[0].color, [0, 0, 255, 255]);
+        assert_eq!(p.stops[2].color, [255, 0, 0, 255]);
+    }
+
+    /// Only the first ColorMap is read; entries of later ones are ignored.
+    #[test]
+    fn first_color_map_wins() {
+        let xml = r##"<StyledLayerDescriptor>
+          <RasterSymbolizer><ColorMap type="intervals">
+            <ColorMapEntry color="#000000" quantity="0"/>
+            <ColorMapEntry color="#FFFFFF" quantity="1"/>
+          </ColorMap></RasterSymbolizer>
+          <RasterSymbolizer><ColorMap>
+            <ColorMapEntry color="#FF0000" quantity="99"/>
+          </ColorMap></RasterSymbolizer>
+        </StyledLayerDescriptor>"##;
+        let p = parse_sld_colormap("c", xml).unwrap();
+        assert_eq!(p.interpolation, Interpolation::Step);
+        assert_eq!(p.stops.len(), 2);
+        assert_eq!(p.stops.last().unwrap().value, 1.0);
+    }
+
+    /// A ColorMapEntry written as a Start/End pair rather than an empty
+    /// element still counts, and its nested end tag doesn't close the map.
+    #[test]
+    fn non_empty_entry_elements_parse() {
+        let xml = r##"<ColorMap>
+            <ColorMapEntry color="#000000" quantity="0"></ColorMapEntry>
+            <ColorMapEntry color="#FFFFFF" quantity="1"></ColorMapEntry>
+        </ColorMap>"##;
+        let p = parse_sld_colormap("c", xml).unwrap();
+        assert_eq!(p.stops.len(), 2);
+    }
+
+    #[test]
+    fn rejects_documents_without_usable_entries() {
+        let no_color_map = r##"<StyledLayerDescriptor><NamedLayer><Name>x</Name></NamedLayer></StyledLayerDescriptor>"##;
+        assert_eq!(
+            parse_sld_colormap("c", no_color_map).unwrap_err(),
+            "no ColorMap element found"
+        );
+        assert!(parse_sld_colormap("c", "").is_err());
+
+        // SE 1.1 Categorize: a ColorMap with no ColorMapEntry children.
+        let categorize = r##"<ColorMap><Categorize fallbackValue="#000000">
+            <LookupValue>Rasterdata</LookupValue>
+            <Value>#00FF00</Value><Threshold>25</Threshold>
+        </Categorize></ColorMap>"##;
+        let err = parse_sld_colormap("c", categorize).unwrap_err();
+        assert!(err.contains("ColorMapEntry"), "{err}");
+        assert!(parse_sld_colormap("c", "<ColorMap/>").is_err());
+    }
+
+    #[test]
+    fn rejects_bad_entries_naming_the_index_and_attribute() {
+        let missing_quantity = r##"<ColorMap>
+            <ColorMapEntry color="#000000" quantity="0"/>
+            <ColorMapEntry color="#FFFFFF"/>
+        </ColorMap>"##;
+        let err = parse_sld_colormap("c", missing_quantity).unwrap_err();
+        assert!(err.contains("ColorMapEntry[1]"), "{err}");
+        assert!(err.contains("quantity"), "{err}");
+
+        let bad_quantity =
+            r##"<ColorMap><ColorMapEntry color="#000000" quantity="lots"/></ColorMap>"##;
+        let err = parse_sld_colormap("c", bad_quantity).unwrap_err();
+        assert!(err.contains("ColorMapEntry[0]"), "{err}");
+        assert!(err.contains("lots"), "{err}");
+
+        // NaN/inf parse as f64 but would poison stop ordering.
+        for q in ["NaN", "inf"] {
+            let xml = format!(
+                r##"<ColorMap><ColorMapEntry color="#000000" quantity="{q}"/></ColorMap>"##
+            );
+            assert!(parse_sld_colormap("c", &xml).is_err(), "quantity={q}");
+        }
+
+        let bad_color = r##"<ColorMap><ColorMapEntry color="#GGG" quantity="0"/></ColorMap>"##;
+        let err = parse_sld_colormap("c", bad_color).unwrap_err();
+        assert!(err.contains("ColorMapEntry[0]"), "{err}");
+        assert!(err.contains("color"), "{err}");
+
+        let missing_color = r##"<ColorMap><ColorMapEntry quantity="0"/></ColorMap>"##;
+        assert!(parse_sld_colormap("c", missing_color)
+            .unwrap_err()
+            .contains("color"));
+    }
+
+    #[test]
+    fn malformed_xml_errors_without_panicking() {
+        for xml in [
+            r##"<ColorMap><ColorMapEntry color="#000000" quantity="0"/>"##, // unclosed
+            r##"<ColorMap><ColorMapEntry color="#000000" quantity="0"/></NotColorMap>"##,
+            r##"<ColorMap><ColorMapEntry color=#000000 quantity="0"/></ColorMap>"##, // unquoted
+            r##"<ColorMap><ColorMapEntry color="#000000" color="#FFFFFF" quantity="0"/></ColorMap>"##,
+            "<<<>>>",
+            "\u{feff}\u{0}<ColorMap",
+        ] {
+            // Only "must not panic" is pinned here; some of these are
+            // recoverable enough that quick-xml still yields the entries.
+            let _ = parse_sld_colormap("c", xml);
+        }
+
+        // The unquoted-attribute and duplicate-attribute cases must be
+        // rejected rather than silently mis-parsed.
+        assert!(parse_sld_colormap(
+            "c",
+            r##"<ColorMap><ColorMapEntry color=#000000 quantity="0"/></ColorMap>"##
+        )
+        .is_err());
+        assert!(parse_sld_colormap(
+            "c",
+            r##"<ColorMap><ColorMapEntry color="#000000" color="#FFFFFF" quantity="0"/></ColorMap>"##
+        )
+        .is_err());
+    }
+
+    /// An internal DTD subset declaring an external entity must never be
+    /// expanded (XXE). Referencing it in an ignored attribute is harmless;
+    /// referencing it in one we read must fail, not resolve.
+    #[test]
+    fn doctype_entity_is_not_resolved() {
+        let in_label = r##"<?xml version="1.0"?>
+<!DOCTYPE StyledLayerDescriptor [
+  <!ENTITY xxe SYSTEM "file:///etc/passwd">
+]>
+<StyledLayerDescriptor><RasterSymbolizer><ColorMap>
+  <ColorMapEntry color="#000000" quantity="0" label="&xxe;"/>
+  <ColorMapEntry color="#FFFFFF" quantity="1"/>
+</ColorMap></RasterSymbolizer></StyledLayerDescriptor>"##;
+        // Either outcome is acceptable; what matters is no panic and no
+        // filesystem read. `label` is never unescaped, so this parses.
+        if let Ok(p) = parse_sld_colormap("c", in_label) {
+            assert_eq!(p.stops.len(), 2);
+            assert_eq!(p.stops[0].color, [0, 0, 0, 255]);
+        }
+
+        let in_color = r##"<?xml version="1.0"?>
+<!DOCTYPE ColorMap [ <!ENTITY xxe SYSTEM "file:///etc/passwd"> ]>
+<ColorMap><ColorMapEntry color="&xxe;" quantity="0"/></ColorMap>"##;
+        let err = parse_sld_colormap("c", in_color).unwrap_err();
+        assert!(!err.contains("root:"), "entity was expanded: {err}");
+    }
+}

--- a/crates/server/src/watcher.rs
+++ b/crates/server/src/watcher.rs
@@ -237,7 +237,12 @@ mod tests {
     /// Build a live `AdminState` over `config_path`, mirroring `main.rs`.
     fn build_state(config_path: &Path) -> AdminState {
         let (config, _) = ServerConfig::from_file(config_path.to_str().unwrap()).unwrap();
+        let style_ctx = ds_render::StyleContext::new(
+            crate::colormaps::build_palette_registry(&config, config_path.parent())
+                .expect("test config palette registry builds"),
+        );
         let result = load_collections(
+            &style_ctx,
             &config.collections,
             &config.style_bundles,
             &config.server.base_url(),
@@ -265,6 +270,9 @@ mod tests {
             nowcast_engines: RwLock::new(result.nowcast_engines),
             reload_lock: tokio::sync::Mutex::new(()),
             admin_token: None,
+            style_fingerprint: std::sync::atomic::AtomicU64::new(
+                crate::colormaps::style_config_fingerprint(&config, config_path.parent()),
+            ),
         })
     }
 


### PR DESCRIPTION
## Summary

Phase 3 of the styling revamp (stacked on #559). Named palettes become first-class config: define once, reference anywhere a built-in colormap name works.

- **`[[colormaps]]`** in top-level config.toml (name, title, `interpolation = "linear"|"step"`, color_stops, nodata_color), validated at load; rejected in per-collection files like `[[style_bundles]]`.
- **`[server] colormaps_dir`** — a directory of palette files, one per file, name = file stem, resolved relative to the config file, re-read on reload. Formats: `.toml` (colormap fields), **GMT `.cpt`** (RGB/hex/gray/HSV segments, discrete-cpt detection → step mode, `N` → nodata), **GDAL color-relief `.txt`/`.clr`**, **SLD `.sld`** (ColorMapEntry form; ramp→linear, intervals/values→step; opacity→alpha; namespace-agnostic; no entity resolution). cpt/GDAL parsers in ds-render with zero new deps; SLD in the server crate via quick-xml.
- Registry per load: built-ins → `[[colormaps]]` → dir files. Duplicate user names fail the load; shadowing a built-in warns and replaces it server-wide (per plan decision). Unknown-name errors now list user palettes as available.

## Bug found & fixed by the smoke test

Editing a palette (or any `[wms]` style config) + `POST /admin/collections/reload` kept serving the **old colors**: the rendered/meta-tile caches are deliberately carried across reloads (#202) and their keys carry no style content → `X-Cache: HIT` with stale pixels. `ServerState` now stores a fingerprint of all style-affecting config (colormaps + bundles + `[wms]` blocks + palette-file bytes); a reload with a changed fingerprint drops the rendered + meta-tile caches (the style-independent vector-tile cache is always kept). Spurious watcher reloads leave the fingerprint unchanged and keep the multi-GB warm caches.

## Verification

- 19 cpt/GDAL parser tests + 11 SLD tests + 6 registry tests, all fixture-driven; full clippy `-D warnings` clean; ds-render/server/api-edr suites green.
- E2E against real data (repo rule): typo'd `colormap = "virids"` fails startup listing available palettes; a `.cpt` palette renders through WMS GetMap and GetLegendGraphic (palette colors verified in the PNG PLTE chunk); palette edit + reload → `X-Cache: MISS` with the new colors; no-op reload → `HIT`.
- Examples shipped: `colormaps.d/` (.cpt + .toml) wired into repo config.toml; docs updated (CLAUDE.md + README).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VWyrJy1FVeinRS8UsSZKrU