### PR TITLE
fix(api): 400 on unknown parameter-name in Maps/Tiles legend endpoints

### DIFF
--- a/crates/api-maps/src/handlers.rs
+++ b/crates/api-maps/src/handlers.rs
@@ -1090,6 +1090,21 @@ pub async fn style_legend(
     })?;
 
     let info = engine.raster_info();
+    // Mirror the render path's validation: an unknown `parameter-name` must
+    // 400 with the available list, not fall back to the collection style and
+    // emit a legend labelled with a parameter that doesn't exist.
+    if let Some(pname) = params.parameter_name.as_deref() {
+        if !info.parameters.is_empty() && !info.parameters.iter().any(|(name, _)| name == pname) {
+            let mut supported: Vec<&str> =
+                info.parameters.iter().map(|(n, _)| n.as_str()).collect();
+            supported.sort_unstable();
+            return Err(MapsError::BadRequest(format!(
+                "parameter-name '{pname}' is not available for collection '{id}'. \
+                 Available: {}",
+                supported.join(", ")
+            )));
+        }
+    }
     let (parameter, unit) = ds_render::legend_parameter_unit(style_info, &info);
     // A ?parameter-name= request labels the legend with the REQUESTED
     // parameter even when no dedicated "{coll}/{param}" style layer exists

--- a/crates/api-maps/tests/integration.rs
+++ b/crates/api-maps/tests/integration.rs
@@ -2564,6 +2564,19 @@ mod parameter_styles {
     /// The legend follows the same resolution, so a client's drawn legend
     /// matches the pixels it gets for that parameter.
     #[tokio::test]
+    async fn legend_with_unknown_parameter_name_is_a_400() {
+        // Mirrors render_map: an unknown parameter must not fall back and
+        // emit a legend labelled with a parameter that doesn't exist.
+        let (status, json) =
+            fetch_json("/collections/radar/styles/default/legend?parameter-name=BOGUS").await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert!(json["description"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("BOGUS"));
+    }
+
+    #[tokio::test]
     async fn legend_with_parameter_name_describes_the_parameter_style() {
         let (status, json) =
             fetch_json("/collections/radar/styles/default/legend?parameter-name=T").await;

--- a/crates/api-tiles/src/handlers.rs
+++ b/crates/api-tiles/src/handlers.rs
@@ -1418,6 +1418,21 @@ pub async fn style_legend(
     })?;
 
     let info = engine.raster_info();
+    // Mirror the render path's validation: an unknown `parameter-name` must
+    // 400 with the available list, not fall back to the collection style and
+    // emit a legend labelled with a parameter that doesn't exist.
+    if let Some(pname) = params.parameter_name.as_deref() {
+        if !info.parameters.is_empty() && !info.parameters.iter().any(|(name, _)| name == pname) {
+            let mut supported: Vec<&str> =
+                info.parameters.iter().map(|(n, _)| n.as_str()).collect();
+            supported.sort_unstable();
+            return Err(TilesError::BadRequest(format!(
+                "parameter-name '{pname}' is not available for collection '{id}'. \
+                 Available: {}",
+                supported.join(", ")
+            )));
+        }
+    }
     let (parameter, unit) = ds_render::legend_parameter_unit(style_info, &info);
     // A ?parameter-name= request labels the legend with the REQUESTED
     // parameter even when no dedicated "{coll}/{param}" style layer exists

--- a/crates/api-tiles/tests/integration.rs
+++ b/crates/api-tiles/tests/integration.rs
@@ -2506,6 +2506,19 @@ mod parameter_styles {
     /// The legend follows the same resolution, so a client's drawn legend
     /// matches the pixels it gets for that parameter.
     #[tokio::test]
+    async fn legend_with_unknown_parameter_name_is_a_400() {
+        // Mirrors render_tile: an unknown parameter must not fall back and
+        // emit a legend labelled with a parameter that doesn't exist.
+        let (status, json) =
+            fetch_json("/collections/radar/styles/default/legend?parameter-name=BOGUS").await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert!(json["description"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("BOGUS"));
+    }
+
+    #[tokio::test]
     async fn legend_with_parameter_name_describes_the_parameter_style() {
         let (status, json) =
             fetch_json("/collections/radar/styles/default/legend?parameter-name=T").await;


### PR DESCRIPTION
## Summary

Follow-up to #566 (its last two review findings, deferred so the merge chain could complete): the Maps and Tiles `/collections/{id}/styles/{styleId}/legend` endpoints accepted any `parameter-name`, silently falling back to the collection style and labelling the legend with a nonexistent parameter. Both handlers now mirror the render path's validation exactly — an unknown name returns 400 with the sorted available-parameter list.

Valid parameters without a dedicated style layer still fall back to the collection style (unchanged, covered by existing tests).

## Tests

New 400-path tests in both crates; full api-maps + api-tiles suites green (247 tests); clippy `-D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VWyrJy1FVeinRS8UsSZKrU