### PR TITLE
feat(core,render): bundles v2 — per-parameter styles in bundles, slot-wise merge

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -402,8 +402,9 @@ time_window = "-PT2H"
 max_files = 24
 
 [collections.wms]
-# Either attach a named style_bundle (defined above), or set colormap/styles
-# inline — mixing the two in one [wms] block is rejected at config load.
+# Attach a shared style_bundle and/or set inline fields — they merge
+# slot-wise (bundles v2), inline winning each slot it defines (palette
+# source, min, max; named styles union with inline winning name clashes).
 style_bundle = "radar_multi"
 # colormap = "radar_dbz"
 
@@ -467,8 +468,13 @@ Rules:
 - `[[style_bundles]]` is NOT allowed in per-collection files — only in
   `config.toml`. Referencing a bundle from a per-collection `[wms]` is fine;
   defining one is rejected with an explicit error.
-- A `style_bundle` cannot coexist with inline `[[wms.parameters]]` defaults on
-  the same collection (rejected at config load).
+- A `style_bundle` MERGES with inline `[wms]` fields (bundles v2): per
+  parameter and per slot (palette source / min / max), the chain is inline
+  `[[wms.parameters]]` → bundle `[[style_bundles.parameters]]` → inline
+  `[wms]` fields → bundle default. Named styles are the union of bundle
+  extras and inline `[[wms.styles]]`, inline winning name clashes. A bundle
+  carries shared per-parameter defaults via `[[style_bundles.parameters]]`
+  (same fields as `[[wms.parameters]]`; names must be unique per bundle).
 - Inside a bundle, an `[[style_bundles.extras]]` entry with a `parameter`
   field is scoped to that parameter's layer only; untagged extras are shared
   across every parameter layer.

--- a/README.md
+++ b/README.md
@@ -1285,7 +1285,7 @@ Or attach a reusable `[[style_bundles]]` block defined in top-level `config.toml
 
 | Field | Required | Default | Description |
 |-------|----------|---------|-------------|
-| `style_bundle` | no | — | Name of a shared `[[style_bundles]]` block. Cannot coexist with the inline fields below. |
+| `style_bundle` | no | — | Name of a shared `[[style_bundles]]` block. Merges with the inline fields below (bundles v2): inline wins slot-wise (palette source / min / max), per parameter; named styles union with inline winning name clashes. Bundles can carry shared `[[style_bundles.parameters]]` blocks. |
 | `colormap` | no | `viridis` | Built-in colormap for the default style |
 | `color_stops` | no | — | Array of `{value, color}` entries. Overrides `colormap` for the default style. |
 | `min` | no | from colormap | Minimum value for the default style's range |

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -445,6 +445,13 @@ pub struct StyleBundle {
     /// collection that references this bundle.
     #[serde(default)]
     pub extras: Vec<StyleBundleExtra>,
+    /// Per-parameter default styles shared by every collection bound to
+    /// this bundle (bundles v2) — same shape as `[[wms.parameters]]`. An
+    /// inline `[[wms.parameters]]` entry with the same name wins slot-wise.
+    /// This is what lets N radar-volume collections share one ~500-line
+    /// per-moment style block instead of copy-pasting it.
+    #[serde(default)]
+    pub parameters: Vec<WmsParameterConfig>,
 }
 
 /// Default style inside a `StyleBundle`.
@@ -2118,6 +2125,23 @@ impl ServerConfig {
                     )));
                 }
             }
+            // Bundle per-parameter defaults (bundles v2): non-empty, unique
+            // names — duplicates would silently overwrite each other.
+            let mut param_names: std::collections::HashSet<&str> = std::collections::HashSet::new();
+            for p in &bundle.parameters {
+                if p.name.is_empty() {
+                    return Err(crate::error::DataServerError::Config(format!(
+                        "Style bundle '{}': parameters entry has an empty 'name' field",
+                        bundle.id
+                    )));
+                }
+                if !param_names.insert(p.name.as_str()) {
+                    return Err(crate::error::DataServerError::Config(format!(
+                        "Style bundle '{}': duplicate parameters entry '{}'",
+                        bundle.id, p.name
+                    )));
+                }
+            }
         }
 
         // Check for duplicate collection IDs
@@ -2525,25 +2549,17 @@ impl ServerConfig {
                 }
             }
 
-            // style_bundle: reference must resolve, must not mix with inline WMS style fields
+            // style_bundle: reference must resolve. Inline [wms] fields are
+            // ALLOWED next to a bundle since bundles v2 — they merge
+            // slot-wise, inline winning per slot (see
+            // ds_render::StyleContext), so a collection can e.g. bind a
+            // shared bundle and override only min/max or one parameter.
             if let Some(wms) = &collection.wms {
                 if let Some(bundle_ref) = &wms.style_bundle {
                     if !bundle_ids.contains(bundle_ref.as_str()) {
                         return Err(crate::error::DataServerError::Config(format!(
                             "Collection '{id}': style_bundle '{bundle_ref}' is not defined \
                              in [[style_bundles]]"
-                        )));
-                    }
-                    if wms.colormap.is_some()
-                        || !wms.color_stops.is_empty()
-                        || !wms.styles.is_empty()
-                        || !wms.parameters.is_empty()
-                        || wms.min.is_some()
-                        || wms.max.is_some()
-                    {
-                        return Err(crate::error::DataServerError::Config(format!(
-                            "Collection '{id}': style_bundle cannot be combined with inline \
-                             colormap/color_stops/min/max/styles/parameters in [wms]"
                         )));
                     }
                 }
@@ -3473,7 +3489,10 @@ style_bundle = "missing"
     }
 
     #[test]
-    fn style_bundle_cannot_be_mixed_with_inline_wms_fields() {
+    fn style_bundle_merges_with_inline_fields() {
+        // Bundles v2: inline [wms] fields and [[wms.styles]]/[[wms.parameters]]
+        // are allowed next to style_bundle — they merge slot-wise at style
+        // resolution (inline wins). The old mutual-exclusion error is gone.
         let tmp = TempDir::new().unwrap();
         let config_toml = format!(
             r#"
@@ -3497,60 +3516,69 @@ data_path = "/tmp"
 
 [collections.wms]
 style_bundle = "radar_multi"
-colormap = "viridis"
-"#,
-            bundle = radar_bundle_toml()
-        );
-        let path = write_config(tmp.path(), "config.toml", &config_toml);
-        let err = ServerConfig::from_file(path.to_str().unwrap())
-            .unwrap_err()
-            .to_string();
-        assert!(
-            err.contains("style_bundle cannot be combined with inline"),
-            "got: {err}"
-        );
-    }
-
-    #[test]
-    fn style_bundle_cannot_be_mixed_with_inline_styles_array() {
-        let tmp = TempDir::new().unwrap();
-        let config_toml = format!(
-            r#"
-[server]
-host = "127.0.0.1"
-port = 8000
-
-{bundle}
-
-[[collections]]
-id = "radar-dwd"
-title = "DWD"
-description = "DWD"
-engine_type = "geotiff"
-
-[collections.geotiff]
-filename_template = "radar_%Y%m%dT%H%MZ.tif"
-parameter = "reflectivity"
-unit = "dBZ"
-data_path = "/tmp"
-
-[collections.wms]
-style_bundle = "radar_multi"
+min = -10.0
+max = 80.0
 
 [[collections.wms.styles]]
 name = "extra"
 colormap = "viridis"
+
+[[collections.wms.parameters]]
+name = "DBZH"
+colormap = "viridis"
 "#,
             bundle = radar_bundle_toml()
         );
         let path = write_config(tmp.path(), "config.toml", &config_toml);
+        ServerConfig::from_file(path.to_str().unwrap())
+            .expect("bundle + inline fields is valid since bundles v2");
+    }
+
+    #[test]
+    fn bundle_parameters_validated() {
+        let tmp = TempDir::new().unwrap();
+        // Duplicate parameter names within a bundle are rejected.
+        let config_toml = r#"
+[server]
+host = "127.0.0.1"
+port = 8000
+
+[[style_bundles]]
+id = "vol"
+[style_bundles.default]
+colormap = "radar_dbz"
+[[style_bundles.parameters]]
+name = "VRADH"
+colormap = "radial_velocity"
+[[style_bundles.parameters]]
+name = "VRADH"
+colormap = "viridis"
+"#;
+        let path = write_config(tmp.path(), "config.toml", config_toml);
         let err = ServerConfig::from_file(path.to_str().unwrap())
             .unwrap_err()
             .to_string();
-        assert!(
-            err.contains("style_bundle cannot be combined with inline"),
-            "got: {err}"
-        );
+        assert!(err.contains("duplicate parameters entry"), "got: {err}");
+
+        // Empty parameter name rejected.
+        let config_toml = r#"
+[server]
+host = "127.0.0.1"
+port = 8000
+
+[[style_bundles]]
+id = "vol"
+[style_bundles.default]
+colormap = "radar_dbz"
+[[style_bundles.parameters]]
+name = ""
+colormap = "viridis"
+"#;
+        let path = write_config(tmp.path(), "config2.toml", config_toml);
+        let err = ServerConfig::from_file(path.to_str().unwrap())
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("empty 'name' field"), "got: {err}");
     }
 
     #[test]

--- a/crates/render/src/style.rs
+++ b/crates/render/src/style.rs
@@ -116,28 +116,41 @@ impl StyleContext {
         })
     }
 
-    /// The collection-level default colormap: the bundle default when a
-    /// bundle is bound, else the inline `[wms]` fields.
+    /// The collection-level default colormap: the inline `[wms]` fields
+    /// merged slot-wise over the bundle default (bundles v2) — inline wins
+    /// each slot it defines, so a collection can bind a shared bundle and
+    /// override only e.g. `min`/`max`.
     pub fn collection_default(
         &self,
         collection: &CollectionConfig,
         bundle: Option<&StyleBundle>,
     ) -> Result<ResolvedColormap, String> {
-        if let Some(bundle) = bundle {
-            return self.build_colormap(&StyleSpec {
-                colormap: bundle.default.colormap.as_deref(),
-                color_stops: &bundle.default.color_stops,
-                min: bundle.default.min,
-                max: bundle.default.max,
-            });
-        }
+        self.build_colormap(&self.collection_default_spec(collection, bundle))
+    }
+
+    /// The merged (inline-over-bundle) spec behind [`collection_default`].
+    fn collection_default_spec<'a>(
+        &self,
+        collection: &'a CollectionConfig,
+        bundle: Option<&'a StyleBundle>,
+    ) -> StyleSpec<'a> {
         let wms = collection.wms.as_ref();
-        self.build_colormap(&StyleSpec {
+        let inline = StyleSpec {
             colormap: wms.and_then(|w| w.colormap.as_deref()),
             color_stops: wms.map(|w| &w.color_stops[..]).unwrap_or(&[]),
             min: wms.and_then(|w| w.min),
             max: wms.and_then(|w| w.max),
-        })
+        };
+        let Some(bundle) = bundle else { return inline };
+        merge_specs(
+            inline,
+            StyleSpec {
+                colormap: bundle.default.colormap.as_deref(),
+                color_stops: &bundle.default.color_stops,
+                min: bundle.default.min,
+                max: bundle.default.max,
+            },
+        )
     }
 
     /// All styles for a collection's base layer: `default` plus named
@@ -164,6 +177,9 @@ impl StyleContext {
             },
         );
 
+        // Named styles: union of bundle extras and inline [[wms.styles]]
+        // (bundles v2) — inline wins on a name clash because it is inserted
+        // second into the same map.
         if let Some(bundle) = bundle {
             for extra in &bundle.extras {
                 let r = self.build_colormap(&StyleSpec {
@@ -185,7 +201,8 @@ impl StyleContext {
                     },
                 );
             }
-        } else if let Some(wms_config) = &collection.wms {
+        }
+        if let Some(wms_config) = &collection.wms {
             for style_config in &wms_config.styles {
                 let r = self.build_colormap(&StyleSpec {
                     colormap: style_config.colormap.as_deref(),
@@ -239,27 +256,48 @@ impl StyleContext {
 
         let shared_named_styles = self.collection_styles(collection, bundle)?;
 
-        // When a bundle is bound, inline per-parameter overrides are
-        // rejected by validation (bundles v2 will merge them instead).
+        // Per-parameter chain (bundles v2), each slot resolved
+        // independently, first level that defines it wins:
+        //   1. inline [[wms.parameters]] entry
+        //   2. bundle [[style_bundles.parameters]] entry
+        //   3. inline [wms] collection fields
+        //   4. bundle default
         let param_configs: HashMap<&str, &WmsParameterConfig> = wms_config
             .parameters
             .iter()
             .map(|p| (p.name.as_str(), p))
             .collect();
+        let bundle_params: HashMap<&str, &WmsParameterConfig> = bundle
+            .map(|b| b.parameters.iter().map(|p| (p.name.as_str(), p)).collect())
+            .unwrap_or_default();
 
-        let fallback = self.collection_default(collection, bundle)?;
+        let collection_spec = self.collection_default_spec(collection, bundle);
+        let fallback = self.build_colormap(&collection_spec)?;
+
+        fn param_spec(pc: &WmsParameterConfig) -> StyleSpec<'_> {
+            StyleSpec {
+                colormap: pc.colormap.as_deref(),
+                color_stops: &pc.color_stops,
+                min: pc.min,
+                max: pc.max,
+            }
+        }
 
         for (short_name, _title) in param_names {
             let layer_key = format!("{}/{}", collection.id, short_name);
             let mut layer_styles = HashMap::new();
 
-            let r = if let Some(pc) = param_configs.get(short_name.as_str()) {
-                self.build_colormap(&StyleSpec {
-                    colormap: pc.colormap.as_deref(),
-                    color_stops: &pc.color_stops,
-                    min: pc.min,
-                    max: pc.max,
-                })?
+            let inline_pc = param_configs.get(short_name.as_str());
+            let bundle_pc = bundle_params.get(short_name.as_str());
+            let r = if inline_pc.is_some() || bundle_pc.is_some() {
+                let mut spec = collection_spec;
+                if let Some(pc) = bundle_pc {
+                    spec = merge_specs(param_spec(pc), spec);
+                }
+                if let Some(pc) = inline_pc {
+                    spec = merge_specs(param_spec(pc), spec);
+                }
+                self.build_colormap(&spec)?
             } else {
                 fallback.clone()
             };
@@ -299,6 +337,26 @@ impl StyleContext {
         }
 
         Ok(out)
+    }
+}
+
+/// Slot-wise merge (bundles v2): `primary` wins every slot it defines. The
+/// palette source — the (colormap name, color_stops) pair — is ONE slot: if
+/// primary defines either, primary's whole pair is taken (mixing primary
+/// stops with a fallback name would be incoherent); `min` and `max` merge
+/// independently, so an override of just the range inherits the palette.
+fn merge_specs<'a>(primary: StyleSpec<'a>, fallback: StyleSpec<'a>) -> StyleSpec<'a> {
+    let primary_has_palette = primary.colormap.is_some() || !primary.color_stops.is_empty();
+    let (colormap, color_stops) = if primary_has_palette {
+        (primary.colormap, primary.color_stops)
+    } else {
+        (fallback.colormap, fallback.color_stops)
+    };
+    StyleSpec {
+        colormap,
+        color_stops,
+        min: primary.min.or(fallback.min),
+        max: primary.max.or(fallback.max),
     }
 }
 
@@ -531,6 +589,141 @@ mod tests {
             &src,
             &maybe_wrap_integer_lut(src.clone(), 0.0, f64::INFINITY)
         ));
+    }
+
+    fn bundle(toml_src: &str) -> StyleBundle {
+        toml::from_str(toml_src).expect("test bundle parses")
+    }
+
+    /// Bundles v2: a bundle carries per-parameter defaults; collections
+    /// inherit them with zero inline config (the nexus radar-volume case
+    /// that previously required ~525 copy-pasted lines per file).
+    #[test]
+    fn bundle_parameters_shared_across_collections() {
+        let ctx = StyleContext::with_builtins();
+        let b = bundle(
+            r#"
+            id = "radar_volume"
+            [default]
+            colormap = "radar_dbz"
+            [[parameters]]
+            name = "VRADH"
+            colormap = "radial_velocity"
+            min = -48.0
+            max = 48.0
+            [[extras]]
+            name = "gray"
+            colormap = "grayscale"
+            min = 0.0
+            max = 70.0
+            "#,
+        );
+        let params = vec![
+            ("DBZH".to_string(), "Z".to_string()),
+            ("VRADH".to_string(), "V".to_string()),
+        ];
+        for id in ["c1", "c2"] {
+            let mut c = coll("style_bundle = \"radar_volume\"\n");
+            c.id = id.to_string();
+            let maps = ctx
+                .parameter_layer_styles(&c, Some(&b), &params, &|_, cm| cm)
+                .unwrap();
+            let dbzh = &maps[&format!("{id}/DBZH")]["default"];
+            assert_eq!(dbzh.palette.name, "radar_dbz");
+            let vradh = &maps[&format!("{id}/VRADH")]["default"];
+            assert_eq!(vradh.palette.name, "radial_velocity");
+            assert_eq!((vradh.min, vradh.max), (-48.0, 48.0));
+            // Bundle extras present on parameter layers too.
+            assert!(maps[&format!("{id}/VRADH")].contains_key("gray"));
+        }
+    }
+
+    /// Slot-wise merge: inline defines only min/max → palette inherited
+    /// from the bundle; an inline parameter entry overrides the bundle's
+    /// parameter entry per slot.
+    #[test]
+    fn slot_wise_merge_inline_over_bundle() {
+        let ctx = StyleContext::with_builtins();
+        let b = bundle(
+            r#"
+            id = "vol"
+            [default]
+            colormap = "radar_dbz"
+            [[parameters]]
+            name = "VRADH"
+            colormap = "radial_velocity"
+            min = -48.0
+            max = 48.0
+            "#,
+        );
+        // Collection overrides ONLY the range of the default style…
+        let c = coll(
+            r#"
+            style_bundle = "vol"
+            min = -10.0
+            max = 80.0
+            [[wms.parameters]]
+            name = "VRADH"
+            min = -24.0
+            max = 24.0
+            "#,
+        );
+        let default = ctx.collection_default(&c, Some(&b)).unwrap();
+        // …palette slot inherited from the bundle, range from inline.
+        assert_eq!(default.palette.name, "radar_dbz");
+        assert_eq!((default.min, default.max), (-10.0, 80.0));
+
+        let params = vec![("VRADH".to_string(), "V".to_string())];
+        let maps = ctx
+            .parameter_layer_styles(&c, Some(&b), &params, &|_, cm| cm)
+            .unwrap();
+        let vradh = &maps["c1/VRADH"]["default"];
+        // Inline param defines only min/max → narrows the range, inherits
+        // the bundle parameter's palette.
+        assert_eq!(vradh.palette.name, "radial_velocity");
+        assert_eq!((vradh.min, vradh.max), (-24.0, 24.0));
+    }
+
+    /// Named styles are the union of bundle extras and inline styles;
+    /// inline wins a name clash.
+    #[test]
+    fn named_styles_union_inline_wins() {
+        let ctx = StyleContext::with_builtins();
+        let b = bundle(
+            r#"
+            id = "vol"
+            [default]
+            colormap = "radar_dbz"
+            [[extras]]
+            name = "gray"
+            colormap = "grayscale"
+            min = 0.0
+            max = 1.0
+            [[extras]]
+            name = "fmi"
+            colormap = "radar_fmi"
+            "#,
+        );
+        let c = coll(
+            r#"
+            style_bundle = "vol"
+            [[wms.styles]]
+            name = "gray"
+            title = "Wide gray"
+            colormap = "grayscale"
+            min = -32.0
+            max = 95.0
+            [[wms.styles]]
+            name = "local_extra"
+            colormap = "viridis"
+            "#,
+        );
+        let styles = ctx.collection_styles(&c, Some(&b)).unwrap();
+        assert_eq!(styles.len(), 4); // default + gray + fmi + local_extra
+        assert_eq!((styles["gray"].min, styles["gray"].max), (-32.0, 95.0));
+        assert_eq!(styles["gray"].title, "Wide gray");
+        assert!(styles.contains_key("fmi"));
+        assert!(styles.contains_key("local_extra"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Phase 4 of the styling revamp (stacked on #560) — the DRY payoff. Bundles gain `[[style_bundles.parameters]]` and merge with inline config instead of being mutually exclusive, so the 7 production radar-volume configs carrying byte-identical ~525-line per-moment style blocks can collapse to one shared bundle (≈ −3,600 config lines on nexus).

**Resolution chain per parameter** — each slot (palette source / min / max) independent, first definer wins: inline `[[wms.parameters]]` → bundle `[[style_bundles.parameters]]` → inline `[wms]` → bundle default. Named styles: union of bundle extras + inline `[[wms.styles]]`, inline wins name clashes.

## Compatibility

- Every previously **valid** config resolves identically (bundle-only and inline-only paths unchanged — pinned by the Phase 2 regression tests).
- Previously **rejected** configs (bundle + inline) now work — that's the feature.
- One intentional refinement: an inline `[[wms.parameters]]` entry with only `min`/`max` now inherits the collection/bundle palette instead of silently resolving to viridis.

## Test plan

- New precedence tests: bundle parameters shared across two collections (the nexus radar-volume replica), slot-wise inline-over-bundle (range-only overrides inherit the palette at both collection and parameter level), named-style union with inline name-clash override.
- ds-core: bundle-parameter validation tests (duplicate/empty names); the old mutual-exclusion tests replaced with merge-acceptance tests.
- `cargo clippy --all-targets -- -D warnings` clean; ds-render + ds-core + server suites green (544 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VWyrJy1FVeinRS8UsSZKrU