### PR TITLE
feat(api): machine-readable legend JSON — WMS FORMAT=application/json, Maps/Tiles /legend

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,7 +145,10 @@ gh issue create --title "..." --label "bug,priority: high" --milestone "v0.2"
   toml). Keep it that way. Use the `PropertyValue` enum, not
   `serde_json::Value`, for feature properties. CRS math and `GeoTransform`
   live in `ds_core::geo`, shared by all engines.
-- **`ds-render` has no framework dependencies** (only ds-core and `png`).
+- **`ds-render` has no framework dependencies** (no axum/tokio/http —
+  encoders and codecs only: `png`, `jpeg-encoder`, `webp`, plus
+  `serde_json` for the shared machine-readable legend document builder
+  `legend_json`, kept in ds-render so WMS/Maps/Tiles can't drift apart).
   `ds-mvt` and `ds-3dtiles` are likewise framework-free byte encoders,
   mirroring `ds-render`.
 - **Byte-bounded LRU caches go through `ds-cache`** (#480):

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -169,6 +169,7 @@ dependencies = [
  "http-body-util",
  "quick-xml 0.37.5",
  "serde",
+ "serde_json",
  "tokio",
  "tower",
  "tracing",
@@ -1069,6 +1070,7 @@ dependencies = [
  "jpeg-encoder",
  "png",
  "quick_cache",
+ "serde_json",
  "toml",
  "webp",
 ]

--- a/crates/api-maps/src/handlers.rs
+++ b/crates/api-maps/src/handlers.rs
@@ -13,7 +13,7 @@ use ds_core::map_engine::MapEngine;
 use ds_render::{CacheKey, RenderedCache, StyleInfo};
 
 use crate::error::MapsError;
-use crate::params::{self, MapQueryParams};
+use crate::params::{self, LegendFormat, LegendQueryParams, MapQueryParams};
 
 /// Shared state for the OGC API Maps service.
 #[derive(Clone)]
@@ -101,6 +101,24 @@ fn with_vary(mut resp: Response) -> Response {
     resp
 }
 
+/// The link entries advertised for one style: the styled-map endpoint and the
+/// machine-readable legend. One builder so the `/collections/{id}` and
+/// `/collections/{id}/styles` representations can't drift.
+fn style_links(collection_id: &str, style_name: &str, base_url: &str) -> serde_json::Value {
+    json!([
+        {
+            "href": format!("{base_url}/maps/collections/{collection_id}/styles/{style_name}/map"),
+            "rel": "map",
+            "type": "image/png"
+        },
+        {
+            "href": format!("{base_url}/maps/collections/{collection_id}/styles/{style_name}/legend"),
+            "rel": "legend",
+            "type": "application/json"
+        }
+    ])
+}
+
 fn build_collection_metadata(
     config: &CollectionConfig,
     info: &ds_core::map_engine::RasterInfo,
@@ -139,13 +157,7 @@ fn build_collection_metadata(
                 style_list.push(json!({
                     "id": s.name,
                     "title": s.title,
-                    "links": [
-                        {
-                            "href": format!("{base_url}/maps/collections/{}/styles/{}/map", config.id, s.name),
-                            "rel": "map",
-                            "type": "image/png"
-                        }
-                    ]
+                    "links": style_links(&config.id, &s.name, base_url)
                 }));
             }
         }
@@ -473,6 +485,48 @@ pub async fn api_definition(State(state): State<AppState>) -> impl IntoResponse 
                 }
             }
         });
+
+        // GET /maps/collections/{id}/styles/{styleId}/legend
+        let legend_path = format!("/maps/collections/{id}/styles/{{styleId}}/legend");
+        collection_paths[&legend_path] = json!({
+            "get": {
+                "summary": format!("Get style legend for {}", config.title),
+                "operationId": format!("getStyleLegend_{id}"),
+                "tags": [id],
+                "parameters": [
+                    {
+                        "name": "styleId",
+                        "in": "path",
+                        "required": true,
+                        "schema": {"type": "string"},
+                        "description": "Style identifier"
+                    },
+                    {
+                        "name": "f",
+                        "in": "query",
+                        "required": false,
+                        "schema": {"type": "string", "default": "json", "enum": ["json", "application/json", "png", "image/png"]},
+                        "description": "Legend representation: the machine-readable description (default) or a rendered legend image."
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Legend description or image",
+                        "content": {
+                            "application/json": {
+                                "schema": {"$ref": "#/components/schemas/legend"}
+                            },
+                            "image/png": {
+                                "schema": {"type": "string", "format": "binary"}
+                            }
+                        }
+                    },
+                    "400": {"description": "Bad request"},
+                    "404": {"description": "Collection or style not found"},
+                    "500": {"description": "Server error"}
+                }
+            }
+        });
     }
 
     let mut paths = json!({
@@ -625,6 +679,33 @@ pub async fn api_definition(State(state): State<AppState>) -> impl IntoResponse 
                         "id": {"type": "string"},
                         "title": {"type": "string"},
                         "links": {"type": "array", "items": {"$ref": "#/components/schemas/link"}}
+                    }
+                },
+                "legend": {
+                    "type": "object",
+                    "required": ["style", "title", "min", "max", "interpolation", "stops"],
+                    "properties": {
+                        "style": {"type": "string", "description": "Style identifier"},
+                        "title": {"type": "string", "description": "Human-readable style title"},
+                        "parameter": {"type": "string", "description": "Data parameter the style renders. Omitted when unknown."},
+                        "unit": {"type": "string", "description": "Unit of the rendered values. Omitted when unknown."},
+                        "min": {"type": "number", "description": "Low end of the value range the colours span"},
+                        "max": {"type": "number", "description": "High end of the value range the colours span"},
+                        "interpolation": {"type": "string", "enum": ["linear", "step"],
+                                          "description": "How colours are produced between stops"},
+                        "nodataColor": {"type": "string", "description": "Colour for no-data pixels, when the palette defines one."},
+                        "stops": {
+                            "type": "array",
+                            "description": "Palette colour stops, ascending by value",
+                            "items": {
+                                "type": "object",
+                                "required": ["value", "color"],
+                                "properties": {
+                                    "value": {"type": "number"},
+                                    "color": {"type": "string", "description": "#RRGGBB, or #RRGGBBAA when not fully opaque"}
+                                }
+                            }
+                        }
                     }
                 },
                 "link": {
@@ -929,13 +1010,7 @@ pub async fn styles(
                 style_list.push(json!({
                     "id": s.name,
                     "title": s.title,
-                    "links": [
-                        {
-                            "href": format!("{base}/maps/collections/{}/styles/{}/map", config.id, s.name),
-                            "rel": "map",
-                            "type": "image/png"
-                        }
-                    ]
+                    "links": style_links(&config.id, &s.name, base)
                 }));
             }
         }
@@ -951,6 +1026,84 @@ pub async fn styles(
             }
         ]
     })))
+}
+
+/// GET /maps/collections/{id}/styles/{styleId}/legend
+///
+/// `?f=json` (the default) returns the machine-readable legend — palette
+/// stops, value range, interpolation — so a client can draw its own legend;
+/// `?f=png` returns the rendered legend image. Cacheable for a day but NOT
+/// immutable: palettes are hot-reloadable.
+pub async fn style_legend(
+    Path((id, style_id)): Path<(String, String)>,
+    Query(params): Query<LegendQueryParams>,
+    State(state): State<AppState>,
+) -> Result<Response, MapsError> {
+    let state = state.load_full();
+    let (engine, _config) = lookup_engine(&state, &id)?;
+    let format = params.validate()?;
+
+    let layer_styles = state
+        .styles
+        .get(&id)
+        .ok_or_else(|| MapsError::NotFound(format!("Collection '{id}' not found")))?;
+    let style_info = layer_styles.get(&style_id).ok_or_else(|| {
+        MapsError::NotFound(format!(
+            "Style '{style_id}' not found for collection '{id}'. Available: {}",
+            layer_styles.keys().cloned().collect::<Vec<_>>().join(", ")
+        ))
+    })?;
+
+    let info = engine.raster_info();
+    let (parameter, unit) = ds_render::legend_parameter_unit(style_info, &info);
+
+    match format {
+        LegendFormat::Json => {
+            let body = ds_render::legend_json(style_info, parameter.as_deref(), unit.as_deref());
+            let mut response = Json(body).into_response();
+            response.headers_mut().insert(
+                header::CACHE_CONTROL,
+                axum::http::HeaderValue::from_static(ds_render::LEGEND_CACHE_CONTROL),
+            );
+            response.headers_mut().insert(
+                header::HeaderName::from_static("x-content-type-options"),
+                axum::http::HeaderValue::from_static("nosniff"),
+            );
+            Ok(response)
+        }
+        LegendFormat::Png => {
+            let colormap = style_info.colormap.clone();
+            let (min, max) = (style_info.min, style_info.max);
+            let title = ds_render::legend_title(style_info, parameter.as_deref(), unit.as_deref());
+            let bytes = tokio::task::spawn_blocking(move || {
+                ds_render::render_legend(
+                    colormap.as_ref(),
+                    min,
+                    max,
+                    ds_render::LEGEND_DEFAULT_WIDTH,
+                    ds_render::LEGEND_DEFAULT_HEIGHT,
+                    ds_render::ImageFormat::Png,
+                    title.as_deref(),
+                )
+            })
+            .await
+            .map_err(|e| MapsError::Internal(format!("Legend render failed: {e}")))?
+            .map_err(|e| MapsError::Internal(format!("Legend render error: {e}")))?;
+
+            Ok((
+                [
+                    (header::CONTENT_TYPE, "image/png"),
+                    (header::CACHE_CONTROL, ds_render::LEGEND_CACHE_CONTROL),
+                    (
+                        header::HeaderName::from_static("x-content-type-options"),
+                        "nosniff",
+                    ),
+                ],
+                bytes,
+            )
+                .into_response())
+        }
+    }
 }
 
 /// GET /maps/collections/{id}/map — render map with default style

--- a/crates/api-maps/src/lib.rs
+++ b/crates/api-maps/src/lib.rs
@@ -21,5 +21,9 @@ pub fn router(state: AppState) -> Router {
             "/collections/{id}/styles/{styleId}/map",
             get(handlers::get_styled_map),
         )
+        .route(
+            "/collections/{id}/styles/{styleId}/legend",
+            get(handlers::style_legend),
+        )
         .with_state(state)
 }

--- a/crates/api-maps/src/params.rs
+++ b/crates/api-maps/src/params.rs
@@ -47,6 +47,42 @@ pub struct MapQueryParams {
     pub elevation: Option<String>,
 }
 
+/// Query parameters for the style legend endpoint.
+#[derive(Debug, Deserialize)]
+pub struct LegendQueryParams {
+    #[serde(rename = "f")]
+    pub format: Option<String>,
+}
+
+/// Representation a legend request asked for.
+pub enum LegendFormat {
+    /// Machine-readable description: palette stops, range, interpolation.
+    Json,
+    /// The rendered legend image.
+    Png,
+}
+
+impl LegendQueryParams {
+    /// Resolve `?f=`; JSON is the default because the legend endpoint exists
+    /// for clients that draw their own legend. Both the short token and the
+    /// media type are accepted, mirroring how `f=` is spelled elsewhere in
+    /// this API (`image/png`) and in the other OGC metadata endpoints (`json`).
+    pub fn validate(&self) -> Result<LegendFormat, MapsError> {
+        match self
+            .format
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+        {
+            None | Some("json") | Some("application/json") => Ok(LegendFormat::Json),
+            Some("png") | Some("image/png") => Ok(LegendFormat::Png),
+            Some(other) => Err(MapsError::BadRequest(format!(
+                "Format '{other}' is not supported for a legend. Supported: json, png"
+            ))),
+        }
+    }
+}
+
 /// Validated map request parameters.
 pub struct ValidatedMapParams {
     pub bbox: [f64; 4],

--- a/crates/api-maps/tests/integration.rs
+++ b/crates/api-maps/tests/integration.rs
@@ -807,6 +807,146 @@ mod styles_endpoint {
         let (status, _) = get("/collections/nonexistent/styles").await;
         assert_eq!(status, StatusCode::NOT_FOUND);
     }
+
+    /// Every style advertises its machine-readable legend, so a client that
+    /// listed the styles can fetch the palette without guessing the URL.
+    #[tokio::test]
+    async fn every_style_links_its_legend() {
+        let (_, json) = get("/collections/radar/styles").await;
+        for style in json["styles"].as_array().unwrap() {
+            let id = style["id"].as_str().unwrap();
+            let legend = style["links"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .find(|l| l["rel"] == "legend")
+                .unwrap_or_else(|| panic!("style {id} has no legend link"));
+            assert_eq!(
+                legend["href"],
+                format!("/maps/collections/radar/styles/{id}/legend")
+            );
+            assert_eq!(legend["type"], "application/json");
+        }
+    }
+
+    /// The collection metadata carries the same legend links as the styles
+    /// listing — the two representations must not drift.
+    #[tokio::test]
+    async fn collection_metadata_styles_link_their_legends() {
+        let (_, json) = get("/collections/radar").await;
+        for style in json["styles"].as_array().unwrap() {
+            let id = style["id"].as_str().unwrap();
+            assert!(
+                style["links"].as_array().unwrap().iter().any(|l| {
+                    l["rel"] == "legend"
+                        && l["href"] == format!("/maps/collections/radar/styles/{id}/legend")
+                }),
+                "style {id} in collection metadata has no legend link"
+            );
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Style legend tests
+// ---------------------------------------------------------------------------
+
+mod style_legend {
+    use super::*;
+
+    /// `?f=` defaults to the machine-readable legend: value range,
+    /// interpolation mode and one entry per palette stop.
+    #[tokio::test]
+    async fn defaults_to_json_description() {
+        let (status, json) = get("/collections/radar/styles/default/legend").await;
+        assert_eq!(status, StatusCode::OK);
+
+        assert_eq!(json["style"], "default");
+        assert_eq!(json["title"], "Default");
+        // Resolved from the engine's raster_info().
+        assert_eq!(json["parameter"], "reflectivity");
+        assert_eq!(json["unit"], "dBZ");
+        assert_eq!(json["min"], 0.0);
+        assert_eq!(json["max"], 1.0);
+        assert_eq!(json["interpolation"], "linear");
+
+        let palette = ds_render::builtin_palette("viridis").unwrap();
+        let stops = json["stops"].as_array().unwrap();
+        assert_eq!(stops.len(), palette.stops.len());
+        assert_eq!(stops[0]["value"], palette.stops[0].value);
+        assert_eq!(stops[0]["color"], "#440154");
+        // Builtin palettes define no explicit nodata colour — omitted, not null.
+        assert!(json.get("nodataColor").is_none());
+    }
+
+    /// A named style describes its own palette, not the default's.
+    #[tokio::test]
+    async fn named_style_describes_its_own_palette() {
+        let (status, json) = get("/collections/radar/styles/grayscale/legend").await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(json["style"], "grayscale");
+        assert_eq!(json["title"], "Grayscale");
+        let stops = json["stops"].as_array().unwrap();
+        assert_eq!(
+            stops.len(),
+            ds_render::builtin_palette("grayscale").unwrap().stops.len()
+        );
+        assert_eq!(stops[0]["color"], "#000000");
+        assert_eq!(stops[stops.len() - 1]["color"], "#FFFFFF");
+    }
+
+    #[tokio::test]
+    async fn png_returns_a_rendered_legend_image() {
+        let (status, headers, body) =
+            get_raw("/collections/radar/styles/default/legend?f=png").await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(headers.get("content-type").unwrap(), "image/png");
+        // Cacheable for a day, but NOT immutable — palettes are hot-reloadable.
+        assert_eq!(
+            headers.get("cache-control").unwrap(),
+            "public, max-age=86400"
+        );
+        assert!(
+            body.starts_with(&[0x89, b'P', b'N', b'G']),
+            "not a PNG: {:?}",
+            &body[..4.min(body.len())]
+        );
+    }
+
+    #[tokio::test]
+    async fn unknown_style_returns_404() {
+        let (status, _) = get("/collections/radar/styles/nope/legend").await;
+        assert_eq!(status, StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn unknown_collection_returns_404() {
+        let (status, _) = get("/collections/nonexistent/styles/default/legend").await;
+        assert_eq!(status, StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn unsupported_format_returns_400() {
+        let (status, _) = get("/collections/radar/styles/default/legend?f=image/jpeg").await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+    }
+
+    /// The OpenAPI document advertises the endpoint (repo rule: every new
+    /// endpoint updates `api_definition()`).
+    #[tokio::test]
+    async fn is_advertised_in_the_api_definition() {
+        let (_, json) = get("/api").await;
+        let path = &json["paths"]["/maps/collections/radar/styles/{styleId}/legend"]["get"];
+        assert!(
+            path.is_object(),
+            "legend path missing from the OpenAPI spec"
+        );
+        assert_eq!(
+            path["responses"]["200"]["content"]["application/json"]["schema"]["$ref"],
+            "#/components/schemas/legend"
+        );
+        assert!(json["components"]["schemas"]["legend"].is_object());
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/api-tiles/src/handlers.rs
+++ b/crates/api-tiles/src/handlers.rs
@@ -19,7 +19,7 @@ use ds_mvt::{
 use ds_render::{CacheKey, RenderedCache, StyleInfo};
 
 use crate::error::TilesError;
-use crate::params::{self, TileQueryParams};
+use crate::params::{self, LegendFormat, LegendQueryParams, TileQueryParams};
 use crate::tilematrixset::{self, SUPPORTED_TILE_MATRIX_SETS};
 
 /// Pre-generated 256×256 fully transparent `CachedRendered` for empty
@@ -155,6 +155,16 @@ fn build_collection_metadata(
                 style_list.push(json!({
                     "id": s.name,
                     "title": s.title,
+                    "links": [
+                        {
+                            "href": format!(
+                                "{base_url}/tiles/collections/{}/styles/{}/legend",
+                                config.id, s.name
+                            ),
+                            "rel": "legend",
+                            "type": "application/json"
+                        }
+                    ]
                 }));
             }
         }
@@ -517,6 +527,51 @@ pub async fn api_definition(State(state): State<AppState>) -> impl IntoResponse 
                 }
             }
         });
+
+        // Legends describe a raster style's palette — vector-only collections
+        // have no styles registry entry and the route would 404, so only
+        // advertise it where a MapEngine is registered.
+        if has_raster {
+            collection_paths[format!("/tiles/collections/{id}/styles/{{styleId}}/legend")] = json!({
+                "get": {
+                    "summary": format!("Get style legend for {}", config.title),
+                    "operationId": format!("getStyleLegend_{id}"),
+                    "tags": [id],
+                    "parameters": [
+                        {
+                            "name": "styleId",
+                            "in": "path",
+                            "required": true,
+                            "schema": {"type": "string"},
+                            "description": "Style identifier"
+                        },
+                        {
+                            "name": "f",
+                            "in": "query",
+                            "required": false,
+                            "schema": {"type": "string", "default": "json", "enum": ["json", "application/json", "png", "image/png"]},
+                            "description": "Legend representation: the machine-readable description (default) or a rendered legend image."
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Legend description or image",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/legend"}
+                                },
+                                "image/png": {
+                                    "schema": {"type": "string", "format": "binary"}
+                                }
+                            }
+                        },
+                        "400": {"description": "Bad request"},
+                        "404": {"description": "Collection or style not found"},
+                        "500": {"description": "Server error"}
+                    }
+                }
+            });
+        }
     }
 
     let mut paths = json!({
@@ -617,6 +672,35 @@ pub async fn api_definition(State(state): State<AppState>) -> impl IntoResponse 
                     "required": false,
                     "schema": {"type": "number"},
                     "description": "Vertical level (e.g. radar elevation angle). Only valid for collections with a vertical dimension."
+                }
+            },
+            "schemas": {
+                "legend": {
+                    "type": "object",
+                    "required": ["style", "title", "min", "max", "interpolation", "stops"],
+                    "properties": {
+                        "style": {"type": "string", "description": "Style identifier"},
+                        "title": {"type": "string", "description": "Human-readable style title"},
+                        "parameter": {"type": "string", "description": "Data parameter the style renders. Omitted when unknown."},
+                        "unit": {"type": "string", "description": "Unit of the rendered values. Omitted when unknown."},
+                        "min": {"type": "number", "description": "Low end of the value range the colours span"},
+                        "max": {"type": "number", "description": "High end of the value range the colours span"},
+                        "interpolation": {"type": "string", "enum": ["linear", "step"],
+                                          "description": "How colours are produced between stops"},
+                        "nodataColor": {"type": "string", "description": "Colour for no-data pixels, when the palette defines one."},
+                        "stops": {
+                            "type": "array",
+                            "description": "Palette colour stops, ascending by value",
+                            "items": {
+                                "type": "object",
+                                "required": ["value", "color"],
+                                "properties": {
+                                    "value": {"type": "number"},
+                                    "color": {"type": "string", "description": "#RRGGBB, or #RRGGBBAA when not fully opaque"}
+                                }
+                            }
+                        }
+                    }
                 }
             }
         }
@@ -1270,6 +1354,84 @@ pub async fn get_tile(
     )
     .await
     .map(|r| r.into_response())
+}
+
+/// GET /tiles/collections/{id}/styles/{styleId}/legend
+///
+/// `?f=json` (the default) returns the machine-readable legend — palette
+/// stops, value range, interpolation — so a client can draw its own legend;
+/// `?f=png` returns the rendered legend image. Cacheable for a day but NOT
+/// immutable: palettes are hot-reloadable.
+pub async fn style_legend(
+    Path((id, style_id)): Path<(String, String)>,
+    Query(params): Query<LegendQueryParams>,
+    State(state): State<AppState>,
+) -> Result<Response, TilesError> {
+    let state = state.load_full();
+    let (engine, _config) = lookup_engine(&state, &id)?;
+    let format = params.validate()?;
+
+    let layer_styles = state
+        .styles
+        .get(&id)
+        .ok_or_else(|| TilesError::NotFound(format!("Collection '{id}' not found")))?;
+    let style_info = layer_styles.get(&style_id).ok_or_else(|| {
+        TilesError::NotFound(format!(
+            "Style '{style_id}' not found for collection '{id}'. Available: {}",
+            layer_styles.keys().cloned().collect::<Vec<_>>().join(", ")
+        ))
+    })?;
+
+    let info = engine.raster_info();
+    let (parameter, unit) = ds_render::legend_parameter_unit(style_info, &info);
+
+    match format {
+        LegendFormat::Json => {
+            let body = ds_render::legend_json(style_info, parameter.as_deref(), unit.as_deref());
+            let mut response = Json(body).into_response();
+            response.headers_mut().insert(
+                header::CACHE_CONTROL,
+                axum::http::HeaderValue::from_static(ds_render::LEGEND_CACHE_CONTROL),
+            );
+            response.headers_mut().insert(
+                header::HeaderName::from_static("x-content-type-options"),
+                axum::http::HeaderValue::from_static("nosniff"),
+            );
+            Ok(response)
+        }
+        LegendFormat::Png => {
+            let colormap = style_info.colormap.clone();
+            let (min, max) = (style_info.min, style_info.max);
+            let title = ds_render::legend_title(style_info, parameter.as_deref(), unit.as_deref());
+            let bytes = tokio::task::spawn_blocking(move || {
+                ds_render::render_legend(
+                    colormap.as_ref(),
+                    min,
+                    max,
+                    ds_render::LEGEND_DEFAULT_WIDTH,
+                    ds_render::LEGEND_DEFAULT_HEIGHT,
+                    ds_render::ImageFormat::Png,
+                    title.as_deref(),
+                )
+            })
+            .await
+            .map_err(|e| TilesError::Internal(format!("Legend render failed: {e}")))?
+            .map_err(|e| TilesError::Internal(format!("Legend render error: {e}")))?;
+
+            Ok((
+                [
+                    (header::CONTENT_TYPE, "image/png"),
+                    (header::CACHE_CONTROL, ds_render::LEGEND_CACHE_CONTROL),
+                    (
+                        header::HeaderName::from_static("x-content-type-options"),
+                        "nosniff",
+                    ),
+                ],
+                bytes,
+            )
+                .into_response())
+        }
+    }
 }
 
 /// GET /tiles/collections/{id}/styles/{styleId}/tiles/{tileMatrixSetId}/{tileMatrix}/{tileRow}/{tileCol}

--- a/crates/api-tiles/src/lib.rs
+++ b/crates/api-tiles/src/lib.rs
@@ -33,5 +33,9 @@ pub fn router(state: AppState) -> Router {
             "/collections/{id}/styles/{styleId}/tiles/{tileMatrixSetId}/{tileMatrix}/{tileRow}/{tileCol}",
             get(handlers::get_styled_tile),
         )
+        .route(
+            "/collections/{id}/styles/{styleId}/legend",
+            get(handlers::style_legend),
+        )
         .with_state(state)
 }

--- a/crates/api-tiles/src/params.rs
+++ b/crates/api-tiles/src/params.rs
@@ -59,6 +59,42 @@ impl TileQueryParams {
     }
 }
 
+/// Query parameters for the style legend endpoint.
+#[derive(Debug, Deserialize)]
+pub struct LegendQueryParams {
+    #[serde(rename = "f")]
+    pub format: Option<String>,
+}
+
+/// Representation a legend request asked for.
+pub enum LegendFormat {
+    /// Machine-readable description: palette stops, range, interpolation.
+    Json,
+    /// The rendered legend image.
+    Png,
+}
+
+impl LegendQueryParams {
+    /// Resolve `?f=`; JSON is the default because the legend endpoint exists
+    /// for clients that draw their own legend. Both the short token and the
+    /// media type are accepted, mirroring how `f=` is spelled elsewhere in
+    /// this API (`image/png`, `mvt`) and in the OGC metadata endpoints (`json`).
+    pub fn validate(&self) -> Result<LegendFormat, TilesError> {
+        match self
+            .format
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+        {
+            None | Some("json") | Some("application/json") => Ok(LegendFormat::Json),
+            Some("png") | Some("image/png") => Ok(LegendFormat::Png),
+            Some(other) => Err(TilesError::BadRequest(format!(
+                "Format '{other}' is not supported for a legend. Supported: json, png"
+            ))),
+        }
+    }
+}
+
 /// Validated tile query parameters.
 pub struct ValidatedTileParams {
     pub time: Option<DateTime<Utc>>,

--- a/crates/api-tiles/tests/integration.rs
+++ b/crates/api-tiles/tests/integration.rs
@@ -1282,6 +1282,131 @@ mod styled_tile {
 }
 
 // ---------------------------------------------------------------------------
+// Style legend tests
+// ---------------------------------------------------------------------------
+
+mod style_legend {
+    use super::*;
+
+    /// `?f=` defaults to the machine-readable legend: value range,
+    /// interpolation mode and one entry per palette stop.
+    #[tokio::test]
+    async fn defaults_to_json_description() {
+        let (status, json) = get("/collections/radar/styles/default/legend").await;
+        assert_eq!(status, StatusCode::OK);
+
+        assert_eq!(json["style"], "default");
+        assert_eq!(json["title"], "Default");
+        // Resolved from the engine's raster_info().
+        assert_eq!(json["parameter"], "reflectivity");
+        assert_eq!(json["unit"], "dBZ");
+        assert_eq!(json["min"], 0.0);
+        assert_eq!(json["max"], 1.0);
+        assert_eq!(json["interpolation"], "linear");
+
+        let palette = ds_render::builtin_palette("viridis").unwrap();
+        let stops = json["stops"].as_array().unwrap();
+        assert_eq!(stops.len(), palette.stops.len());
+        assert_eq!(stops[0]["value"], palette.stops[0].value);
+        assert_eq!(stops[0]["color"], "#440154");
+        // Builtin palettes define no explicit nodata colour — omitted, not null.
+        assert!(json.get("nodataColor").is_none());
+    }
+
+    /// A named style describes its own palette, not the default's.
+    #[tokio::test]
+    async fn named_style_describes_its_own_palette() {
+        let (status, json) = get("/collections/radar/styles/grayscale/legend").await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(json["style"], "grayscale");
+        assert_eq!(json["title"], "Grayscale");
+        let stops = json["stops"].as_array().unwrap();
+        assert_eq!(
+            stops.len(),
+            ds_render::builtin_palette("grayscale").unwrap().stops.len()
+        );
+        assert_eq!(stops[0]["color"], "#000000");
+        assert_eq!(stops[stops.len() - 1]["color"], "#FFFFFF");
+    }
+
+    #[tokio::test]
+    async fn png_returns_a_rendered_legend_image() {
+        let (status, headers, body) =
+            get_raw("/collections/radar/styles/default/legend?f=png").await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(headers.get("content-type").unwrap(), "image/png");
+        // Cacheable for a day, but NOT immutable — palettes are hot-reloadable.
+        assert_eq!(
+            headers.get("cache-control").unwrap(),
+            "public, max-age=86400"
+        );
+        assert!(
+            body.starts_with(&[0x89, b'P', b'N', b'G']),
+            "not a PNG: {:?}",
+            &body[..4.min(body.len())]
+        );
+    }
+
+    #[tokio::test]
+    async fn unknown_style_returns_404() {
+        let (status, _) = get("/collections/radar/styles/nope/legend").await;
+        assert_eq!(status, StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn unknown_collection_returns_404() {
+        let (status, _) = get("/collections/nonexistent/styles/default/legend").await;
+        assert_eq!(status, StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn unsupported_format_returns_400() {
+        let (status, _) = get("/collections/radar/styles/default/legend?f=mvt").await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+    }
+
+    /// The collection metadata links every style's legend, so a client that
+    /// read `/collections/{id}` can fetch the palette without guessing a URL.
+    #[tokio::test]
+    async fn collection_metadata_styles_link_their_legends() {
+        let (_, json) = get("/collections/radar").await;
+        let styles = json["styles"].as_array().unwrap();
+        assert!(!styles.is_empty());
+        for style in styles {
+            let id = style["id"].as_str().unwrap();
+            let legend = style["links"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .find(|l| l["rel"] == "legend")
+                .unwrap_or_else(|| panic!("style {id} has no legend link"));
+            assert_eq!(
+                legend["href"],
+                format!("/tiles/collections/radar/styles/{id}/legend")
+            );
+            assert_eq!(legend["type"], "application/json");
+        }
+    }
+
+    /// The OpenAPI document advertises the endpoint (repo rule: every new
+    /// endpoint updates `api_definition()`).
+    #[tokio::test]
+    async fn is_advertised_in_the_api_definition() {
+        let (_, json) = get("/api").await;
+        let path = &json["paths"]["/tiles/collections/radar/styles/{styleId}/legend"]["get"];
+        assert!(
+            path.is_object(),
+            "legend path missing from the OpenAPI spec"
+        );
+        assert_eq!(
+            path["responses"]["200"]["content"]["application/json"]["schema"]["$ref"],
+            "#/components/schemas/legend"
+        );
+        assert!(json["components"]["schemas"]["legend"].is_object());
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Vector tile (MVT) tests
 // ---------------------------------------------------------------------------
 

--- a/crates/api-wms/Cargo.toml
+++ b/crates/api-wms/Cargo.toml
@@ -16,6 +16,7 @@ tokio = { version = "1", features = ["sync"] }
 tracing = "0.1"
 
 [dev-dependencies]
+serde_json = "1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 tower = { version = "0.5", features = ["util"] }
 http-body-util = "0.1"

--- a/crates/api-wms/src/handlers.rs
+++ b/crates/api-wms/src/handlers.rs
@@ -626,34 +626,16 @@ pub async fn wms_handler(
                 ))
             })?;
 
-            // Default to a size that fits the value-tick labels + title (#371);
-            // a client can still request a smaller thumbnail, where the renderer
-            // degrades to a bare swatch.
-            let width: u32 = query
-                .width
-                .as_deref()
-                .and_then(|s| s.parse().ok())
-                .unwrap_or(180);
-            let height: u32 = query
-                .height
-                .as_deref()
-                .and_then(|s| s.parse().ok())
-                .unwrap_or(300);
-            let width = width.clamp(1, 512);
-            let height = height.clamp(1, 1024);
+            let format = crate::params::parse_legend_format(query.format.as_deref())?;
 
-            let format = crate::params::parse_image_format(query.format.as_deref())?;
-
-            let colormap = style_info.colormap.clone();
-            let min = style_info.min;
-            let max = style_info.max;
-
-            // Resolve a title ("<parameter> (<unit>)") for the legend from the
+            // Resolve the parameter + unit the legend describes from the
             // engine's raster metadata (#371). The parameter is the style's
             // configured one (set for per-parameter layers), falling back to the
             // "collection/param" layer segment, then the engine's default
             // parameter. The unit is the collection-level unit; multi-unit
             // sources (e.g. radar polar volumes) report none, so it's omitted.
+            // Both feed the rendered legend's title and the JSON legend, so the
+            // two representations describe the same thing.
             let info = state
                 .engines
                 .get(legend_collection_id)
@@ -671,23 +653,51 @@ pub async fn wms_handler(
                 .as_ref()
                 .map(|i| i.unit.clone())
                 .filter(|u| !u.is_empty());
-            let param_unit = match (param, unit) {
-                (Some(p), Some(u)) => Some(format!("{p} ({u})")),
-                (Some(s), None) | (None, Some(s)) => Some(s),
-                (None, None) => None,
+
+            // Machine-readable legend: palette stops + range, for clients that
+            // draw their own legend.
+            let format = match format {
+                crate::params::LegendFormat::Json => {
+                    let body =
+                        ds_render::legend_json(style_info, param.as_deref(), unit.as_deref());
+                    let mut response = axum::Json(body).into_response();
+                    let headers = response.headers_mut();
+                    headers.insert(
+                        header::CACHE_CONTROL,
+                        axum::http::HeaderValue::from_static(ds_render::LEGEND_CACHE_CONTROL),
+                    );
+                    headers.insert(
+                        header::HeaderName::from_static("x-content-type-options"),
+                        axum::http::HeaderValue::from_static("nosniff"),
+                    );
+                    return Ok(response);
+                }
+                crate::params::LegendFormat::Image(format) => format,
             };
-            // For a non-default style, show its name on a second line so the
-            // legend identifies which of a layer's styles it depicts (the colours
-            // already come from this style's colormap). "default"/"Default" carry
-            // no information, so they're omitted.
-            let style_line = (style_name != "default")
-                .then(|| style_info.title.trim().to_string())
-                .filter(|t| !t.is_empty() && !t.eq_ignore_ascii_case("default"));
-            let title = match (param_unit, style_line) {
-                (Some(pu), Some(sl)) => Some(format!("{pu}\n{sl}")),
-                (Some(s), None) | (None, Some(s)) => Some(s),
-                (None, None) => None,
-            };
+
+            // Default to a size that fits the value-tick labels + title (#371);
+            // a client can still request a smaller thumbnail, where the renderer
+            // degrades to a bare swatch.
+            let width: u32 = query
+                .width
+                .as_deref()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(ds_render::LEGEND_DEFAULT_WIDTH);
+            let height: u32 = query
+                .height
+                .as_deref()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(ds_render::LEGEND_DEFAULT_HEIGHT);
+            let width = width.clamp(1, 512);
+            let height = height.clamp(1, 1024);
+
+            let colormap = style_info.colormap.clone();
+            let min = style_info.min;
+            let max = style_info.max;
+
+            // Title shared with the Maps/Tiles legend endpoints so the three
+            // services label the same style identically.
+            let title = ds_render::legend_title(style_info, param.as_deref(), unit.as_deref());
 
             let legend_bytes = tokio::task::spawn_blocking(move || {
                 ds_render::render_legend(

--- a/crates/api-wms/src/params.rs
+++ b/crates/api-wms/src/params.rs
@@ -44,6 +44,33 @@ pub fn parse_image_format(format: Option<&str>) -> Result<ds_render::ImageFormat
     }
 }
 
+/// MIME type selecting the machine-readable legend from `GetLegendGraphic`.
+pub const LEGEND_JSON_FORMAT: &str = "application/json";
+
+/// What a `GetLegendGraphic` request asked for: a rendered image, or the
+/// machine-readable legend description (palette stops + value range) that lets
+/// a client draw its own legend.
+pub enum LegendFormat {
+    Image(ds_render::ImageFormat),
+    Json,
+}
+
+/// Parse `FORMAT=` for `GetLegendGraphic`.
+///
+/// `application/json` (case-insensitive) selects the machine-readable legend;
+/// every other value — including an omitted one — goes through
+/// [`parse_image_format`] unchanged, so image requests and their errors behave
+/// exactly as before. `GetMap` keeps using `parse_image_format` directly and
+/// therefore still rejects `application/json`.
+pub fn parse_legend_format(format: Option<&str>) -> Result<LegendFormat, WmsError> {
+    if let Some(f) = format {
+        if f.trim().eq_ignore_ascii_case(LEGEND_JSON_FORMAT) {
+            return Ok(LegendFormat::Json);
+        }
+    }
+    parse_image_format(format).map(LegendFormat::Image)
+}
+
 /// Raw WMS query parameters (case-insensitive keys handled by axum).
 #[derive(Debug, Deserialize)]
 pub struct WmsQuery {

--- a/crates/api-wms/tests/integration.rs
+++ b/crates/api-wms/tests/integration.rs
@@ -2383,6 +2383,126 @@ async fn legend_graphic_honours_explicit_size() {
     assert_eq!(png_dims(&body), (20, 120));
 }
 
+/// `GetLegendGraphic&FORMAT=application/json` returns the machine-readable
+/// legend instead of a picture: the style's range, interpolation mode, and one
+/// entry per palette stop, so a client can draw its own legend.
+#[tokio::test]
+async fn legend_graphic_json_describes_the_style_palette() {
+    let app = build_empty_router();
+    let req = Request::builder()
+        .uri(
+            "/?SERVICE=WMS&REQUEST=GetLegendGraphic&VERSION=1.3.0\
+             &LAYER=empty&FORMAT=application/json",
+        )
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(
+        resp.headers().get("content-type").unwrap(),
+        "application/json"
+    );
+    // A day is fine, but not `immutable` — palettes are hot-reloadable.
+    assert_eq!(
+        resp.headers().get("cache-control").unwrap(),
+        "public, max-age=86400"
+    );
+    let body = resp.into_body().collect().await.unwrap().to_bytes();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+    assert_eq!(json["style"], "default");
+    assert_eq!(json["title"], "Default");
+    // Resolved from the engine's raster_info(), as the legend image title is.
+    assert_eq!(json["parameter"], "reflectivity");
+    assert_eq!(json["unit"], "dBZ");
+    assert_eq!(json["min"], 0.0);
+    assert_eq!(json["max"], 1.0);
+    assert_eq!(json["interpolation"], "linear");
+
+    let stops = json["stops"].as_array().unwrap();
+    let palette = ds_render::builtin_palette("viridis").unwrap();
+    assert_eq!(
+        stops.len(),
+        palette.stops.len(),
+        "every palette stop must be described"
+    );
+    assert_eq!(stops[0]["value"], palette.stops[0].value);
+    assert_eq!(stops[0]["color"], "#440154");
+}
+
+/// The JSON legend follows `STYLES=` just like the rendered one: the named
+/// style's palette, range, and title — not the default's.
+#[tokio::test]
+async fn legend_graphic_json_reflects_selected_style() {
+    let app = build_empty_router();
+    let req = Request::builder()
+        .uri(
+            "/?SERVICE=WMS&REQUEST=GetLegendGraphic&VERSION=1.3.0\
+             &LAYER=empty&FORMAT=application/json&STYLES=radar_fmi",
+        )
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = resp.into_body().collect().await.unwrap().to_bytes();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+    assert_eq!(json["style"], "radar_fmi");
+    assert_eq!(json["title"], "FMI Radar");
+    assert_eq!(json["min"], -32.0);
+    assert_eq!(json["max"], 95.0);
+    assert_eq!(
+        json["stops"].as_array().unwrap().len(),
+        ds_render::builtin_palette("radar_dbz").unwrap().stops.len()
+    );
+    // Fully transparent stops keep their alpha channel in the hex string.
+    assert_eq!(json["stops"][0]["color"], "#00000000");
+}
+
+/// `FORMAT=APPLICATION/JSON` is matched case-insensitively, and the image
+/// formats are untouched: a PNG request still returns PNG bytes, and an
+/// unsupported FORMAT is still a ServiceException.
+#[tokio::test]
+async fn legend_graphic_json_format_is_case_insensitive_and_images_unchanged() {
+    let app = build_empty_router();
+    let fetch = |format: &str| {
+        let uri = format!(
+            "/?SERVICE=WMS&REQUEST=GetLegendGraphic&VERSION=1.3.0\
+             &LAYER=empty&FORMAT={format}"
+        );
+        let app = app.clone();
+        async move {
+            let resp = app
+                .oneshot(Request::builder().uri(uri).body(Body::empty()).unwrap())
+                .await
+                .unwrap();
+            let status = resp.status();
+            let content_type = resp
+                .headers()
+                .get("content-type")
+                .map(|v| v.to_str().unwrap().to_string());
+            let body = resp.into_body().collect().await.unwrap().to_bytes();
+            (status, content_type, body)
+        }
+    };
+
+    let (status, content_type, _) = fetch("APPLICATION/JSON").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(content_type.as_deref(), Some("application/json"));
+
+    let (status, content_type, body) = fetch("image/png").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(content_type.as_deref(), Some("image/png"));
+    assert_eq!(png_dims(&body), (180, 300));
+
+    let (status, _, _) = fetch("text/html").await;
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "an unsupported FORMAT must still be rejected"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Explicit pin of the current latest run keeps fallback-tolerant resolution
 // ---------------------------------------------------------------------------

--- a/crates/render/Cargo.toml
+++ b/crates/render/Cargo.toml
@@ -12,6 +12,7 @@ quick_cache = "0.6"
 ds-cache = { path = "../ds-cache" }
 bytes = "1"
 chrono = { version = "0.4", features = ["serde"] }
+serde_json = "1"
 
 [dev-dependencies]
 toml = "0.8"

--- a/crates/render/src/lib.rs
+++ b/crates/render/src/lib.rs
@@ -465,6 +465,120 @@ fn format_tick(v: f64) -> String {
     }
 }
 
+/// Default legend image size — large enough for the title and the value-tick
+/// labels (#371). Shared by every service that renders one (WMS
+/// `GetLegendGraphic` without WIDTH/HEIGHT, the Maps/Tiles legend endpoints)
+/// so a legend looks the same whichever API served it.
+pub const LEGEND_DEFAULT_WIDTH: u32 = 180;
+pub const LEGEND_DEFAULT_HEIGHT: u32 = 300;
+
+/// `Cache-Control` for a legend response (image or JSON). A day is plenty for
+/// a palette, but deliberately NOT `immutable`: colormaps and styles are
+/// hot-reloadable, so a client must be able to revalidate.
+pub const LEGEND_CACHE_CONTROL: &str = "public, max-age=86400";
+
+/// Machine-readable legend description for a style, so a map client can draw
+/// its own legend instead of embedding the rendered PNG.
+///
+/// One builder shared by WMS `GetLegendGraphic&FORMAT=application/json`, OGC
+/// API Maps and OGC API Tiles — the three services must emit the identical
+/// shape, and a copy per API layer would drift.
+///
+/// `parameter` and `unit` are resolved by the caller (the API layer knows its
+/// own layer-name conventions and holds the engine's `RasterInfo`); empty or
+/// absent values are omitted from the payload rather than emitted as `""`.
+/// `nodataColor` appears only when the palette carries an explicit one.
+pub fn legend_json(
+    style: &StyleInfo,
+    parameter: Option<&str>,
+    unit: Option<&str>,
+) -> serde_json::Value {
+    let stops: Vec<serde_json::Value> = style
+        .palette
+        .stops
+        .iter()
+        .map(|s| {
+            serde_json::json!({
+                "value": s.value,
+                "color": Palette::color_hex(s.color),
+            })
+        })
+        .collect();
+
+    let mut legend = serde_json::json!({
+        "style": style.name,
+        "title": style.title,
+        "min": style.min,
+        "max": style.max,
+        "interpolation": style.palette.interpolation.as_str(),
+        "stops": stops,
+    });
+
+    if let Some(p) = parameter.map(str::trim).filter(|p| !p.is_empty()) {
+        legend["parameter"] = serde_json::json!(p);
+    }
+    if let Some(u) = unit.map(str::trim).filter(|u| !u.is_empty()) {
+        legend["unit"] = serde_json::json!(u);
+    }
+    if let Some(nodata) = style.palette.nodata_color {
+        legend["nodataColor"] = serde_json::json!(Palette::color_hex(nodata));
+    }
+
+    legend
+}
+
+/// Resolve the `(parameter, unit)` a legend describes from a style plus the
+/// engine's raster metadata: the style's configured parameter (set for
+/// per-parameter styles) falling back to the collection's default parameter,
+/// and the collection-level unit. Empty strings mean "unknown" and become
+/// `None`, so the pair can be handed straight to [`legend_json`] /
+/// [`legend_title`].
+///
+/// WMS resolves the parameter itself — a WMS layer name may carry it as a
+/// `collection/parameter` segment, which takes precedence over the engine
+/// default. Maps and Tiles have no such layer syntax and use this directly.
+pub fn legend_parameter_unit(
+    style: &StyleInfo,
+    info: &ds_core::map_engine::RasterInfo,
+) -> (Option<String>, Option<String>) {
+    let parameter = style
+        .parameter
+        .clone()
+        .or_else(|| Some(info.parameter.clone()).filter(|p| !p.is_empty()));
+    let unit = Some(info.unit.clone()).filter(|u| !u.is_empty());
+    (parameter, unit)
+}
+
+/// The title for a rendered legend image: `"<parameter> (<unit>)"`, with the
+/// style's own title on a second line for non-default styles.
+///
+/// Shared by every service that renders a legend PNG (WMS, Maps, Tiles) so the
+/// three cannot drift. `parameter`/`unit` are resolved by the caller, as for
+/// [`legend_json`]. `None` when nothing informative is known.
+pub fn legend_title(
+    style: &StyleInfo,
+    parameter: Option<&str>,
+    unit: Option<&str>,
+) -> Option<String> {
+    let parameter = parameter.map(str::trim).filter(|p| !p.is_empty());
+    let unit = unit.map(str::trim).filter(|u| !u.is_empty());
+    let param_unit = match (parameter, unit) {
+        (Some(p), Some(u)) => Some(format!("{p} ({u})")),
+        (Some(s), None) | (None, Some(s)) => Some(s.to_string()),
+        (None, None) => None,
+    };
+    // "default"/"Default" carries no information — the colours already come
+    // from the selected style, so only a named style earns the second line.
+    let style_line = (style.name != "default")
+        .then(|| style.title.trim().to_string())
+        .filter(|t| !t.is_empty() && !t.eq_ignore_ascii_case("default"));
+    match (param_unit, style_line) {
+        (Some(pu), Some(sl)) => Some(format!("{pu}\n{sl}")),
+        (Some(s), None) | (None, Some(s)) => Some(s),
+        (None, None) => None,
+    }
+}
+
 /// Render a legend image showing the colormap scale.
 ///
 /// Produces a vertical colour gradient (top = `max`, bottom = `min`) with a
@@ -717,6 +831,110 @@ pub(crate) fn colorize(tile: &RasterTile, colormap: &dyn ColorMap) -> Vec<u8> {
 mod tests {
     use super::*;
     use ds_core::map_engine::RasterTile;
+
+    /// Build a `StyleInfo` over a builtin palette for the legend tests.
+    fn style_over(palette: &str, name: &str, title: &str, min: f64, max: f64) -> StyleInfo {
+        let palette = builtin_palette_arc(palette).expect("builtin palette");
+        StyleInfo {
+            name: name.to_string(),
+            title: title.to_string(),
+            colormap: Arc::new(LinearColorMap::new(palette.stops.clone())),
+            palette,
+            min,
+            max,
+            parameter: None,
+        }
+    }
+
+    #[test]
+    fn legend_json_carries_every_palette_stop_and_range() {
+        let style = style_over("radar_dbz", "default", "Default", -32.0, 94.5);
+        let legend = legend_json(&style, Some("DBZH"), Some("dBZ"));
+
+        assert_eq!(legend["style"], "default");
+        assert_eq!(legend["title"], "Default");
+        assert_eq!(legend["parameter"], "DBZH");
+        assert_eq!(legend["unit"], "dBZ");
+        assert_eq!(legend["min"], -32.0);
+        assert_eq!(legend["max"], 94.5);
+        assert_eq!(legend["interpolation"], "linear");
+        // No explicit nodata colour on a builtin → the key is omitted, not null.
+        assert!(legend.get("nodataColor").is_none());
+
+        let stops = legend["stops"].as_array().expect("stops array");
+        assert_eq!(stops.len(), style.palette.stops.len());
+        // First radar_dbz stop is fully transparent → 8-digit hex; a solid
+        // stop is 6-digit.
+        assert_eq!(stops[0]["value"], 0.0);
+        assert_eq!(stops[0]["color"], "#00000000");
+        assert_eq!(stops[2]["value"], 5.1);
+        assert_eq!(stops[2]["color"], "#0080FF");
+    }
+
+    #[test]
+    fn legend_json_omits_unknown_parameter_and_unit() {
+        let style = style_over("viridis", "default", "Default", 0.0, 1.0);
+        let legend = legend_json(&style, None, Some("   "));
+        assert!(legend.get("parameter").is_none());
+        assert!(legend.get("unit").is_none(), "blank unit must be omitted");
+    }
+
+    #[test]
+    fn legend_json_emits_step_interpolation_and_nodata_colour() {
+        let mut palette = Palette::new(
+            "classes",
+            vec![
+                ColorStop {
+                    value: 0.0,
+                    color: [0, 0, 0, 255],
+                },
+                ColorStop {
+                    value: 1.0,
+                    color: [255, 255, 255, 255],
+                },
+            ],
+            Interpolation::Step,
+        );
+        palette.nodata_color = Some([0, 0, 0, 0]);
+        let palette = Arc::new(palette);
+        let style = StyleInfo {
+            name: "classes".to_string(),
+            title: "Classes".to_string(),
+            colormap: Arc::new(LinearColorMap::new(palette.stops.clone())),
+            palette,
+            min: 0.0,
+            max: 1.0,
+            parameter: Some("class".to_string()),
+        };
+        let legend = legend_json(&style, style.parameter.as_deref(), None);
+        assert_eq!(legend["interpolation"], "step");
+        assert_eq!(legend["nodataColor"], "#00000000");
+        assert_eq!(legend["parameter"], "class");
+    }
+
+    #[test]
+    fn legend_title_combines_parameter_unit_and_named_style() {
+        let default = style_over("radar_dbz", "default", "Default", 0.0, 70.0);
+        assert_eq!(
+            legend_title(&default, Some("DBZH"), Some("dBZ")).as_deref(),
+            Some("DBZH (dBZ)")
+        );
+        assert_eq!(
+            legend_title(&default, Some("DBZH"), None).as_deref(),
+            Some("DBZH")
+        );
+        assert_eq!(legend_title(&default, None, None), None);
+
+        let named = style_over("radar_fmi", "radar_fmi", "FMI Radar", 0.0, 70.0);
+        assert_eq!(
+            legend_title(&named, Some("DBZH"), Some("dBZ")).as_deref(),
+            Some("DBZH (dBZ)\nFMI Radar"),
+            "a named style adds its own title on a second line"
+        );
+        // A named style whose title is still "Default" adds nothing.
+        let noise = style_over("viridis", "viridis", "Default", 0.0, 1.0);
+        assert_eq!(legend_title(&noise, Some("t"), None).as_deref(), Some("t"));
+    }
 
     #[test]
     fn empty_tile_is_deterministic_and_memoized() {

--- a/crates/render/src/palette.rs
+++ b/crates/render/src/palette.rs
@@ -90,6 +90,29 @@ impl Palette {
     pub fn sample(&self, value: f64) -> [u8; 4] {
         sample_stops(&self.stops, value, self.interpolation)
     }
+
+    /// Hex-encode a stop color for machine-readable legends: `#RRGGBB`,
+    /// or `#RRGGBBAA` when the alpha channel is not fully opaque.
+    pub fn color_hex(color: [u8; 4]) -> String {
+        if color[3] == 255 {
+            format!("#{:02X}{:02X}{:02X}", color[0], color[1], color[2])
+        } else {
+            format!(
+                "#{:02X}{:02X}{:02X}{:02X}",
+                color[0], color[1], color[2], color[3]
+            )
+        }
+    }
+}
+
+impl Interpolation {
+    /// The config / legend-JSON string form.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Interpolation::Linear => "linear",
+            Interpolation::Step => "step",
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/render/src/palette_formats.rs
+++ b/crates/render/src/palette_formats.rs
@@ -230,9 +230,19 @@ fn cpt_err(lineno: usize, line: &str, msg: &str) -> String {
 }
 
 fn parse_cpt_z(token: &str, lineno: usize, line: &str) -> Result<f64, String> {
-    token
+    let z = token
         .parse::<f64>()
-        .map_err(|_| cpt_err(lineno, line, &format!("invalid z value '{token}'")))
+        .map_err(|_| cpt_err(lineno, line, &format!("invalid z value '{token}'")))?;
+    // f64::from_str accepts "nan"/"inf"; a non-finite stop would silently
+    // poison the sort order / default range / LUT bounds — fail at load.
+    if !z.is_finite() {
+        return Err(cpt_err(
+            lineno,
+            line,
+            &format!("non-finite z value '{token}'"),
+        ));
+    }
+    Ok(z)
 }
 
 /// Parse a `.cpt` color from either 1 token (hex, packed triplet, or gray)
@@ -389,6 +399,13 @@ pub fn parse_gdal_txt(name: &str, text: &str) -> Result<Palette, String> {
         let value = tokens[0]
             .parse::<f64>()
             .map_err(|_| cpt_err(lineno, trimmed, &format!("invalid value '{head}'")))?;
+        if !value.is_finite() {
+            return Err(cpt_err(
+                lineno,
+                trimmed,
+                &format!("non-finite value '{head}'"),
+            ));
+        }
         stops.push(ColorStop { value, color });
     }
 
@@ -458,6 +475,14 @@ fn parse_gdal_color(tokens: &[&str], lineno: usize, line: &str) -> Result<[u8; 4
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn non_finite_values_rejected() {
+        assert!(parse_cpt("x", "nan 0 0 0 10 255 255 255\n").is_err());
+        assert!(parse_cpt("x", "0 0 0 0 inf 255 255 255\n").is_err());
+        assert!(parse_gdal_txt("x", "nan 255 0 0\n").is_err());
+        assert!(parse_gdal_txt("x", "-inf 255 0 0\n").is_err());
+    }
 
     /// `(value, color)` view of a palette's stops, for compact assertions.
     fn stops_of(p: &Palette) -> Vec<(f64, [u8; 4])> {


### PR DESCRIPTION
## Summary

Phase 6 of the styling revamp (stacked on #562) — the client-facing payoff: map clients get the colormap definition as JSON and draw their own legends, guaranteed to match what the server renders (both come from the same resolved `StyleInfo.palette`).

**One payload shape across WMS, Maps and Tiles** (built by a single `ds_render::legend_json`):
```json
{ "style": "default", "title": "Default", "parameter": "DBZH", "unit": "dBZ",
  "min": -32.0, "max": 94.5, "interpolation": "linear",
  "stops": [ { "value": 5.0, "color": "#414141" }, ... ] }
```

- **WMS:** `GetLegendGraphic&FORMAT=application/json` (GeoServer precedent). Image formats unchanged.
- **Maps + Tiles:** new `GET /collections/{id}/styles/{styleId}/legend` — `f=json` (default) and `f=png` (these APIs had no legend at all); `rel="legend"` links on style listings; `api_definition()` updated in both.
- `Cache-Control: public, max-age=86400`, deliberately not `immutable` (palettes are hot-reloadable since #560).
- Shaped so a future OGC API - Styles facade (spec still a draft) can wrap the same data without breaking clients.
- Also carries a review fix from #560: cpt/GDAL palette parsers now reject non-finite stop values at load.

## Verification

- Integration tests in all three API crates (JSON fields + stop counts, named styles, 404s, PNG magic, legend links).
- Live smoke: WMS JSON legend returns a `colormaps_dir` user palette's stops; Maps `/legend` resolves the engine unit (dBZ); `f=png` renders; the WMS PNG path is unchanged.
- Clippy `-D warnings` clean; 445 tests green in ds-render/api-wms/api-maps/api-tiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VWyrJy1FVeinRS8UsSZKrU